### PR TITLE
Fix #18781

### DIFF
--- a/core/constants_test.py
+++ b/core/constants_test.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Oppia Authors. All Rights Reserved.
+s# Copyright 2017 The Oppia Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 """Tests for Constants object and cosntants.json file."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 import pkgutil
@@ -185,5 +186,5 @@ class ConstantsTests(test_utils.GenericTestBase):
 
     def test_constants_can_be_set(self) -> None:
         """Test __setattr__ to see if constants can be set as needed."""
-        with self.swap(constants.constants, 'TESTING_CONSTANT', 'test_2'):
+        with patch.object(constants.constants, 'TESTING_CONSTANT', 'test_2'):
             self.assertEqual(constants.constants.TESTING_CONSTANT, 'test_2')

--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -17,6 +17,7 @@
 """Tests for core.domain.acl_decorators."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import json
 
@@ -91,13 +92,13 @@ class OpenAccessDecoratorTests(test_utils.GenericTestBase):
 
     def test_access_with_logged_in_user(self) -> None:
         self.login(self.VIEWER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_access_with_guest_user(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock')
         self.assertTrue(response['success'])
 
@@ -133,7 +134,7 @@ class IsSourceMailChimpDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_error_when_mailchimp_webhook_secret_is_none(self) -> None:
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         swap_api_key_secrets_return_none = self.swap_with_checks(
             secrets_services,
             'get_secret',
@@ -158,7 +159,7 @@ class IsSourceMailChimpDecoratorTests(test_utils.GenericTestBase):
         self.assertEqual(response['status_code'], 404)
 
     def test_error_when_given_webhook_secret_is_invalid(self) -> None:
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         mailchimp_swap = self.swap_to_always_return(
             secrets_services, 'get_secret', self.secret)
 
@@ -176,7 +177,7 @@ class IsSourceMailChimpDecoratorTests(test_utils.GenericTestBase):
         self.assertEqual(response['status_code'], 404)
 
     def test_no_error_when_given_webhook_secret_is_valid(self) -> None:
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         mailchimp_swap = self.swap_to_always_return(
             secrets_services, 'get_secret', self.secret)
 
@@ -225,14 +226,14 @@ class ViewSkillsDecoratorTests(test_utils.GenericTestBase):
         skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(skill_id, self.admin_id, description='Description')
         skill_ids = [skill_id]
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_skills/%s' % json.dumps(skill_ids))
         self.assertEqual(response['selected_skill_ids'], skill_ids)
 
     def test_invalid_input_exception_with_invalid_skill_ids(self) -> None:
         skill_ids = ['abcd1234']
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_skills/%s' % json.dumps(skill_ids),
                 expected_status_int=400)
@@ -240,7 +241,7 @@ class ViewSkillsDecoratorTests(test_utils.GenericTestBase):
 
     def test_page_not_found_exception_with_invalid_skill_ids(self) -> None:
         skill_ids = ['invalid_id12', 'invalid_id13']
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_skills/%s' % json.dumps(skill_ids),
                 expected_status_int=404)
@@ -297,7 +298,7 @@ class DownloadExplorationDecoratorTests(test_utils.GenericTestBase):
     def test_cannot_download_exploration_with_disabled_exploration_ids(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_download_exploration/%s' % (
                     feconf.DISABLED_EXPLORATION_IDS[0]),
@@ -312,13 +313,13 @@ class DownloadExplorationDecoratorTests(test_utils.GenericTestBase):
         self.assertEqual(response['error'], error_msg)
 
     def test_guest_can_download_published_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_download_exploration/%s' % self.published_exp_id)
         self.assertEqual(response['exploration_id'], self.published_exp_id)
 
     def test_guest_cannot_download_private_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_download_exploration/%s' % self.private_exp_id,
                 expected_status_int=404)
@@ -332,7 +333,7 @@ class DownloadExplorationDecoratorTests(test_utils.GenericTestBase):
 
     def test_moderator_can_download_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_download_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -340,7 +341,7 @@ class DownloadExplorationDecoratorTests(test_utils.GenericTestBase):
 
     def test_owner_can_download_private_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_download_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -348,7 +349,7 @@ class DownloadExplorationDecoratorTests(test_utils.GenericTestBase):
 
     def test_logged_in_user_cannot_download_unowned_exploration(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_download_exploration/%s' % self.private_exp_id,
                 expected_status_int=404)
@@ -365,7 +366,7 @@ class DownloadExplorationDecoratorTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         exp_rights_swap = self.swap_to_always_return(
             rights_manager, 'get_exploration_rights', value=None)
         with testapp_swap, exp_rights_swap:
@@ -428,7 +429,7 @@ class ViewExplorationStatsDecoratorTests(test_utils.GenericTestBase):
     def test_cannot_view_exploration_stats_with_disabled_exploration_ids(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_exploration_stats/%s' % (
                     feconf.DISABLED_EXPLORATION_IDS[0]),
@@ -443,13 +444,13 @@ class ViewExplorationStatsDecoratorTests(test_utils.GenericTestBase):
         self.assertEqual(response['error'], error_msg)
 
     def test_guest_can_view_published_exploration_stats(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_exploration_stats/%s' % self.published_exp_id)
         self.assertEqual(response['exploration_id'], self.published_exp_id)
 
     def test_guest_cannot_view_private_exploration_stats(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_exploration_stats/%s' % self.private_exp_id,
                 expected_status_int=404)
@@ -463,7 +464,7 @@ class ViewExplorationStatsDecoratorTests(test_utils.GenericTestBase):
 
     def test_moderator_can_view_private_exploration_stats(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_exploration_stats/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -471,7 +472,7 @@ class ViewExplorationStatsDecoratorTests(test_utils.GenericTestBase):
 
     def test_owner_can_view_private_exploration_stats(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_exploration_stats/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -479,7 +480,7 @@ class ViewExplorationStatsDecoratorTests(test_utils.GenericTestBase):
 
     def test_logged_in_user_cannot_view_unowned_exploration_stats(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_exploration_stats/%s' % self.private_exp_id,
                 expected_status_int=404)
@@ -496,7 +497,7 @@ class ViewExplorationStatsDecoratorTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         exp_rights_swap = self.swap_to_always_return(
             rights_manager, 'get_exploration_rights', value=None)
         with testapp_swap, exp_rights_swap:
@@ -538,14 +539,14 @@ class RequireUserIdElseRedirectToHomepageTests(test_utils.GenericTestBase):
 
     def test_logged_in_user_is_redirected_to_access_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response('/mock/', expected_status_int=302)
         self.assertEqual(
             'http://localhost/access_page', response.headers['location'])
         self.logout()
 
     def test_guest_user_is_redirected_to_homepage(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response('/mock/', expected_status_int=302)
         self.assertEqual(
             'http://localhost/', response.headers['location'])
@@ -596,26 +597,26 @@ class PlayExplorationDecoratorTests(test_utils.GenericTestBase):
     def test_cannot_access_exploration_with_disabled_exploration_ids(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_exploration/%s'
                 % (feconf.DISABLED_EXPLORATION_IDS[0]), expected_status_int=404)
 
     def test_guest_can_access_published_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_exploration/%s' % self.published_exp_id)
         self.assertEqual(response['exploration_id'], self.published_exp_id)
 
     def test_guest_cannot_access_private_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_exploration/%s' % self.private_exp_id,
                 expected_status_int=404)
 
     def test_moderator_can_access_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -623,7 +624,7 @@ class PlayExplorationDecoratorTests(test_utils.GenericTestBase):
 
     def test_owner_can_access_private_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -631,7 +632,7 @@ class PlayExplorationDecoratorTests(test_utils.GenericTestBase):
 
     def test_logged_in_user_cannot_access_not_owned_exploration(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_exploration/%s' % self.private_exp_id,
                 expected_status_int=404)
@@ -684,7 +685,7 @@ class PlayExplorationAsLoggedInUserTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 (
                     '/mock_play_exploration/%s' %
@@ -696,7 +697,7 @@ class PlayExplorationAsLoggedInUserTests(test_utils.GenericTestBase):
 
     def test_moderator_user_can_access_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_exploration/%s' % self.private_exp_id
             )
@@ -705,7 +706,7 @@ class PlayExplorationAsLoggedInUserTests(test_utils.GenericTestBase):
 
     def test_exp_owner_can_access_private_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_exploration/%s' % self.private_exp_id
             )
@@ -714,7 +715,7 @@ class PlayExplorationAsLoggedInUserTests(test_utils.GenericTestBase):
 
     def test_logged_in_user_cannot_access_not_owned_exploration(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_exploration/%s' % self.private_exp_id,
                 expected_status_int=404
@@ -723,7 +724,7 @@ class PlayExplorationAsLoggedInUserTests(test_utils.GenericTestBase):
 
     def test_invalid_exploration_id_raises_error(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_exploration/%s' % 'invalid_exp_id',
                 expected_status_int=404
@@ -783,20 +784,20 @@ class PlayCollectionDecoratorTests(test_utils.GenericTestBase):
         rights_manager.publish_collection(self.owner, self.published_col_id)
 
     def test_guest_can_access_published_collection(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_collection/%s' % self.published_col_id)
         self.assertEqual(response['collection_id'], self.published_col_id)
 
     def test_guest_cannot_access_private_collection(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_collection/%s' % self.private_col_id,
                 expected_status_int=404)
 
     def test_moderator_can_access_private_collection(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_collection/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
@@ -804,7 +805,7 @@ class PlayCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_owner_can_access_private_collection(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_play_collection/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
@@ -814,7 +815,7 @@ class PlayCollectionDecoratorTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_collection/%s' % self.private_col_id,
                 expected_status_int=404)
@@ -822,7 +823,7 @@ class PlayCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_access_collection_with_invalid_collection_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_collection/invalid_collection_id',
                 expected_status_int=404)
@@ -878,19 +879,19 @@ class EditCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_edit_collection_with_invalid_collection_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_collection/invalid_col_id', expected_status_int=404)
         self.logout()
 
     def test_guest_cannot_edit_collection_via_json_handler(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_collection/%s' % self.published_col_id,
                 expected_status_int=401)
 
     def test_guest_is_redirected_when_using_html_handler(self) -> None:
-        with self.swap(
+        with patch.object(
             self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
             feconf.HANDLER_TYPE_HTML):
             response = self.mock_testapp.get(
@@ -900,7 +901,7 @@ class EditCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_edit_collection(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_collection/%s' % self.private_col_id,
                 expected_status_int=401)
@@ -908,7 +909,7 @@ class EditCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_owner_can_edit_owned_collection(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_collection/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
@@ -916,7 +917,7 @@ class EditCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_moderator_can_edit_private_collection(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_collection/%s' % self.private_col_id)
 
@@ -925,7 +926,7 @@ class EditCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_moderator_can_edit_public_collection(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_collection/%s' % self.published_col_id)
         self.assertEqual(response['collection_id'], self.published_col_id)
@@ -933,7 +934,7 @@ class EditCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_admin_can_edit_any_private_collection(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_collection/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
@@ -1015,18 +1016,18 @@ class ClassroomExistDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_any_user_can_access_a_valid_classroom(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_classroom_data/math', expected_status_int=200)
 
     def test_redirects_user_to_default_classroom_if_given_not_available(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_classroom_data/invalid', expected_status_int=404)
 
     def test_raises_error_if_return_type_is_not_json(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_html_response(
                 '/mock_classroom_page/invalid', expected_status_int=500)
 
@@ -1058,23 +1059,23 @@ class CreateExplorationDecoratorTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_create_exploration(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/create', expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_create_exploration(self) -> None:
         self.login(self.EDITOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/create')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_guest_cannot_create_exploration_via_json_handler(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/create', expected_status_int=401)
 
     def test_guest_is_redirected_when_using_html_handler(self) -> None:
-        with self.swap(
+        with patch.object(
             self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
             feconf.HANDLER_TYPE_HTML):
             response = self.mock_testapp.get('/mock/create', expect_errors=True)
@@ -1109,11 +1110,11 @@ class CreateCollectionDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_create_collection_via_json_handler(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/create', expected_status_int=401)
 
     def test_guest_is_redirected_when_using_html_handler(self) -> None:
-        with self.swap(
+        with patch.object(
             self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
             feconf.HANDLER_TYPE_HTML):
             response = self.mock_testapp.get('/mock/create', expect_errors=True)
@@ -1121,13 +1122,13 @@ class CreateCollectionDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_create_collection(self) -> None:
         self.login(self.EDITOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/create', expected_status_int=401)
         self.logout()
 
     def test_collection_editor_can_create_collection(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/create')
         self.assertTrue(response['success'])
         self.logout()
@@ -1160,19 +1161,19 @@ class AccessCreatorDashboardTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_access_editor_dashboard(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/access', expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_access_editor_dashboard(self) -> None:
         self.login(self.EDITOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/access')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_guest_user_cannot_access_editor_dashboard(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/access', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -1227,7 +1228,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_comment_on_feedback_thread/exploration.%s.thread1'
                 % feconf.DISABLED_EXPLORATION_IDS[0],
@@ -1238,7 +1239,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_comment_on_feedback_thread/exploration.%s.thread1'
                 % self.private_exp_id, expected_status_int=401)
@@ -1251,7 +1252,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_comment_on_feedback_thread/invalid_thread_id',
                 expected_status_int=400)
@@ -1261,7 +1262,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
     def test_guest_cannot_comment_on_feedback_threads_via_json_handler(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_comment_on_feedback_thread/exploration.%s.thread1'
                 % (self.private_exp_id), expected_status_int=401)
@@ -1270,7 +1271,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
                 % (self.published_exp_id), expected_status_int=401)
 
     def test_guest_is_redirected_when_using_html_handler(self) -> None:
-        with self.swap(
+        with patch.object(
             self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
             feconf.HANDLER_TYPE_HTML):
             response = self.mock_testapp.get(
@@ -1286,7 +1287,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_comment_on_feedback_thread/exploration.%s.thread1'
                 % (self.private_exp_id))
@@ -1296,7 +1297,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_comment_on_feedback_thread/exploration.%s.thread1'
                 % (self.published_exp_id))
@@ -1306,7 +1307,7 @@ class CommentOnFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_comment_on_feedback_thread/exploration.%s.thread1'
                 % (self.private_exp_id))
@@ -1359,7 +1360,7 @@ class CreateFeedbackThreadTests(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
     def test_cannot_create_feedback_threads_with_disabled_exp_id(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_create_feedback_thread/%s'
                 % (feconf.DISABLED_EXPLORATION_IDS[0]), expected_status_int=404)
@@ -1368,7 +1369,7 @@ class CreateFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_create_feedback_thread/%s' % self.private_exp_id,
                 expected_status_int=401)
@@ -1380,27 +1381,27 @@ class CreateFeedbackThreadTests(test_utils.GenericTestBase):
     def test_guest_can_create_feedback_threads_for_public_exploration(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_create_feedback_thread/%s' % self.published_exp_id)
 
     def test_owner_cannot_create_feedback_for_private_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_create_feedback_thread/%s' % self.private_exp_id)
         self.logout()
 
     def test_moderator_can_create_feeback_for_public_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_create_feedback_thread/%s' % self.published_exp_id)
         self.logout()
 
     def test_moderator_can_create_feeback_for_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_create_feedback_thread/%s' % self.private_exp_id)
         self.logout()
@@ -1461,14 +1462,14 @@ class ViewFeedbackThreadTests(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
     def test_cannot_view_feedback_threads_with_disabled_exp_id(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_view_feedback_thread/%s' % self.disabled_exp_thread_id,
                 expected_status_int=404)
 
     def test_viewer_cannot_view_feedback_for_private_exploration(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_feedback_thread/%s' % self.private_exp_thread_id,
                 expected_status_int=401)
@@ -1481,7 +1482,7 @@ class ViewFeedbackThreadTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_feedback_thread/invalid_thread_id',
                 expected_status_int=400)
@@ -1492,33 +1493,33 @@ class ViewFeedbackThreadTests(test_utils.GenericTestBase):
         self.login(self.viewer_email)
         skill_thread_id = feedback_services.create_thread(
             'skill', 'skillid1', None, 'unused subject', 'unused text')
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_view_feedback_thread/%s' % skill_thread_id)
 
     def test_guest_can_view_feedback_threads_for_public_exploration(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_view_feedback_thread/%s' % self.public_exp_thread_id)
 
     def test_owner_cannot_view_feedback_for_private_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_view_feedback_thread/%s' % self.private_exp_thread_id)
         self.logout()
 
     def test_moderator_can_view_feeback_for_public_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_view_feedback_thread/%s' % self.public_exp_thread_id)
         self.logout()
 
     def test_moderator_can_view_feeback_for_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_view_feedback_thread/%s' % self.private_exp_thread_id)
         self.logout()
@@ -1567,23 +1568,23 @@ class ManageEmailDashboardTests(test_utils.GenericTestBase):
 
     def test_moderator_cannot_access_email_dashboard(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
         self.logout()
 
     def test_super_admin_can_access_email_dashboard(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.mock_testapp.put('/mock/%s' % self.query_id)
         self.assertEqual(response.status_int, 200)
         self.logout()
 
     def test_error_when_user_is_not_logged_in(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -1620,13 +1621,13 @@ class RateExplorationTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_give_rating(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.exp_id, expected_status_int=401)
 
     def test_normal_user_can_give_rating(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.exp_id)
         self.assertEqual(response['exploration_id'], self.exp_id)
         self.logout()
@@ -1659,19 +1660,19 @@ class AccessModeratorPageTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_moderator_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
         self.logout()
 
     def test_moderator_can_access_moderator_page(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
         self.logout()
 
     def test_guest_cannot_access_moderator_page(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -1708,13 +1709,13 @@ class FlagExplorationTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_flag_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.exp_id, expected_status_int=401)
 
     def test_normal_user_can_flag_exploration(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.exp_id)
         self.assertEqual(response['exploration_id'], self.exp_id)
         self.logout()
@@ -1744,12 +1745,12 @@ class SubscriptionToUsersTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_subscribe_to_users(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
 
     def test_normal_user_can_subscribe_to_users(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertTrue(response['success'])
         self.logout()
@@ -1782,19 +1783,19 @@ class SendModeratorEmailsTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_send_moderator_emails(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
         self.logout()
 
     def test_moderator_can_send_moderator_emails(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
         self.logout()
 
     def test_guest_cannot_send_moderator_emails(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -1834,7 +1835,7 @@ class CanAccessReleaseCoordinatorPageDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_release_coordinator_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/release-coordinator', expected_status_int=401)
 
@@ -1844,7 +1845,7 @@ class CanAccessReleaseCoordinatorPageDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_access_release_coordinator_page(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/release-coordinator', expected_status_int=401)
 
@@ -1856,7 +1857,7 @@ class CanAccessReleaseCoordinatorPageDecoratorTests(test_utils.GenericTestBase):
     def test_super_admin_cannot_access_release_coordinator_page(self) -> None:
         self.login(feconf.SYSTEM_EMAIL_ADDRESS)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/release-coordinator', expected_status_int=401)
 
@@ -1870,7 +1871,7 @@ class CanAccessReleaseCoordinatorPageDecoratorTests(test_utils.GenericTestBase):
     ) -> None:
         self.login(self.RELEASE_COORDINATOR_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/release-coordinator')
 
         self.assertEqual(response['success'], 1)
@@ -1909,7 +1910,7 @@ class CanAccessBlogAdminPageDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_blog_admin_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blog-admin', expected_status_int=401)
 
@@ -1919,7 +1920,7 @@ class CanAccessBlogAdminPageDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_access_blog_admin_page(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blog-admin', expected_status_int=401)
 
@@ -1930,7 +1931,7 @@ class CanAccessBlogAdminPageDecoratorTests(test_utils.GenericTestBase):
 
     def test_blog_post_editor_cannot_access_blog_admin_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blog-admin', expected_status_int=401)
 
@@ -1942,7 +1943,7 @@ class CanAccessBlogAdminPageDecoratorTests(test_utils.GenericTestBase):
     def test_blog_admin_can_access_blog_admin_page(self) -> None:
         self.login(self.BLOG_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/blog-admin')
 
         self.assertEqual(response['success'], 1)
@@ -1982,7 +1983,7 @@ class CanManageBlogPostEditorsDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_manage_blog_post_editors(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blogadminrolehandler', expected_status_int=401)
 
@@ -1992,7 +1993,7 @@ class CanManageBlogPostEditorsDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_manage_blog_post_editors(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blogadminrolehandler', expected_status_int=401)
 
@@ -2003,7 +2004,7 @@ class CanManageBlogPostEditorsDecoratorTests(test_utils.GenericTestBase):
 
     def test_blog_post_editors_cannot_manage_blog_post_editors(self) -> None:
         self.login(self.BLOG_EDITOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blogadminrolehandler', expected_status_int=401)
 
@@ -2015,7 +2016,7 @@ class CanManageBlogPostEditorsDecoratorTests(test_utils.GenericTestBase):
     def test_blog_admin_can_manage_blog_editors(self) -> None:
         self.login(self.BLOG_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/blogadminrolehandler')
 
         self.assertEqual(response['success'], 1)
@@ -2057,7 +2058,7 @@ class CanAccessBlogDashboardDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_blog_dashboard(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blog-dashboard', expected_status_int=401)
 
@@ -2067,7 +2068,7 @@ class CanAccessBlogDashboardDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_access_blog_dashboard(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/blog-dashboard', expected_status_int=401)
 
@@ -2079,7 +2080,7 @@ class CanAccessBlogDashboardDecoratorTests(test_utils.GenericTestBase):
     def test_blog_editors_can_access_blog_dashboard(self) -> None:
         self.login(self.BLOG_EDITOR_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/blog-dashboard')
 
         self.assertEqual(response['success'], 1)
@@ -2088,7 +2089,7 @@ class CanAccessBlogDashboardDecoratorTests(test_utils.GenericTestBase):
     def test_blog_admins_can_access_blog_dashboard(self) -> None:
         self.login(self.BLOG_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/blog-dashboard')
 
         self.assertEqual(response['success'], 1)
@@ -2141,7 +2142,7 @@ class CanDeleteBlogPostTests(test_utils.GenericTestBase):
         self.blog_post_id = blog_post.id
 
     def test_guest_cannot_delete_blog_post(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_blog_post/%s' % self.blog_post_id,
                 expected_status_int=401)
@@ -2151,7 +2152,7 @@ class CanDeleteBlogPostTests(test_utils.GenericTestBase):
 
     def test_blog_editor_can_delete_owned_blog_post(self) -> None:
         self.login(self.BLOG_EDITOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_blog_post/%s' % self.blog_post_id)
         self.assertEqual(response['blog_id'], self.blog_post_id)
@@ -2159,7 +2160,7 @@ class CanDeleteBlogPostTests(test_utils.GenericTestBase):
 
     def test_blog_admin_can_delete_any_blog_post(self) -> None:
         self.login(self.BLOG_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_blog_post/%s' % self.blog_post_id)
         self.assertEqual(response['blog_id'], self.blog_post_id)
@@ -2167,7 +2168,7 @@ class CanDeleteBlogPostTests(test_utils.GenericTestBase):
 
     def test_blog_editor_cannot_delete_not_owned_blog_post(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_blog_post/%s' % self.blog_post_id,
                 expected_status_int=401)
@@ -2179,7 +2180,7 @@ class CanDeleteBlogPostTests(test_utils.GenericTestBase):
 
     def test_error_with_invalid_blog_post_id(self) -> None:
         self.login(self.user_email)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         blog_post_rights_swap = self.swap_to_always_return(
             blog_services, 'get_blog_post_rights', value=None)
         with testapp_swap, blog_post_rights_swap:
@@ -2241,7 +2242,7 @@ class CanEditBlogPostTests(test_utils.GenericTestBase):
         self.blog_post_id = blog_post.id
 
     def test_guest_cannot_edit_blog_post(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_blog_post/%s' % self.blog_post_id,
                 expected_status_int=401)
@@ -2251,7 +2252,7 @@ class CanEditBlogPostTests(test_utils.GenericTestBase):
 
     def test_blog_editor_can_edit_owned_blog_post(self) -> None:
         self.login(self.BLOG_EDITOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_blog_post/%s' % self.blog_post_id)
         self.assertEqual(response['blog_id'], self.blog_post_id)
@@ -2259,7 +2260,7 @@ class CanEditBlogPostTests(test_utils.GenericTestBase):
 
     def test_blog_admin_can_edit_any_blog_post(self) -> None:
         self.login(self.BLOG_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_blog_post/%s' % self.blog_post_id)
         self.assertEqual(response['blog_id'], self.blog_post_id)
@@ -2267,7 +2268,7 @@ class CanEditBlogPostTests(test_utils.GenericTestBase):
 
     def test_blog_editor_cannot_edit_not_owned_blog_post(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_blog_post/%s' % self.blog_post_id,
                 expected_status_int=401)
@@ -2279,7 +2280,7 @@ class CanEditBlogPostTests(test_utils.GenericTestBase):
 
     def test_error_with_invalid_blog_post_id(self) -> None:
         self.login(self.user_email)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         blog_post_rights_swap = self.swap_to_always_return(
             blog_services, 'get_blog_post_rights', value=None)
         with testapp_swap, blog_post_rights_swap:
@@ -2328,7 +2329,7 @@ class CanRunAnyJobDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_release_coordinator_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/run-anny-job', expected_status_int=401)
 
         self.assertEqual(
@@ -2337,7 +2338,7 @@ class CanRunAnyJobDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_access_release_coordinator_page(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/run-anny-job', expected_status_int=401)
 
         self.assertEqual(
@@ -2348,7 +2349,7 @@ class CanRunAnyJobDecoratorTests(test_utils.GenericTestBase):
     def test_super_admin_cannot_access_release_coordinator_page(self) -> None:
         self.login(feconf.SYSTEM_EMAIL_ADDRESS)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/run-anny-job', expected_status_int=401)
 
         self.assertEqual(
@@ -2359,7 +2360,7 @@ class CanRunAnyJobDecoratorTests(test_utils.GenericTestBase):
     def test_release_coordinator_can_run_any_job(self) -> None:
         self.login(self.RELEASE_COORDINATOR_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/run-anny-job')
 
         self.assertEqual(response['success'], 1)
@@ -2398,7 +2399,7 @@ class CanAccessTranslationStatsDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_not_logged_in_user_cannot_access_translation_stats(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/translation-stats', expected_status_int=401)
 
@@ -2408,7 +2409,7 @@ class CanAccessTranslationStatsDecoratorTests(test_utils.GenericTestBase):
 
     def test_unauthorized_user_cannot_access_translation_stats(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/translation-stats', expected_status_int=401)
 
@@ -2419,7 +2420,7 @@ class CanAccessTranslationStatsDecoratorTests(test_utils.GenericTestBase):
 
     def test_authorized_user_can_access_translation_stats(self) -> None:
         self.login(self.TRANSLATION_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/translation-stats')
 
         self.assertEqual(response['success'], 1)
@@ -2460,7 +2461,7 @@ class CanManageMemcacheDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_release_coordinator_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/manage-memcache', expected_status_int=401)
 
@@ -2470,7 +2471,7 @@ class CanManageMemcacheDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_access_release_coordinator_page(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/manage-memcache', expected_status_int=401)
 
@@ -2482,7 +2483,7 @@ class CanManageMemcacheDecoratorTests(test_utils.GenericTestBase):
     def test_super_admin_cannot_access_release_coordinator_page(self) -> None:
         self.login(feconf.SYSTEM_EMAIL_ADDRESS)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/manage-memcache', expected_status_int=401)
 
@@ -2494,7 +2495,7 @@ class CanManageMemcacheDecoratorTests(test_utils.GenericTestBase):
     def test_release_coordinator_can_run_any_job(self) -> None:
         self.login(self.RELEASE_COORDINATOR_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/manage-memcache')
 
         self.assertEqual(response['success'], 1)
@@ -2547,7 +2548,7 @@ class CanManageContributorsRoleDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_release_coordinator_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/can_manage_contributors_role/translation',
                 expected_status_int=401)
@@ -2558,7 +2559,7 @@ class CanManageContributorsRoleDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_manage_contributors_role(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/can_manage_contributors_role/translation',
                 expected_status_int=401)
@@ -2571,7 +2572,7 @@ class CanManageContributorsRoleDecoratorTests(test_utils.GenericTestBase):
     def test_translation_admin_can_manage_translation_role(self) -> None:
         self.login(self.TRANSLATION_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/can_manage_contributors_role/translation')
 
@@ -2581,7 +2582,7 @@ class CanManageContributorsRoleDecoratorTests(test_utils.GenericTestBase):
     def test_translation_admin_cannot_manage_question_role(self) -> None:
         self.login(self.TRANSLATION_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/can_manage_contributors_role/question',
                 expected_status_int=401)
@@ -2594,7 +2595,7 @@ class CanManageContributorsRoleDecoratorTests(test_utils.GenericTestBase):
     def test_question_admin_can_manage_question_role(self) -> None:
         self.login(self.QUESTION_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/can_manage_contributors_role/question')
 
@@ -2604,7 +2605,7 @@ class CanManageContributorsRoleDecoratorTests(test_utils.GenericTestBase):
     def test_question_admin_cannot_manage_translation_role(self) -> None:
         self.login(self.QUESTION_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/can_manage_contributors_role/translation',
                 expected_status_int=401)
@@ -2617,7 +2618,7 @@ class CanManageContributorsRoleDecoratorTests(test_utils.GenericTestBase):
     def test_invalid_category_raise_error(self) -> None:
         self.login(self.QUESTION_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/can_manage_contributors_role/invalid',
                 expected_status_int=400)
@@ -2652,17 +2653,17 @@ class DeleteAnyUserTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_delete_any_user(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
         self.logout()
 
     def test_not_logged_user_cannot_delete_any_user(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
 
     def test_primary_admin_can_delete_any_user(self) -> None:
         self.login(feconf.SYSTEM_EMAIL_ADDRESS)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
         self.logout()
@@ -2739,28 +2740,28 @@ class VoiceoverExplorationTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_voiceover_exploration(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.private_exp_id_1, expected_status_int=401)
         self.logout()
 
     def test_owner_can_voiceover_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id_1)
         self.assertEqual(response['exploration_id'], self.private_exp_id_1)
         self.logout()
 
     def test_moderator_can_voiceover_public_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.published_exp_id_1)
         self.assertEqual(response['exploration_id'], self.published_exp_id_1)
         self.logout()
 
     def test_moderator_can_voiceover_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id_1)
 
         self.assertEqual(response['exploration_id'], self.private_exp_id_1)
@@ -2768,7 +2769,7 @@ class VoiceoverExplorationTests(test_utils.GenericTestBase):
 
     def test_admin_can_voiceover_private_exploration(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id_1)
         self.assertEqual(response['exploration_id'], self.private_exp_id_1)
         self.logout()
@@ -2778,13 +2779,13 @@ class VoiceoverExplorationTests(test_utils.GenericTestBase):
     ) -> None:
         self.login(self.VOICE_ARTIST_EMAIL)
         # Checking voice artist can voiceover assigned public exploration.
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.published_exp_id_1)
         self.assertEqual(response['exploration_id'], self.published_exp_id_1)
 
         # Checking voice artist cannot voiceover public exploration which he/she
         # is not assigned for.
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.published_exp_id_2, expected_status_int=401)
         self.logout()
@@ -2793,7 +2794,7 @@ class VoiceoverExplorationTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.published_exp_id_1, expected_status_int=401)
         self.logout()
@@ -2802,13 +2803,13 @@ class VoiceoverExplorationTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.private_exp_id_1, expected_status_int=401)
         self.logout()
 
     def test_guest_cannot_voiceover_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.private_exp_id_1, expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
@@ -2817,7 +2818,7 @@ class VoiceoverExplorationTests(test_utils.GenericTestBase):
     def test_error_with_invalid_voiceover_exploration_id(self) -> None:
         self.login(self.user_email)
         invalid_id = 'invalid'
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % invalid_id, expected_status_int=404)
         error_msg = (
@@ -2916,7 +2917,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
     def test_voiceover_admin_can_add_voice_artist_to_public_exp(self) -> None:
         self.login(self.VOICEOVER_ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/mock/exploration/%s' % self.published_exp_id_1,
                 {}, csrf_token=csrf_token)
@@ -2926,7 +2927,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.VOICEOVER_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.delete_json(
                 '/mock/exploration/%s' % self.published_exp_id_1, {})
         self.logout()
@@ -2937,7 +2938,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
         unsupported_entity_type = 'topic'
         self.login(self.VOICEOVER_ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.post_json(
                 '/mock/%s/abc' % unsupported_entity_type,
                 {}, csrf_token=csrf_token, expected_status_int=400)
@@ -2951,7 +2952,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
     ) -> None:
         unsupported_entity_type = 'topic'
         self.login(self.VOICEOVER_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.delete_json(
                 '/mock/%s/abc' % unsupported_entity_type,
                 {}, expected_status_int=400
@@ -2966,7 +2967,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
     ) -> None:
         self.login(self.VOICEOVER_ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.post_json(
                 '/mock/exploration/%s' % self.private_exp_id_1, {},
                 csrf_token=csrf_token, expected_status_int=400
@@ -2980,14 +2981,14 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.VOICEOVER_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.delete_json('/mock/exploration/%s' % self.private_exp_id_1, {})
         self.logout()
 
     def test_owner_cannot_add_voice_artist_to_public_exp(self) -> None:
         self.login(self.OWNER_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.post_json(
                 '/mock/exploration/%s' % self.published_exp_id_1, {},
                 csrf_token=csrf_token, expected_status_int=401)
@@ -2998,7 +2999,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
 
     def test_owner_cannot_remove_voice_artist_in_public_exp(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.delete_json(
                 '/mock/exploration/%s' % self.private_exp_id_1, {},
                 expected_status_int=401)
@@ -3010,7 +3011,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
     def test_random_user_cannot_add_voice_artist_to_public_exp(self) -> None:
         self.login(self.user_email)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.post_json(
                 '/mock/exploration/%s' % self.published_exp_id_1, {},
                 csrf_token=csrf_token, expected_status_int=401)
@@ -3023,7 +3024,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.delete_json(
                 '/mock/exploration/%s' % self.published_exp_id_1, {},
                 expected_status_int=401)
@@ -3037,7 +3038,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
     ) -> None:
         self.login(self.VOICEOVER_ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/mock/exploration/invalid_exp_id', {},
                 csrf_token=csrf_token, expected_status_int=404)
@@ -3047,7 +3048,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.VOICEOVER_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.delete_json(
                 '/mock/exploration/invalid_exp_id', {},
                 expected_status_int=404)
@@ -3057,7 +3058,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
         self
     ) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/mock/exploration/%s' % self.private_exp_id_1, {},
                 csrf_token=csrf_token, expected_status_int=401)
@@ -3065,7 +3066,7 @@ class VoiceArtistManagementTests(test_utils.GenericTestBase):
     def test_voiceover_admin_cannot_remove_voice_artist_without_login(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.delete_json(
                 '/mock/exploration/%s' % self.private_exp_id_1, {},
                 expected_status_int=401)
@@ -3119,7 +3120,7 @@ class EditExplorationTests(test_utils.GenericTestBase):
 
     def test_cannot_edit_exploration_with_invalid_exp_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_exploration/invalid_exp_id',
                 expected_status_int=404)
@@ -3127,7 +3128,7 @@ class EditExplorationTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_edit_exploration(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_exploration/%s' % self.private_exp_id,
                 expected_status_int=401)
@@ -3135,7 +3136,7 @@ class EditExplorationTests(test_utils.GenericTestBase):
 
     def test_owner_can_edit_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -3143,7 +3144,7 @@ class EditExplorationTests(test_utils.GenericTestBase):
 
     def test_moderator_can_edit_public_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_exploration/%s' % self.published_exp_id)
         self.assertEqual(response['exploration_id'], self.published_exp_id)
@@ -3151,7 +3152,7 @@ class EditExplorationTests(test_utils.GenericTestBase):
 
     def test_moderator_can_edit_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_exploration/%s' % self.private_exp_id)
 
@@ -3160,14 +3161,14 @@ class EditExplorationTests(test_utils.GenericTestBase):
 
     def test_admin_can_edit_private_exploration(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_guest_cannot_cannot_edit_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_exploration/%s' % self.private_exp_id,
                 expected_status_int=401)
@@ -3204,19 +3205,19 @@ class ManageOwnAccountTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_update_preferences(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_manage_preferences(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
         self.logout()
 
     def test_guest_cannot_update_preferences(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -3251,14 +3252,14 @@ class AccessAdminPageTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_access_admin_page(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/', expected_status_int=401)
         self.logout()
 
     def test_normal_user_cannot_access_admin_page(self) -> None:
         self.login(self.user_email)
         user_id = user_services.get_user_id_from_username(self.username)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = '%s is not a super admin of this application' % user_id
         self.assertEqual(response['error'], error_msg)
@@ -3266,13 +3267,13 @@ class AccessAdminPageTests(test_utils.GenericTestBase):
 
     def test_super_admin_can_access_admin_page(self) -> None:
         self.login(self.user_email, is_super_admin=True)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
         self.logout()
 
     def test_guest_cannot_access_admin_page(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -3313,7 +3314,7 @@ class AccessContributorDashboardAdminPageTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = (
             'You do not have credentials to access contributor dashboard '
@@ -3349,8 +3350,8 @@ class AccessContributorDashboardAdminPageTests(test_utils.GenericTestBase):
         self.add_user_role(
             self.username, feconf.ROLE_ID_QUESTION_ADMIN)
         self.login(self.user_email)
-        with self.swap(constants, 'DEV_MODE', True):
-            with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(constants, 'DEV_MODE', True):
+            with patch.object(self, 'testapp', self.mock_testapp):
                 response = self.get_json('/mock/', expected_status_int=401)
         error_msg = (
             'You do not have credentials to access contributor dashboard '
@@ -3386,8 +3387,8 @@ class AccessContributorDashboardAdminPageTests(test_utils.GenericTestBase):
         self.add_user_role(
             self.username, feconf.ROLE_ID_QUESTION_COORDINATOR)
         self.login(self.user_email)
-        with self.swap(constants, 'DEV_MODE', True):
-            with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(constants, 'DEV_MODE', True):
+            with patch.object(self, 'testapp', self.mock_testapp):
                 response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
         self.logout()
@@ -3398,7 +3399,7 @@ class AccessContributorDashboardAdminPageTests(test_utils.GenericTestBase):
         self.add_user_role(
             self.username, feconf.ROLE_ID_QUESTION_ADMIN)
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertEqual(response['success'], 1)
         self.logout()
@@ -3406,7 +3407,7 @@ class AccessContributorDashboardAdminPageTests(test_utils.GenericTestBase):
     def test_guest_cannot_access_contributor_dashboard_admin_page(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -3415,7 +3416,7 @@ class AccessContributorDashboardAdminPageTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = (
             'You do not have credentials to access contributor dashboard '
@@ -3448,13 +3449,13 @@ class UploadExplorationTests(test_utils.GenericTestBase):
 
     def test_super_admin_can_upload_explorations(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_upload_exploration/')
         self.logout()
 
     def test_normal_user_cannot_upload_explorations(self) -> None:
         self.login(self.EDITOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_upload_exploration/', expected_status_int=401)
         self.assertEqual(
@@ -3463,7 +3464,7 @@ class UploadExplorationTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_cannot_upload_explorations(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_upload_exploration/', expected_status_int=401)
         self.assertEqual(
@@ -3512,7 +3513,7 @@ class DeleteExplorationTests(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
     def test_guest_cannot_delete_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_exploration/%s' % self.private_exp_id,
                 expected_status_int=401)
@@ -3522,7 +3523,7 @@ class DeleteExplorationTests(test_utils.GenericTestBase):
 
     def test_owner_can_delete_owned_private_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -3530,7 +3531,7 @@ class DeleteExplorationTests(test_utils.GenericTestBase):
 
     def test_moderator_can_delete_published_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_exploration/%s' % self.published_exp_id)
         self.assertEqual(response['exploration_id'], self.published_exp_id)
@@ -3538,7 +3539,7 @@ class DeleteExplorationTests(test_utils.GenericTestBase):
 
     def test_owner_cannot_delete_published_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_exploration/%s' % self.published_exp_id,
                 expected_status_int=401)
@@ -3550,7 +3551,7 @@ class DeleteExplorationTests(test_utils.GenericTestBase):
 
     def test_moderator_can_delete_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_exploration/%s' % self.private_exp_id)
 
@@ -3594,14 +3595,14 @@ class SuggestChangesToExplorationTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_suggest_changes(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.exploration_id, expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_suggest_changes(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.exploration_id)
         self.assertEqual(response['exploration_id'], self.exploration_id)
         self.logout()
@@ -3637,13 +3638,13 @@ class SuggestChangesDecoratorsTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_suggest_changes(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock', expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_suggest_changes(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock')
         self.logout()
 
@@ -3707,14 +3708,14 @@ class ResubmitSuggestionDecoratorsTests(test_utils.GenericTestBase):
 
     def test_author_can_resubmit_suggestion(self) -> None:
         self.login(self.author_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.suggestion_id)
         self.assertEqual(response['suggestion_id'], self.suggestion_id)
         self.logout()
 
     def test_non_author_cannot_resubmit_suggestion(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.suggestion_id, expected_status_int=401)
         self.logout()
@@ -3722,7 +3723,7 @@ class ResubmitSuggestionDecoratorsTests(test_utils.GenericTestBase):
     def test_error_with_invalid_suggestion_id(self) -> None:
         invalid_id = 'invalid'
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % invalid_id, expected_status_int=400)
         error_msg = 'No suggestion found with given suggestion id'
@@ -3846,7 +3847,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
         self.suggestion_id_3 = self.suggestion_3.suggestion_id
 
     def test_guest_cannot_accept_suggestion(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_accept_suggestion/%s/%s'
                 % (self.EXPLORATION_ID, self.suggestion_id_1),
@@ -3857,7 +3858,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
 
     def test_owner_can_accept_suggestion(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_accept_suggestion/%s/%s'
                 % (self.EXPLORATION_ID, self.suggestion_id_1))
@@ -3867,7 +3868,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
 
     def test_user_with_review_rights_can_accept_suggestion(self) -> None:
         self.login(self.EDITOR_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         review_swap = self.swap_to_always_return(
             suggestion_services, 'can_user_review_category', value=True)
         with testapp_swap, review_swap:
@@ -3882,7 +3883,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.EDITOR_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         translation_review_swap = self.swap_to_always_return(
             user_services, 'can_review_translation_suggestions', value=True)
         with testapp_swap, translation_review_swap:
@@ -3897,7 +3898,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.EDITOR_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         question_review_swap = self.swap_to_always_return(
             user_services, 'can_review_question_suggestions', value=True)
         with testapp_swap, question_review_swap:
@@ -3910,7 +3911,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
 
     def test_curriculum_admin_can_accept_suggestions(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_accept_suggestion/%s/%s'
                 % (self.EXPLORATION_ID, self.suggestion_id_1))
@@ -3920,7 +3921,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
 
     def test_error_when_format_of_suggestion_id_is_invalid(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_accept_suggestion/%s/%s'
                 % (self.EXPLORATION_ID, 'invalid_suggestion_id'),
@@ -3935,7 +3936,7 @@ class DecoratorForAcceptingSuggestionTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_accept_suggestion/%s/%s'
                 % (self.EXPLORATION_ID, 'invalid.suggestion.id'),
@@ -3984,7 +3985,7 @@ class ViewReviewableSuggestionsTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_review_suggestion(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_review_suggestion/%s/%s' % (
                     self.TARGET_TYPE, feconf.SUGGESTION_TYPE_ADD_QUESTION),
@@ -3994,7 +3995,7 @@ class ViewReviewableSuggestionsTests(test_utils.GenericTestBase):
 
     def test_error_when_suggestion_type_is_invalid(self) -> None:
         self.login(self.VIEWER_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         with testapp_swap:
             response = self.get_json(
                 '/mock_review_suggestion/%s/%s' % (
@@ -4011,7 +4012,7 @@ class ViewReviewableSuggestionsTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         translation_review_swap = self.swap_to_always_return(
             user_services, 'can_review_translation_suggestions', value=True)
         with testapp_swap, translation_review_swap:
@@ -4029,7 +4030,7 @@ class ViewReviewableSuggestionsTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         question_review_swap = self.swap_to_always_return(
             user_services, 'can_review_question_suggestions', value=True)
         with testapp_swap, question_review_swap:
@@ -4047,7 +4048,7 @@ class ViewReviewableSuggestionsTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         user_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
         question_review_swap = self.swap_to_always_return(
             user_services, 'can_review_question_suggestions', value=False)
@@ -4069,7 +4070,7 @@ class ViewReviewableSuggestionsTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         user_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
         translation_review_swap = self.swap_to_always_return(
             user_services, 'can_review_translation_suggestions', value=False)
@@ -4132,7 +4133,7 @@ class PublishExplorationTests(test_utils.GenericTestBase):
 
     def test_cannot_publish_exploration_with_invalid_exp_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_publish_exploration/invalid_exp_id',
                 expected_status_int=404)
@@ -4140,7 +4141,7 @@ class PublishExplorationTests(test_utils.GenericTestBase):
 
     def test_owner_can_publish_owned_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_publish_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -4148,7 +4149,7 @@ class PublishExplorationTests(test_utils.GenericTestBase):
 
     def test_already_published_exploration_cannot_be_published(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_publish_exploration/%s' % self.public_exp_id,
                 expected_status_int=401)
@@ -4156,7 +4157,7 @@ class PublishExplorationTests(test_utils.GenericTestBase):
 
     def test_moderator_cannot_publish_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_publish_exploration/%s' % self.private_exp_id,
                 expected_status_int=401)
@@ -4164,7 +4165,7 @@ class PublishExplorationTests(test_utils.GenericTestBase):
 
     def test_admin_can_publish_any_exploration(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_publish_exploration/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
@@ -4211,7 +4212,7 @@ class ModifyExplorationRolesTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_modify_exploration_roles(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.private_exp_id, expected_status_int=401)
         error_msg = (
@@ -4223,20 +4224,20 @@ class ModifyExplorationRolesTests(test_utils.GenericTestBase):
 
     def test_owner_can_modify_exploration_roles(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_moderator_can_modify_roles_of_unowned_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/%s' % self.private_exp_id)
         self.logout()
 
     def test_admin_can_modify_roles_of_any_exploration(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
@@ -4321,7 +4322,7 @@ class CollectionPublishStatusTests(test_utils.GenericTestBase):
 
     def test_cannot_publish_collection_with_invalid_exp_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_publish_collection/invalid_col_id',
                 expected_status_int=404)
@@ -4329,7 +4330,7 @@ class CollectionPublishStatusTests(test_utils.GenericTestBase):
 
     def test_cannot_unpublish_collection_with_invalid_exp_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_unpublish_collection/invalid_col_id',
                 expected_status_int=404)
@@ -4337,7 +4338,7 @@ class CollectionPublishStatusTests(test_utils.GenericTestBase):
 
     def test_owner_can_publish_collection(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_publish_collection/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
@@ -4345,7 +4346,7 @@ class CollectionPublishStatusTests(test_utils.GenericTestBase):
 
     def test_owner_cannot_unpublish_public_collection(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_unpublish_collection/%s' % self.published_col_id,
                 expected_status_int=401)
@@ -4353,7 +4354,7 @@ class CollectionPublishStatusTests(test_utils.GenericTestBase):
 
     def test_moderator_can_unpublish_public_collection(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_unpublish_collection/%s' % self.published_col_id)
         self.assertEqual(response['collection_id'], self.published_col_id)
@@ -4361,7 +4362,7 @@ class CollectionPublishStatusTests(test_utils.GenericTestBase):
 
     def test_admin_can_publish_any_collection(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_publish_collection/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
@@ -4369,7 +4370,7 @@ class CollectionPublishStatusTests(test_utils.GenericTestBase):
 
     def test_admin_cannot_publish_already_published_collection(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_publish_collection/%s' % self.published_col_id,
                 expected_status_int=401)
@@ -4405,7 +4406,7 @@ class AccessLearnerDashboardDecoratorTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_access_learner_dashboard(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You do not have the credentials to access this page.'
         self.assertEqual(response['error'], error_msg)
@@ -4413,13 +4414,13 @@ class AccessLearnerDashboardDecoratorTests(test_utils.GenericTestBase):
 
     def test_exploration_editor_can_access_learner_dashboard(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_guest_user_cannot_access_learner_dashboard(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -4454,7 +4455,7 @@ class AccessFeedbackUpdatesDecoratorTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_access_feedback_updates(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You do not have the credentials to access this page.'
         self.assertEqual(response['error'], error_msg)
@@ -4462,13 +4463,13 @@ class AccessFeedbackUpdatesDecoratorTests(test_utils.GenericTestBase):
 
     def test_exploration_editor_can_access_feedback_updates(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_guest_user_cannot_access_feedback_updates(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -4503,7 +4504,7 @@ class AccessLearnerGroupsDecoratorTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_access_teacher_dashboard(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You do not have the credentials to access this page.'
         self.assertEqual(response['error'], error_msg)
@@ -4511,13 +4512,13 @@ class AccessLearnerGroupsDecoratorTests(test_utils.GenericTestBase):
 
     def test_exploration_editor_can_access_learner_groups(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_guest_user_cannot_access_teacher_dashboard(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
         self.assertEqual(response['error'], error_msg)
@@ -4568,34 +4569,34 @@ class EditTopicDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_edit_topic_with_invalid_topic_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_topic/invalid_topic_id', expected_status_int=404)
         self.logout()
 
     def test_admin_can_edit_topic(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_topic/%s' % self.topic_id)
         self.assertEqual(response['topic_id'], self.topic_id)
         self.logout()
 
     def test_topic_manager_can_edit_topic(self) -> None:
         self.login(self.manager_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_topic/%s' % self.topic_id)
         self.assertEqual(response['topic_id'], self.topic_id)
         self.logout()
 
     def test_normal_user_cannot_edit_topic(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_topic/%s' % self.topic_id, expected_status_int=401)
         self.logout()
 
     def test_guest_user_cannot_edit_topic(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_topic/%s' % self.topic_id, expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
@@ -4643,21 +4644,21 @@ class DeleteTopicDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_delete_topic_with_invalid_topic_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_delete_topic/invalid_topic_id', expected_status_int=404)
         self.logout()
 
     def test_admin_can_delete_topic(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_delete_topic/%s' % self.topic_id)
         self.assertEqual(response['topic_id'], self.topic_id)
         self.logout()
 
     def test_normal_user_cannot_delete_topic(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_topic/%s' % self.topic_id,
                 expected_status_int=401)
@@ -4669,7 +4670,7 @@ class DeleteTopicDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_delete_topic(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_topic/%s' % self.topic_id,
                 expected_status_int=401)
@@ -4719,7 +4720,7 @@ class ViewAnyTopicEditorDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_delete_topic_with_invalid_topic_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_view_topic_editor/invalid_topic_id',
                 expected_status_int=404)
@@ -4727,7 +4728,7 @@ class ViewAnyTopicEditorDecoratorTests(test_utils.GenericTestBase):
 
     def test_admin_can_view_topic_editor(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_view_topic_editor/%s' % (
                 self.topic_id))
         self.assertEqual(response['topic_id'], self.topic_id)
@@ -4735,7 +4736,7 @@ class ViewAnyTopicEditorDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_view_topic_editor(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_topic_editor/%s' % self.topic_id,
                 expected_status_int=401)
@@ -4747,7 +4748,7 @@ class ViewAnyTopicEditorDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_view_topic_editor(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_topic_editor/%s' % self.topic_id,
                 expected_status_int=401)
@@ -4798,7 +4799,7 @@ class EditStoryDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_edit_story_with_invalid_story_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_story/story_id_new', expected_status_int=404)
         self.logout()
@@ -4808,14 +4809,14 @@ class EditStoryDecoratorTests(test_utils.GenericTestBase):
         story_id = story_services.get_new_story_id()
         topic_id = topic_fetchers.get_new_topic_id()
         self.save_new_story(story_id, self.admin_id, topic_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_story/%s' % story_id, expected_status_int=404)
         self.logout()
 
     def test_cannot_edit_story_with_invalid_canonical_story_ids(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         canonical_story_ids_swap = self.swap_to_always_return(
             topic_domain.Topic, 'get_canonical_story_ids', value=[])
         with testapp_swap, canonical_story_ids_swap:
@@ -4830,7 +4831,7 @@ class EditStoryDecoratorTests(test_utils.GenericTestBase):
 
     def test_admin_can_edit_story(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_story/%s' % self.story_id)
         self.assertEqual(response['story_id'], self.story_id)
         self.logout()
@@ -4840,7 +4841,7 @@ class EditStoryDecoratorTests(test_utils.GenericTestBase):
         self.set_topic_managers([self.manager_username], self.topic_id)
 
         self.login(self.manager_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_story/%s' % self.story_id)
         self.assertEqual(response['story_id'], self.story_id)
         self.logout()
@@ -4849,13 +4850,13 @@ class EditStoryDecoratorTests(test_utils.GenericTestBase):
         self.signup(self.viewer_email, self.viewer_username)
 
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_story/%s' % self.story_id, expected_status_int=401)
         self.logout()
 
     def test_guest_user_cannot_edit_story(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_story/%s' % self.story_id, expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
@@ -4905,7 +4906,7 @@ class DeleteStoryDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_delete_story_with_invalid_story_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_delete_story/story_id_new', expected_status_int=404)
         self.logout()
@@ -4915,14 +4916,14 @@ class DeleteStoryDecoratorTests(test_utils.GenericTestBase):
         story_id = story_services.get_new_story_id()
         topic_id = topic_fetchers.get_new_topic_id()
         self.save_new_story(story_id, self.admin_id, topic_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_delete_story/%s' % story_id, expected_status_int=404)
         self.logout()
 
     def test_admin_can_delete_story(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_delete_story/%s' % self.story_id)
         self.assertEqual(response['story_id'], self.story_id)
         self.logout()
@@ -4932,7 +4933,7 @@ class DeleteStoryDecoratorTests(test_utils.GenericTestBase):
         self.set_topic_managers([self.manager_username], self.topic_id)
 
         self.login(self.manager_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_delete_story/%s' % self.story_id)
         self.assertEqual(response['story_id'], self.story_id)
         self.logout()
@@ -4941,7 +4942,7 @@ class DeleteStoryDecoratorTests(test_utils.GenericTestBase):
         self.signup(self.viewer_email, self.viewer_username)
 
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_story/%s' % self.story_id,
                 expected_status_int=401)
@@ -4950,7 +4951,7 @@ class DeleteStoryDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_delete_story(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_story/%s' % self.story_id,
                 expected_status_int=401)
@@ -4998,21 +4999,21 @@ class AccessTopicsAndSkillsDashboardDecoratorTests(test_utils.GenericTestBase):
 
     def test_admin_can_access_dashboard(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_access_dashboard/')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_topic_manager_can_access_dashboard(self) -> None:
         self.login(self.manager_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_access_dashboard/')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_normal_user_cannot_access_dashboard(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_access_dashboard/', expected_status_int=401)
         error_msg = (
@@ -5023,7 +5024,7 @@ class AccessTopicsAndSkillsDashboardDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_access_dashboard(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_access_dashboard/', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
@@ -5076,7 +5077,7 @@ class AddStoryToTopicTests(test_utils.GenericTestBase):
 
     def test_cannot_add_story_to_topic_with_invalid_topic_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_add_story_to_topic/invalid_topic_id',
                 expected_status_int=404)
@@ -5084,7 +5085,7 @@ class AddStoryToTopicTests(test_utils.GenericTestBase):
 
     def test_admin_can_add_story_to_topic(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_add_story_to_topic/%s' % self.topic_id)
         self.assertEqual(response['topic_id'], self.topic_id)
@@ -5094,7 +5095,7 @@ class AddStoryToTopicTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.manager_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_add_story_to_topic/incorrect_id',
                 expected_status_int=404)
@@ -5102,7 +5103,7 @@ class AddStoryToTopicTests(test_utils.GenericTestBase):
 
     def test_topic_manager_can_add_story_to_topic(self) -> None:
         self.login(self.manager_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_add_story_to_topic/%s' % self.topic_id)
         self.assertEqual(response['topic_id'], self.topic_id)
@@ -5110,7 +5111,7 @@ class AddStoryToTopicTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_add_story_to_topic(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_add_story_to_topic/%s' % self.topic_id,
                 expected_status_int=401)
@@ -5120,7 +5121,7 @@ class AddStoryToTopicTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_cannot_add_story_to_topic(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_add_story_to_topic/%s' % self.topic_id,
                 expected_status_int=401)
@@ -5228,13 +5229,13 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
         self.login(self.user_email)
 
     def test_user_cannot_access_non_existent_story(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/non-existent-frag',
                 expected_status_int=404)
 
     def test_user_cannot_access_story_when_topic_is_not_published(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/%s'
                 % self.story_url_fragment,
@@ -5242,7 +5243,7 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
 
     def test_user_cannot_access_story_when_story_is_not_published(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/%s'
                 % self.story_url_fragment,
@@ -5254,7 +5255,7 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/%s'
                 % self.story_url_fragment,
@@ -5266,7 +5267,7 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_html_response(
                 '/mock_story_page/staging/topic/story/%s'
                 % self.story_url_fragment,
@@ -5278,7 +5279,7 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/staging/topic/story/000',
                 expected_status_int=302)
@@ -5292,7 +5293,7 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/staging/invalid-topic/story/%s'
                 % self.story_url_fragment,
@@ -5306,7 +5307,7 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/math/topic/story/%s'
                 % self.story_url_fragment,
@@ -5320,7 +5321,7 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/staging/topic/story/Story-frag',
                 expected_status_int=302)
@@ -5424,13 +5425,13 @@ class StoryViewerTests(test_utils.GenericTestBase):
             subtopics=[subtopic_1], next_subtopic_id=2)
 
     def test_cannot_access_non_existent_story(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/non-existent-frag',
                 expected_status_int=404)
 
     def test_cannot_access_story_when_topic_is_not_published(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/%s'
                 % self.story_url_fragment,
@@ -5438,7 +5439,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
 
     def test_cannot_access_story_when_story_is_not_published(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/%s'
                 % self.story_url_fragment,
@@ -5448,7 +5449,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_story_data/staging/topic/%s'
                 % self.story_url_fragment,
@@ -5458,7 +5459,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_html_response(
                 '/mock_story_page/staging/topic/story/%s'
                 % self.story_url_fragment,
@@ -5470,7 +5471,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/staging/topic/story/000',
                 expected_status_int=302)
@@ -5484,7 +5485,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/staging/invalid-topic/story/%s'
                 % self.story_url_fragment,
@@ -5498,7 +5499,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/math/topic/story/%s'
                 % self.story_url_fragment,
@@ -5512,7 +5513,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_story_page/staging/topic/story/Story-frag',
                 expected_status_int=302)
@@ -5636,27 +5637,27 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
             url_fragment='topic-frag')
 
     def test_cannot_access_non_existent_subtopic(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_subtopic_data/staging/topic-frag/non-existent-frag',
                 expected_status_int=404)
 
     def test_cannot_access_subtopic_when_topic_is_not_published(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_subtopic_data/staging/topic-frag/sub-one-frag',
                 expected_status_int=404)
 
     def test_can_access_subtopic_when_topic_is_published(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_subtopic_data/staging/topic-frag/sub-one-frag',
                 expected_status_int=200)
 
     def test_redirect_to_classroom_if_user_is_banned(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_subtopic_page/staging/topic-frag/revision/000',
                 expected_status_int=302)
@@ -5666,7 +5667,7 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
 
     def test_can_access_subtopic_when_all_url_fragments_are_valid(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_html_response(
                 '/mock_subtopic_page/staging/topic-frag/revision/sub-one-frag',
                 expected_status_int=200)
@@ -5675,7 +5676,7 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
         self
     ) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_subtopic_page/staging/topic-frag/revision/000',
                 expected_status_int=302)
@@ -5687,7 +5688,7 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
         self
     ) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         subtopic_swap = self.swap_to_always_return(
             subtopic_page_services, 'get_subtopic_page_by_id', None)
         with testapp_swap, subtopic_swap:
@@ -5702,7 +5703,7 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
         self
     ) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_subtopic_page/math/invalid-topic/revision/sub-one-frag',
                 expected_status_int=302)
@@ -5712,7 +5713,7 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
 
     def test_redirect_with_correct_classroom_name_in_url(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_subtopic_page/math/topic-frag/revision/sub-one-frag',
                 expected_status_int=302)
@@ -5723,7 +5724,7 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
 
     def test_redirect_with_lowercase_subtopic_url_fragment(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_subtopic_page/staging/topic-frag/revision/Sub-One-Frag',
                 expected_status_int=302)
@@ -5811,27 +5812,27 @@ class TopicViewerTests(test_utils.GenericTestBase):
             subtopics=[subtopic_1], next_subtopic_id=2)
 
     def test_cannot_access_non_existent_topic(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_topic_data/staging/invalid-topic',
                 expected_status_int=404)
 
     def test_cannot_access_unpublished_topic(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_topic_data/staging/topic',
                 expected_status_int=404)
 
     def test_can_access_published_topic(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_topic_data/staging/topic',
                 expected_status_int=200)
 
     def test_can_access_topic_when_all_url_fragments_are_valid(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_html_response(
                 '/mock_topic_page/staging/topic',
                 expected_status_int=200)
@@ -5840,7 +5841,7 @@ class TopicViewerTests(test_utils.GenericTestBase):
         self
     ) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_topic_page/math/invalid-topic',
                 expected_status_int=302)
@@ -5850,7 +5851,7 @@ class TopicViewerTests(test_utils.GenericTestBase):
 
     def test_redirect_with_correct_classroom_name_in_url(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_topic_page/math/topic',
                 expected_status_int=302)
@@ -5860,7 +5861,7 @@ class TopicViewerTests(test_utils.GenericTestBase):
 
     def test_redirect_with_lowercase_topic_url_fragment(self) -> None:
         topic_services.publish_topic(self.topic_id, self.admin_id)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_html_response(
                 '/mock_topic_page/staging/TOPIC',
                 expected_status_int=302)
@@ -5901,13 +5902,13 @@ class CreateSkillTests(test_utils.GenericTestBase):
 
     def test_admin_can_create_skill(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_create_skill')
         self.logout()
 
     def test_banned_user_cannot_create_skill(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_create_skill', expected_status_int=401)
             self.assertEqual(
@@ -5916,7 +5917,7 @@ class CreateSkillTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_cannot_add_create_skill(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_create_skill', expected_status_int=401)
 
@@ -5972,7 +5973,7 @@ class ManageQuestionSkillStatusTests(test_utils.GenericTestBase):
 
     def test_admin_can_manage_question_skill_status(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_manage_question_skill_status/%s' % self.skill_id)
             self.assertEqual(response['skill_id'], self.skill_id)
@@ -5980,7 +5981,7 @@ class ManageQuestionSkillStatusTests(test_utils.GenericTestBase):
 
     def test_viewer_cannot_manage_question_skill_status(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_manage_question_skill_status/%s' % self.skill_id,
                 expected_status_int=401)
@@ -5990,7 +5991,7 @@ class ManageQuestionSkillStatusTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_cannot_manage_question_skill_status(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_manage_question_skill_status/%s' % self.skill_id,
                 expected_status_int=401)
@@ -6028,13 +6029,13 @@ class CreateTopicTests(test_utils.GenericTestBase):
 
     def test_admin_can_create_topic(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_create_topic')
         self.logout()
 
     def test_banned_user_cannot_create_topic(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_create_topic', expected_status_int=401)
             self.assertIn(
@@ -6043,7 +6044,7 @@ class CreateTopicTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_cannot_create_topic(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_create_topic', expected_status_int=401)
         self.assertEqual(
@@ -6089,13 +6090,13 @@ class ManageRightsForTopicTests(test_utils.GenericTestBase):
 
     def test_admin_can_manage_rights(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_manage_rights_for_topic/%s' % self.topic_id)
         self.logout()
 
     def test_banned_user_cannot_manage_rights(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_manage_rights_for_topic/%s' % self.topic_id,
                 expected_status_int=401)
@@ -6105,7 +6106,7 @@ class ManageRightsForTopicTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_cannot_manage_rights(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_manage_rights_for_topic/%s' % self.topic_id,
                 expected_status_int=401)
@@ -6156,7 +6157,7 @@ class ChangeTopicPublicationStatusTests(test_utils.GenericTestBase):
 
     def test_admin_can_change_topic_publication_status(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_change_publication_status/%s' % self.topic_id)
         self.logout()
 
@@ -6164,7 +6165,7 @@ class ChangeTopicPublicationStatusTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_change_publication_status/invalid_topic_id',
                 expected_status_int=404)
@@ -6172,7 +6173,7 @@ class ChangeTopicPublicationStatusTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_change_topic_publication_status(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_change_publication_status/%s' % self.topic_id,
                 expected_status_int=401)
@@ -6182,7 +6183,7 @@ class ChangeTopicPublicationStatusTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_cannot_change_topic_publication_status(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_change_publication_status/%s' % self.topic_id,
                 expected_status_int=401)
@@ -6219,13 +6220,13 @@ class PerformTasksInTaskqueueTests(test_utils.GenericTestBase):
 
     def test_super_admin_can_perform_tasks_in_taskqueue(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_perform_tasks_in_taskqueue')
         self.logout()
 
     def test_normal_user_cannot_perform_tasks_in_taskqueue(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_perform_tasks_in_taskqueue', expected_status_int=401)
             self.assertEqual(
@@ -6236,7 +6237,7 @@ class PerformTasksInTaskqueueTests(test_utils.GenericTestBase):
     def test_request_with_appropriate_header_can_perform_tasks_in_taskqueue(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_perform_tasks_in_taskqueue',
                 headers={'X-AppEngine-QueueName': 'name'})
@@ -6270,13 +6271,13 @@ class PerformCronTaskTests(test_utils.GenericTestBase):
 
     def test_super_admin_can_perform_cron_tasks(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_perform_cron_task')
         self.logout()
 
     def test_normal_user_cannot_perform_cron_tasks(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_perform_cron_task', expected_status_int=401)
             self.assertEqual(
@@ -6287,7 +6288,7 @@ class PerformCronTaskTests(test_utils.GenericTestBase):
     def test_request_with_appropriate_header_can_perform_cron_tasks(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_perform_cron_task', headers={'X-AppEngine-Cron': 'true'})
 
@@ -6336,34 +6337,34 @@ class EditSkillDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_edit_skill_with_invalid_skill_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_custom_response(
                 '/mock_edit_skill/', 'text/plain', expected_status_int=404)
         self.logout()
 
     def test_admin_can_edit_skill(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_skill/%s' % self.skill_id)
         self.assertEqual(response['skill_id'], self.skill_id)
         self.logout()
 
     def test_topic_manager_can_edit_public_skill(self) -> None:
         self.login(self.manager_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_skill/%s' % self.skill_id)
         self.assertEqual(response['skill_id'], self.skill_id)
         self.logout()
 
     def test_normal_user_cannot_edit_public_skill(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_skill/%s' % self.skill_id, expected_status_int=401)
         self.logout()
 
     def test_guest_cannot_edit_public_skill(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_skill/%s' % self.skill_id, expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
@@ -6399,19 +6400,19 @@ class DeleteSkillDecoratorTests(test_utils.GenericTestBase):
 
     def test_admin_can_delete_skill(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_delete_skill')
         self.assertTrue(response['success'])
         self.logout()
 
     def test_normal_user_cannot_delete_public_skill(self) -> None:
         self.login(self.viewer_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_delete_skill', expected_status_int=401)
         self.logout()
 
     def test_guest_cannot_delete_public_skill(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_skill', expected_status_int=401)
         error_msg = 'You must be logged in to access this resource.'
@@ -6471,7 +6472,7 @@ class EditQuestionDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_edit_question(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_question/%s' % self.question_id,
                 expected_status_int=401)
@@ -6481,7 +6482,7 @@ class EditQuestionDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_edit_question_with_invalid_question_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_question/invalid_question_id',
                 expected_status_int=404)
@@ -6489,7 +6490,7 @@ class EditQuestionDecoratorTests(test_utils.GenericTestBase):
 
     def test_admin_can_edit_question(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_question/%s' % self.question_id)
         self.assertEqual(response['question_id'], self.question_id)
@@ -6497,7 +6498,7 @@ class EditQuestionDecoratorTests(test_utils.GenericTestBase):
 
     def test_topic_manager_can_edit_question(self) -> None:
         self.login(self.user_a_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_question/%s' % self.question_id)
         self.assertEqual(response['question_id'], self.question_id)
@@ -6505,7 +6506,7 @@ class EditQuestionDecoratorTests(test_utils.GenericTestBase):
 
     def test_any_user_cannot_edit_question(self) -> None:
         self.login(self.user_b_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_question/%s' % self.question_id,
                 expected_status_int=401)
@@ -6565,7 +6566,7 @@ class ViewQuestionEditorDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_view_question_editor(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_question_editor/%s' % self.question_id,
                 expected_status_int=401)
@@ -6577,7 +6578,7 @@ class ViewQuestionEditorDecoratorTests(test_utils.GenericTestBase):
     ) -> None:
         invalid_id = 'invalid_question_id'
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_question_editor/%s' % invalid_id,
                 expected_status_int=404)
@@ -6590,7 +6591,7 @@ class ViewQuestionEditorDecoratorTests(test_utils.GenericTestBase):
 
     def test_curriculum_admin_can_view_question_editor(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_question_editor/%s' % self.question_id)
         self.assertEqual(response['question_id'], self.question_id)
@@ -6598,7 +6599,7 @@ class ViewQuestionEditorDecoratorTests(test_utils.GenericTestBase):
 
     def test_topic_manager_can_view_question_editor(self) -> None:
         self.login(self.user_a_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_question_editor/%s' % self.question_id)
         self.assertEqual(response['question_id'], self.question_id)
@@ -6607,7 +6608,7 @@ class ViewQuestionEditorDecoratorTests(test_utils.GenericTestBase):
     def test_normal_user_cannot_view_question_editor(self) -> None:
         self.login(self.user_b_email)
         user_id_b = self.get_user_id_from_email(self.user_b_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_view_question_editor/%s' % self.question_id,
                 expected_status_int=401)
@@ -6665,7 +6666,7 @@ class DeleteQuestionDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_guest_cannot_delete_question(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_question/%s' % self.question_id,
                 expected_status_int=401)
@@ -6674,7 +6675,7 @@ class DeleteQuestionDecoratorTests(test_utils.GenericTestBase):
 
     def test_curriculum_admin_can_delete_question(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_question/%s' % self.question_id)
         self.assertEqual(response['question_id'], self.question_id)
@@ -6682,7 +6683,7 @@ class DeleteQuestionDecoratorTests(test_utils.GenericTestBase):
 
     def test_topic_manager_can_delete_question(self) -> None:
         self.login(self.user_a_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_question/%s' % self.question_id)
         self.assertEqual(response['question_id'], self.question_id)
@@ -6691,7 +6692,7 @@ class DeleteQuestionDecoratorTests(test_utils.GenericTestBase):
     def test_normal_user_cannot_delete_question(self) -> None:
         self.login(self.user_b_email)
         user_id_b = self.get_user_id_from_email(self.user_b_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_delete_question/%s' % self.question_id,
                 expected_status_int=401)
@@ -6739,7 +6740,7 @@ class PlayQuestionDecoratorTests(test_utils.GenericTestBase):
             content_id_generator.next_content_id_index)
 
     def test_can_play_question_with_valid_question_id(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_play_question/%s' % (
                 self.question_id))
             self.assertEqual(response['question_id'], self.question_id)
@@ -6802,7 +6803,7 @@ class PlayEntityDecoratorTests(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
     def test_cannot_play_exploration_on_disabled_exploration_ids(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_play_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_EXPLORATION,
                 feconf.DISABLED_EXPLORATION_IDS[0]), expected_status_int=404)
@@ -6810,7 +6811,7 @@ class PlayEntityDecoratorTests(test_utils.GenericTestBase):
     def test_guest_can_play_exploration_on_published_exploration(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_play_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_EXPLORATION, self.published_exp_id))
             self.assertEqual(
@@ -6819,20 +6820,20 @@ class PlayEntityDecoratorTests(test_utils.GenericTestBase):
                 response['entity_id'], self.published_exp_id)
 
     def test_guest_cannot_play_exploration_on_private_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_play_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_EXPLORATION,
                 self.private_exp_id), expected_status_int=404)
 
     def test_cannot_play_exploration_with_none_exploration_rights(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_play_entity/%s/%s'
                 % (feconf.ENTITY_TYPE_EXPLORATION, 'fake_exp_id'),
                 expected_status_int=404)
 
     def test_can_play_question_for_valid_question_id(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_play_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_QUESTION, self.question_id))
         self.assertEqual(
@@ -6841,13 +6842,13 @@ class PlayEntityDecoratorTests(test_utils.GenericTestBase):
         self.assertEqual(response['entity_type'], 'question')
 
     def test_cannot_play_question_invalid_question_id(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_play_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_QUESTION, 'question_id'),
                           expected_status_int=404)
 
     def test_cannot_play_entity_for_invalid_entity(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_play_entity/%s/%s' % (
                 'fake_entity_type', 'fake_entity_id'), expected_status_int=404)
 
@@ -6917,7 +6918,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
 
     def test_can_edit_exploration_with_valid_exp_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock_edit_entity/exploration/%s' % (
                     self.published_exp_id))
@@ -6929,7 +6930,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
 
     def test_cannot_edit_exploration_with_invalid_exp_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_entity/exploration/invalid_exp_id',
                 expected_status_int=404)
@@ -6937,7 +6938,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_edit_exploration(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_entity/%s/%s' % (
                     feconf.ENTITY_TYPE_EXPLORATION, self.private_exp_id),
@@ -6946,7 +6947,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
 
     def test_can_edit_question_with_valid_question_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_QUESTION, self.question_id))
             self.assertEqual(response['entity_id'], self.question_id)
@@ -6961,7 +6962,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
             description='Description', canonical_story_ids=[],
             additional_story_ids=[], uncategorized_skill_ids=[],
             subtopics=[], next_subtopic_id=1)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_TOPIC, topic_id))
             self.assertEqual(response['entity_id'], topic_id)
@@ -6971,7 +6972,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
     def test_cannot_edit_topic_with_invalid_topic_id(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         topic_id = 'incorrect_id'
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock_edit_entity/%s/%s' % (
                     feconf.ENTITY_TYPE_TOPIC, topic_id),
@@ -6982,7 +6983,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(skill_id, self.admin_id, description='Description')
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_SKILL, skill_id))
             self.assertEqual(response['entity_id'], skill_id)
@@ -6993,7 +6994,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(skill_id, self.admin_id, description='Description')
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.IMAGE_CONTEXT_QUESTION_SUGGESTIONS, skill_id))
             self.assertEqual(response['entity_id'], skill_id)
@@ -7005,7 +7006,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
     ) -> None:
         skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(skill_id, self.admin_id, description='Description')
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.IMAGE_CONTEXT_QUESTION_SUGGESTIONS, skill_id),
                 expected_status_int=401)
@@ -7016,7 +7017,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
         self.login(self.user_email)
         skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(skill_id, self.admin_id, description='Description')
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.IMAGE_CONTEXT_QUESTION_SUGGESTIONS, skill_id),
                 expected_status_int=401)
@@ -7027,7 +7028,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
 
     def test_can_submit_images_to_explorations(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.IMAGE_CONTEXT_EXPLORATION_SUGGESTIONS,
                 self.published_exp_id))
@@ -7038,7 +7039,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
     def test_unauthenticated_users_cannot_submit_images_to_explorations(
         self
     ) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.IMAGE_CONTEXT_EXPLORATION_SUGGESTIONS,
                 self.published_exp_id),
@@ -7048,7 +7049,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.IMAGE_CONTEXT_EXPLORATION_SUGGESTIONS,
                 self.published_exp_id),
@@ -7064,7 +7065,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
             self.get_user_id_from_email(self.BLOG_ADMIN_EMAIL))
         blog_post = blog_services.create_new_blog_post(blog_admin_id)
         blog_post_id = blog_post.id
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_BLOG_POST, blog_post_id))
             self.assertEqual(response['entity_id'], blog_post_id)
@@ -7081,7 +7082,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
             description='Description', canonical_story_ids=[story_id],
             additional_story_ids=[], uncategorized_skill_ids=[],
             subtopics=[], next_subtopic_id=1)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_STORY, story_id))
             self.assertEqual(response['entity_id'], story_id)
@@ -7089,7 +7090,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_cannot_edit_entity_invalid_entity(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json('/mock_edit_entity/%s/%s' % (
                 'invalid_entity_type', 'q_id'), expected_status_int=404)
 
@@ -7165,41 +7166,41 @@ class SaveExplorationTests(test_utils.GenericTestBase):
             self.role)
 
     def test_unautheticated_user_cannot_save_exploration(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.private_exp_id_1, expected_status_int=401)
 
     def test_cannot_save_exploration_with_invalid_exp_id(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/invalid_exp_id', expected_status_int=404)
         self.logout()
 
     def test_banned_user_cannot_save_exploration(self) -> None:
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.private_exp_id_1, expected_status_int=401)
         self.logout()
 
     def test_owner_can_save_exploration(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id_1)
         self.assertEqual(response['exploration_id'], self.private_exp_id_1)
         self.logout()
 
     def test_moderator_can_save_public_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.published_exp_id_1)
         self.assertEqual(response['exploration_id'], self.published_exp_id_1)
         self.logout()
 
     def test_moderator_can_save_private_exploration(self) -> None:
         self.login(self.MODERATOR_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id_1)
 
         self.assertEqual(response['exploration_id'], self.private_exp_id_1)
@@ -7207,7 +7208,7 @@ class SaveExplorationTests(test_utils.GenericTestBase):
 
     def test_admin_can_save_private_exploration(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.private_exp_id_1)
         self.assertEqual(response['exploration_id'], self.private_exp_id_1)
         self.logout()
@@ -7215,13 +7216,13 @@ class SaveExplorationTests(test_utils.GenericTestBase):
     def test_voice_artist_can_only_save_assigned_exploration(self) -> None:
         self.login(self.VOICE_ARTIST_EMAIL)
         # Checking voice artist can only save assigned public exploration.
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.published_exp_id_1)
         self.assertEqual(response['exploration_id'], self.published_exp_id_1)
 
         # Checking voice artist cannot save public exploration which he/she
         # is not assigned for.
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.published_exp_id_2, expected_status_int=401)
         self.logout()
@@ -7324,7 +7325,7 @@ class OppiaMLAccessDecoratorTest(test_utils.GenericTestBase):
             expected_args=[('VM_ID',), ('SHARED_SECRET_KEY',)],
         )
 
-        with self.swap(self, 'testapp', self.mock_testapp), swap_secret:
+        with patch.object(self, 'testapp', self.mock_testapp), swap_secret:
             self.post_json(
                 '/ml/nextjobhandler', payload,
                 expected_status_int=401)
@@ -7338,8 +7339,8 @@ class OppiaMLAccessDecoratorTest(test_utils.GenericTestBase):
             secret.encode('utf-8'),
             payload['message'].encode('utf-8'),
             payload['vm_id'])
-        with self.swap(self, 'testapp', self.mock_testapp):
-            with self.swap(constants, 'DEV_MODE', False):
+        with patch.object(self, 'testapp', self.mock_testapp):
+            with patch.object(constants, 'DEV_MODE', False):
                 self.post_json(
                     '/ml/nextjobhandler', payload, expected_status_int=401)
 
@@ -7357,7 +7358,7 @@ class OppiaMLAccessDecoratorTest(test_utils.GenericTestBase):
             expected_args=[('VM_ID',), ('SHARED_SECRET_KEY',)],
         )
 
-        with self.swap(self, 'testapp', self.mock_testapp), swap_secret:
+        with patch.object(self, 'testapp', self.mock_testapp), swap_secret:
             self.post_json(
                 '/ml/nextjobhandler', payload, expected_status_int=401)
 
@@ -7377,7 +7378,7 @@ class OppiaMLAccessDecoratorTest(test_utils.GenericTestBase):
             expected_args=[('VM_ID',), ('SHARED_SECRET_KEY',)],
         )
 
-        with self.swap(self, 'testapp', self.mock_testapp), swap_secret:
+        with patch.object(self, 'testapp', self.mock_testapp), swap_secret:
             json_response = self.post_json('/ml/nextjobhandler', payload)
 
         self.assertEqual(json_response['job_id'], 'new_job')
@@ -7553,7 +7554,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
 
     def test_authors_cannot_update_suggestion_that_they_created(self) -> None:
         self.login(self.author_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.translation_suggestion_id,
                 expected_status_int=401)
@@ -7565,7 +7566,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
 
     def test_admin_can_update_any_given_translation_suggestion(self) -> None:
         self.login(self.curriculum_admin_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.translation_suggestion_id)
         self.assertEqual(
@@ -7574,14 +7575,14 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
 
     def test_admin_can_update_any_given_question_suggestion(self) -> None:
         self.login(self.curriculum_admin_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.question_suggestion_id)
         self.assertEqual(response['suggestion_id'], self.question_suggestion_id)
         self.logout()
 
     def test_reviewer_can_update_translation_suggestion(self) -> None:
         self.login(self.hi_language_reviewer)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.translation_suggestion_id)
         self.assertEqual(
@@ -7590,14 +7591,14 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
 
     def test_reviewer_can_update_question_suggestion(self) -> None:
         self.login(self.hi_language_reviewer)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock/%s' % self.question_suggestion_id)
         self.assertEqual(
             response['suggestion_id'], self.question_suggestion_id)
         self.logout()
 
     def test_guest_cannot_update_any_suggestion(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.translation_suggestion_id,
                 expected_status_int=401)
@@ -7609,7 +7610,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.en_language_reviewer)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.translation_suggestion_id,
                 expected_status_int=401)
@@ -7621,7 +7622,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.hi_language_reviewer)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % 'suggestion-id',
                 expected_status_int=400)
@@ -7632,7 +7633,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
 
     def test_non_existent_suggestions_cannot_be_updated(self) -> None:
         self.login(self.hi_language_reviewer)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % 'exploration.exp1.' +
                 'WzE2MTc4NzExNzExNDEuOTE0XQ==WzQ5NTs',
@@ -7641,7 +7642,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
 
     def test_not_allowed_suggestions_cannot_be_updated(self) -> None:
         self.login(self.en_language_reviewer)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/mock/%s' % self.edit_state_suggestion_id,
                 expected_status_int=400)
@@ -7771,7 +7772,7 @@ class OppiaAndroidDecoratorTest(test_utils.GenericTestBase):
         payload = {}
         payload['report'] = self.REPORT_JSON
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/appfeedbackreporthandler/incoming_android_report', payload,
                 headers=headers)
@@ -7787,7 +7788,7 @@ class OppiaAndroidDecoratorTest(test_utils.GenericTestBase):
         payload = {}
         payload['report'] = self.REPORT_JSON
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/appfeedbackreporthandler/incoming_android_report', payload,
                 headers=invalid_headers, expected_status_int=401)
@@ -7802,7 +7803,7 @@ class OppiaAndroidDecoratorTest(test_utils.GenericTestBase):
         payload = {}
         payload['report'] = self.REPORT_JSON
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/appfeedbackreporthandler/incoming_android_report', payload,
                 headers=invalid_headers, expected_status_int=401)
@@ -7818,7 +7819,7 @@ class OppiaAndroidDecoratorTest(test_utils.GenericTestBase):
         payload = {}
         payload['report'] = self.REPORT_JSON
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/appfeedbackreporthandler/incoming_android_report', payload,
                 headers=invalid_headers, expected_status_int=401)
@@ -7834,7 +7835,7 @@ class OppiaAndroidDecoratorTest(test_utils.GenericTestBase):
         payload = {}
         payload['report'] = self.REPORT_JSON
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             self.post_json(
                 '/appfeedbackreporthandler/incoming_android_report', payload,
                 headers=invalid_headers, expected_status_int=401)
@@ -7870,7 +7871,7 @@ class CanAccessClassroomAdminPageDecoratorTests(test_utils.GenericTestBase):
 
     def test_normal_user_cannot_access_classroom_admin_page(self) -> None:
         self.login(self.user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/classroom-admin', expected_status_int=401)
 
@@ -7880,7 +7881,7 @@ class CanAccessClassroomAdminPageDecoratorTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_cannot_access_classroom_admin_page(self) -> None:
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json(
                 '/classroom-admin', expected_status_int=401)
 
@@ -7891,7 +7892,7 @@ class CanAccessClassroomAdminPageDecoratorTests(test_utils.GenericTestBase):
     def test_classroom_admin_can_manage_blog_editors(self) -> None:
         self.login(self.CLASSROOM_ADMIN_EMAIL)
 
-        with self.swap(self, 'testapp', self.mock_testapp):
+        with patch.object(self, 'testapp', self.mock_testapp):
             response = self.get_json('/classroom-admin')
 
         self.assertEqual(response['success'], 1)
@@ -7925,7 +7926,7 @@ class IsFromOppiaAndroidBuildDecoratorTests(test_utils.GenericTestBase):
         ))
 
     def test_error_when_android_build_secret_is_none(self) -> None:
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         swap_api_key_secrets_return_none = self.swap_with_checks(
             secrets_services,
             'get_secret',
@@ -7949,7 +7950,7 @@ class IsFromOppiaAndroidBuildDecoratorTests(test_utils.GenericTestBase):
         )
 
     def test_error_when_given_api_key_is_invalid(self) -> None:
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         mailchimp_swap = self.swap_to_always_return(
             secrets_services, 'get_secret', 'secret')
 
@@ -7966,7 +7967,7 @@ class IsFromOppiaAndroidBuildDecoratorTests(test_utils.GenericTestBase):
         )
 
     def test_no_error_when_given_api_key_is_valid(self) -> None:
-        testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
+        testapp_swap = patch.object(self, 'testapp', self.mock_testapp)
         mailchimp_swap = self.swap_to_always_return(
             secrets_services, 'get_secret', 'secret')
 

--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -15,6 +15,7 @@
 """Tests for the admin page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import enum
@@ -90,7 +91,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
         self.signup(self.CURRICULUM_ADMIN_EMAIL, self.CURRICULUM_ADMIN_USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.admin_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
-        self.prod_mode_swap = self.swap(constants, 'DEV_MODE', False)
+        self.prod_mode_swap = patch.object(constants, 'DEV_MODE', False)
 
     def test_admin_get(self) -> None:
         """Test `/admin` returns a 200 response."""
@@ -514,7 +515,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
 
         self.assertFalse(collection_rights.community_owned)
 
-        with self.swap(logging, 'info', _mock_logging_function):
+        with patch.object(logging, 'info', _mock_logging_function):
             self.post_json(
                 '/adminhandler', {
                     'action': 'reload_collection',
@@ -823,7 +824,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             }]
         )
 
-        with self.swap(logging, 'info', _mock_logging_function):
+        with patch.object(logging, 'info', _mock_logging_function):
             self.post_json(
                 '/adminhandler', {
                     'action': 'revert_config_property',
@@ -885,7 +886,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
                 'Param for test.',
                 platform_parameter_domain.DataTypes.BOOL)
         )
-        with self.swap(
+        with patch.object(
             platform_feature_list,
             'ALL_PLATFORM_PARAMS_EXCEPT_FEATURE_FLAGS',
             [ParamNames.TEST_PARAMETER_1]
@@ -920,7 +921,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             }
         ]
 
-        with self.swap(
+        with patch.object(
             platform_feature_list,
             'ALL_PLATFORM_PARAMS_EXCEPT_FEATURE_FLAGS',
             [ParamNames.TEST_PARAMETER_1]
@@ -968,7 +969,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             }
         ]
 
-        with self.swap(
+        with patch.object(
             platform_feature_list,
             'ALL_PLATFORM_PARAMS_EXCEPT_FEATURE_FLAGS',
             [ParamNames.TEST_PARAMETER_1]
@@ -1012,7 +1013,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             }
         ]
 
-        with self.swap(
+        with patch.object(
             platform_feature_list,
             'ALL_PLATFORM_PARAMS_EXCEPT_FEATURE_FLAGS',
             [ParamNames.TEST_PARAMETER_1]
@@ -1441,7 +1442,7 @@ class GenerateDummyExplorationsTest(test_utils.GenericTestBase):
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
         csrf_token = self.get_new_csrf_token()
 
-        prod_mode_swap = self.swap(constants, 'DEV_MODE', False)
+        prod_mode_swap = patch.object(constants, 'DEV_MODE', False)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception, 'Cannot generate dummy explorations in production.')
 
@@ -2557,13 +2558,13 @@ class SendDummyMailTest(test_utils.GenericTestBase):
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
         csrf_token = self.get_new_csrf_token()
 
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             generated_response = self.post_json(
                 '/senddummymailtoadminhandler', {},
                 csrf_token=csrf_token, expected_status_int=200)
             self.assertEqual(generated_response, {})
 
-        with self.swap(feconf, 'CAN_SEND_EMAILS', False):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', False):
             generated_response = self.post_json(
                 '/senddummymailtoadminhandler', {},
                 csrf_token=csrf_token, expected_status_int=400)
@@ -2714,7 +2715,7 @@ class UpdateUsernameHandlerTest(test_utils.GenericTestBase):
         # swap flakes can occur, since as the time flows the saved milliseconds
         # can differ from the milliseconds saved into the
         # UsernameChangeAuditModel's ID.
-        with self.swap(
+        with patch.object(
             utils, 'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs):
             self.put_json(

--- a/core/controllers/android_test.py
+++ b/core/controllers/android_test.py
@@ -15,6 +15,7 @@
 """Tests for the android handler."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.constants import constants
 from core.domain import classroom_config_domain
@@ -41,7 +42,7 @@ class InitializeAndroidTestDataHandlerTest(test_utils.GenericTestBase):
     """Server integration tests for operations on the admin page."""
 
     def test_initialize_in_production_raises_exception(self) -> None:
-        prod_mode_swap = self.swap(constants, 'DEV_MODE', False)
+        prod_mode_swap = patch.object(constants, 'DEV_MODE', False)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception, 'Cannot load new structures data in production.'
         )

--- a/core/controllers/blog_homepage_test.py
+++ b/core/controllers/blog_homepage_test.py
@@ -15,6 +15,7 @@
 """Tests for the blog homepage page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 import logging
 
 from core import feconf
@@ -524,8 +525,8 @@ class BlogPostSearchHandlerTest(test_utils.GenericTestBase):
         self.assertEqual(len(response_dict['blog_post_summaries_list']), 4)
         self.assertEqual(response_dict['search_offset'], None)
 
-        default_query_limit_swap = self.swap(feconf, 'DEFAULT_QUERY_LIMIT', 2)
-        max_cards_limit_swap = self.swap(
+        default_query_limit_swap = patch.object(feconf, 'DEFAULT_QUERY_LIMIT', 2)
+        max_cards_limit_swap = patch.object(
             feconf, 'MAX_NUM_CARDS_TO_DISPLAY_ON_BLOG_SEARCH_RESULTS_PAGE', 2)
         # Load the search results with an empty query.
         with self.capture_logging(min_level=logging.ERROR) as logs:

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -17,6 +17,7 @@ classifiers.
 """
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import json
@@ -65,7 +66,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
         self.login(feconf.ADMIN_EMAIL_ADDRESS, is_super_admin=True)
 
         assets_list: List[Tuple[str, bytes]] = []
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.save_new_exploration_from_yaml_and_assets(
                 feconf.SYSTEM_COMMITTER_ID, self.yaml_content, self.exp_id,
                 assets_list)
@@ -197,11 +198,11 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
         def mock_get_classifier_training_job_by_id(_: str) -> FakeTrainingJob:
             return FakeTrainingJob()
 
-        can_send_emails_ctx = self.swap(
+        can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        can_send_feedback_email_ctx = self.swap(
+        can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
-        fail_training_job = self.swap(
+        fail_training_job = patch.object(
             classifier_services,
             'get_classifier_training_job_by_id',
             mock_get_classifier_training_job_by_id)
@@ -234,7 +235,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
 
     def test_error_on_prod_mode_and_default_vm_id(self) -> None:
         # Turn off DEV_MODE.
-        with self.swap(constants, 'DEV_MODE', False):
+        with patch.object(constants, 'DEV_MODE', False):
             self.post_blob(
                 '/ml/trainedclassifierhandler',
                 self.payload_proto.SerializeToString(), expected_status_int=401)
@@ -433,7 +434,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
                 }
             })]
 
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, new_exp_id, change_list, '')
 
@@ -471,7 +472,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
                 }
             })]
 
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, new_exp_id, change_list, '')
 
@@ -499,7 +500,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
             },
         }
 
-        with self.swap(
+        with patch.object(
             feconf, 'INTERACTION_CLASSIFIER_MAPPING',
             interaction_classifier_mapping):
             self.get_json(
@@ -521,7 +522,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
             expected_args=[('VM_ID',), ('SHARED_SECRET_KEY',)],
         )
 
-        with self.swap(
+        with patch.object(
             feconf, 'INTERACTION_CLASSIFIER_MAPPING',
             interaction_classifier_mapping):
             with swap_secret:
@@ -561,7 +562,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
             },
         }
 
-        with self.swap(
+        with patch.object(
             feconf, 'INTERACTION_CLASSIFIER_MAPPING',
             interaction_classifier_mapping):
             self.get_json(
@@ -583,7 +584,7 @@ class TrainedClassifierHandlerTests(test_utils.ClassifierTestBase):
             expected_args=[('VM_ID',), ('SHARED_SECRET_KEY',)],
         )
 
-        with self.swap(
+        with patch.object(
             feconf, 'INTERACTION_CLASSIFIER_MAPPING',
             interaction_classifier_mapping):
             with swap_secret:

--- a/core/controllers/contributor_dashboard_test.py
+++ b/core/controllers/contributor_dashboard_test.py
@@ -15,6 +15,7 @@
 """Tests for the contributor dashboard controllers."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import unittest.mock
@@ -228,7 +229,7 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
         self.assertIsInstance(response['next_cursor'], str)
 
     def test_get_skill_opportunity_data_pagination(self) -> None:
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
+        with patch.object(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
             response = self.get_json(
                 '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
                 params={})
@@ -293,7 +294,7 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
         # fetched first. Since skill_id_0, skill_id_1, skill_id_2 are not linked
         # to a classroom, another fetch will be made to retrieve skill_id_3,
         # skill_id_4, skill_id_5 to fulfill the page size.
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 3):
+        with patch.object(constants, 'OPPORTUNITIES_PAGE_SIZE', 3):
             response = self.get_json(
                 '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
                 params={})
@@ -324,7 +325,7 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             self.assertIsInstance(response['next_cursor'], str)
 
     def test_get_translation_opportunity_data_pagination(self) -> None:
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
+        with patch.object(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
             response = self.get_json(
                 '%s/translation' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
                 params={'language_code': 'hi', 'topic_name': 'topic'})
@@ -352,14 +353,14 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
     def test_get_translation_opportunity_with_invalid_language_code(
         self
     ) -> None:
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
+        with patch.object(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
             self.get_json(
                 '%s/translation' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
                 params={'language_code': 'invalid_lang_code'},
                 expected_status_int=400)
 
     def test_get_translation_opportunity_without_language_code(self) -> None:
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
+        with patch.object(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
             self.get_json(
                 '%s/translation' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
                 expected_status_int=400)
@@ -395,7 +396,7 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
         self.assertIsInstance(response['next_cursor'], str)
 
     def test_get_opportunity_for_invalid_opportunity_type(self) -> None:
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
+        with patch.object(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
             self.get_json(
                 '%s/invalid_opportunity_type' % (
                     feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL),

--- a/core/controllers/creator_dashboard_test.py
+++ b/core/controllers/creator_dashboard_test.py
@@ -15,6 +15,7 @@
 """Tests for the creator dashboard and the notifications dashboard."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 import os
@@ -267,7 +268,7 @@ class CreatorDashboardHandlerTests(test_utils.GenericTestBase):
             return [feedback_domain.FeedbackAnalytics(
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXP_ID, 2, 3)]
 
-        with self.swap(
+        with patch.object(
             feedback_services, 'get_thread_analytics_multi',
             mock_get_thread_analytics_multi):
 
@@ -372,7 +373,7 @@ class CreatorDashboardHandlerTests(test_utils.GenericTestBase):
     def test_last_week_stats_produce_exception(self) -> None:
         self.login(self.OWNER_EMAIL, is_super_admin=True)
 
-        get_last_week_dashboard_stats_swap = self.swap(
+        get_last_week_dashboard_stats_swap = patch.object(
             user_services,
             'get_last_week_dashboard_stats',
             lambda _: {
@@ -399,7 +400,7 @@ class CreatorDashboardHandlerTests(test_utils.GenericTestBase):
     def test_broken_last_week_stats_produce_exception(self) -> None:
         self.login(self.OWNER_EMAIL, is_super_admin=True)
 
-        get_last_week_dashboard_stats_swap = self.swap(
+        get_last_week_dashboard_stats_swap = patch.object(
             user_services,
             'get_last_week_dashboard_stats',
             lambda _: {'key_1': 1, 'key_2': 2}
@@ -559,7 +560,7 @@ class CreationButtonsTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_can_upload_exploration(self) -> None:
-        with self.swap(constants, 'ALLOW_YAML_FILE_UPLOAD', True):
+        with patch.object(constants, 'ALLOW_YAML_FILE_UPLOAD', True):
             self.set_curriculum_admins([self.CURRICULUM_ADMIN_USERNAME])
             self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
 

--- a/core/controllers/cron_test.py
+++ b/core/controllers/cron_test.py
@@ -15,6 +15,7 @@
 """Tests for the cron jobs."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 
@@ -73,7 +74,7 @@ class CronJobTests(test_utils.GenericTestBase):
         self.signup(self.CURRICULUM_ADMIN_EMAIL, self.CURRICULUM_ADMIN_USERNAME)
         self.admin_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
         self.set_curriculum_admins([self.CURRICULUM_ADMIN_USERNAME])
-        self.testapp_swap = self.swap(
+        self.testapp_swap = patch.object(
             self, 'testapp', webtest.TestApp(main.app_without_context))
 
         self.email_subjects: List[str] = []
@@ -88,7 +89,7 @@ class CronJobTests(test_utils.GenericTestBase):
             self.email_subjects.append(email_subject)
             self.email_bodies.append(email_body)
 
-        self.send_mail_to_admin_swap = self.swap(
+        self.send_mail_to_admin_swap = patch.object(
             email_manager, 'send_mail_to_admin', _mock_send_mail_to_admin)
 
         self.task_status = 'Not Started'
@@ -100,7 +101,7 @@ class CronJobTests(test_utils.GenericTestBase):
             """
             self.task_status = 'Started'
 
-        self.taskqueue_service_defer_swap = self.swap(
+        self.taskqueue_service_defer_swap = patch.object(
             taskqueue_services, 'defer', _mock_taskqueue_service_defer)
 
     def test_run_cron_to_hard_delete_models_marked_as_deleted(self) -> None:
@@ -350,9 +351,9 @@ class CronMailReviewersContributorDashboardSuggestionsHandlerTests(
             .create_reviewable_suggestion_email_info_from_suggestion(
                 translation_suggestion))
 
-        self.can_send_emails = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_emails = self.swap(feconf, 'CAN_SEND_EMAILS', False)
-        self.testapp_swap = self.swap(
+        self.can_send_emails = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_emails = patch.object(feconf, 'CAN_SEND_EMAILS', False)
+        self.testapp_swap = patch.object(
             self, 'testapp', webtest.TestApp(main.app_without_context))
 
         self.reviewers_suggestion_email_infos = []
@@ -364,7 +365,7 @@ class CronMailReviewersContributorDashboardSuggestionsHandlerTests(
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
 
         with self.can_send_emails, self.testapp_swap:
-            with self.swap(
+            with patch.object(
                 email_manager,
                 'send_mail_to_notify_contributor_dashboard_reviewers',
                 self._mock_send_contributor_dashboard_reviewers_emails):
@@ -385,7 +386,7 @@ class CronMailReviewersContributorDashboardSuggestionsHandlerTests(
         )
 
         with self.cannot_send_emails, self.testapp_swap:
-            with swap_platform_parameter_value, self.swap(
+            with swap_platform_parameter_value, patch.object(
                 email_manager,
                 'send_mail_to_notify_contributor_dashboard_reviewers',
                 self._mock_send_contributor_dashboard_reviewers_emails):
@@ -408,7 +409,7 @@ class CronMailReviewersContributorDashboardSuggestionsHandlerTests(
         )
 
         with self.can_send_emails, self.testapp_swap:
-            with swap_platform_parameter_value, self.swap(
+            with swap_platform_parameter_value, patch.object(
                 email_manager,
                 'send_mail_to_notify_contributor_dashboard_reviewers',
                 self._mock_send_contributor_dashboard_reviewers_emails):
@@ -434,7 +435,7 @@ class CronMailReviewersContributorDashboardSuggestionsHandlerTests(
             self.reviewer_id, self.language_code)
 
         with self.can_send_emails, self.testapp_swap:
-            with swap_platform_parameter_value, self.swap(
+            with swap_platform_parameter_value, patch.object(
                 email_manager,
                 'send_mail_to_notify_contributor_dashboard_reviewers',
                 self._mock_send_contributor_dashboard_reviewers_emails):
@@ -602,9 +603,9 @@ class CronMailAdminContributorDashboardBottlenecksHandlerTests(
             feconf.SUGGESTION_TYPE_ADD_QUESTION: set()
         }
 
-        self.can_send_emails = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_emails = self.swap(feconf, 'CAN_SEND_EMAILS', False)
-        self.testapp_swap = self.swap(
+        self.can_send_emails = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_emails = patch.object(feconf, 'CAN_SEND_EMAILS', False)
+        self.testapp_swap = patch.object(
             self, 'testapp', webtest.TestApp(main.app_without_context))
 
         self.admin_ids = []
@@ -622,15 +623,15 @@ class CronMailAdminContributorDashboardBottlenecksHandlerTests(
         )
 
         with self.cannot_send_emails, self.testapp_swap:
-            with swap_platform_parameter_value, self.swap(
+            with swap_platform_parameter_value, patch.object(
                 email_manager,
                 'send_mail_to_notify_admins_that_reviewers_are_needed',
                 self.mock_send_mail_to_notify_admins_that_reviewers_are_needed):
-                with self.swap(
+                with patch.object(
                     email_manager,
                     'send_mail_to_notify_admins_suggestions_waiting_long',
                     self._mock_send_mail_to_notify_admins_suggestions_waiting):
-                    with self.swap(
+                    with patch.object(
                         suggestion_models,
                         'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0):
                         self.get_json(
@@ -647,7 +648,7 @@ class CronMailAdminContributorDashboardBottlenecksHandlerTests(
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
 
         with self.can_send_emails, self.testapp_swap:
-            with self.swap(
+            with patch.object(
                 email_manager,
                 'send_mail_to_notify_admins_that_reviewers_are_needed',
                 self.mock_send_mail_to_notify_admins_that_reviewers_are_needed):
@@ -665,7 +666,7 @@ class CronMailAdminContributorDashboardBottlenecksHandlerTests(
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
 
         with self.can_send_emails, self.testapp_swap:
-            with self.swap(
+            with patch.object(
                 email_manager,
                 'send_mail_to_notify_admins_that_reviewers_are_needed',
                 self.mock_send_mail_to_notify_admins_that_reviewers_are_needed):
@@ -688,7 +689,7 @@ class CronMailAdminContributorDashboardBottlenecksHandlerTests(
         )
 
         with self.can_send_emails, self.testapp_swap:
-            with swap_platform_parameter_value, self.swap(
+            with swap_platform_parameter_value, patch.object(
                 email_manager,
                 'send_mail_to_notify_admins_that_reviewers_are_needed',
                 self.mock_send_mail_to_notify_admins_that_reviewers_are_needed):
@@ -729,11 +730,11 @@ class CronMailAdminContributorDashboardBottlenecksHandlerTests(
         )
 
         with self.can_send_emails, self.testapp_swap:
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
-                with self.swap(
+                with patch.object(
                     email_manager,
                     'send_mail_to_notify_admins_suggestions_waiting_long',
                     self._mock_send_mail_to_notify_admins_suggestions_waiting):
@@ -819,9 +820,9 @@ class CronMailChapterPublicationsNotificationsHandlerTests(
             story_domain.StoryPublicationTimeliness(
             'story_2', 'Story 2', 'Topic', ['Chapter 3'], ['Chapter 4']))
 
-        self.can_send_emails = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_emails = self.swap(feconf, 'CAN_SEND_EMAILS', False)
-        self.testapp_swap = self.swap(
+        self.can_send_emails = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_emails = patch.object(feconf, 'CAN_SEND_EMAILS', False)
+        self.testapp_swap = patch.object(
             self, 'testapp', webtest.TestApp(main.app_without_context))
 
         self.curriculum_admin_ids: List[str] = []
@@ -857,7 +858,7 @@ class CronMailChapterPublicationsNotificationsHandlerTests(
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
 
         with self.cannot_send_emails, self.testapp_swap:
-            with self.swap(
+            with patch.object(
                 email_manager,
                 'send_reminder_mail_to_notify_curriculum_admins',
                 self._mock_send_reminder_mail_to_notify_curriculum_admins):
@@ -874,11 +875,11 @@ class CronMailChapterPublicationsNotificationsHandlerTests(
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
 
         with self.can_send_emails, self.testapp_swap:
-            with self.swap(
+            with patch.object(
                 email_manager,
                 'send_reminder_mail_to_notify_curriculum_admins',
                 self._mock_send_reminder_mail_to_notify_curriculum_admins):
-                with self.swap(
+                with patch.object(
                     story_services, 'get_chapter_notifications_stories_list',
                     self._mock_get_chapter_notifications_stories_list):
                     self.get_json(

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -17,6 +17,7 @@
 """Tests for the exploration editor page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import io
@@ -1124,7 +1125,7 @@ class StateInteractionStatsHandlerTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'exception', _mock_logging_function)
+        logging_swap = patch.object(logging, 'exception', _mock_logging_function)
 
         self.login(self.OWNER_EMAIL)
         exp_id = 'eid'
@@ -1254,7 +1255,7 @@ class ExplorationDeletionRightsTests(BaseEditorControllerTests):
             if msg != log_from_google_app_engine:
                 observed_log_messages.append(msg)
 
-        with self.swap(logging, 'info', mock_logging_function), self.swap(
+        with patch.object(logging, 'info', mock_logging_function), patch.object(
             logging, 'debug', mock_logging_function):
             # Checking for non-moderator/non-admin.
 
@@ -2529,9 +2530,9 @@ class ModeratorEmailsTests(test_utils.EmailTestBase):
         )
 
     def test_error_cases_for_email_sending(self) -> None:
-        with self.swap(
+        with patch.object(
             feconf, 'REQUIRE_EMAIL_ON_MODERATOR_ACTION', True
-            ), self.swap(
+            ), patch.object(
                 feconf, 'CAN_SEND_EMAILS', False):
             # Log in as a moderator.
             self.login(self.MODERATOR_EMAIL)
@@ -2572,7 +2573,7 @@ class ModeratorEmailsTests(test_utils.EmailTestBase):
                 valid_payload, csrf_token=csrf_token,
                 expected_status_int=500)
 
-            with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+            with patch.object(feconf, 'CAN_SEND_EMAILS', True):
                 # Now the email gets sent with no error.
                 self.put_json(
                     '/createhandler/moderatorrights/%s' % self.EXP_ID,
@@ -2582,9 +2583,9 @@ class ModeratorEmailsTests(test_utils.EmailTestBase):
             self.logout()
 
     def test_email_is_sent_correctly_when_unpublishing(self) -> None:
-        with self.swap(
+        with patch.object(
             feconf, 'REQUIRE_EMAIL_ON_MODERATOR_ACTION', True
-            ), self.swap(
+            ), patch.object(
                 feconf, 'CAN_SEND_EMAILS', True):
             # Log in as a moderator.
             self.login(self.MODERATOR_EMAIL)
@@ -2642,9 +2643,9 @@ class ModeratorEmailsTests(test_utils.EmailTestBase):
             self.logout()
 
     def test_email_functionality_cannot_be_used_by_non_moderators(self) -> None:
-        with self.swap(
+        with patch.object(
             feconf, 'REQUIRE_EMAIL_ON_MODERATOR_ACTION', True
-            ), self.swap(
+            ), patch.object(
                 feconf, 'CAN_SEND_EMAILS', True):
             # Log in as a non-moderator.
             self.login(self.EDITOR_EMAIL)
@@ -3380,14 +3381,14 @@ class LearnerAnswerInfoHandlerTests(BaseEditorControllerTests):
 
     def test_get_learner_answer_details_of_exploration_states(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', False):
             response = self.get_json(
                 '%s/%s/%s' % (
                     feconf.LEARNER_ANSWER_INFO_HANDLER_URL,
                     feconf.ENTITY_TYPE_EXPLORATION, self.exp_id),
                 expected_status_int=404)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', True):
             learner_answer_details = stats_services.get_learner_answer_details(
                 self.entity_type, self.state_reference)
@@ -3429,7 +3430,7 @@ class LearnerAnswerInfoHandlerTests(BaseEditorControllerTests):
         stats_services.record_learner_answer_info(
             feconf.ENTITY_TYPE_QUESTION, state_reference, self.interaction_id,
             self.answer, self.answer_details)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', True):
             learner_answer_details = stats_services.get_learner_answer_details(
                 feconf.ENTITY_TYPE_QUESTION, state_reference)
@@ -3452,7 +3453,7 @@ class LearnerAnswerInfoHandlerTests(BaseEditorControllerTests):
 
     def test_delete_learner_answer_info_of_exploration_states(self) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', False):
             self.delete_json(
                 '%s/%s/%s?state_name=%s&learner_answer_info_id=%s' % (
@@ -3460,7 +3461,7 @@ class LearnerAnswerInfoHandlerTests(BaseEditorControllerTests):
                     feconf.ENTITY_TYPE_EXPLORATION, self.exp_id,
                     self.state_name, 'learner_answer_info_id'),
                 expected_status_int=404)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', True):
             learner_answer_details = stats_services.get_learner_answer_details(
                 self.entity_type, self.state_reference)
@@ -3514,7 +3515,7 @@ class LearnerAnswerInfoHandlerTests(BaseEditorControllerTests):
         stats_services.record_learner_answer_info(
             feconf.ENTITY_TYPE_QUESTION, state_reference, self.interaction_id,
             self.answer, self.answer_details)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', True):
             learner_answer_details = stats_services.get_learner_answer_details(
                 feconf.ENTITY_TYPE_QUESTION, state_reference)

--- a/core/controllers/email_dashboard_test.py
+++ b/core/controllers/email_dashboard_test.py
@@ -15,6 +15,7 @@
 """Tests for email dashboard handler."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import user_query_services
@@ -261,7 +262,7 @@ class EmailDashboardResultTests(test_utils.EmailTestBase):
         )
         query_model.put()
 
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             # Send email from email dashboard result page.
             self.login(self.SUBMITTER_EMAIL, is_super_admin=True)
             csrf_token = self.get_new_csrf_token()
@@ -383,7 +384,7 @@ class EmailDashboardResultTests(test_utils.EmailTestBase):
             user_ids=[self.user_a_id, self.user_b_id]
         ).put()
 
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             csrf_token = self.get_new_csrf_token()
             self.post_json(
                 '/emaildashboardcancelresult/%s' % query_id, {},
@@ -457,7 +458,7 @@ class EmailDashboardResultTests(test_utils.EmailTestBase):
             user_ids=[self.user_a_id, self.user_b_id]
         ).put()
 
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             email_subject = 'email_subject'
             email_body = 'email_body'
 

--- a/core/controllers/firebase_test.py
+++ b/core/controllers/firebase_test.py
@@ -15,6 +15,7 @@
 """Tests for the firebase controllers."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import collections
 
@@ -55,7 +56,7 @@ class FirebaseProxyPageTest(test_utils.GenericTestBase):
     def test_get_request_forwarded_to_firebase_proxy(self) -> None:
         url = '/__/auth'
         params = {'param_1': 'value_1', 'param_2': 'value_2'}
-        with self.swap(
+        with patch.object(
             firebase, 'FIREBASE_DOMAINS',
             {'localhost': self.MOCK_FIREBASE_DOMAIN}
         ), self.swap_with_checks(
@@ -80,7 +81,7 @@ class FirebaseProxyPageTest(test_utils.GenericTestBase):
             'Content-Length': '20'
         }
         payload = {'payload': 'value'}
-        with self.swap(
+        with patch.object(
             firebase, 'FIREBASE_DOMAINS',
             {'localhost': self.MOCK_FIREBASE_DOMAIN}
         ), self.swap_with_checks(

--- a/core/controllers/incoming_app_feedback_report_test.py
+++ b/core/controllers/incoming_app_feedback_report_test.py
@@ -17,6 +17,7 @@
 """Tests for the controller managing incoming feedback reports."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 
@@ -168,10 +169,10 @@ class IncomingAndroidFeedbackReportHandlerTests(test_utils.GenericTestBase):
         # Webapp requires the header values to be str-types, so they must have
         # parity for the tests to correctly check these fields.
         token = self.get_new_csrf_token()
-        with self.swap(
+        with patch.object(
             android_validation_constants, 'ANDROID_API_KEY',
             ANDROID_API_KEY_STRING):
-            with self.swap(
+            with patch.object(
                 android_validation_constants, 'ANDROID_APP_PACKAGE_NAME',
                 ANDROID_APP_PACKAGE_NAME_STRING):
                 return (

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -15,6 +15,7 @@
 """Tests for the library page and associated handlers."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import json
 import logging
@@ -303,8 +304,8 @@ class LibraryPageTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg)
 
-        logging_swap = self.swap(logging, 'exception', _mock_logging_function)
-        default_query_limit_swap = self.swap(feconf, 'DEFAULT_QUERY_LIMIT', 1)
+        logging_swap = patch.object(logging, 'exception', _mock_logging_function)
+        default_query_limit_swap = patch.object(feconf, 'DEFAULT_QUERY_LIMIT', 1)
         # Load the search results with an empty query.
         with default_query_limit_swap, logging_swap:
             self.get_json(feconf.LIBRARY_SEARCH_DATA_URL)

--- a/core/controllers/moderator_test.py
+++ b/core/controllers/moderator_test.py
@@ -15,6 +15,7 @@
 """Tests for the moderator page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import rights_manager
@@ -109,9 +110,9 @@ class EmailDraftHandlerTests(test_utils.GenericTestBase):
         self.signup(self.MODERATOR_EMAIL, self.MODERATOR_USERNAME)
         self.set_moderators([self.MODERATOR_USERNAME])
 
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_email_moderator_action_ctx = self.swap(
+        self.can_send_email_moderator_action_ctx = patch.object(
             feconf, 'REQUIRE_EMAIL_ON_MODERATOR_ACTION', True)
 
     def test_get_draft_email_body(self) -> None:

--- a/core/controllers/platform_feature_test.py
+++ b/core/controllers/platform_feature_test.py
@@ -15,6 +15,7 @@
 """Tests for platform feature evaluation handler."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import enum
 
@@ -99,7 +100,7 @@ class PlatformFeaturesEvaluationHandlerTest(test_utils.GenericTestBase):
     def test_get_dev_mode_android_client_returns_correct_flag_values(
         self
     ) -> None:
-        with self.swap(constants, 'DEV_MODE', True):
+        with patch.object(constants, 'DEV_MODE', True):
             result = self.get_json(
                 '/platform_features_evaluation_handler',
                 params={
@@ -114,7 +115,7 @@ class PlatformFeaturesEvaluationHandlerTest(test_utils.GenericTestBase):
     def test_get_features_invalid_platform_type_returns_features_disabled(
         self
     ) -> None:
-        with self.swap(constants, 'DEV_MODE', True):
+        with patch.object(constants, 'DEV_MODE', True):
             result = self.get_json(
                 '/platform_features_evaluation_handler',
                 params={
@@ -129,7 +130,7 @@ class PlatformFeaturesEvaluationHandlerTest(test_utils.GenericTestBase):
     def test_get_features_missing_platform_type_returns_features_disabled(
         self
     ) -> None:
-        with self.swap(constants, 'DEV_MODE', True):
+        with patch.object(constants, 'DEV_MODE', True):
             result = self.get_json(
                 '/platform_features_evaluation_handler',
                 params={}
@@ -141,7 +142,7 @@ class PlatformFeaturesEvaluationHandlerTest(test_utils.GenericTestBase):
     def test_get_features_invalid_version_flavor_raises_400(
         self
     ) -> None:
-        with self.swap(constants, 'DEV_MODE', True):
+        with patch.object(constants, 'DEV_MODE', True):
             resp_dict = self.get_json(
                 '/platform_features_evaluation_handler',
                 params={
@@ -157,7 +158,7 @@ class PlatformFeaturesEvaluationHandlerTest(test_utils.GenericTestBase):
             )
 
     def test_get_features_invalid_app_version_raises_400(self) -> None:
-        with self.swap(constants, 'DEV_MODE', True):
+        with patch.object(constants, 'DEV_MODE', True):
             result = self.get_json(
                 '/platform_features_evaluation_handler',
                 params={
@@ -220,7 +221,7 @@ class PlatformFeatureDummyHandlerTest(test_utils.GenericTestBase):
 
         feature = registry.Registry.parameter_registry.get(
             param_list.ParamNames.DUMMY_FEATURE_FLAG_FOR_E2E_TESTS.value)
-        return self.swap(feature, '_feature_stage', stage.value)
+        return patch.object(feature, '_feature_stage', stage.value)
 
     def test_get_with_dummy_feature_enabled_returns_ok(self) -> None:
         self.get_json(

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -15,6 +15,7 @@
 """Tests for the profile page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import io
@@ -511,7 +512,7 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
 
         # The email update preference should be True in all cases.
         editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
-        with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
+        with patch.object(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
             email_preferences = user_services.get_email_preferences(editor_id)
             self.assertEqual(email_preferences.can_receive_email_updates, True)
             self.assertEqual(
@@ -523,7 +524,7 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
             self.assertEqual(
                 email_preferences.can_receive_subscription_email,
                 feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
-        with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
+        with patch.object(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             email_preferences = user_services.get_email_preferences(editor_id)
             self.assertEqual(email_preferences.can_receive_email_updates, True)
             self.assertEqual(
@@ -540,7 +541,7 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         self.login(self.EDITOR_EMAIL)
         self.get_html_response(feconf.SIGNUP_URL + '?return_url=/')
         csrf_token = self.get_new_csrf_token()
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             with self.swap_to_always_return(
                 user_services, 'has_ever_registered', False
             ):
@@ -594,7 +595,7 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
 
         # The email update preference should be False in all cases.
         editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
-        with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
+        with patch.object(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
             email_preferences = user_services.get_email_preferences(editor_id)
             self.assertEqual(email_preferences.can_receive_email_updates, False)
             self.assertEqual(
@@ -607,7 +608,7 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
                 email_preferences.can_receive_subscription_email,
                 feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
 
-        with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
+        with patch.object(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             email_preferences = user_services.get_email_preferences(editor_id)
             self.assertEqual(email_preferences.can_receive_email_updates, False)
             self.assertEqual(
@@ -963,7 +964,7 @@ class SignupTests(test_utils.GenericTestBase):
             'has_ever_registered': True,
             'username': 'owner',
         }
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             response = self.get_json(feconf.SIGNUP_DATA_URL)
             self.assertDictEqual(values_dict, response)
 
@@ -985,7 +986,7 @@ class DeleteAccountPageTests(test_utils.GenericTestBase):
 class MailingListSubscriptionHandlerTests(test_utils.GenericTestBase):
 
     def test_put_function(self) -> None:
-        swap_add_fn = self.swap(
+        swap_add_fn = patch.object(
             user_services, 'add_user_to_mailing_list', lambda *args,
             **kwargs: True)
 
@@ -1007,7 +1008,7 @@ class MailingListSubscriptionHandlerTests(test_utils.GenericTestBase):
     def test_email_provider_error(self) -> None:
         def raise_exception() -> None:
             raise Exception('Backend error')
-        swap_add_fn = self.swap(
+        swap_add_fn = patch.object(
             user_services, 'add_user_to_mailing_list', raise_exception)
 
         self.signup(self.VIEWER_EMAIL, self.VIEWER_USERNAME)
@@ -1025,7 +1026,7 @@ class MailingListSubscriptionHandlerTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_invalid_inputs(self) -> None:
-        swap_add_fn = self.swap(
+        swap_add_fn = patch.object(
             user_services, 'add_user_to_mailing_list', lambda *args: True)
 
         self.signup(self.VIEWER_EMAIL, self.VIEWER_USERNAME)
@@ -1066,7 +1067,7 @@ class BulkEmailWebhookEndpointTests(test_utils.GenericTestBase):
         self.swap_secret = self.swap_to_always_return(
             secrets_services, 'get_secret', 'secret')
         self.swap_audience_id = (
-            self.swap(feconf, 'MAILCHIMP_AUDIENCE_ID', 'audience_id'))
+            patch.object(feconf, 'MAILCHIMP_AUDIENCE_ID', 'audience_id'))
         user_services.update_email_preferences(
             self.editor_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE,
@@ -1224,7 +1225,7 @@ class ExportAccountHandlerTests(test_utils.GenericTestBase):
             deleted=user_settings.deleted
         ).put()
 
-        time_swap = self.swap(
+        time_swap = patch.object(
             user_services, 'record_user_logged_in', lambda *args: None)
 
         with time_swap:
@@ -1305,7 +1306,7 @@ class ExportAccountHandlerTests(test_utils.GenericTestBase):
         fs.commit('profile_picture.png', raw_image_png, mimetype='image/png')
         fs.commit('profile_picture.webp', raw_image_webp, mimetype='image/webp')
 
-        time_swap = self.swap(
+        time_swap = patch.object(
             user_services, 'record_user_logged_in', lambda *args: None)
 
         with time_swap:

--- a/core/controllers/question_editor_test.py
+++ b/core/controllers/question_editor_test.py
@@ -15,6 +15,7 @@
 """Tests for the Question Editor controller."""
 
 from __future__ import annotations
+from unittest.mock import patch
 import json
 import os
 
@@ -703,7 +704,7 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTests):
             """Mocks '_get_question_by_id'. Returns None."""
             return None
 
-        question_services_swap = self.swap(
+        question_services_swap = patch.object(
             question_services, 'get_question_by_id', _mock_get_question_by_id)
 
         with question_services_swap:

--- a/core/controllers/questions_list_test.py
+++ b/core/controllers/questions_list_test.py
@@ -15,6 +15,7 @@
 """ Tests for the questions list. """
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.constants import constants
@@ -80,7 +81,7 @@ class QuestionsListHandlerTests(BaseQuestionsListControllerTests):
                 self.admin_id, question_id, self.skill_id_2, 0.3)
 
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(constants, 'NUM_QUESTIONS_PER_PAGE', 2):
+        with patch.object(constants, 'NUM_QUESTIONS_PER_PAGE', 2):
             json_response = self.get_json(
                 '%s/%s,%s?offset=0' % (
                     feconf.QUESTIONS_LIST_URL_PREFIX,

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -15,6 +15,7 @@
 """Tests for the page that allows learners to play through an exploration."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 
@@ -307,7 +308,7 @@ class ExplorationPretestsUnitTest(test_utils.GenericTestBase):
         question_services.create_new_question_skill_link(
             self.editor_id, question_id_2, self.skill_id, 0.5)
         # Call the handler.
-        with self.swap(feconf, 'NUM_PRETEST_QUESTIONS', 1):
+        with patch.object(feconf, 'NUM_PRETEST_QUESTIONS', 1):
             json_response_1 = self.get_json(
                 '%s/%s?story_url_fragment=title' % (
                     feconf.EXPLORATION_PRETESTS_URL_PREFIX, exp_id))
@@ -388,7 +389,7 @@ class ExplorationPretestsUnitTest(test_utils.GenericTestBase):
         question_services.create_new_question_skill_link(
             self.editor_id, question_id_2, self.skill_id, 0.5)
         # Call the handler.
-        with self.swap(feconf, 'NUM_PRETEST_QUESTIONS', 1):
+        with patch.object(feconf, 'NUM_PRETEST_QUESTIONS', 1):
             with self.swap_to_always_return(
                 story_domain.Story,
                 'get_prerequisite_skill_ids_for_exp_id',
@@ -1214,7 +1215,7 @@ class FlagExplorationHandlerTests(test_utils.EmailTestBase):
             title='Welcome to Oppia!',
             category='This is just a spam category',
             objective='Test a spam exploration.')
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
         rights_manager.publish_exploration(self.editor, self.EXP_ID)
         self.logout()
@@ -1581,7 +1582,7 @@ class LearnerProgressTest(test_utils.GenericTestBase):
             """Mocks None."""
             return None
 
-        story_fetchers_swap = self.swap(
+        story_fetchers_swap = patch.object(
             story_fetchers, 'get_story_by_id', _mock_none_function)
 
         with story_fetchers_swap:
@@ -2910,7 +2911,7 @@ class LearnerAnswerDetailsSubmissionHandlerTests(test_utils.GenericTestBase):
         entity_type = feconf.ENTITY_TYPE_EXPLORATION
 
         csrf_token = self.get_new_csrf_token()
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', False):
             self.put_json(
                 '%s/%s/%s' % (
@@ -2922,7 +2923,7 @@ class LearnerAnswerDetailsSubmissionHandlerTests(test_utils.GenericTestBase):
                     'answer': 'This is an answer.',
                     'answer_details': 'This is an answer details.',
                 }, csrf_token=csrf_token, expected_status_int=404)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', True):
             exploration_dict = self.get_json(
                 '%s/%s' % (feconf.EXPLORATION_INIT_URL_PREFIX, exp_id))
@@ -2984,7 +2985,7 @@ class LearnerAnswerDetailsSubmissionHandlerTests(test_utils.GenericTestBase):
         entity_type = feconf.ENTITY_TYPE_EXPLORATION
 
         csrf_token = self.get_new_csrf_token()
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', True):
             exploration_dict = self.get_json(
                 '%s/%s' % (feconf.EXPLORATION_INIT_URL_PREFIX, exp_id))
@@ -3026,7 +3027,7 @@ class LearnerAnswerDetailsSubmissionHandlerTests(test_utils.GenericTestBase):
             self._create_valid_question_data('ABC', content_id_generator),
             ['skill_1'],
             content_id_generator.next_content_id_index)
-        with self.swap(
+        with patch.object(
             constants, 'ENABLE_SOLICIT_ANSWER_DETAILS_FEATURE', True):
             state_reference = (
                 stats_services.get_state_reference_for_question(question_id))

--- a/core/controllers/release_coordinator_test.py
+++ b/core/controllers/release_coordinator_test.py
@@ -15,6 +15,7 @@
 """Tests for the release coordinator page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import enum
 
@@ -105,7 +106,7 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
         self.login(self.RELEASE_COORDINATOR_EMAIL)
         csrf_token = self.get_new_csrf_token()
 
-        prod_mode_swap = self.swap(constants, 'DEV_MODE', False)
+        prod_mode_swap = patch.object(constants, 'DEV_MODE', False)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception,
             'The \'feature_name\' must be provided when the action is '
@@ -126,7 +127,7 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
         self.login(self.RELEASE_COORDINATOR_EMAIL)
         csrf_token = self.get_new_csrf_token()
 
-        prod_mode_swap = self.swap(constants, 'DEV_MODE', False)
+        prod_mode_swap = patch.object(constants, 'DEV_MODE', False)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception,
             'The \'new_rules\' must be provided when the action is '
@@ -148,7 +149,7 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
         self.login(self.RELEASE_COORDINATOR_EMAIL)
         csrf_token = self.get_new_csrf_token()
 
-        prod_mode_swap = self.swap(constants, 'DEV_MODE', False)
+        prod_mode_swap = patch.object(constants, 'DEV_MODE', False)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception,
             'The \'commit_message\' must be provided when the action is '
@@ -170,10 +171,10 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
         feature = platform_parameter_registry.Registry.create_feature_flag(
             ParamNames.TEST_FEATURE_1, 'feature for test.', FeatureStages.DEV)
 
-        feature_list_ctx = self.swap(
+        feature_list_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURE_FLAGS',
             [ParamNames.TEST_FEATURE_1])
-        feature_set_ctx = self.swap(
+        feature_set_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURES_NAMES_SET',
             set([feature.name]))
         with feature_list_ctx, feature_set_ctx:
@@ -203,10 +204,10 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
             }
         ]
 
-        feature_list_ctx = self.swap(
+        feature_list_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURE_FLAGS',
             [ParamNames.TEST_FEATURE_1])
-        feature_set_ctx = self.swap(
+        feature_set_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURES_NAMES_SET',
             set([feature.name]))
         with feature_list_ctx, feature_set_ctx:
@@ -235,9 +236,9 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
         self.login(self.RELEASE_COORDINATOR_EMAIL)
         csrf_token = self.get_new_csrf_token()
 
-        feature_list_ctx = self.swap(
+        feature_list_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURE_FLAGS', [])
-        feature_set_ctx = self.swap(
+        feature_set_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURES_NAMES_SET', set([]))
         with feature_list_ctx, feature_set_ctx:
             response = self.post_json(
@@ -274,10 +275,10 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
             }
         ]
 
-        feature_list_ctx = self.swap(
+        feature_list_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURE_FLAGS',
             [ParamNames.TEST_FEATURE_2])
-        feature_set_ctx = self.swap(
+        feature_set_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURES_NAMES_SET',
             set([feature.name]))
         with feature_list_ctx, feature_set_ctx:
@@ -307,10 +308,10 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
         self.login(self.RELEASE_COORDINATOR_EMAIL)
         csrf_token = self.get_new_csrf_token()
 
-        feature_list_ctx = self.swap(
+        feature_list_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURE_FLAGS',
             [ParamNames.TEST_FEATURE_2])
-        feature_set_ctx = self.swap(
+        feature_set_ctx = patch.object(
             platform_feature_services, 'ALL_FEATURES_NAMES_SET',
             set([ParamNames.TEST_FEATURE_2.value]))
         # Here we use MyPy ignore because we are assigning a None value

--- a/core/controllers/resources_test.py
+++ b/core/controllers/resources_test.py
@@ -15,6 +15,7 @@
 """Tests for Oppia resource handling (e.g. templates, images)."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 
@@ -504,7 +505,7 @@ class AssetDevHandlerImageTests(test_utils.GenericTestBase):
         self
     ) -> None:
         self.login(self.EDITOR_EMAIL)
-        with self.swap(constants, 'EMULATOR_MODE', False):
+        with patch.object(constants, 'EMULATOR_MODE', False):
             self.get_json(
                 '/assetsdevhandler/exploration/0/assets/image/myfile.png',
                 expected_status_int=404)

--- a/core/controllers/skill_editor_test.py
+++ b/core/controllers/skill_editor_test.py
@@ -15,6 +15,7 @@
 """Tests for the skill editor page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core import utils
@@ -139,7 +140,7 @@ class SkillRightsHandlerTest(BaseSkillEditorControllerTests):
             actions = list(self.admin.actions)
             actions.remove(role_services.ACTION_EDIT_SKILL_DESCRIPTION)
             return actions
-        with self.swap(role_services, 'get_all_actions', mock_get_all_actions):
+        with patch.object(role_services, 'get_all_actions', mock_get_all_actions):
             json_response = self.get_json(self.url)
             self.assertEqual(json_response['can_edit_skill_description'], False)
         self.logout()
@@ -320,7 +321,7 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
         csrf_token = self.get_new_csrf_token()
         # Check PUT returns 400 when an exception is raised updating the
         # skill.
-        update_skill_swap = self.swap(
+        update_skill_swap = patch.object(
             skill_services, 'update_skill',
             self._mock_update_skill_raise_exception)
         with update_skill_swap:
@@ -346,7 +347,7 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
     def test_editable_skill_handler_delete_succeeds(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         # Check that admins can delete a skill.
-        skill_has_topics_swap = self.swap(
+        skill_has_topics_swap = patch.object(
             topic_fetchers,
             'get_all_skill_ids_assigned_to_some_topic',
             lambda: [])
@@ -360,9 +361,9 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         # Check DELETE returns 400 when the skill still has associated
         # questions.
-        skill_has_questions_swap = self.swap(
+        skill_has_questions_swap = patch.object(
             skill_services, 'skill_has_associated_questions', lambda x: True)
-        skill_has_topics_swap = self.swap(
+        skill_has_topics_swap = patch.object(
             topic_fetchers,
             'get_all_skill_ids_assigned_to_some_topic',
             lambda: [])

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -15,6 +15,7 @@
 """Tests for the story viewer page"""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 
@@ -328,7 +329,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
     ) -> None:
         self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
         self.login(self.NEW_USER_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             response = self.get_html_response(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -344,7 +345,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             self.viewer_id, self.STORY_ID, self.NODE_ID_2)
         story_services.record_completed_node_in_story_context(
             self.viewer_id, self.STORY_ID, self.NODE_ID_1)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             response = self.get_html_response(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -410,7 +411,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
         self.logout()
         self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
         self.login(self.NEW_USER_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             response = self.get_html_response(
                 '%s/staging/topic-frag/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -422,7 +423,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
     def test_redirect_to_next_node(self) -> None:
         self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
         self.login(self.NEW_USER_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             response = self.get_html_response(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -436,7 +437,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
 
     def test_post_fails_when_new_structures_not_enabled(self) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', False):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', False):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -446,7 +447,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
 
     def test_post_succeeds_when_story_and_node_exist(self) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             json_response = self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -462,7 +463,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
         self
     ) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             json_response = self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -476,7 +477,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
 
     def test_post_fails_when_story_does_not_exist(self) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, 'invalid-story',
@@ -486,7 +487,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
 
     def test_post_fails_when_node_does_not_exist(self) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -496,7 +497,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
 
     def test_post_fails_when_node_id_schema_is_invalid(self) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -508,7 +509,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
         topic_services.unpublish_story(
             self.TOPIC_ID, self.STORY_ID, self.admin_id)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -522,7 +523,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             self.viewer_id, self.STORY_ID, self.NODE_ID_2)
         story_services.record_completed_node_in_story_context(
             self.viewer_id, self.STORY_ID, self.NODE_ID_1)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             json_response = self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -566,7 +567,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             self.viewer_id, self.STORY_ID, self.NODE_ID_2)
         story_services.record_completed_node_in_story_context(
             self.viewer_id, self.STORY_ID, self.NODE_ID_1)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             json_response = self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -581,7 +582,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
         self
     ) -> None:
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -607,7 +608,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             self.viewer_id, self.STORY_ID, self.NODE_ID_2)
         story_services.record_completed_node_in_story_context(
             self.viewer_id, self.STORY_ID, self.NODE_ID_1)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -674,7 +675,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             self.viewer_id, self.STORY_ID, self.NODE_ID_2)
         story_services.record_completed_node_in_story_context(
             self.viewer_id, self.STORY_ID, self.NODE_ID_1)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,
@@ -693,7 +694,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             """Mocks None."""
             return None
 
-        story_fetchers_swap = self.swap(
+        story_fetchers_swap = patch.object(
             story_fetchers, 'get_story_by_id', _mock_none_function)
 
         with story_fetchers_swap:
@@ -720,7 +721,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             self.viewer_id, self.STORY_ID, self.NODE_ID_2)
         story_services.record_completed_node_in_story_context(
             self.viewer_id, self.STORY_ID, self.NODE_ID_1)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.post_json(
                 '%s/staging/topic/%s/%s' % (
                     feconf.STORY_PROGRESS_URL_PREFIX, self.STORY_URL_FRAGMENT,

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -17,6 +17,7 @@
 """Tests for suggestion controllers."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import base64
 import os
@@ -603,9 +604,9 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
         # has a high enough score to review suggestions in this category. This
         # will be used to test whether the author can review a suggestion in
         # the same category because of the author's high score in a later test.
-        enable_recording_of_scores_swap = self.swap(
+        enable_recording_of_scores_swap = patch.object(
             feconf, 'ENABLE_RECORDING_OF_SCORES', True)
-        increment_score_of_author_swap = self.swap(
+        increment_score_of_author_swap = patch.object(
             suggestion_models, 'INCREMENT_SCORE_OF_AUTHOR_BY',
             feconf.MINIMUM_SCORE_REQUIRED_TO_REVIEW)
 
@@ -833,7 +834,7 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
                 self.translator_id))['suggestions'][0]
 
         csrf_token = self.get_new_csrf_token()
-        with self.swap(
+        with patch.object(
             opportunity_services,
             'update_translation_opportunity_with_accepted_suggestion',
             lambda x, _: x
@@ -974,7 +975,7 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
         self.login(self.EDITOR_EMAIL)
         csrf_token = self.get_new_csrf_token()
 
-        with self.swap(
+        with patch.object(
             opportunity_services,
             'update_translation_opportunity_with_accepted_suggestion',
             lambda x, _: x
@@ -1122,7 +1123,7 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
             feconf.ENTITY_TYPE_EXPLORATION,
             'exp1', 1, self.translator_id, change_dict, 'description')
-        with self.swap(
+        with patch.object(
             opportunity_services,
             'update_translation_opportunity_with_accepted_suggestion',
             lambda x, _: x
@@ -1924,7 +1925,7 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
 
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.put_json('%s/skill/%s/%s' % (
                 feconf.SUGGESTION_ACTION_URL_PREFIX,
                 suggestion_to_accept['target_id'],
@@ -2106,7 +2107,7 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.put_json('%s/skill/%s/%s' % (
                 feconf.SUGGESTION_ACTION_URL_PREFIX,
                 suggestion.target_id,
@@ -2327,7 +2328,7 @@ class SkillSuggestionTests(test_utils.GenericTestBase):
 
         csrf_token = self.get_new_csrf_token()
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             response = self.put_json(
                 '%s/skill/%s/%s' % (
                     feconf.SUGGESTION_ACTION_URL_PREFIX,
@@ -2354,7 +2355,7 @@ class SkillSuggestionTests(test_utils.GenericTestBase):
 
         csrf_token = self.get_new_csrf_token()
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             response = self.put_json(
                 '%s/skill/%s/%s' % (
                     feconf.SUGGESTION_ACTION_URL_PREFIX,
@@ -2381,7 +2382,7 @@ class SkillSuggestionTests(test_utils.GenericTestBase):
                 self.author_id))['suggestions'][0]
 
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             response = self.put_json(
                 '%s/skill/%s/%s' % (
                     feconf.SUGGESTION_ACTION_URL_PREFIX,
@@ -2411,7 +2412,7 @@ class SkillSuggestionTests(test_utils.GenericTestBase):
             suggestion.status, suggestion_models.STATUS_IN_REVIEW)
 
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.put_json('%s/skill/%s/%s' % (
                 feconf.SUGGESTION_ACTION_URL_PREFIX,
                 suggestion_to_reject['target_id'],
@@ -2440,7 +2441,7 @@ class SkillSuggestionTests(test_utils.GenericTestBase):
             suggestion.status, suggestion_models.STATUS_IN_REVIEW)
 
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.put_json('%s/skill/%s/%s' % (
                 feconf.SUGGESTION_ACTION_URL_PREFIX,
                 suggestion_to_accept['target_id'],
@@ -2470,7 +2471,7 @@ class SkillSuggestionTests(test_utils.GenericTestBase):
             suggestion.status, suggestion_models.STATUS_IN_REVIEW)
 
         csrf_token = self.get_new_csrf_token()
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
+        with patch.object(constants, 'ENABLE_NEW_STRUCTURE_VIEWER_UPDATES', True):
             self.put_json('%s/skill/%s/%s' % (
                 feconf.SUGGESTION_ACTION_URL_PREFIX,
                 suggestion_to_accept['target_id'],

--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -15,6 +15,7 @@
 """Tests for Tasks Email Handler."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import exp_fetchers
@@ -55,9 +56,9 @@ class TasksTests(test_utils.EmailTestBase):
 
         self.exploration = self.save_new_default_exploration(
             'A', self.editor_id, title='Title')
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
         self.THREAD_ID = 'exploration.exp1.thread_1'
 
@@ -278,7 +279,7 @@ class TasksTests(test_utils.EmailTestBase):
         def fake_get_user_ids_by_role(_: str) -> List[str]:
             """Replaces get_user_ids_by_role for testing purposes."""
             return [self.moderator_id]
-        get_moderator_id_as_list = self.swap(
+        get_moderator_id_as_list = patch.object(
             user_services, 'get_user_ids_by_role',
             fake_get_user_ids_by_role)
 

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -15,6 +15,7 @@
 """Tests for the topic editor page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import os
@@ -268,7 +269,7 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
         def mock_get_current_time_in_millisecs() -> int:
             return 1690555400000
 
-        with self.swap(
+        with patch.object(
             utils, 'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs):
             response = self.get_json(
@@ -592,7 +593,7 @@ class TopicEditorTests(
 
         # Check that admins can access the editable topic data.
         self.login(self.CURRICULUM_ADMIN_EMAIL)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             messages = self._get_sent_email_messages(
                 feconf.ADMIN_EMAIL_ADDRESS)
             self.assertEqual(len(messages), 0)
@@ -763,7 +764,7 @@ class TopicEditorTests(
         csrf_token = self.get_new_csrf_token()
         skill_services.delete_skill(self.admin_id, self.skill_id_2)
 
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             messages = self._get_sent_email_messages(
                 feconf.ADMIN_EMAIL_ADDRESS)
             self.assertEqual(len(messages), 0)
@@ -1051,7 +1052,7 @@ class TopicPublishSendMailHandlerTests(
     def test_send_mail(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             self.put_json(
                 '%s/%s' % (
                     feconf.TOPIC_SEND_MAIL_URL_PREFIX, self.topic_id),

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -15,6 +15,7 @@
 """Tests for the topic viewer page."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.constants import constants
@@ -179,7 +180,7 @@ class TopicPageDataHandlerTests(
     def test_get_with_user_logged_in(self) -> None:
         skill_services.delete_skill(self.admin_id, self.skill_id_1)
         self.login(self.NEW_USER_EMAIL)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             messages = self._get_sent_email_messages(
                 feconf.ADMIN_EMAIL_ADDRESS)
             self.assertEqual(len(messages), 0)

--- a/core/domain/auth_services_test.py
+++ b/core/domain/auth_services_test.py
@@ -17,6 +17,7 @@
 """Tests for core.domain.auth_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.constants import constants
 from core.domain import auth_domain
@@ -250,7 +251,7 @@ class AuthServicesTests(test_utils.GenericTestBase):
         ) -> None:
             auth_section.remove('established')
 
-        with self.swap(
+        with patch.object(
             platform_auth_services,
             'establish_auth_session',
             mock_establish_auth_session
@@ -260,7 +261,7 @@ class AuthServicesTests(test_utils.GenericTestBase):
                 webapp2.Response()
             )
             self.assertEqual(['established'], auth_section)
-        with self.swap(
+        with patch.object(
             platform_auth_services,
             'destroy_auth_session',
             mock_destroy_auth_session
@@ -276,14 +277,14 @@ class AuthServicesTests(test_utils.GenericTestBase):
         def mock_revoke_super_admin_privileges(uid: str) -> None:
             super_admin_privilage.remove(uid)
 
-        with self.swap(
+        with patch.object(
             platform_auth_services,
             'grant_super_admin_privileges',
             mock_grant_super_admin_privileges
         ):
             auth_services.grant_super_admin_privileges('uid1')
             self.assertEqual(['uid1'], super_admin_privilage)
-        with self.swap(
+        with patch.object(
             platform_auth_services,
             'revoke_super_admin_privileges',
             mock_revoke_super_admin_privileges

--- a/core/domain/blog_services_test.py
+++ b/core/domain/blog_services_test.py
@@ -17,6 +17,7 @@
 """Tests for blog post services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -644,7 +645,7 @@ class BlogServicesUnitTests(test_utils.GenericTestBase):
             return ids
 
         add_docs_counter = test_utils.CallCounter(mock_add_documents_to_index)
-        add_docs_swap = self.swap(
+        add_docs_swap = patch.object(
             search_services,
             'add_documents_to_index',
             add_docs_counter)
@@ -698,7 +699,7 @@ class BlogServicesUnitTests(test_utils.GenericTestBase):
             actual_docs.extend(docs)
 
         add_docs_counter = test_utils.CallCounter(mock_add_documents_to_index)
-        add_docs_swap = self.swap(
+        add_docs_swap = patch.object(
             search_services,
             'add_documents_to_index',
             add_docs_counter)
@@ -777,7 +778,7 @@ class BlogAuthorDetailsTests(test_utils.GenericTestBase):
         def _mock_get_author_details_by_author(unused_user_id: str) -> None:
             return None
 
-        get_author_details_swap = self.swap(
+        get_author_details_swap = patch.object(
             blog_models.BlogAuthorDetailsModel,
             'get_by_author',
             _mock_get_author_details_by_author
@@ -1057,7 +1058,7 @@ class BlogPostSummaryQueriesUnitTests(test_utils.GenericTestBase):
     ) -> None:
         # Ensure the maximum number of blog posts that can fit on the search
         # results page is maintained by the summaries function.
-        with self.swap(
+        with patch.object(
             feconf, 'MAX_NUM_CARDS_TO_DISPLAY_ON_BLOG_SEARCH_RESULTS_PAGE', 2
             ):
             # Need to load 3 pages to find all of the blog posts. Since the
@@ -1119,10 +1120,10 @@ class BlogPostSummaryQueriesUnitTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-        search_results_page_size_swap = self.swap(
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
+        search_results_page_size_swap = patch.object(
             feconf, 'MAX_NUM_CARDS_TO_DISPLAY_ON_BLOG_SEARCH_RESULTS_PAGE', 5)
-        max_iterations_swap = self.swap(blog_services, 'MAX_ITERATIONS', 1)
+        max_iterations_swap = patch.object(blog_services, 'MAX_ITERATIONS', 1)
 
         def _mock_delete_documents_from_index(
             unused_doc_ids: List[str], unused_index: int
@@ -1133,7 +1134,7 @@ class BlogPostSummaryQueriesUnitTests(test_utils.GenericTestBase):
             """
             pass
 
-        with self.swap(
+        with patch.object(
             search_services,
             'delete_documents_from_index',
             _mock_delete_documents_from_index):

--- a/core/domain/caching_services_test.py
+++ b/core/domain/caching_services_test.py
@@ -17,6 +17,7 @@
 """Tests for methods in core.domain.caching_services"""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import json
 
@@ -611,7 +612,7 @@ class CachingServicesUnitTests(test_utils.GenericTestBase):
                     json.loads(value),
                     json.loads(
                         self.json_encoded_string_representing_an_exploration))
-        with self.swap(
+        with patch.object(
             memory_cache_services, 'set_multi',
             mock_memory_cache_services_set_multi):
             caching_services.set_multi(

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -17,6 +17,7 @@
 """Tests for classifier services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import copy
 import datetime
@@ -71,7 +72,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             feconf.TESTS_DATA_DIR, 'string_classifier_test.yaml')
         yaml_content = utils.get_file_contents(test_exp_filepath)
         assets_list: List[Tuple[str, bytes]] = []
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.save_new_exploration_from_yaml_and_assets(
                 feconf.SYSTEM_COMMITTER_ID, yaml_content, exploration_id,
                 assets_list)
@@ -146,7 +147,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             'property_name': 'recorded_voiceovers',
             'new_value': state.recorded_voiceovers.to_dict()
         })]
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
 
@@ -164,7 +165,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             'property_name': 'title',
             'new_value': 'New title'
         })]
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
 
@@ -185,7 +186,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             'old_state_name': 'Home2',
             'new_state_name': 'Home3'
         })]
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
 
@@ -237,7 +238,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             'property_name': 'recorded_voiceovers',
             'new_value': state.recorded_voiceovers.to_dict()
         })]
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
 
@@ -255,7 +256,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             'property_name': 'title',
             'new_value': 'New title'
         })]
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', False):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', False):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
 
@@ -275,7 +276,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             'property_name': 'title',
             'new_value': 'New title'
         })]
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
 
@@ -827,7 +828,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
         )
         # Ruling out the possibility of None for mypy type checking.
         assert expected_state_training_jobs is not None
-        with self.swap(
+        with patch.object(
             feconf,
             'INTERACTION_CLASSIFIER_MAPPING',
             mock_interaction_classifier_mapping):
@@ -851,7 +852,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
                 'algorithm_version': 2
                 },
             }
-        with self.swap(
+        with patch.object(
             feconf,
             'INTERACTION_CLASSIFIER_MAPPING',
             mock_interaction_classifier_mapping):
@@ -889,7 +890,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
             'property_name': 'title',
             'new_value': 'A new title'
         })]
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
                 feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
 
@@ -902,7 +903,7 @@ class ClassifierServicesTests(test_utils.ClassifierTestBase):
         assert old_job is not None
         old_job_id = old_job.job_id
         # Revert the exploration.
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.revert_exploration(
                 feconf.SYSTEM_COMMITTER_ID,
                 self.exp_id,

--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.collection_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -301,7 +302,7 @@ class CollectionQueriesUnitTests(CollectionServicesUnitTests):
         collection = self.save_new_valid_collection(
             'collection_id', self.owner_id)
 
-        apply_change_list_swap = self.swap(
+        apply_change_list_swap = patch.object(
             collection_services, 'apply_change_list', lambda _, __: collection)
 
         with apply_change_list_swap, self.assertRaisesRegex(
@@ -471,7 +472,7 @@ class CollectionQueriesUnitTests(CollectionServicesUnitTests):
             """Mocks logging.error()."""
             observed_log_messages.append(msg)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
 
         self.save_new_valid_collection('collection_id', self.owner_id)
 
@@ -861,7 +862,7 @@ class CollectionSummaryQueriesUnitTests(CollectionServicesUnitTests):
     ) -> None:
         # Ensure the maximum number of collections that can fit on the search
         # results page is maintained by the summaries function.
-        with self.swap(feconf, 'SEARCH_RESULTS_PAGE_SIZE', 2):
+        with patch.object(feconf, 'SEARCH_RESULTS_PAGE_SIZE', 2):
             # Need to load 3 pages to find all of the collections. Since the
             # returned order is arbitrary, we need to concatenate the results
             # to ensure all collections are returned. We validate the correct
@@ -1192,7 +1193,7 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
                 index, collection_services.SEARCH_INDEX_COLLECTIONS)
             self.assertEqual(doc_ids, [self.COLLECTION_0_ID])
 
-        delete_docs_swap = self.swap(
+        delete_docs_swap = patch.object(
             gae_search_services,
             'delete_documents_from_index',
             mock_delete_docs)
@@ -1212,7 +1213,7 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
             self.assertEqual(
                 doc_ids, [self.COLLECTION_0_ID, self.COLLECTION_1_ID])
 
-        delete_docs_swap = self.swap(
+        delete_docs_swap = patch.object(
             gae_search_services,
             'delete_documents_from_index',
             mock_delete_docs)
@@ -1921,7 +1922,7 @@ class CollectionSearchTests(CollectionServicesUnitTests):
             return ids
 
         add_docs_counter = test_utils.CallCounter(mock_add_documents_to_index)
-        add_docs_swap = self.swap(
+        add_docs_swap = patch.object(
             gae_search_services,
             'add_documents_to_index',
             add_docs_counter)

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -17,6 +17,7 @@
 """Tests for draft upgrade services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core import utils
@@ -142,7 +143,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
         # The migration will automatically migrate the exploration to the latest
         # state schema version, so we set the latest schema version to be the
         # target_schema_version.
-        with self.swap(
+        with patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', int(target_schema_version)):
 
             # Create and migrate the exploration.

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -15,6 +15,7 @@
 """Tests for methods relating to sending emails."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -62,9 +63,9 @@ class FailedMLTest(test_utils.EmailTestBase):
     def setUp(self) -> None:
         super().setUp()
         self.ADMIN_USERNAME = 'admusername'
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
         self.signup(
             feconf.ADMIN_EMAIL_ADDRESS, self.ADMIN_USERNAME, True)
@@ -94,12 +95,12 @@ class EmailToAdminTest(test_utils.EmailTestBase):
         dummy_system_address = 'dummy@system.com'
         dummy_admin_address = 'admin@system.com'
 
-        send_email_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        system_name_ctx = self.swap(
+        send_email_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        system_name_ctx = patch.object(
             feconf, 'SYSTEM_EMAIL_NAME', dummy_system_name)
-        system_email_ctx = self.swap(
+        system_email_ctx = patch.object(
             feconf, 'SYSTEM_EMAIL_ADDRESS', dummy_system_address)
-        admin_email_ctx = self.swap(
+        admin_email_ctx = patch.object(
             feconf, 'ADMIN_EMAIL_ADDRESS', dummy_admin_address)
 
         with send_email_ctx, system_name_ctx, system_email_ctx, admin_email_ctx:
@@ -130,12 +131,12 @@ class DummyMailTest(test_utils.EmailTestBase):
         dummy_system_address = 'dummy@system.com'
         dummy_receiver_address = 'admin@system.com'
 
-        send_email_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        system_name_ctx = self.swap(
+        send_email_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        system_name_ctx = patch.object(
             feconf, 'SYSTEM_EMAIL_NAME', dummy_system_name)
-        system_email_ctx = self.swap(
+        system_email_ctx = patch.object(
             feconf, 'SYSTEM_EMAIL_ADDRESS', dummy_system_address)
-        admin_email_ctx = self.swap(
+        admin_email_ctx = patch.object(
             feconf, 'ADMIN_EMAIL_ADDRESS', dummy_receiver_address)
 
         with send_email_ctx, system_name_ctx, system_email_ctx, admin_email_ctx:
@@ -237,13 +238,13 @@ class ExplorationMembershipEmailTests(test_utils.EmailTestBase):
         self.expected_email_subject = (
             '%s - invitation to collaborate') % self.EXPLORATION_TITLE
 
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
-        self.can_send_editor_role_email_ctx = self.swap(
+        self.can_send_editor_role_email_ctx = patch.object(
             feconf, 'CAN_SEND_EDITOR_ROLE_EMAILS', True)
-        self.can_not_send_editor_role_email_ctx = self.swap(
+        self.can_not_send_editor_role_email_ctx = patch.object(
             feconf, 'CAN_SEND_EDITOR_ROLE_EMAILS', False)
 
     def test_role_email_is_sent_when_editor_assigns_role(self) -> None:
@@ -636,7 +637,7 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 self.new_footer
             )
         )
-        with swap_get_platform_parameter_value_return_email_footer, self.swap(
+        with swap_get_platform_parameter_value_return_email_footer, patch.object(
             feconf, 'CAN_SEND_EMAILS', False
         ):
             self._set_signup_email_content_platform_parameter(
@@ -664,10 +665,10 @@ class SignupEmailTests(test_utils.EmailTestBase):
             self._reset_signup_email_content_platform_parameters()
 
     def test_email_not_sent_if_content_parameter_is_not_modified(self) -> None:
-        can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
 
         log_new_error_counter = test_utils.CallCounter(logging.error)
-        log_new_error_ctx = self.swap(
+        log_new_error_ctx = patch.object(
             logging, 'error', log_new_error_counter)
 
         with self.capture_logging(min_level=logging.ERROR) as logs:
@@ -708,7 +709,7 @@ class SignupEmailTests(test_utils.EmailTestBase):
     def test_email_not_sent_if_content_config_is_partially_modified(
         self
     ) -> None:
-        can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
 
         platform_parameter_registry.Registry.update_platform_parameter(
             email_manager.SIGNUP_EMAIL_SUBJECT_CONTENT.name,
@@ -731,7 +732,7 @@ class SignupEmailTests(test_utils.EmailTestBase):
         )
 
         log_new_error_counter = test_utils.CallCounter(logging.error)
-        log_new_error_ctx = self.swap(
+        log_new_error_ctx = patch.object(
             logging, 'error', log_new_error_counter)
 
         with self.capture_logging(min_level=logging.ERROR) as logs:
@@ -771,12 +772,12 @@ class SignupEmailTests(test_utils.EmailTestBase):
         self._reset_signup_email_content_platform_parameters()
 
     def test_email_with_bad_content_is_not_sent(self) -> None:
-        can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
         self._set_signup_email_content_platform_parameter(
             'New email subject', 'New HTML body.<script>alert(3);</script>')
 
         log_new_error_counter = test_utils.CallCounter(logging.error)
-        log_new_error_ctx = self.swap(
+        log_new_error_ctx = patch.object(
             logging, 'error', log_new_error_counter)
 
         with self.capture_logging(min_level=logging.ERROR) as logs:
@@ -813,7 +814,7 @@ class SignupEmailTests(test_utils.EmailTestBase):
         self._reset_signup_email_content_platform_parameters()
 
     def test_contents_of_signup_email_are_correct(self) -> None:
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             platform_parameter_registry.Registry.update_platform_parameter(
                 email_manager.EMAIL_SENDER_NAME.name,
                 self.admin_id,
@@ -896,7 +897,7 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 self.new_footer
             )
         )
-        with swap_get_platform_parameter_value_return_email_footer, self.swap(
+        with swap_get_platform_parameter_value_return_email_footer, patch.object(
             feconf, 'CAN_SEND_EMAILS', True
         ):
             self._set_signup_email_content_platform_parameter(
@@ -950,7 +951,7 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 self.new_footer
             )
         )
-        with swap_get_platform_parameter_value_return_email_footer, self.swap(
+        with swap_get_platform_parameter_value_return_email_footer, patch.object(
             feconf, 'CAN_SEND_EMAILS', True
         ):
             self._set_signup_email_content_platform_parameter(
@@ -998,7 +999,7 @@ class SignupEmailTests(test_utils.EmailTestBase):
             self._reset_signup_email_content_platform_parameters()
 
     def test_record_of_sent_email_is_written_to_datastore(self) -> None:
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             platform_parameter_registry.Registry.update_platform_parameter(
                 email_manager.EMAIL_SENDER_NAME.name,
                 self.admin_id,
@@ -1123,20 +1124,20 @@ class DuplicateEmailTests(test_utils.EmailTestBase):
             """Returns the generated hash for tests."""
             return 'Email Hash'
 
-        self.generate_hash_ctx = self.swap(
+        self.generate_hash_ctx = patch.object(
             email_models.SentEmailModel, '_generate_hash',
             types.MethodType(
                 _generate_hash_for_tests, email_models.SentEmailModel))
 
     def test_send_email_does_not_resend_if_same_hash_exists(self) -> None:
-        can_send_emails_ctx = self.swap(
+        can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
 
-        duplicate_email_ctx = self.swap(
+        duplicate_email_ctx = patch.object(
             feconf, 'DUPLICATE_EMAIL_INTERVAL_MINS', 1000)
 
         log_new_error_counter = test_utils.CallCounter(logging.error)
-        log_new_error_ctx = self.swap(
+        log_new_error_ctx = patch.object(
             logging, 'error', log_new_error_counter)
 
         with self.capture_logging(min_level=logging.ERROR) as logs:
@@ -1180,14 +1181,14 @@ class DuplicateEmailTests(test_utils.EmailTestBase):
                 self.assertEqual(len(all_models), 1)
 
     def test_send_email_does_not_resend_within_duplicate_interval(self) -> None:
-        can_send_emails_ctx = self.swap(
+        can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
 
-        duplicate_email_ctx = self.swap(
+        duplicate_email_ctx = patch.object(
             feconf, 'DUPLICATE_EMAIL_INTERVAL_MINS', 2)
 
         log_new_error_counter = test_utils.CallCounter(logging.error)
-        log_new_error_ctx = self.swap(
+        log_new_error_ctx = patch.object(
             logging, 'error', log_new_error_counter)
 
         swap_get_platform_parameter_value = self.swap_to_always_return(
@@ -1242,10 +1243,10 @@ class DuplicateEmailTests(test_utils.EmailTestBase):
 
     def test_sending_email_with_different_recipient_but_same_hash(self) -> None:
         """Hash for both messages is same but recipients are different."""
-        can_send_emails_ctx = self.swap(
+        can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
 
-        duplicate_email_ctx = self.swap(
+        duplicate_email_ctx = patch.object(
             feconf, 'DUPLICATE_EMAIL_INTERVAL_MINS', 2)
 
         with can_send_emails_ctx, duplicate_email_ctx, self.generate_hash_ctx:
@@ -1292,10 +1293,10 @@ class DuplicateEmailTests(test_utils.EmailTestBase):
 
     def test_sending_email_with_different_subject_but_same_hash(self) -> None:
         """Hash for both messages is same but subjects are different."""
-        can_send_emails_ctx = self.swap(
+        can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
 
-        duplicate_email_ctx = self.swap(
+        duplicate_email_ctx = patch.object(
             feconf, 'DUPLICATE_EMAIL_INTERVAL_MINS', 2)
 
         with can_send_emails_ctx, duplicate_email_ctx, self.generate_hash_ctx:
@@ -1343,10 +1344,10 @@ class DuplicateEmailTests(test_utils.EmailTestBase):
 
     def test_sending_email_with_different_body_but_same_hash(self) -> None:
         """Hash for both messages is same but body is different."""
-        can_send_emails_ctx = self.swap(
+        can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
 
-        duplicate_email_ctx = self.swap(
+        duplicate_email_ctx = patch.object(
             feconf, 'DUPLICATE_EMAIL_INTERVAL_MINS', 2)
 
         with can_send_emails_ctx, duplicate_email_ctx, self.generate_hash_ctx:
@@ -1395,10 +1396,10 @@ class DuplicateEmailTests(test_utils.EmailTestBase):
     def test_duplicate_emails_are_sent_after_some_time_has_elapsed(
         self
     ) -> None:
-        can_send_emails_ctx = self.swap(
+        can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
 
-        duplicate_email_ctx = self.swap(
+        duplicate_email_ctx = patch.object(
             feconf, 'DUPLICATE_EMAIL_INTERVAL_MINS', 2)
 
         with can_send_emails_ctx, duplicate_email_ctx:
@@ -1472,12 +1473,12 @@ class FeedbackMessageBatchEmailTests(test_utils.EmailTestBase):
         self.expected_email_subject = (
             'You\'ve received 3 new messages on your explorations')
 
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
-        self.can_not_send_feedback_email_ctx = self.swap(
+        self.can_not_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', False)
 
     def test_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -1612,13 +1613,13 @@ class SuggestionEmailTests(test_utils.EmailTestBase):
             'A', self.editor_id, title='Title')
         self.recipient_list = [self.editor_id]
 
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
-        self.can_not_send_feedback_email_ctx = self.swap(
+        self.can_not_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', False)
 
     def test_that_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -1721,13 +1722,13 @@ class SubscriptionEmailTests(test_utils.EmailTestBase):
         subscription_services.subscribe_to_creator(
             self.new_user_id, self.editor_id)
 
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
-        self.can_send_subscription_email_ctx = self.swap(
+        self.can_send_subscription_email_ctx = patch.object(
             feconf, 'CAN_SEND_SUBSCRIPTION_EMAILS', True)
-        self.can_not_send_subscription_email_ctx = self.swap(
+        self.can_not_send_subscription_email_ctx = patch.object(
             feconf, 'CAN_SEND_SUBSCRIPTION_EMAILS', False)
 
     def test_that_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -1821,13 +1822,13 @@ class FeedbackMessageInstantEmailTests(test_utils.EmailTestBase):
             'A', self.editor_id, title='Title')
         self.recipient_list = [self.editor_id]
 
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
-        self.can_not_send_feedback_email_ctx = self.swap(
+        self.can_not_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', False)
 
     def test_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -1943,8 +1944,8 @@ class FlagExplorationEmailTest(test_utils.EmailTestBase):
 
         self.report_text = 'AD'
 
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_that_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -2046,8 +2047,8 @@ class OnboardingReviewerInstantEmailTests(test_utils.EmailTestBase):
         self.reviewer_id = self.get_user_id_from_email(self.REVIEWER_EMAIL)
         user_services.update_email_preferences(
             self.reviewer_id, True, False, False, False)
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_that_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -2123,8 +2124,8 @@ class NotifyReviewerInstantEmailTests(test_utils.EmailTestBase):
         self.reviewer_id = self.get_user_id_from_email(self.REVIEWER_EMAIL)
         user_services.update_email_preferences(
             self.reviewer_id, True, False, False, False)
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_that_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -2193,8 +2194,8 @@ class NotifyContributionAchievementEmailTests(test_utils.EmailTestBase):
         self.user_id = self.get_user_id_from_email(self.USER_EMAIL)
         user_services.update_email_preferences(
             self.user_id, True, False, False, False)
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_that_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -2566,7 +2567,7 @@ class NotifyContributionDashboardReviewersEmailTests(test_utils.EmailTestBase):
         """Creates a question suggestion with the given question html and
         submission datetime.
         """
-        with self.swap(
+        with patch.object(
             feconf, 'DEFAULT_INIT_STATE_CONTENT_STR', question_html):
             content_id_generator = translation_domain.ContentIdGenerator()
             add_question_change_dict: Dict[
@@ -2698,15 +2699,15 @@ class NotifyContributionDashboardReviewersEmailTests(test_utils.EmailTestBase):
         user_services.update_email_preferences(
             self.reviewer_2_id, True, False, False, False)
 
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
         self.log_new_error_counter = test_utils.CallCounter(
             logging.error)
-        self.log_new_error_ctx = self.swap(
+        self.log_new_error_ctx = patch.object(
             logging, 'error', self.log_new_error_counter)
         self.logged_info: List[str] = []
-        self.log_new_info_ctx = self.swap(
+        self.log_new_info_ctx = patch.object(
             logging, 'info', self._mock_logging_info)
 
         self.save_new_valid_exploration(self.target_id, self.author_id)
@@ -2719,7 +2720,7 @@ class NotifyContributionDashboardReviewersEmailTests(test_utils.EmailTestBase):
             suggestion_services
             .create_reviewable_suggestion_email_info_from_suggestion(
                 question_suggestion))
-        self.swap_get_platform_parameter_value = self.swap(
+        self.swap_get_platform_parameter_value = patch.object(
             platform_feature_services,
             'get_platform_parameter_value',
             self._swap_get_platform_parameter_value_function
@@ -4152,7 +4153,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         """Creates a question suggestion with the given question html and
         submission datetime.
         """
-        with self.swap(
+        with patch.object(
             feconf, 'DEFAULT_INIT_STATE_CONTENT_STR', question_html):
             content_id_generator = translation_domain.ContentIdGenerator()
             add_question_change_dict: Dict[
@@ -4280,15 +4281,15 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         self.admin_2_id = self.get_user_id_from_email(
             self.CURRICULUM_ADMIN_2_EMAIL)
 
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
         self.log_new_error_counter = test_utils.CallCounter(
             logging.error)
-        self.log_new_error_ctx = self.swap(
+        self.log_new_error_ctx = patch.object(
             logging, 'error', self.log_new_error_counter)
         self.logged_info: List[str] = []
-        self.log_new_info_ctx = self.swap(
+        self.log_new_info_ctx = patch.object(
             logging, 'info', self._mock_logging_info)
 
         self.save_new_valid_exploration(self.target_id, self.author_id)
@@ -4301,7 +4302,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             suggestion_services
             .create_reviewable_suggestion_email_info_from_suggestion(
                 question_suggestion))
-        self.swap_get_platform_parameter_value = self.swap(
+        self.swap_get_platform_parameter_value = patch.object(
             platform_feature_services,
             'get_platform_parameter_value',
             self._swap_get_platform_parameter_value_function
@@ -4311,7 +4312,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         with self.swap_get_platform_parameter_value, self.capture_logging(
             min_level=logging.ERROR) as logs:
             with self.cannot_send_emails_ctx, self.log_new_error_ctx:
-                with self.swap(
+                with patch.object(
                     suggestion_models,
                     'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0):
                     (
@@ -4334,7 +4335,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
     ) -> None:
         with self.capture_logging(min_level=logging.ERROR) as logs:
             with self.can_send_emails_ctx, self.log_new_error_ctx:
-                with self.swap(
+                with patch.object(
                     suggestion_models,
                     'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0):
                     (
@@ -4357,7 +4358,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         with self.swap_get_platform_parameter_value, self.capture_logging(
             min_level=logging.ERROR) as logs:
             with self.can_send_emails_ctx, self.log_new_error_ctx:
-                with self.swap(
+                with patch.object(
                     suggestion_models,
                     'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
                 ):
@@ -4381,7 +4382,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         with self.swap_get_platform_parameter_value, self.capture_logging(
             min_level=logging.ERROR) as logs:
             with self.can_send_emails_ctx, self.log_new_error_ctx:
-                with self.swap(
+                with patch.object(
                     suggestion_models,
                     'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
                 ):
@@ -4401,7 +4402,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         self
     ) -> None:
         with self.can_send_emails_ctx, self.log_new_info_ctx:
-            with self.swap_get_platform_parameter_value, self.swap(
+            with self.swap_get_platform_parameter_value, patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
@@ -4463,7 +4464,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
-            with self.swap_get_platform_parameter_value, self.swap(
+            with self.swap_get_platform_parameter_value, patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
@@ -4539,7 +4540,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
-            with self.swap_get_platform_parameter_value, self.swap(
+            with self.swap_get_platform_parameter_value, patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
@@ -4606,7 +4607,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
-            with self.swap_get_platform_parameter_value, self.swap(
+            with self.swap_get_platform_parameter_value, patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
@@ -4682,7 +4683,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
-            with self.swap_get_platform_parameter_value, self.swap(
+            with self.swap_get_platform_parameter_value, patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
@@ -4766,7 +4767,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
-            with self.swap_get_platform_parameter_value, self.swap(
+            with self.swap_get_platform_parameter_value, patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
@@ -4891,7 +4892,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL))
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
-            with self.swap_get_platform_parameter_value, self.swap(
+            with self.swap_get_platform_parameter_value, patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0
             ):
@@ -5066,22 +5067,22 @@ class NotifyAdminsContributorDashboardReviewersNeededTests(
         self.save_new_valid_exploration(self.target_id, self.author_id)
         self.save_new_skill(self.skill_id, self.author_id)
 
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
         self.log_new_error_counter = test_utils.CallCounter(
             logging.error)
-        self.log_new_error_ctx = self.swap(
+        self.log_new_error_ctx = patch.object(
             logging, 'error', self.log_new_error_counter)
         self.logged_info: List[str] = []
-        self.log_new_info_ctx = self.swap(
+        self.log_new_info_ctx = patch.object(
             logging, 'info', self._mock_logging_info)
 
         self.suggestion_types_needing_reviewers: Dict[str, Set[str]] = {
             feconf.SUGGESTION_TYPE_ADD_QUESTION: set()
         }
 
-        self.swap_get_platform_parameter_value = self.swap(
+        self.swap_get_platform_parameter_value = patch.object(
             platform_feature_services,
             'get_platform_parameter_value',
             self._swap_get_platform_parameter_value_function
@@ -5648,7 +5649,7 @@ class QueryStatusNotificationEmailTests(test_utils.EmailTestBase):
         self.submitter_id = self.get_user_id_from_email(self.SUBMITTER_EMAIL)
         self.signup(self.SENDER_EMAIL, self.SENDER_USERNAME)
         self.sender_id = self.get_user_id_from_email(self.SENDER_EMAIL)
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
         self.signup(self.RECIPIENT_A_EMAIL, self.RECIPIENT_A_USERNAME)
         self.signup(self.RECIPIENT_B_EMAIL, self.RECIPIENT_B_USERNAME)
         self.set_curriculum_admins([self.SENDER_USERNAME, ])
@@ -5843,8 +5844,8 @@ class AccountDeletionEmailUnitTest(test_utils.EmailTestBase):
         super().setUp()
         self.signup(self.APPLICANT_EMAIL, self.APPLICANT_USERNAME)
         self.applicant_id = self.get_user_id_from_email(self.APPLICANT_EMAIL)
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_that_email_not_sent_if_can_send_emails_is_false(self) -> None:
@@ -5859,7 +5860,7 @@ class AccountDeletionEmailUnitTest(test_utils.EmailTestBase):
     def test_account_deletion_failed_email_is_sent_correctly(self) -> None:
         dummy_admin_address = 'admin@system.com'
 
-        admin_email_ctx = self.swap(
+        admin_email_ctx = patch.object(
             feconf, 'ADMIN_EMAIL_ADDRESS', dummy_admin_address)
 
         with self.can_send_emails_ctx, admin_email_ctx:
@@ -5954,7 +5955,7 @@ class BulkEmailsTests(test_utils.EmailTestBase):
         self.recipient_ids = [self.recipient_a_id, self.recipient_b_id]
 
         self.set_curriculum_admins([self.SENDER_USERNAME])
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
 
     def test_that_correct_email_is_sent(self) -> None:
         email_subject = 'Dummy subject'
@@ -6137,11 +6138,11 @@ class ModeratorActionEmailsTests(test_utils.EmailTestBase):
         self.signup(self.RECIPIENT_EMAIL, self.RECIPIENT_USERNAME)
         self.recipient_id = self.get_user_id_from_email(
             self.RECIPIENT_EMAIL)
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
-        self.can_send_email_moderator_action_ctx = self.swap(
+        self.can_send_email_moderator_action_ctx = patch.object(
             feconf, 'REQUIRE_EMAIL_ON_MODERATOR_ACTION', True)
 
     def test_exception_raised_if_email_on_moderator_action_is_false(
@@ -6219,9 +6220,9 @@ class CDUserEmailTest(test_utils.EmailTestBase):
         user_services.update_email_preferences(
             self.question_submitter_id, True, False, False, False)
 
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_assign_translation_reviewer_email_for_can_send_emails_is_false(
@@ -6616,8 +6617,8 @@ class NotMergeableChangesEmailUnitTest(test_utils.EmailTestBase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.admin_email_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.admin_email_ctx = patch.object(
             feconf, 'ADMIN_EMAIL_ADDRESS', self.dummy_admin_address)
 
     def test_not_mergeable_change_list_email_is_sent_correctly(self) -> None:
@@ -6706,8 +6707,8 @@ class CurriculumAdminsChapterNotificationsReminderMailTests(
             self.CURRICULUM_ADMIN_2_EMAIL, self.CURRICULUM_ADMIN_2_USERNAME)
         self.admin_2_id = self.get_user_id_from_email(
             self.CURRICULUM_ADMIN_2_EMAIL)
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        self.can_not_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_not_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
         self.log_new_error_counter = test_utils.CallCounter(
             logging.error)

--- a/core/domain/email_services_test.py
+++ b/core/domain/email_services_test.py
@@ -15,6 +15,7 @@
 """ Tests for services relating to emails."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.constants import constants
@@ -34,14 +35,14 @@ class EmailServicesTest(test_utils.EmailTestBase):
         send_email_exception = (
             self.assertRaisesRegex(
                 Exception, 'This app cannot send emails to users.'))
-        with send_email_exception, self.swap(constants, 'DEV_MODE', False):
+        with send_email_exception, patch.object(constants, 'DEV_MODE', False):
             email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=False)
 
     def test_send_mail_data_properly_sent(self) -> None:
         """Verifies that the data sent in send_mail is correct."""
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = patch.object(feconf, 'CAN_SEND_EMAILS', True)
 
         with allow_emailing:
             email_services.send_mail(
@@ -57,7 +58,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         """Verifies that the bcc admin flag is working properly in
         send_mail.
         """
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = patch.object(feconf, 'CAN_SEND_EMAILS', True)
 
         with allow_emailing:
             email_services.send_mail(
@@ -75,7 +76,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
             self.assertRaisesRegex(
                 Exception, 'This app cannot send emails to users.'))
         with send_email_exception, (
-            self.swap(constants, 'DEV_MODE', False)
+            patch.object(constants, 'DEV_MODE', False)
         ):
             email_services.send_bulk_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
@@ -85,7 +86,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         """Verifies that the data sent in send_bulk_mail is correct
            for each user in the recipient list.
         """
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = patch.object(feconf, 'CAN_SEND_EMAILS', True)
         recipients = [feconf.ADMIN_EMAIL_ADDRESS]
 
         with allow_emailing:
@@ -105,7 +106,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         email_exception = self.assertRaisesRegex(
             ValueError, 'Malformed recipient email address: %s'
             % malformed_recipient_email)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True), email_exception:
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True), email_exception:
             # TODO(#13528): Here we use MyPy ignore because we remove this test
             # after the backend is fully type-annotated. send_mail() method
             # doesn't expect recipient_email to be None, and the case when
@@ -121,7 +122,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         email_exception = self.assertRaisesRegex(
             ValueError, 'Malformed recipient email address: %s'
             % malformed_recipient_email)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True), email_exception:
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True), email_exception:
             email_services.send_mail(
                 'sender@example.com', malformed_recipient_email,
                 'subject', 'body', 'html')
@@ -131,7 +132,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         email_exception = self.assertRaisesRegex(
             ValueError, 'Malformed sender email address: %s'
             % malformed_sender_email)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True), email_exception:
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True), email_exception:
             email_services.send_mail(
                 malformed_sender_email, 'recipient@example.com',
                 'subject', 'body', 'html')
@@ -142,7 +143,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         email_exception = self.assertRaisesRegex(
             ValueError, 'Malformed sender email address: %s'
             % malformed_sender_email)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True), email_exception:
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True), email_exception:
             email_services.send_mail(
                 malformed_sender_email, 'recipient@example.com',
                 'subject', 'body', 'html')
@@ -152,7 +153,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         email_exception = self.assertRaisesRegex(
             ValueError, 'Malformed sender email address: %s'
             % malformed_sender_email)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True), email_exception:
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True), email_exception:
             email_services.send_bulk_mail(
                 malformed_sender_email, ['recipient@example.com'],
                 'subject', 'body', 'html')
@@ -162,7 +163,7 @@ class EmailServicesTest(test_utils.EmailTestBase):
         email_exception = self.assertRaisesRegex(
             ValueError, 'Malformed recipient email address: %s'
             % malformed_recipient_emails[1])
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True), email_exception:
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True), email_exception:
             email_services.send_bulk_mail(
                 'sender@example.com', malformed_recipient_emails,
                 'subject', 'body', 'html')
@@ -173,8 +174,8 @@ class EmailServicesTest(test_utils.EmailTestBase):
         email_exception = self.assertRaisesRegex(
             Exception, 'Bulk email failed to send. Please try again later or' +
             ' contact us to report a bug at https://www.oppia.org/contact.')
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        swap_send_email_to_recipients = self.swap(
+        allow_emailing = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        swap_send_email_to_recipients = patch.object(
             platform_email_services, 'send_email_to_recipients',
             lambda *_: False)
         recipients = [feconf.ADMIN_EMAIL_ADDRESS]
@@ -189,8 +190,8 @@ class EmailServicesTest(test_utils.EmailTestBase):
                 'Email to %s failed to send. Please try again later or ' +
                 'contact us to report a bug at ' +
                 'https://www.oppia.org/contact.') % feconf.ADMIN_EMAIL_ADDRESS)
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        swap_send_email_to_recipients = self.swap(
+        allow_emailing = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        swap_send_email_to_recipients = patch.object(
             platform_email_services, 'send_email_to_recipients',
             lambda *_: False)
 

--- a/core/domain/email_subscription_services_test.py
+++ b/core/domain/email_subscription_services_test.py
@@ -17,6 +17,7 @@
 """Tests for email_subscription_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import email_subscription_services
@@ -61,9 +62,9 @@ class InformSubscribersTest(test_utils.EmailTestBase):
         self.exploration = self.save_new_default_exploration(
             'A', self.editor_id, title='Title')
 
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_subscription_email_ctx = self.swap(
+        self.can_send_subscription_email_ctx = patch.object(
             feconf, 'CAN_SEND_SUBSCRIPTION_EMAILS', True)
 
     def test_inform_subscribers(self) -> None:

--- a/core/domain/event_services_test.py
+++ b/core/domain/event_services_test.py
@@ -17,6 +17,7 @@
 """Tests for event handling."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import importlib
 import inspect
@@ -389,7 +390,7 @@ class StatsEventsHandlerUnitTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
         with logging_swap:
             event_services.StatsEventsHandler.record(
                 'eid1', 1, {

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for exploration domain objects and methods defined on them."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import copy
 import os
@@ -17950,7 +17951,7 @@ class ExplorationChangesMergeabilityUnitTests(
         self
     ) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             messages = self._get_sent_email_messages(
                 feconf.ADMIN_EMAIL_ADDRESS)
             self.assertEqual(len(messages), 0)
@@ -18285,7 +18286,7 @@ class ExplorationChangesMergeabilityUnitTests(
         self
     ) -> None:
         self.login(self.OWNER_EMAIL)
-        with self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with patch.object(feconf, 'CAN_SEND_EMAILS', True):
             messages = self._get_sent_email_messages(
                 feconf.ADMIN_EMAIL_ADDRESS)
             self.assertEqual(len(messages), 0)
@@ -18481,7 +18482,7 @@ class ExplorationMetadataDomainUnitTests(test_utils.GenericTestBase):
     def test_metadata_properties_are_synced(self) -> None:
         self._require_metadata_properties_to_be_synced()
 
-        swapped_metadata_properties = self.swap(
+        swapped_metadata_properties = patch.object(
             constants, 'METADATA_PROPERTIES', [
                 'title', 'category', 'objective', 'language_code',
                 'blurb', 'author_notes', 'states_schema_version',
@@ -18503,7 +18504,7 @@ class ExplorationMetadataDomainUnitTests(test_utils.GenericTestBase):
         ):
             self._require_metadata_properties_to_be_synced()
 
-        swapped_metadata_properties = self.swap(
+        swapped_metadata_properties = patch.object(
             constants, 'METADATA_PROPERTIES', [
                 'title', 'category', 'objective', 'language_code', 'tags',
                 'blurb', 'author_notes', 'states_schema_version',

--- a/core/domain/exp_fetchers_test.py
+++ b/core/domain/exp_fetchers_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.exp_fetchers."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import caching_services
@@ -176,7 +177,7 @@ class ExplorationRetrievalTests(test_utils.GenericTestBase):
                     '61'
                 )
         )
-        with self.swap(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 61):
+        with patch.object(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 61):
             with self.assertRaisesRegex(Exception, error_regex):
                 (
                 exp_fetchers
@@ -717,9 +718,9 @@ title: Old Title
 
         # Create exploration that uses an old states schema version and ensure
         # it is properly converted.
-        swap_states_schema_41 = self.swap(
+        swap_states_schema_41 = patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', 41)
-        swap_exp_schema_46 = self.swap(
+        swap_exp_schema_46 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 46)
         with swap_states_schema_41, swap_exp_schema_46:
             exploration = exp_domain.Exploration.create_default_exploration(
@@ -769,9 +770,9 @@ title: Old Title
     def test_migration_with_invalid_state_schema(self) -> None:
         self.save_new_valid_exploration('fake_eid', self.albert_id)
         swap_earlier_state_to_60 = (
-            self.swap(feconf, 'EARLIEST_SUPPORTED_STATE_SCHEMA_VERSION', 60)
+            patch.object(feconf, 'EARLIEST_SUPPORTED_STATE_SCHEMA_VERSION', 60)
         )
-        swap_current_state_61 = self.swap(
+        swap_current_state_61 = patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', 61)
         with swap_earlier_state_to_60, swap_current_state_61:
             exploration_model = exp_models.ExplorationModel.get(
@@ -807,9 +808,9 @@ title: Old Title
         end_state_name: str = 'End'
 
         # Create an exploration with an old states schema version.
-        swap_states_schema_41 = self.swap(
+        swap_states_schema_41 = patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', 41)
-        swap_exp_schema_46 = self.swap(
+        swap_exp_schema_46 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 46)
         with swap_states_schema_41, swap_exp_schema_46:
             exploration = exp_domain.Exploration.create_default_exploration(

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.exp_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -205,9 +206,9 @@ class ExplorationRevertClassifierTests(ExplorationServicesUnitTests):
             Exception,
             'No classifier algorithm found for NumericInput interaction'
         ):
-            with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
-                with self.swap(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
-                    with self.swap(feconf, 'MIN_ASSIGNED_LABELS', 1):
+            with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+                with patch.object(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
+                    with patch.object(feconf, 'MIN_ASSIGNED_LABELS', 1):
                         exp_services.update_exploration(
                             self.owner_id, 'tes_exp_id', change_list, '')
 
@@ -215,7 +216,7 @@ class ExplorationRevertClassifierTests(ExplorationServicesUnitTests):
         """Test that when exploration is reverted to previous version
         it maintains appropriate classifier models mapping.
         """
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             self.save_new_valid_exploration(
                 self.EXP_0_ID, self.owner_id, title='Bridges in England',
                 category='Architecture', language_code='en')
@@ -254,9 +255,9 @@ class ExplorationRevertClassifierTests(ExplorationServicesUnitTests):
             'new_value': interaction_answer_groups
         })]
 
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
-            with self.swap(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
-                with self.swap(feconf, 'MIN_ASSIGNED_LABELS', 1):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+            with patch.object(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
+                with patch.object(feconf, 'MIN_ASSIGNED_LABELS', 1):
                     exp_services.update_exploration(
                         self.owner_id, self.EXP_0_ID, change_list, '')
 
@@ -278,9 +279,9 @@ class ExplorationRevertClassifierTests(ExplorationServicesUnitTests):
             'new_value': 'A new title'
         })]
 
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
-            with self.swap(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
-                with self.swap(feconf, 'MIN_ASSIGNED_LABELS', 1):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+            with patch.object(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
+                with patch.object(feconf, 'MIN_ASSIGNED_LABELS', 1):
                     exp_services.update_exploration(
                         self.owner_id, self.EXP_0_ID, change_list, '')
 
@@ -575,7 +576,7 @@ class ExplorationSummaryQueriesUnitTests(ExplorationServicesUnitTests):
     ) -> None:
         # Ensure the maximum number of explorations that can fit on the search
         # results page is maintained by the summaries function.
-        with self.swap(feconf, 'SEARCH_RESULTS_PAGE_SIZE', 3):
+        with patch.object(feconf, 'SEARCH_RESULTS_PAGE_SIZE', 3):
             # Need to load 3 pages to find all of the explorations. Since the
             # returned order is arbitrary, we need to concatenate the results
             # to ensure all explorations are returned. We validate the correct
@@ -620,10 +621,10 @@ class ExplorationSummaryQueriesUnitTests(ExplorationServicesUnitTests):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-        search_results_page_size_swap = self.swap(
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
+        search_results_page_size_swap = patch.object(
             feconf, 'SEARCH_RESULTS_PAGE_SIZE', 6)
-        max_iterations_swap = self.swap(exp_services, 'MAX_ITERATIONS', 1)
+        max_iterations_swap = patch.object(exp_services, 'MAX_ITERATIONS', 1)
 
         def _mock_delete_documents_from_index(
             unused_doc_ids: List[str], unused_index: str
@@ -634,7 +635,7 @@ class ExplorationSummaryQueriesUnitTests(ExplorationServicesUnitTests):
             """
             pass
 
-        with self.swap(
+        with patch.object(
             search_services, 'delete_documents_from_index',
             _mock_delete_documents_from_index):
             exp_services.delete_exploration(self.owner_id, self.EXP_ID_0)
@@ -1088,7 +1089,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
             self.assertEqual(index, exp_services.SEARCH_INDEX_EXPLORATIONS)
             self.assertEqual(doc_ids, [self.EXP_0_ID])
 
-        delete_docs_swap = self.swap(
+        delete_docs_swap = patch.object(
             search_services, 'delete_documents_from_index', mock_delete_docs)
 
         with delete_docs_swap:
@@ -1105,7 +1106,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
             self.assertEqual(index, exp_services.SEARCH_INDEX_EXPLORATIONS)
             self.assertEqual(doc_ids, [self.EXP_0_ID, self.EXP_1_ID])
 
-        delete_docs_swap = self.swap(
+        delete_docs_swap = patch.object(
             search_services, 'delete_documents_from_index', mock_delete_docs)
 
         with delete_docs_swap:
@@ -1134,7 +1135,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
             feconf.TESTS_DATA_DIR, 'string_classifier_test.yaml')
         yaml_content = utils.get_file_contents(test_exp_filepath)
         assets_list: List[Tuple[str, bytes]] = []
-        with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
+        with patch.object(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.save_new_exploration_from_yaml_and_assets(
                 feconf.SYSTEM_COMMITTER_ID, yaml_content, exploration_id,
                 assets_list)
@@ -5828,7 +5829,7 @@ class ExplorationSearchTests(ExplorationServicesUnitTests):
             return ids
 
         add_docs_counter = test_utils.CallCounter(mock_add_documents_to_index)
-        add_docs_swap = self.swap(
+        add_docs_swap = patch.object(
             search_services,
             'add_documents_to_index',
             add_docs_counter)
@@ -5881,7 +5882,7 @@ class ExplorationSearchTests(ExplorationServicesUnitTests):
             actual_docs.extend(docs)
 
         add_docs_counter = test_utils.CallCounter(mock_add_documents_to_index)
-        add_docs_swap = self.swap(
+        add_docs_swap = patch.object(
             search_services,
             'add_documents_to_index',
             add_docs_counter)
@@ -6167,7 +6168,7 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
         with logging_swap:
             exp_services.regenerate_exploration_summary_with_new_contributor(
                 'dummy_id', self.albert_id)
@@ -6701,7 +6702,7 @@ title: Old Title
             """Mocks exp_fetchers.get_exploration_by_id()."""
             return exploration
 
-        fetch_swap = self.swap(
+        fetch_swap = patch.object(
             exp_services, 'apply_change_list',
             _mock_apply_change_list)
 
@@ -7615,7 +7616,7 @@ title: Old Title
             """Mocks exploration.validate()."""
             raise utils.ValidationError('Bad')
 
-        validate_swap = self.swap(
+        validate_swap = patch.object(
             exp_domain.Exploration, 'validate',
             _mock_exploration_validate_function)
         with validate_swap:
@@ -7984,7 +7985,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
             draft_change_list_last_updated=self.DATETIME,
             draft_change_list_exp_version=1,
             draft_change_list_id=2).put()
-        with self.swap(state_domain.SubtitledHtml, 'validate', lambda x: True):
+        with patch.object(state_domain.SubtitledHtml, 'validate', lambda x: True):
             updated_exploration = exp_services.get_exp_with_draft_applied(
                 'exp_id', self.USER_ID)
         self.assertIsNone(updated_exploration)
@@ -9447,7 +9448,7 @@ class RegenerateMissingExpStatsUnitTests(test_utils.GenericTestBase):
         def _mock_logging_function(msg: str, *args: str) -> None:
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
 
         self.save_new_default_exploration('ID', 'owner_id')
         exp_snapshot_id = exp_models.ExplorationModel.get_snapshot_id('ID', 1)

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -15,6 +15,7 @@
 """Tests for feedback-related services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import event_services
@@ -684,7 +685,7 @@ class FeedbackThreadUnitTests(test_utils.GenericTestBase):
 
         event_handler_call_counter_exploration = test_utils.CallCounter(
             event_services.FeedbackThreadCreatedEventHandler.record)
-        with self.swap(
+        with patch.object(
             event_services.FeedbackThreadCreatedEventHandler, 'record',
             event_handler_call_counter_exploration):
             feedback_services.create_thread(
@@ -697,7 +698,7 @@ class FeedbackThreadUnitTests(test_utils.GenericTestBase):
         event_handler_call_counter_non_exploration = (
             test_utils.CallCounter(
                 event_services.FeedbackThreadCreatedEventHandler.record))
-        with self.swap(
+        with patch.object(
             event_services.FeedbackThreadCreatedEventHandler, 'record',
             event_handler_call_counter_non_exploration):
             feedback_services.create_thread(
@@ -887,9 +888,9 @@ class FeedbackMessageEmailTests(test_utils.EmailTestBase):
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         self.exploration = self.save_new_default_exploration(
             'A', self.editor_id, title='Title')
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
 
     def test_pop_feedback_message_references(self) -> None:
@@ -967,7 +968,7 @@ class FeedbackMessageEmailTests(test_utils.EmailTestBase):
                 self.editor_id)
             self.assertEqual(model.retries, 0)
 
-            with self.swap(
+            with patch.object(
                 feconf, 'DEFAULT_FEEDBACK_MESSAGE_EMAIL_COUNTDOWN_SECS', -1
             ):
                 feedback_services.update_feedback_email_retries_transactional(
@@ -1119,9 +1120,9 @@ class FeedbackMessageEmailTests(test_utils.EmailTestBase):
             self.assertEqual(len(messages), 1)
 
     def test_that_emails_are_not_sent_if_service_is_disabled(self) -> None:
-        cannot_send_emails_ctx = self.swap(
+        cannot_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
-        cannot_send_feedback_message_email_ctx = self.swap(
+        cannot_send_feedback_message_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', False)
         with cannot_send_emails_ctx, cannot_send_feedback_message_email_ctx:
             feedback_services.create_thread(
@@ -1247,9 +1248,9 @@ class FeedbackMessageBatchEmailHandlerTests(test_utils.EmailTestBase):
 
         self.exploration = self.save_new_default_exploration(
             'A', self.editor_id, title='Title')
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
 
     def test_that_emails_are_sent(self) -> None:
@@ -1403,9 +1404,9 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.EmailTestBase):
 
         self.exploration = self.save_new_default_exploration(
             'A', self.editor_id, title='Title')
-        self.can_send_emails_ctx = self.swap(
+        self.can_send_emails_ctx = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_feedback_email_ctx = self.swap(
+        self.can_send_feedback_email_ctx = patch.object(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
 
     def test_that_emails_are_sent_for_feedback_message(self) -> None:

--- a/core/domain/fs_services_test.py
+++ b/core/domain/fs_services_test.py
@@ -15,6 +15,7 @@
 """Tests for File System services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import json
 import os
@@ -234,7 +235,7 @@ class SaveOriginalAndCompressedVersionsOfImageTests(test_utils.GenericTestBase):
             encoding=None) as f:
             original_image_content = f.read()
 
-        with self.swap(constants, 'DEV_MODE', False):
+        with patch.object(constants, 'DEV_MODE', False):
             fs = fs_services.GcsFileSystem(
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXPLORATION_ID)
 
@@ -278,7 +279,7 @@ class SaveOriginalAndCompressedVersionsOfImageTests(test_utils.GenericTestBase):
             encoding=None) as f:
             image_content = f.read()
 
-        with self.swap(constants, 'DEV_MODE', False):
+        with patch.object(constants, 'DEV_MODE', False):
             fs = fs_services.GcsFileSystem(
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXPLORATION_ID)
 

--- a/core/domain/interaction_registry_test.py
+++ b/core/domain/interaction_registry_test.py
@@ -17,6 +17,7 @@
 """Tests for methods in the interaction registry."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import json
 import os
@@ -87,7 +88,7 @@ class InteractionRegistryUnitTests(test_utils.GenericTestBase):
             },
             set(interaction_registry.Registry.get_all_interaction_ids()))
 
-        with self.swap(interaction_registry.Registry, '_interactions', {}):
+        with patch.object(interaction_registry.Registry, '_interactions', {}):
             self.assertEqual(
                 {
                     type(i).__name__

--- a/core/domain/moderator_services_test.py
+++ b/core/domain/moderator_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.moderator services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import moderator_services
@@ -47,7 +48,7 @@ class FlagExplorationEmailEnqueueTaskTests(test_utils.EmailTestBase):
 
         self.report_text = 'AD'
 
-        self.can_send_emails_ctx = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        self.can_send_emails_ctx = patch.object(feconf, 'CAN_SEND_EMAILS', True)
 
     def test_that_flag_exploration_emails_are_correct(self) -> None:
 

--- a/core/domain/opportunity_domain_test.py
+++ b/core/domain/opportunity_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for opportunity domain objects."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import re
 
@@ -37,7 +38,7 @@ class ExplorationOpportunitySummaryDomainTests(test_utils.GenericTestBase):
         }, {
             'id': 'hi-en'
         }]
-        self.mock_supported_audio_languages_context = self.swap(
+        self.mock_supported_audio_languages_context = patch.object(
             constants, 'SUPPORTED_AUDIO_LANGUAGES',
             self.mock_supported_audio_languages)
 
@@ -59,7 +60,7 @@ class ExplorationOpportunitySummaryDomainTests(test_utils.GenericTestBase):
                     'is_pinned': False
                 }))
         # Re-initializing this swap, so that we can use this in test method.
-        self.mock_supported_audio_languages_context = self.swap(
+        self.mock_supported_audio_languages_context = patch.object(
             constants, 'SUPPORTED_AUDIO_LANGUAGES',
             self.mock_supported_audio_languages)
 

--- a/core/domain/opportunity_services_test.py
+++ b/core/domain/opportunity_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.opportunity_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 import unittest.mock
@@ -163,7 +164,7 @@ class OpportunityServicesIntegrationTest(test_utils.GenericTestBase):
         """Creates a translation suggestion for exploration 0 and performs basic
         assertions.
         """
-        with self.swap(
+        with patch.object(
             feedback_models.GeneralFeedbackThreadModel,
             'generate_new_thread_id',
             self.mock_generate_new_thread_id_for_suggestion):
@@ -972,7 +973,7 @@ class OpportunityServicesUnitTest(test_utils.GenericTestBase):
 
         self.assertEqual(len(observed_log_messages), 0)
 
-        with self.swap(logging, 'info', _mock_logging_function), self.swap(
+        with patch.object(logging, 'info', _mock_logging_function), patch.object(
             constants, 'SUPPORTED_AUDIO_LANGUAGES', mock_supported_languages):
             opportunities = (
                 opportunity_services
@@ -1069,7 +1070,7 @@ class OpportunityServicesUnitTest(test_utils.GenericTestBase):
             language_codes_with_assigned_voice_artists=[]
         )
         # Mock the get method of ExplorationOpportunitySummaryModel.
-        with self.swap(
+        with patch.object(
             opportunity_models.ExplorationOpportunitySummaryModel, 'get',
             lambda _id: mock_opportunity_summary if _id == lesson_id else None
         ):

--- a/core/domain/platform_feature_services_test.py
+++ b/core/domain/platform_feature_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for platform_feature_services.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import enum
 
@@ -128,19 +129,19 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
             False
         )
 
-        self.swap_all_platform_params_except_feature_flags = self.swap(
+        self.swap_all_platform_params_except_feature_flags = patch.object(
             platform_feature_list,
             'ALL_PLATFORM_PARAMS_EXCEPT_FEATURE_FLAGS',
             self.param_name_enums
         )
 
-        self.swap_all_feature_flags = self.swap(
+        self.swap_all_feature_flags = patch.object(
             feature_services,
             'ALL_FEATURE_FLAGS',
             self.param_name_enums_features
         )
 
-        self.swap_all_feature_names_set = self.swap(
+        self.swap_all_feature_names_set = patch.object(
             feature_services,
             'ALL_FEATURES_NAMES_SET',
             set(self.param_names_features)
@@ -181,7 +182,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
     def test_create_evaluation_context_for_client_returns_correct_context(
         self
     ) -> None:
-        with self.swap(constants, 'DEV_MODE', True):
+        with patch.object(constants, 'DEV_MODE', True):
             context = feature_services.create_evaluation_context_for_client(
                 {
                     'platform_type': 'Android',
@@ -209,7 +210,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
         self
     ) -> None:
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
-            with self.swap(constants, 'DEV_MODE', True):
+            with patch.object(constants, 'DEV_MODE', True):
                 context = (
                     feature_services.create_evaluation_context_for_client({
                         'platform_type': 'Android',
@@ -228,8 +229,8 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
     def test_get_all_feature_flag_values_in_test_returns_correct_values(
         self
     ) -> None:
-        constants_swap = self.swap(constants, 'DEV_MODE', False)
-        env_swap = self.swap(
+        constants_swap = patch.object(constants, 'DEV_MODE', False)
+        env_swap = patch.object(
             feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False)
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
             with constants_swap, env_swap:
@@ -251,8 +252,8 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
     def test_get_all_feature_flag_values_in_prod_returns_correct_values(
         self
     ) -> None:
-        constants_swap = self.swap(constants, 'DEV_MODE', False)
-        env_swap = self.swap(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True)
+        constants_swap = patch.object(constants, 'DEV_MODE', False)
+        env_swap = patch.object(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True)
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
             with constants_swap, env_swap:
                 context = (
@@ -272,26 +273,26 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
 
     def test_evaluate_dev_feature_for_dev_server_returns_true(self) -> None:
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
-            with self.swap(constants, 'DEV_MODE', True):
+            with patch.object(constants, 'DEV_MODE', True):
                 self.assertTrue(
                     feature_services.is_feature_enabled(self.dev_feature.name))
 
     def test_evaluate_test_feature_for_dev_server_returns_true(self) -> None:
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
-            with self.swap(constants, 'DEV_MODE', True):
+            with patch.object(constants, 'DEV_MODE', True):
                 self.assertTrue(
                     feature_services.is_feature_enabled(self.test_feature.name))
 
     def test_evaluate_prod_feature_for_dev_server_returns_true(self) -> None:
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
-            with self.swap(constants, 'DEV_MODE', True):
+            with patch.object(constants, 'DEV_MODE', True):
                 self.assertTrue(
                     feature_services.is_feature_enabled(self.prod_feature.name))
 
     def test_evaluate_dev_feature_for_test_server_returns_false(self) -> None:
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
-            with self.swap(constants, 'DEV_MODE', False):
-                with self.swap(
+            with patch.object(constants, 'DEV_MODE', False):
+                with patch.object(
                     feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False
                 ):
                     self.assertFalse(
@@ -300,8 +301,8 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
 
     def test_evaluate_test_feature_for_test_server_returns_true(self) -> None:
         with self.swap_all_feature_flags, self.swap_all_feature_names_set:
-            with self.swap(constants, 'DEV_MODE', False):
-                with self.swap(
+            with patch.object(constants, 'DEV_MODE', False):
+                with patch.object(
                     feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False
                 ):
                     self.assertTrue(
@@ -309,40 +310,40 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                             self.test_feature.name))
 
     def test_evaluate_prod_feature_for_test_server_returns_true(self) -> None:
-        with self.swap_all_feature_flags, self.swap(
+        with self.swap_all_feature_flags, patch.object(
             constants, 'DEV_MODE', False
         ):
-            with self.swap_all_feature_names_set, self.swap(
+            with self.swap_all_feature_names_set, patch.object(
                 feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False
             ):
                 self.assertTrue(
                     feature_services.is_feature_enabled(self.prod_feature.name))
 
     def test_evaluate_dev_feature_for_prod_server_returns_false(self) -> None:
-        with self.swap_all_feature_flags, self.swap(
+        with self.swap_all_feature_flags, patch.object(
             constants, 'DEV_MODE', False
         ):
-            with self.swap_all_feature_names_set, self.swap(
+            with self.swap_all_feature_names_set, patch.object(
                 feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True
             ):
                 self.assertFalse(
                     feature_services.is_feature_enabled(self.dev_feature.name))
 
     def test_evaluate_test_feature_for_prod_server_returns_false(self) -> None:
-        with self.swap_all_feature_flags, self.swap(
+        with self.swap_all_feature_flags, patch.object(
             constants, 'DEV_MODE', False
         ):
-            with self.swap_all_feature_names_set, self.swap(
+            with self.swap_all_feature_names_set, patch.object(
                 feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True
             ):
                 self.assertFalse(
                     feature_services.is_feature_enabled(self.test_feature.name))
 
     def test_evaluate_prod_feature_for_prod_server_returns_true(self) -> None:
-        with self.swap_all_feature_flags, self.swap(
+        with self.swap_all_feature_flags, patch.object(
             constants, 'DEV_MODE', False
         ):
-            with self.swap_all_feature_names_set, self.swap(
+            with self.swap_all_feature_names_set, patch.object(
                 feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True
             ):
                 self.assertTrue(
@@ -371,15 +372,15 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                 False
             )
 
-            with self.swap(constants, 'BRANCH_NAME', ''):
+            with patch.object(constants, 'BRANCH_NAME', ''):
                 self.assertTrue(feature_services.get_platform_parameter_value(
                     self.param_c.name))
 
-            with self.swap(constants, 'BRANCH_NAME', 'release-3-3-1-hotfix-5'):
+            with patch.object(constants, 'BRANCH_NAME', 'release-3-3-1-hotfix-5'):
                 self.assertTrue(feature_services.get_platform_parameter_value(
                     self.param_c.name))
 
-            with self.swap(constants, 'BRANCH_NAME', 'release-3-3-1'):
+            with patch.object(constants, 'BRANCH_NAME', 'release-3-3-1'):
                 self.assertTrue(feature_services.get_platform_parameter_value(
                     self.param_c.name))
 
@@ -404,8 +405,8 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                 ],
                 False
             )
-            with self.swap(constants, 'DEV_MODE', False):
-                with self.swap(
+            with patch.object(constants, 'DEV_MODE', False):
+                with patch.object(
                     feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True
                 ):
                     self.assertTrue(
@@ -431,7 +432,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                 ]
             )
 
-            with self.swap(constants, 'DEV_MODE', True):
+            with patch.object(constants, 'DEV_MODE', True):
                 self.assertFalse(
                     feature_services.is_feature_enabled(self.dev_feature.name))
 

--- a/core/domain/platform_parameter_domain_test.py
+++ b/core/domain/platform_parameter_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for the domain objects relating to platform parameters."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import collections
 import enum
@@ -1667,7 +1668,7 @@ class PlatformParameterTests(test_utils.GenericTestBase):
             param.validate()
 
     def test_create_with_old_rule_schema_version_failure(self) -> None:
-        with self.swap(
+        with patch.object(
             feconf, 'CURRENT_PLATFORM_PARAMETER_RULE_SCHEMA_VERSION', 2):
             with self.assertRaisesRegex(
                 Exception,
@@ -2008,8 +2009,8 @@ class PlatformParameterTests(test_utils.GenericTestBase):
             'is_feature': True,
             'feature_stage': 'dev',
         })
-        with self.swap(constants, 'DEV_MODE', False):
-            with self.swap(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False):
+        with patch.object(constants, 'DEV_MODE', False):
+            with patch.object(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False):
                 with self.assertRaisesRegex(
                     utils.ValidationError,
                     'Feature in dev stage cannot be updated in test '
@@ -2034,8 +2035,8 @@ class PlatformParameterTests(test_utils.GenericTestBase):
             'is_feature': True,
             'feature_stage': 'dev',
         })
-        with self.swap(constants, 'DEV_MODE', False):
-            with self.swap(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
+        with patch.object(constants, 'DEV_MODE', False):
+            with patch.object(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
                 with self.assertRaisesRegex(
                     utils.ValidationError,
                     'Feature in dev stage cannot be updated in prod '
@@ -2062,8 +2063,8 @@ class PlatformParameterTests(test_utils.GenericTestBase):
             'is_feature': True,
             'feature_stage': 'test',
         })
-        with self.swap(constants, 'DEV_MODE', False):
-            with self.swap(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
+        with patch.object(constants, 'DEV_MODE', False):
+            with patch.object(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
                 with self.assertRaisesRegex(
                     utils.ValidationError,
                     'Feature in test stage cannot be updated in prod '
@@ -2126,7 +2127,7 @@ class PlatformParameterTests(test_utils.GenericTestBase):
             'is_feature': False,
             'feature_stage': 'dev',
         })
-        swap_platform_params_list = self.swap(
+        swap_platform_params_list = patch.object(
             platform_feature_list,
             'ALL_PLATFORM_PARAMS_EXCEPT_FEATURE_FLAGS',
             [DummyParamNames.PARAMETER_A]

--- a/core/domain/platform_parameter_registry_test.py
+++ b/core/domain/platform_parameter_registry_test.py
@@ -17,6 +17,7 @@
 """Tests for the platform parameter registry."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import enum
 
@@ -255,8 +256,8 @@ class PlatformParameterRegistryTests(test_utils.GenericTestBase):
         registry.Registry.create_feature_flag(
             ParamNames.PARAMETER_A, 'dev feature', FeatureStages.DEV)
 
-        with self.swap(constants, 'DEV_MODE', False):
-            with self.swap(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
+        with patch.object(constants, 'DEV_MODE', False):
+            with patch.object(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
                 with self.assertRaisesRegex(
                     utils.ValidationError,
                     'Feature in dev stage cannot be updated in prod '
@@ -282,8 +283,8 @@ class PlatformParameterRegistryTests(test_utils.GenericTestBase):
         registry.Registry.create_feature_flag(
             ParamNames.PARAMETER_A, 'dev feature', FeatureStages.DEV)
 
-        with self.swap(constants, 'DEV_MODE', False):
-            with self.swap(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False):
+        with patch.object(constants, 'DEV_MODE', False):
+            with patch.object(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', False):
                 with self.assertRaisesRegex(
                     utils.ValidationError,
                     'Feature in dev stage cannot be updated in test '
@@ -309,8 +310,8 @@ class PlatformParameterRegistryTests(test_utils.GenericTestBase):
         registry.Registry.create_feature_flag(
             ParamNames.PARAMETER_A, 'dev feature', FeatureStages.TEST)
 
-        with self.swap(constants, 'DEV_MODE', False):
-            with self.swap(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
+        with patch.object(constants, 'DEV_MODE', False):
+            with patch.object(feconf, 'ENV_IS_OPPIA_ORG_PRODUCTION_SERVER', True):
                 with self.assertRaisesRegex(
                     utils.ValidationError,
                     'Feature in test stage cannot be updated in prod '
@@ -405,7 +406,7 @@ class PlatformParameterRegistryTests(test_utils.GenericTestBase):
                 [name]
             )
 
-        with self.swap(
+        with patch.object(
             registry.Registry,
             'update_platform_parameter',
             _mock_update_platform_parameter

--- a/core/domain/question_services_test.py
+++ b/core/domain/question_services_test.py
@@ -17,6 +17,7 @@
 """Tests for core.domain.question_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 import re
@@ -649,7 +650,7 @@ class QuestionServicesUnitTest(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
         assert_raises_context_manager = self.assertRaisesRegex(
             Exception, '\'str\' object has no attribute \'cmd\'')
 

--- a/core/domain/rating_services_test.py
+++ b/core/domain/rating_services_test.py
@@ -17,6 +17,7 @@
 """Tests for the ratings system."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 
@@ -229,7 +230,7 @@ class RatingServicesTests(test_utils.GenericTestBase):
             exp_summary.ratings = {}
             return exp_summary
 
-        with self.swap(
+        with patch.object(
             exp_fetchers,
             'get_exploration_summary_by_id',
             _mock_get_exploration_summary_by_id

--- a/core/domain/rights_domain_test.py
+++ b/core/domain/rights_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for rights domain objects."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 
@@ -169,7 +170,7 @@ class ActivityRightsTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
 
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception, 'The ownership of this exploration cannot be released.')

--- a/core/domain/search_services_test.py
+++ b/core/domain/search_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.search_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.domain import blog_services
 from core.domain import collection_services
@@ -144,7 +145,7 @@ class SearchServicesUnitTests(test_utils.GenericTestBase):
 
             return doc_ids, expected_result_offset
 
-        with self.swap(gae_search_services, 'search', mock_search):
+        with patch.object(gae_search_services, 'search', mock_search):
             result, result_offset = search_services.search_explorations(
                 expected_query_string, [], [], expected_size,
                 offset=expected_offset,
@@ -180,7 +181,7 @@ class SearchServicesUnitTests(test_utils.GenericTestBase):
 
             return doc_ids, expected_result_offset
 
-        with self.swap(gae_search_services, 'search', mock_search):
+        with patch.object(gae_search_services, 'search', mock_search):
             result, result_offset = search_services.search_collections(
                 expected_query_string, [], [], expected_size,
                 offset=expected_offset,
@@ -230,7 +231,7 @@ class SearchServicesUnitTests(test_utils.GenericTestBase):
 
         delete_docs_counter = test_utils.CallCounter(_mock_delete_docs)
 
-        delete_docs_swap = self.swap(
+        delete_docs_swap = patch.object(
             gae_search_services, 'delete_documents_from_index',
             delete_docs_counter)
 
@@ -248,7 +249,7 @@ class SearchServicesUnitTests(test_utils.GenericTestBase):
 
         delete_docs_counter = test_utils.CallCounter(_mock_delete_docs)
 
-        delete_docs_swap = self.swap(
+        delete_docs_swap = patch.object(
             gae_search_services, 'delete_documents_from_index',
             delete_docs_counter)
 
@@ -317,7 +318,7 @@ class BlogPostSearchServicesUnitTests(test_utils.GenericTestBase):
 
             return doc_ids, expected_result_offset
 
-        with self.swap(
+        with patch.object(
             gae_search_services, 'blog_post_summaries_search', mock_search
         ):
             result, result_offset = (
@@ -349,7 +350,7 @@ class BlogPostSearchServicesUnitTests(test_utils.GenericTestBase):
 
         delete_docs_counter = test_utils.CallCounter(_mock_delete_docs)
 
-        delete_docs_swap = self.swap(
+        delete_docs_swap = patch.object(
             gae_search_services, 'delete_documents_from_index',
             delete_docs_counter)
 

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -15,6 +15,7 @@
 """Tests the methods defined in skill services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 
@@ -1272,7 +1273,7 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
         assert_raises_context_manager = self.assertRaisesRegex(
             Exception, '\'str\' object has no attribute \'cmd\'')
 
@@ -1548,14 +1549,14 @@ class SkillMasteryServicesUnitTests(test_utils.GenericTestBase):
     def test_get_sorted_skill_ids(self) -> None:
         degrees_of_masteries = skill_services.get_multi_user_skill_mastery(
             self.USER_ID, self.SKILL_IDS)
-        with self.swap(feconf, 'MAX_NUMBER_OF_SKILL_IDS', 2):
+        with patch.object(feconf, 'MAX_NUMBER_OF_SKILL_IDS', 2):
             sorted_skill_ids = skill_services.get_sorted_skill_ids(
                 degrees_of_masteries)
         expected_sorted_skill_ids = [self.SKILL_ID_3, self.SKILL_ID_1]
         self.assertEqual(len(sorted_skill_ids), 2)
         self.assertEqual(sorted_skill_ids, expected_sorted_skill_ids)
 
-        with self.swap(feconf, 'MAX_NUMBER_OF_SKILL_IDS', 3):
+        with patch.object(feconf, 'MAX_NUMBER_OF_SKILL_IDS', 3):
             sorted_skill_ids = skill_services.get_sorted_skill_ids(
                 degrees_of_masteries)
         expected_sorted_skill_ids = [
@@ -1563,7 +1564,7 @@ class SkillMasteryServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(sorted_skill_ids, expected_sorted_skill_ids)
 
     def test_filter_skills_by_mastery(self) -> None:
-        with self.swap(feconf, 'MAX_NUMBER_OF_SKILL_IDS', 2):
+        with patch.object(feconf, 'MAX_NUMBER_OF_SKILL_IDS', 2):
             arranged_filtered_skill_ids = (
                 skill_services.filter_skills_by_mastery(
                     self.USER_ID, self.SKILL_IDS))
@@ -1571,7 +1572,7 @@ class SkillMasteryServicesUnitTests(test_utils.GenericTestBase):
         expected_skill_ids = [self.SKILL_ID_1, self.SKILL_ID_3]
         self.assertEqual(arranged_filtered_skill_ids, expected_skill_ids)
 
-        with self.swap(feconf, 'MAX_NUMBER_OF_SKILL_IDS', len(self.SKILL_IDS)):
+        with patch.object(feconf, 'MAX_NUMBER_OF_SKILL_IDS', len(self.SKILL_IDS)):
             arranged_filtered_skill_ids = (
                 skill_services.filter_skills_by_mastery(
                     self.USER_ID, self.SKILL_IDS))
@@ -1675,7 +1676,7 @@ class SkillMigrationTests(test_utils.GenericTestBase):
         model.commit(
             'user_id_admin', 'skill model created', commit_cmd_dicts)
 
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_SKILL_CONTENTS_SCHEMA_VERSION', 4)
 
         with current_schema_version_swap:
@@ -1739,7 +1740,7 @@ class SkillMigrationTests(test_utils.GenericTestBase):
         model.commit(
             'user_id_admin', 'skill model created', commit_cmd_dicts)
 
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_MISCONCEPTIONS_SCHEMA_VERSION', 5)
 
         with current_schema_version_swap:
@@ -1801,7 +1802,7 @@ class SkillMigrationTests(test_utils.GenericTestBase):
         model.commit(
             'user_id_admin', 'skill model created', commit_cmd_dicts)
 
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_RUBRIC_SCHEMA_VERSION', 5)
 
         with current_schema_version_swap:

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for state domain objects and methods defined on them."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import contextlib
 import copy
@@ -203,11 +204,11 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             interaction.answer_type = 'ListOfSetsOfHtmlStrings'
             return interaction
 
-        rules_registry_swap = self.swap(
+        rules_registry_swap = patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs))
 
-        interaction_registry_swap = self.swap(
+        interaction_registry_swap = patch.object(
             interaction_registry.Registry, 'get_interaction_by_id',
             classmethod(mock_get_interaction_by_id))
 
@@ -471,11 +472,11 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             interaction.can_have_solution = True
             return interaction
 
-        rules_registry_swap = self.swap(
+        rules_registry_swap = patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs))
 
-        interaction_registry_swap = self.swap(
+        interaction_registry_swap = patch.object(
             interaction_registry.Registry, 'get_interaction_by_id',
             classmethod(mock_get_interaction_by_id))
 
@@ -561,7 +562,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ) -> Dict[str, rules_registry.RuleSpecsExtensionDict]:
             return mock_html_field_types_to_rule_specs_dict
 
-        with self.swap(
+        with patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs)
         ):
@@ -687,7 +688,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ) -> Dict[str, rules_registry.RuleSpecsExtensionDict]:
             return mock_html_field_types_to_rule_specs_dict
 
-        with self.swap(
+        with patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs)
         ):
@@ -786,7 +787,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ) -> Dict[str, rules_registry.RuleSpecsExtensionDict]:
             return mock_html_field_types_to_rule_specs_dict
 
-        with self.swap(
+        with patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs)):
             with self.assertRaisesRegex(
@@ -2137,7 +2138,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ) -> Dict[str, rules_registry.RuleSpecsExtensionDict]:
             return mock_html_field_types_to_rule_specs_dict
 
-        with self.swap(
+        with patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs)):
             with self.assertRaisesRegex(
@@ -2257,7 +2258,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ) -> Dict[str, rules_registry.RuleSpecsExtensionDict]:
             return mock_html_field_types_to_rule_specs_dict
 
-        with self.swap(
+        with patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs)
         ):
@@ -2354,7 +2355,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ) -> Dict[str, rules_registry.RuleSpecsExtensionDict]:
             return mock_html_field_types_to_rule_specs_dict
 
-        with self.swap(
+        with patch.object(
             rules_registry.Registry, 'get_html_field_types_to_rule_specs',
             classmethod(mock_get_html_field_types_to_rule_specs)
         ):
@@ -2509,7 +2510,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid content HTML'
             ):
-            with self.swap(subtitled_html, 'html', 20):
+            with patch.object(subtitled_html, 'html', 20):
                 subtitled_html.validate()
 
     def test_subtitled_html_validation_with_invalid_content(self) -> None:
@@ -2520,7 +2521,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected content id to be a string, ' +
             'received 20'):
-            with self.swap(subtitled_html, 'content_id', 20):
+            with patch.object(subtitled_html, 'content_id', 20):
                 subtitled_html.validate()
 
     def test_subtitled_unicode_validation_with_invalid_html_type(self) -> None:
@@ -2532,7 +2533,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid content unicode'
             ):
-            with self.swap(subtitled_unicode, 'unicode_str', 20):
+            with patch.object(subtitled_unicode, 'unicode_str', 20):
                 subtitled_unicode.validate()
 
     def test_subtitled_unicode_validation_with_invalid_content(self) -> None:
@@ -2543,7 +2544,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected content id to be a string, ' +
             'received 20'):
-            with self.swap(subtitled_unicode, 'content_id', 20):
+            with patch.object(subtitled_unicode, 'content_id', 20):
                 subtitled_unicode.validate()
 
     def test_voiceover_validation(self) -> None:
@@ -2554,56 +2555,56 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected audio filename to be a string'
         ):
-            with self.swap(audio_voiceover, 'filename', 20):
+            with patch.object(audio_voiceover, 'filename', 20):
                 audio_voiceover.validate()
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid audio filename'
         ):
-            with self.swap(audio_voiceover, 'filename', '.invalidext'):
+            with patch.object(audio_voiceover, 'filename', '.invalidext'):
                 audio_voiceover.validate()
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid audio filename'
         ):
-            with self.swap(audio_voiceover, 'filename', 'justanextension'):
+            with patch.object(audio_voiceover, 'filename', 'justanextension'):
                 audio_voiceover.validate()
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid audio filename'
         ):
-            with self.swap(audio_voiceover, 'filename', 'a.invalidext'):
+            with patch.object(audio_voiceover, 'filename', 'a.invalidext'):
                 audio_voiceover.validate()
 
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected file size to be an int'
         ):
-            with self.swap(audio_voiceover, 'file_size_bytes', 'abc'):
+            with patch.object(audio_voiceover, 'file_size_bytes', 'abc'):
                 audio_voiceover.validate()
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid file size'
         ):
-            with self.swap(audio_voiceover, 'file_size_bytes', -3):
+            with patch.object(audio_voiceover, 'file_size_bytes', -3):
                 audio_voiceover.validate()
 
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected needs_update to be a bool'
         ):
-            with self.swap(audio_voiceover, 'needs_update', 'hello'):
+            with patch.object(audio_voiceover, 'needs_update', 'hello'):
                 audio_voiceover.validate()
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected duration_secs to be a float'
         ):
-            with self.swap(audio_voiceover, 'duration_secs', 'test'):
+            with patch.object(audio_voiceover, 'duration_secs', 'test'):
                 audio_voiceover.validate()
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected duration_secs to be a float'
         ):
-            with self.swap(audio_voiceover, 'duration_secs', '10'):
+            with patch.object(audio_voiceover, 'duration_secs', '10'):
                 audio_voiceover.validate()
         with self.assertRaisesRegex(
             utils.ValidationError,
             'Expected duration_secs to be positive number, '
             'or zero if not yet specified'
         ):
-            with self.swap(audio_voiceover, 'duration_secs', -3.45):
+            with patch.object(audio_voiceover, 'duration_secs', -3.45):
                 audio_voiceover.validate()
 
     def test_hints_validation(self) -> None:
@@ -2770,7 +2771,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected solicit_answer_details to be ' +
             'a boolean, received'):
-            with self.swap(init_state, 'solicit_answer_details', 'abc'):
+            with patch.object(init_state, 'solicit_answer_details', 'abc'):
                 exploration.validate()
         self.assertEqual(init_state.solicit_answer_details, False)
         self.set_interaction_for_state(
@@ -2780,7 +2781,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'The Continue interaction does not ' +
             'support soliciting answer details from learners.'):
-            with self.swap(init_state, 'solicit_answer_details', True):
+            with patch.object(init_state, 'solicit_answer_details', True):
                 exploration.validate()
         self.set_interaction_for_state(
             init_state, 'TextInput', content_id_generator)
@@ -2804,7 +2805,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected linked_skill_id to be ' +
             'a str, received 12.'):
-            with self.swap(init_state, 'linked_skill_id', 12):
+            with patch.object(init_state, 'linked_skill_id', 12):
                 exploration.validate()
         self.assertEqual(init_state.linked_skill_id, None)
 
@@ -2816,7 +2817,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected card_is_checkpoint to be ' +
             'a boolean, received'):
-            with self.swap(init_state, 'card_is_checkpoint', 'abc'):
+            with patch.object(init_state, 'card_is_checkpoint', 'abc'):
                 exploration.validate()
         self.assertEqual(init_state.card_is_checkpoint, True)
 
@@ -3205,7 +3206,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'warning', _mock_logging_function)
+        logging_swap = patch.object(logging, 'warning', _mock_logging_function)
 
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
         state_answer_group = state_domain.AnswerGroup(

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for core.domain.stats_domain."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import re
@@ -1210,9 +1211,9 @@ class ExplorationIssueTests(test_utils.GenericTestBase):
         # Ruling out the possibility of None for mypy type checking.
         assert exp_issues_model is not None
 
-        current_issue_schema_version_swap = self.swap(
+        current_issue_schema_version_swap = patch.object(
             stats_models, 'CURRENT_ISSUE_SCHEMA_VERSION', 2)
-        convert_issue_dict_swap = self.swap(
+        convert_issue_dict_swap = patch.object(
             stats_domain.ExplorationIssue,
             '_convert_issue_v1_dict_to_v2_dict',
             self._dummy_convert_issue_v1_dict_to_v2_dict)
@@ -1244,9 +1245,9 @@ class ExplorationIssueTests(test_utils.GenericTestBase):
         # Ruling out the possibility of None for mypy type checking.
         assert exp_issues_model1 is not None
 
-        current_issue_schema_version_swap = self.swap(
+        current_issue_schema_version_swap = patch.object(
             stats_models, 'CURRENT_ISSUE_SCHEMA_VERSION', 2)
-        convert_issue_dict_swap = self.swap(
+        convert_issue_dict_swap = patch.object(
             stats_domain.ExplorationIssue,
             '_convert_issue_v1_dict_to_v2_dict',
             self._dummy_convert_issue_v1_dict_to_v2_dict)
@@ -1463,9 +1464,9 @@ class LearnerActionTests(test_utils.GenericTestBase):
 
         playthrough_model = stats_models.PlaythroughModel.get(playthrough_id)
 
-        current_action_schema_version_swap = self.swap(
+        current_action_schema_version_swap = patch.object(
             stats_models, 'CURRENT_ACTION_SCHEMA_VERSION', 2)
-        convert_action_dict_swap = self.swap(
+        convert_action_dict_swap = patch.object(
             stats_domain.LearnerAction,
             '_convert_action_v1_dict_to_v2_dict',
             self._dummy_convert_action_v1_dict_to_v2_dict)
@@ -1497,9 +1498,9 @@ class LearnerActionTests(test_utils.GenericTestBase):
         playthrough_model_1 = stats_models.PlaythroughModel.get(
             playthrough_id_1)
 
-        current_action_schema_version_swap = self.swap(
+        current_action_schema_version_swap = patch.object(
             stats_models, 'CURRENT_ACTION_SCHEMA_VERSION', 2)
-        convert_action_dict_swap = self.swap(
+        convert_action_dict_swap = patch.object(
             stats_domain.LearnerAction,
             '_convert_action_v1_dict_to_v2_dict',
             self._dummy_convert_action_v1_dict_to_v2_dict)

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.stats_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 
@@ -406,7 +407,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             feconf.TESTS_DATA_DIR, 'string_classifier_test.yaml')
         yaml_content = utils.get_file_contents(test_exp_filepath)
         assets_list: List[Tuple[str, bytes]] = []
-        with self.swap(
+        with patch.object(
             stats_services, 'get_stats_for_new_exploration',
             stats_for_new_exploration_log):
             exp_services.save_new_exploration_from_yaml_and_assets(
@@ -439,7 +440,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             'property_name': 'next_content_id_index',
             'new_value': content_id_generator.next_content_id_index
         })]
-        with self.swap(
+        with patch.object(
             stats_services, 'get_stats_for_new_exp_version',
             stats_for_new_exp_version_log):
             exp_services.update_exploration(
@@ -2265,7 +2266,7 @@ class RecordAnswerTests(test_utils.GenericTestBase):
     def test_record_answers_exceeding_one_shard(self) -> None:
         # Use a smaller max answer list size so less answers are needed to
         # exceed a shard.
-        with self.swap(
+        with patch.object(
             stats_models.StateAnswersModel, '_MAX_ANSWER_LIST_BYTE_SIZE',
             100000):
             state_answers = stats_services.get_state_answers(
@@ -2494,7 +2495,7 @@ class SampleAnswerTests(test_utils.GenericTestBase):
     def test_only_sample_answers_in_main_shard_returned(self) -> None:
         # Use a smaller max answer list size so fewer answers are needed to
         # exceed a shard.
-        with self.swap(
+        with patch.object(
             stats_models.StateAnswersModel, '_MAX_ANSWER_LIST_BYTE_SIZE',
             15000):
             state_answers = stats_services.get_state_answers(

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -15,6 +15,7 @@
 """Tests for story domain objects and methods defined on them."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import os
@@ -941,7 +942,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         def _mock_get_current_time_in_millisecs() -> int:
             return 1672483686000
 
-        with self.swap(
+        with patch.object(
             utils, 'get_current_time_in_millisecs',
             _mock_get_current_time_in_millisecs):
             self.assertEqual(
@@ -961,7 +962,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         def _mock_get_current_time_in_millisecs() -> int:
             return 1672483686000
 
-        with self.swap(
+        with patch.object(
             utils, 'get_current_time_in_millisecs',
             _mock_get_current_time_in_millisecs):
             self.assertEqual(

--- a/core/domain/story_services_test.py
+++ b/core/domain/story_services_test.py
@@ -15,6 +15,7 @@
 """Tests the methods defined in story services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -713,7 +714,7 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception, 'Expected change to be of type StoryChange')
 
@@ -1234,8 +1235,8 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             """Mocks logging.exception()."""
             raise Exception('Error in exploration')
 
-        logging_swap = self.swap(logging, 'exception', _mock_logging_function)
-        validate_fn_swap = self.swap(
+        logging_swap = patch.object(logging, 'exception', _mock_logging_function)
+        validate_fn_swap = patch.object(
             exp_services, 'validate_exploration_for_story',
             _mock_validate_function)
         with logging_swap, validate_fn_swap:
@@ -2190,7 +2191,7 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
         def mock_get_current_time_in_millisecs() -> int:
             return 1690555400000
 
-        with self.swap(
+        with patch.object(
             utils, 'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs):
             chapter_notifications = (
@@ -2537,7 +2538,7 @@ class StoryContentsMigrationTests(test_utils.GenericTestBase):
             story_contents=self.VERSION_1_STORY_CONTENTS_DICT
         )
 
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_STORY_CONTENTS_SCHEMA_VERSION', 5)
 
         with current_schema_version_swap:

--- a/core/domain/subtopic_page_services_test.py
+++ b/core/domain/subtopic_page_services_test.py
@@ -17,6 +17,7 @@
 """Tests for subtopic page domain objects."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import re
 
@@ -280,7 +281,7 @@ class SubtopicPageServicesUnitTests(test_utils.GenericTestBase):
                 self.user_id, self.TOPIC_ID, 1)
 
     def test_migrate_page_contents_from_v1_to_v2_schema(self) -> None:
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION', 2)
         html_content = (
             '<p>Value</p><oppia-noninteractive-math raw_latex-with-value="&a'
@@ -345,7 +346,7 @@ class SubtopicPageServicesUnitTests(test_utils.GenericTestBase):
             subtopic_page.page_contents.to_dict(), expected_page_contents_dict)
 
     def test_migrate_page_contents_from_v2_to_v3_schema(self) -> None:
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION', 3)
         html_content = (
             '<oppia-noninteractive-svgdiagram '
@@ -412,7 +413,7 @@ class SubtopicPageServicesUnitTests(test_utils.GenericTestBase):
             subtopic_page.page_contents.to_dict(), expected_page_contents_dict)
 
     def test_migrate_page_contents_from_v3_to_v4_schema(self) -> None:
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION', 4)
         expected_html_content = (
             '<p>1 × 3 😕 😊</p>'
@@ -476,7 +477,7 @@ class SubtopicPageServicesUnitTests(test_utils.GenericTestBase):
     def test_cannot_migrate_page_contents_to_latest_schema_with_invalid_version(
         self
     ) -> None:
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION', 2)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception,

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -15,6 +15,7 @@
 """Tests for suggestion related services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import random
@@ -131,16 +132,16 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
         """Sets up the appropriate mocks to successfully call
         accept_suggestion.
         """
-        with self.swap(
+        with patch.object(
             exp_services, 'update_exploration', self.mock_update_exploration):
-            with self.swap(
+            with patch.object(
                 exp_fetchers, 'get_exploration_by_id',
                 self.mock_get_exploration_by_id):
-                with self.swap(
+                with patch.object(
                     suggestion_registry.SuggestionEditStateContent,
                     'pre_accept_validate',
                     self.mock_pre_accept_validate_does_nothing):
-                    with self.swap(
+                    with patch.object(
                         suggestion_registry.SuggestionEditStateContent,
                         '_get_change_list_for_accepting_edit_state_content_suggestion',  # pylint: disable=line-too-long
                         self.mock_get_change_list_does_nothing
@@ -153,10 +154,10 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
         """Sets up the appropriate mocks to successfully call
         create_suggestion.
         """
-        with self.swap(
+        with patch.object(
             feedback_models.GeneralFeedbackThreadModel,
             'generate_new_thread_id', self.mock_generate_new_thread_id):
-            with self.swap(
+            with patch.object(
                 exp_fetchers, 'get_exploration_by_id',
                 self.mock_get_exploration_by_id):
                 suggestion_services.create_suggestion(
@@ -305,12 +306,12 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
             self.target_id, self.target_version_at_submission,
             self.author_id, self.change, 'test description')
 
-        with self.swap(
+        with patch.object(
             suggestion_models, 'THRESHOLD_TIME_BEFORE_ACCEPT_IN_MSECS', 0):
             self.assertEqual(
                 len(suggestion_services.get_all_stale_suggestion_ids()), 1)
 
-        with self.swap(
+        with patch.object(
             suggestion_models, 'THRESHOLD_TIME_BEFORE_ACCEPT_IN_MSECS',
             7 * 24 * 60 * 60 * 1000):
             self.assertEqual(
@@ -382,10 +383,10 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
         # score of the author of that suggestion is increased by 1. Therefore,
         # by setting that increment to minimum score required to review, we can
         # ensure that the email is sent.
-        with self.swap(feconf, 'ENABLE_RECORDING_OF_SCORES', True):
-            with self.swap(
+        with patch.object(feconf, 'ENABLE_RECORDING_OF_SCORES', True):
+            with patch.object(
                 feconf, 'SEND_SUGGESTION_REVIEW_RELATED_EMAILS', True):
-                with self.swap(
+                with patch.object(
                     suggestion_models, 'INCREMENT_SCORE_OF_AUTHOR_BY',
                     feconf.MINIMUM_SCORE_REQUIRED_TO_REVIEW):
                     suggestion_services.accept_suggestion(
@@ -430,8 +431,8 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
         # score of the author of that suggestion is increased by 1. This is
         # less than the minimum score required to review so an email should not
         # be sent.
-        with self.swap(feconf, 'ENABLE_RECORDING_OF_SCORES', True):
-            with self.swap(
+        with patch.object(feconf, 'ENABLE_RECORDING_OF_SCORES', True):
+            with patch.object(
                 feconf, 'SEND_SUGGESTION_REVIEW_RELATED_EMAILS', True):
                 self.mock_accept_suggestion(
                     self.suggestion_id, self.reviewer_id, self.COMMIT_MESSAGE,
@@ -470,7 +471,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
         self.assertIsNone(user_models.UserContributionProficiencyModel.get(
             self.author_id, self.score_category))
 
-        with self.swap(feconf, 'ENABLE_RECORDING_OF_SCORES', True):
+        with patch.object(feconf, 'ENABLE_RECORDING_OF_SCORES', True):
             self.mock_accept_suggestion(
                 self.suggestion_id, self.reviewer_id, self.COMMIT_MESSAGE,
                 'review message')
@@ -529,10 +530,10 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     'uot;"></oppia-noninteractive-math>')
             }
         }
-        with self.swap(
+        with patch.object(
             feedback_models.GeneralFeedbackThreadModel,
             'generate_new_thread_id', self.mock_generate_new_thread_id):
-            with self.swap(
+            with patch.object(
                 exp_fetchers, 'get_exploration_by_id',
                 self.mock_get_exploration_by_id):
                 suggestion_services.create_suggestion(
@@ -1277,10 +1278,10 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
             'data_format': 'html'
         }
 
-        with self.swap(
+        with patch.object(
             exp_fetchers, 'get_exploration_by_id',
             self.mock_get_exploration_by_id):
-            with self.swap(
+            with patch.object(
                 exp_domain.Exploration, 'get_content_html',
                 self.MockExploration.get_content_html
             ):
@@ -1309,7 +1310,7 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
             self.explorations[2].id]
         self.topic_name = 'topic'
 
-        with self.swap(
+        with patch.object(
             exp_fetchers, 'get_exploration_by_id',
             self.mock_get_exploration_by_id):
 
@@ -1428,10 +1429,10 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
     ) -> None:
         # Create the translation suggestion associated with exploration id
         # target_id_1.
-        with self.swap(
+        with patch.object(
             exp_fetchers, 'get_exploration_by_id',
             self.mock_get_exploration_by_id):
-            with self.swap(
+            with patch.object(
                 exp_domain.Exploration, 'get_content_html',
                 self.MockExploration.get_content_html):
                 suggestion_services.create_suggestion(
@@ -1453,10 +1454,10 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
     ) -> None:
         # Create the translation suggestion associated with exploration id
         # target_id_2.
-        with self.swap(
+        with patch.object(
             exp_fetchers, 'get_exploration_by_id',
             self.mock_get_exploration_by_id):
-            with self.swap(
+            with patch.object(
                 exp_domain.Exploration, 'get_content_html',
                 self.MockExploration.get_content_html):
                 suggestion_services.create_suggestion(
@@ -1466,10 +1467,10 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
                     self.add_translation_change_dict, 'test description')
         # Create the translation suggestion associated with exploration id
         # target_id_3.
-        with self.swap(
+        with patch.object(
             exp_fetchers, 'get_exploration_by_id',
             self.mock_get_exploration_by_id):
-            with self.swap(
+            with patch.object(
                 exp_domain.Exploration, 'get_content_html',
                 self.MockExploration.get_content_html):
                 suggestion_services.create_suggestion(
@@ -2246,7 +2247,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
             suggestions[0].status, suggestion_models.STATUS_IN_REVIEW)
 
     def test_create_and_accept_suggestion(self) -> None:
-        with self.swap(
+        with patch.object(
             feedback_models.GeneralFeedbackThreadModel,
             'generate_new_thread_id', self.mock_generate_new_thread_id):
             suggestion_services.create_suggestion(
@@ -4317,7 +4318,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
         )
 
     def test_create_and_reject_suggestion(self) -> None:
-        with self.swap(
+        with patch.object(
             feedback_models.GeneralFeedbackThreadModel,
             'generate_new_thread_id', self.mock_generate_new_thread_id):
             suggestion_services.create_suggestion(
@@ -4344,7 +4345,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
         self.assertEqual(suggestion.status, suggestion_models.STATUS_REJECTED)
 
     def test_create_and_accept_suggestion_with_message(self) -> None:
-        with self.swap(
+        with patch.object(
             feedback_models.GeneralFeedbackThreadModel,
             'generate_new_thread_id', self.mock_generate_new_thread_id):
             suggestion_services.create_suggestion(
@@ -4373,7 +4374,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
         self.assertEqual(suggestion.status, suggestion_models.STATUS_ACCEPTED)
 
     def test_auto_reject_translation_suggestions_for_content_ids(self) -> None:
-        with self.swap(
+        with patch.object(
             feedback_models.GeneralFeedbackThreadModel,
             'generate_new_thread_id', self.mock_generate_new_thread_id):
             self.create_translation_suggestion_associated_with_exp(
@@ -4640,7 +4641,7 @@ class ReviewableSuggestionEmailInfoUnitTests(
         """Creates a question suggestion with the html content used for the
         question in the question suggestion.
         """
-        with self.swap(
+        with patch.object(
             feconf, 'DEFAULT_INIT_STATE_CONTENT_STR', question_html_content):
             content_id_generator = translation_domain.ContentIdGenerator()
             add_question_change_dict: Dict[
@@ -4748,7 +4749,7 @@ class ReviewableSuggestionEmailInfoUnitTests(
         # Dashboard in the future.
         suggestion_emphasized_text_getter_functions_mock: Dict[str, str] = {}
 
-        with self.swap(
+        with patch.object(
             suggestion_services, 'SUGGESTION_EMPHASIZED_TEXT_GETTER_FUNCTIONS',
             suggestion_emphasized_text_getter_functions_mock):
             with self.assertRaisesRegex(
@@ -5660,7 +5661,7 @@ class GetSuggestionsWaitingForReviewInfoToNotifyReviewersUnitTests(
             self._create_reviewable_suggestion_email_infos_from_suggestions(
                 [translation_suggestion_1]))
 
-        with self.swap(
+        with patch.object(
             suggestion_services,
             'MAX_NUMBER_OF_SUGGESTIONS_TO_EMAIL_REVIEWER', 1):
             reviewable_suggestion_email_infos = (
@@ -5699,7 +5700,7 @@ class GetSuggestionsWaitingForReviewInfoToNotifyReviewersUnitTests(
             self._create_reviewable_suggestion_email_infos_from_suggestions(
                 [translation_suggestion_1, translation_suggestion_2]))
 
-        with self.swap(
+        with patch.object(
             suggestion_services,
             'MAX_NUMBER_OF_SUGGESTIONS_TO_EMAIL_REVIEWER', 2):
             reviewable_suggestion_email_infos = (
@@ -5862,7 +5863,7 @@ class GetSuggestionsWaitingForReviewInfoToNotifyReviewersUnitTests(
             self._create_reviewable_suggestion_email_infos_from_suggestions(
                 [question_suggestion_1]))
 
-        with self.swap(
+        with patch.object(
             suggestion_services,
             'MAX_NUMBER_OF_SUGGESTIONS_TO_EMAIL_REVIEWER', 1):
             reviewable_suggestion_email_infos = (
@@ -5958,7 +5959,7 @@ class GetSuggestionsWaitingForReviewInfoToNotifyReviewersUnitTests(
             self._create_reviewable_suggestion_email_infos_from_suggestions(
                 [translation_suggestion_1]))
 
-        with self.swap(
+        with patch.object(
             suggestion_services,
             'MAX_NUMBER_OF_SUGGESTIONS_TO_EMAIL_REVIEWER', 1):
             reviewable_suggestion_email_infos = (
@@ -6700,10 +6701,10 @@ class GetSuggestionsWaitingTooLongForReviewInfoForAdminsUnitTests(
         mocked_contributor_dashboard_suggestion_types = [
             feconf.SUGGESTION_TYPE_ADD_QUESTION]
 
-        with self.swap(
+        with patch.object(
             feconf, 'CONTRIBUTOR_DASHBOARD_SUGGESTION_TYPES',
             mocked_contributor_dashboard_suggestion_types):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0):
                 info_about_suggestions_waiting_too_long_for_review = (
@@ -6720,7 +6721,7 @@ class GetSuggestionsWaitingTooLongForReviewInfoForAdminsUnitTests(
         self._create_translation_suggestion()
 
         # Make sure the threshold is nonzero.
-        with self.swap(
+        with patch.object(
             suggestion_models,
             'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 1):
             info_about_suggestions_waiting_too_long_for_review = (
@@ -6743,7 +6744,7 @@ class GetSuggestionsWaitingTooLongForReviewInfoForAdminsUnitTests(
 
         with self.mock_datetime_utcnow(
             mocked_datetime_less_than_review_wait_time_threshold):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS',
                 mocked_threshold_review_wait_time_in_days):
@@ -6767,7 +6768,7 @@ class GetSuggestionsWaitingTooLongForReviewInfoForAdminsUnitTests(
 
         with self.mock_datetime_utcnow(
             mocked_datetime_eq_review_wait_time_threshold):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS',
                 mocked_threshold_review_wait_time_in_days):
@@ -6799,7 +6800,7 @@ class GetSuggestionsWaitingTooLongForReviewInfoForAdminsUnitTests(
 
         with self.mock_datetime_utcnow(
             mocked_datetime_past_review_wait_time_threshold):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS',
                 mocked_threshold_review_wait_time_in_days):
@@ -6832,7 +6833,7 @@ class GetSuggestionsWaitingTooLongForReviewInfoForAdminsUnitTests(
 
         with self.mock_datetime_utcnow(
             mocked_datetime_past_review_wait_time_threshold):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS',
                 mocked_threshold_review_wait_time_in_days):

--- a/core/domain/takeout_service_test.py
+++ b/core/domain/takeout_service_test.py
@@ -15,6 +15,7 @@
 """Unit tests for core.domain.takeout_service."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import json
@@ -1350,7 +1351,7 @@ class TakeoutServiceFullUserUnitTests(test_utils.GenericTestBase):
             user_bio='I want to leak uid_abcdefghijabcdefghijabcdefghijab'
         ).put()
 
-        with self.swap(
+        with patch.object(
             user_services, 'get_user_settings', lambda _, strict: None # pylint: disable=unused-argument
         ):
             user_takeout_object = takeout_service.export_data_for_user(

--- a/core/domain/taskqueue_services_test.py
+++ b/core/domain/taskqueue_services_test.py
@@ -17,6 +17,7 @@
 """Tests for the domain taskqueue services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 
@@ -125,7 +126,7 @@ class TaskqueueDomainServicesUnitTests(test_utils.TestBase):
             self.assertIsNotNone(scheduled_for)
             self.assertIsNone(task_name)
 
-        swap_create_http_task = self.swap(
+        swap_create_http_task = patch.object(
             platform_taskqueue_services, 'create_http_task',
             mock_create_http_task)
 

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for topic domain objects."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 
@@ -1219,12 +1220,12 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
                 'story_references': [story_ref_dict]
             }
         )
-        swap_topic_object = self.swap(
+        swap_topic_object = patch.object(
             topic_domain,
             'Topic',
             self.MockTopicObject
         )
-        current_schema_version_swap = self.swap(
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_STORY_REFERENCE_SCHEMA_VERSION', 2)
         with swap_topic_object, current_schema_version_swap:
             topic_domain.Topic.update_story_references_from_model(

--- a/core/domain/topic_fetchers_test.py
+++ b/core/domain/topic_fetchers_test.py
@@ -17,6 +17,7 @@
 """Tests for topic domain objects."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import topic_domain
@@ -299,8 +300,8 @@ class TopicFetchersUnitTests(test_utils.GenericTestBase):
         commit_cmd_dicts = [commit_cmd.to_dict()]
         model.commit(
             self.user_id_a, 'topic model created', commit_cmd_dicts)
-        swap_topic_object = self.swap(topic_domain, 'Topic', MockTopicObject)
-        current_story_refrence_schema_version_swap = self.swap(
+        swap_topic_object = patch.object(topic_domain, 'Topic', MockTopicObject)
+        current_story_refrence_schema_version_swap = patch.object(
             feconf, 'CURRENT_STORY_REFERENCE_SCHEMA_VERSION', 2)
         with swap_topic_object, current_story_refrence_schema_version_swap:
             topic: topic_domain.Topic = (

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -17,6 +17,7 @@
 """Tests for topic services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 import os
@@ -2326,7 +2327,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         def mock_get_current_time_in_millisecs() -> int:
             return 1690555400000
 
-        with self.swap(
+        with patch.object(
             utils, 'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs):
             topic_summary = (
@@ -2389,7 +2390,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         def mock_get_current_time_in_millisecs() -> int:
             return 1690555400000
 
-        with self.swap(
+        with patch.object(
             utils, 'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs):
             with self.capture_logging(min_level=logging.ERROR) as logs:
@@ -2494,8 +2495,8 @@ class SubtopicMigrationTests(test_utils.GenericTestBase):
         model.commit(
             'user_id_admin', 'topic model created', commit_cmd_dicts)
 
-        swap_topic_object = self.swap(topic_domain, 'Topic', MockTopicObject)
-        current_schema_version_swap = self.swap(
+        swap_topic_object = patch.object(topic_domain, 'Topic', MockTopicObject)
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_SUBTOPIC_SCHEMA_VERSION', 4)
 
         with swap_topic_object, current_schema_version_swap:
@@ -2541,8 +2542,8 @@ class StoryReferenceMigrationTests(test_utils.GenericTestBase):
         model.commit(
             'user_id_admin', 'topic model created', commit_cmd_dicts)
 
-        swap_topic_object = self.swap(topic_domain, 'Topic', MockTopicObject)
-        current_schema_version_swap = self.swap(
+        swap_topic_object = patch.object(topic_domain, 'Topic', MockTopicObject)
+        current_schema_version_swap = patch.object(
             feconf, 'CURRENT_STORY_REFERENCE_SCHEMA_VERSION', 2)
 
         with swap_topic_object, current_schema_version_swap:

--- a/core/domain/translation_domain_test.py
+++ b/core/domain/translation_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for domain objects related to translations."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import re
 
@@ -337,7 +338,7 @@ class BaseTranslatableObjectUnitTest(test_utils.GenericTestBase):
         entity_translations = translation_domain.EntityTranslation(
             'exp_id', feconf.TranslatableEntityType.EXPLORATION, 1, 'en',
             translation_dict)
-        min_value_swap = self.swap(
+        min_value_swap = patch.object(
             feconf,
             'MIN_ALLOWED_MISSING_OR_UPDATE_NEEDED_WRITTEN_TRANSLATIONS',
             1)
@@ -942,23 +943,23 @@ class WrittenTranslationsDomainUnitTests(test_utils.GenericTestBase):
 
         with self.assertRaisesRegex(
             AssertionError, 'Expected unicode HTML string, received 30'):
-            with self.swap(written_translation, 'translation', 30):
+            with patch.object(written_translation, 'translation', 30):
                 written_translation.validate()
 
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected needs_update to be a bool'
         ):
-            with self.swap(written_translation, 'needs_update', 20):
+            with patch.object(written_translation, 'needs_update', 20):
                 written_translation.validate()
 
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid data_format'
         ):
-            with self.swap(written_translation, 'data_format', 'int'):
+            with patch.object(written_translation, 'data_format', 'int'):
                 written_translation.validate()
 
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid data_format'
         ):
-            with self.swap(written_translation, 'data_format', 2):
+            with patch.object(written_translation, 'data_format', 2):
                 written_translation.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -17,6 +17,7 @@
 """Tests for user domain objects."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -445,7 +446,7 @@ class UserSettingsTests(test_utils.GenericTestBase):
             """Mocks logging.error()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
+        logging_swap = patch.object(logging, 'error', _mock_logging_function)
         assert_raises_user_not_found = self.assertRaisesRegex(
             Exception, 'User not found.')
 

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.user_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -612,7 +613,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         gravatar_url = user_services.get_gravatar_url(user_email)
 
         error_messages: List[str] = []
-        logging_mocker = self.swap(logging, 'error', error_messages.append)
+        logging_mocker = patch.object(logging, 'error', error_messages.append)
 
         with logging_mocker, requests_mock.Mocker() as requests_mocker:
             requests_mocker.get(gravatar_url, status_code=404)
@@ -628,7 +629,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         gravatar_url = user_services.get_gravatar_url(user_email)
 
         error_messages: List[str] = []
-        logging_mocker = self.swap(logging, 'exception', error_messages.append)
+        logging_mocker = patch.object(logging, 'exception', error_messages.append)
 
         with logging_mocker, requests_mock.Mocker() as requests_mocker:
             requests_mocker.get(gravatar_url, exc=Exception)
@@ -687,7 +688,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             })
             return can_receive_email_updates
 
-        fn_swap = self.swap(
+        fn_swap = patch.object(
             bulk_email_services, 'add_or_update_user_status',
             _mock_add_or_update_user_status)
         with fn_swap:
@@ -708,7 +709,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             self.assertNotIn('NAME', merge_fields)
             return can_receive_email_updates
 
-        fn_swap = self.swap(
+        fn_swap = patch.object(
             bulk_email_services, 'add_or_update_user_status',
             _mock_add_or_update_user_status)
         with fn_swap:
@@ -741,8 +742,8 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             """Mocks logging.info()."""
             observed_log_messages.append(msg % args)
 
-        logging_swap = self.swap(logging, 'info', _mock_logging_function)
-        send_mail_swap = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        logging_swap = patch.object(logging, 'info', _mock_logging_function)
+        send_mail_swap = patch.object(feconf, 'CAN_SEND_EMAILS', True)
         with logging_swap, send_mail_swap:
             user_services.update_email_preferences(
                 user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,
@@ -766,8 +767,8 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             """Mocks bulk_email_services.add_or_update_user_status()."""
             return not can_receive_email_updates
 
-        send_mail_swap = self.swap(feconf, 'CAN_SEND_EMAILS', True)
-        bulk_email_swap = self.swap(
+        send_mail_swap = patch.object(feconf, 'CAN_SEND_EMAILS', True)
+        bulk_email_swap = patch.object(
             bulk_email_services, 'add_or_update_user_status',
             _mock_add_or_update_user_status)
         with send_mail_swap, bulk_email_swap:
@@ -828,7 +829,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             """
             raise Exception('Server error')
 
-        with self.swap(
+        with patch.object(
             bulk_email_services, 'add_or_update_user_status',
             _mock_add_or_update_user_status):
             try:
@@ -3004,7 +3005,7 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
         self.assertEqual(
             user_services.get_last_week_dashboard_stats(self.owner_id), None)
 
-        with self.swap(
+        with patch.object(
             user_services, 'get_current_date_as_string',
             self.mock_get_current_date_as_string):
             user_services.update_dashboard_stats_log(self.owner_id)
@@ -3045,7 +3046,7 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
         self.assertEqual(
             user_services.get_last_week_dashboard_stats(self.owner_id), None)
 
-        with self.swap(
+        with patch.object(
             user_services, 'get_current_date_as_string',
             self.mock_get_current_date_as_string
         ):
@@ -3094,7 +3095,7 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
 
     def test_get_user_impact_score(self) -> None:
         expected_impact_score = 3
-        with self.swap(
+        with patch.object(
             user_models.UserStatsModel, 'impact_score',
             expected_impact_score
         ):
@@ -3140,7 +3141,7 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
     def test_update_dashboard_stats_log_with_invalid_schema_version(
         self
     ) -> None:
-        with self.swap(user_models.UserStatsModel, 'schema_version', 5):
+        with patch.object(user_models.UserStatsModel, 'schema_version', 5):
             with self.assertRaisesRegex(
                 Exception,
                 'Sorry, we can only process v1-v%d dashboard stats schemas at'

--- a/core/domain/value_generators_domain_test.py
+++ b/core/domain/value_generators_domain_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core.domain.value_generators_domain."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import importlib
 import inspect
@@ -112,7 +113,7 @@ class ValueGeneratorsUnitTests(test_utils.GenericTestBase):
         expected_generators = {
             'RandomSelector': type(generators.RandomSelector())
         }
-        with self.swap(module, 'Copier', MockCopier):
+        with patch.object(module, 'Copier', MockCopier):
             value_generators = (
                 value_generators_domain.Registry.get_all_generator_classes()
             )

--- a/core/domain/wipeout_service_test.py
+++ b/core/domain/wipeout_service_test.py
@@ -15,6 +15,7 @@
 """Tests for wipeout service."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -287,7 +288,7 @@ class WipeoutServicePreDeleteTests(test_utils.GenericTestBase):
             """Mocks logging.info()."""
             observed_log_messages.append(msg % args)
 
-        with self.swap(logging, 'info', _mock_logging_function):
+        with patch.object(logging, 'info', _mock_logging_function):
             wipeout_service.pre_delete_user(self.user_1_id)
         self.process_and_flush_pending_tasks()
 
@@ -695,7 +696,7 @@ class WipeoutServiceRunFunctionsTests(test_utils.GenericTestBase):
             )]
         )
 
-        with send_email_swap, self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with send_email_swap, patch.object(feconf, 'CAN_SEND_EMAILS', True):
             self.assertEqual(
                 wipeout_service.run_user_deletion_completion(
                     self.pending_deletion_request),
@@ -738,7 +739,7 @@ class WipeoutServiceRunFunctionsTests(test_utils.GenericTestBase):
             expected_args=[('WIPEOUT: Account deletion failed', email_content)]
         )
 
-        with send_email_swap, self.swap(feconf, 'CAN_SEND_EMAILS', True):
+        with send_email_swap, patch.object(feconf, 'CAN_SEND_EMAILS', True):
             self.assertEqual(
                 wipeout_service.run_user_deletion_completion(
                     self.pending_deletion_request),
@@ -769,7 +770,7 @@ class WipeoutServiceRunFunctionsTests(test_utils.GenericTestBase):
             called=False
         )
 
-        with self.swap(feconf, 'CAN_SEND_EMAILS', False), send_email_swap:
+        with patch.object(feconf, 'CAN_SEND_EMAILS', False), send_email_swap:
             self.assertEqual(
                 wipeout_service.run_user_deletion_completion(
                     self.pending_deletion_request),
@@ -5596,11 +5597,11 @@ class PendingUserDeletionTaskServiceTests(test_utils.GenericTestBase):
             self.email_subjects.append(email_subject)
             self.email_bodies.append(email_body)
 
-        self.send_mail_to_admin_swap = self.swap(
+        self.send_mail_to_admin_swap = patch.object(
             email_manager, 'send_mail_to_admin', _mock_send_mail_to_admin)
-        self.can_send_email_swap = self.swap(
+        self.can_send_email_swap = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_email_swap = self.swap(
+        self.cannot_send_email_swap = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_repeated_deletion_is_successful_when_emails_enabled(
@@ -5707,11 +5708,11 @@ class CheckCompletionOfUserDeletionTaskServiceTests(
             self.email_subjects.append(email_subject)
             self.email_bodies.append(email_body)
 
-        self.send_mail_to_admin_swap = self.swap(
+        self.send_mail_to_admin_swap = patch.object(
             email_manager, 'send_mail_to_admin', _mock_send_mail_to_admin)
-        self.can_send_email_swap = self.swap(
+        self.can_send_email_swap = patch.object(
             feconf, 'CAN_SEND_EMAILS', True)
-        self.cannot_send_email_swap = self.swap(
+        self.cannot_send_email_swap = patch.object(
             feconf, 'CAN_SEND_EMAILS', False)
 
     def test_verification_when_user_is_not_deleted_emails_enabled(

--- a/core/feconf_test.py
+++ b/core/feconf_test.py
@@ -17,6 +17,7 @@
 """Unit tests for core/feconf.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import os
@@ -36,7 +37,7 @@ class FeconfTests(test_utils.GenericTestBase):
                 return 'Production'
             return 'Development'
 
-        swap_getenv = self.swap(os, 'getenv', mock_getenv)
+        swap_getenv = patch.object(os, 'getenv', mock_getenv)
         with swap_getenv, self.assertRaisesRegex(
                 Exception, 'DEV_MODE can\'t be true on production.'):
             feconf.check_dev_mode_is_true()
@@ -45,7 +46,7 @@ class FeconfTests(test_utils.GenericTestBase):
         def mock_getenv(*unused_args: str) -> str:
             return 'Development'
 
-        swap_getenv = self.swap(os, 'getenv', mock_getenv)
+        swap_getenv = patch.object(os, 'getenv', mock_getenv)
         with swap_getenv:
             feconf.check_dev_mode_is_true()
 

--- a/core/jobs/batch_jobs/blog_post_search_indexing_jobs_test.py
+++ b/core/jobs/batch_jobs/blog_post_search_indexing_jobs_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.batch_jobs.blog_post_search_indexing_jobs."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import math
@@ -132,7 +133,7 @@ class IndexBlogPostSummariesInSearchJobTests(job_test_utils.JobTestBase):
             ]
         )
 
-        max_batch_size_swap = self.swap(
+        max_batch_size_swap = patch.object(
             blog_post_search_indexing_jobs.IndexBlogPostsInSearchJob,
             'MAX_BATCH_SIZE', 1)
 

--- a/core/jobs/batch_jobs/exp_migration_jobs_test.py
+++ b/core/jobs/batch_jobs/exp_migration_jobs_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.batch_jobs.exp_migration_jobs."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core import utils
@@ -1310,7 +1311,7 @@ class ExpSnapshotsMigrationAuditJobTests(
         mock_conversion = classmethod(
             lambda cls, exploration_dict: exploration_dict['property_that_dne'])
 
-        with self.swap(
+        with patch.object(
             exp_domain.Exploration, '_convert_states_v46_dict_to_v47_dict',
             mock_conversion
         ):
@@ -1360,9 +1361,9 @@ class ExpSnapshotsMigrationAuditJobTests(
         ])
 
     def test_audit_job_detects_exploration_that_is_not_up_to_date(self) -> None:
-        swap_states_schema_41 = self.swap(
+        swap_states_schema_41 = patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', 41)
-        swap_exp_schema_46 = self.swap(
+        swap_exp_schema_46 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 46)
         with swap_states_schema_41, swap_exp_schema_46:
             exploration = exp_domain.Exploration.create_default_exploration(
@@ -1373,9 +1374,9 @@ class ExpSnapshotsMigrationAuditJobTests(
             exploration.states_schema_version,
             feconf.CURRENT_STATE_SCHEMA_VERSION)
 
-        swap_states_schema_42 = self.swap(
+        swap_states_schema_42 = patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', 42)
-        swap_exp_schema_47 = self.swap(
+        swap_exp_schema_47 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 47)
         with swap_states_schema_42, swap_exp_schema_47:
             self.assert_job_output_is([
@@ -1389,10 +1390,10 @@ class ExpSnapshotsMigrationAuditJobTests(
             ])
 
     def test_audit_job_handles_missing_states_schema_version(self) -> None:
-        swap_exp_schema_37 = self.swap(
+        swap_exp_schema_37 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 37)
         with swap_exp_schema_37:
-            with self.swap(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
+            with patch.object(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
                 exploration = exp_domain.Exploration.create_default_exploration(
                     self.VALID_EXP_ID, title='title', category='category')
                 exp_services.save_new_exploration(
@@ -1410,7 +1411,7 @@ class ExpSnapshotsMigrationAuditJobTests(
                     'to_version': '44'
                 })
             ]
-            with self.swap(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
+            with patch.object(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
                 exp_services.update_exploration(
                     feconf.SYSTEM_COMMITTER_ID,
                     self.VALID_EXP_ID,
@@ -1432,7 +1433,7 @@ class ExpSnapshotsMigrationAuditJobTests(
             snapshot_content_model.put()
 
             # There is no failure due to a missing states schema version.
-            with self.swap(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
+            with patch.object(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
                 self.assert_job_output_is([
                     job_run_result.JobRunResult(
                         stdout='',
@@ -1655,9 +1656,9 @@ class ExpSnapshotsMigrationJobTests(
     def test_migration_job_detects_exploration_that_is_not_up_to_date(
         self
     ) -> None:
-        swap_states_schema_41 = self.swap(
+        swap_states_schema_41 = patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', 41)
-        swap_exp_schema_46 = self.swap(
+        swap_exp_schema_46 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 46)
         with swap_states_schema_41, swap_exp_schema_46:
             exploration = exp_domain.Exploration.create_default_exploration(
@@ -1668,9 +1669,9 @@ class ExpSnapshotsMigrationJobTests(
             exploration.states_schema_version,
             feconf.CURRENT_STATE_SCHEMA_VERSION)
 
-        swap_states_schema_42 = self.swap(
+        swap_states_schema_42 = patch.object(
             feconf, 'CURRENT_STATE_SCHEMA_VERSION', 42)
-        swap_exp_schema_47 = self.swap(
+        swap_exp_schema_47 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 47)
         with swap_states_schema_42, swap_exp_schema_47:
             self.assert_job_output_is([
@@ -1756,7 +1757,7 @@ class ExpSnapshotsMigrationJobTests(
         mock_conversion = classmethod(
             lambda cls, exploration_dict: exploration_dict['property_that_dne'])
 
-        with self.swap(
+        with patch.object(
             exp_domain.Exploration, '_convert_states_v46_dict_to_v47_dict',
             mock_conversion
         ):
@@ -1779,10 +1780,10 @@ class ExpSnapshotsMigrationJobTests(
             ])
 
     def test_audit_job_handles_missing_states_schema_version(self) -> None:
-        swap_exp_schema_37 = self.swap(
+        swap_exp_schema_37 = patch.object(
             exp_domain.Exploration, 'CURRENT_EXP_SCHEMA_VERSION', 37)
         with swap_exp_schema_37:
-            with self.swap(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
+            with patch.object(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
                 exploration = exp_domain.Exploration.create_default_exploration(
                     self.VALID_EXP_ID, title='title', category='category')
                 exp_services.save_new_exploration(
@@ -1800,7 +1801,7 @@ class ExpSnapshotsMigrationJobTests(
                     'to_version': '44'
                 })
             ]
-            with self.swap(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
+            with patch.object(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
                 exp_services.update_exploration(
                     feconf.SYSTEM_COMMITTER_ID,
                     self.VALID_EXP_ID,
@@ -1822,7 +1823,7 @@ class ExpSnapshotsMigrationJobTests(
             snapshot_content_model.put()
 
             # There is no failure due to a missing states schema version.
-            with self.swap(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
+            with patch.object(feconf, 'CURRENT_STATE_SCHEMA_VERSION', 44):
                 self.assert_job_output_is([
                     job_run_result.JobRunResult(
                         stdout='',

--- a/core/jobs/batch_jobs/exp_search_indexing_jobs_test.py
+++ b/core/jobs/batch_jobs/exp_search_indexing_jobs_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.batch_jobs.exp_search_indexing_jobs."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.constants import constants
 from core.domain import search_services
@@ -121,7 +122,7 @@ class IndexExplorationsInSearchJobTests(job_test_utils.JobTestBase):
             ]
         )
 
-        max_batch_size_swap = self.swap(
+        max_batch_size_swap = patch.object(
             exp_search_indexing_jobs.IndexExplorationsInSearchJob,
             'MAX_BATCH_SIZE', 1)
 

--- a/core/jobs/batch_jobs/opportunity_management_jobs_test.py
+++ b/core/jobs/batch_jobs/opportunity_management_jobs_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.batch_jobs.opportunity_management_jobs."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.constants import constants
@@ -326,7 +327,7 @@ class GenerateSkillOpportunityModelJobTests(job_test_utils.JobTestBase):
             opportunity_models.SkillOpportunityModel.get_all())
         self.assertEqual(len(all_opportunity_models), 0)
 
-        with self.swap(
+        with patch.object(
             opportunity_management_jobs.GenerateSkillOpportunityModelJob,
             '_count_unique_question_ids',
             lambda _: -1

--- a/core/jobs/batch_jobs/remove_profile_picture_data_url_field_jobs_test.py
+++ b/core/jobs/batch_jobs/remove_profile_picture_data_url_field_jobs_test.py
@@ -17,6 +17,7 @@
 """Remove profile_picture_data_url field from UserSettingsModel."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.domain import user_services
@@ -88,7 +89,7 @@ class RemoveProfilePictureFieldJobTests(job_test_utils.JobTestBase):
             'profile_picture_data_url', migrated_setting_model._properties)  # pylint: disable=protected-access
 
     def test_removal_of_profile_field(self) -> None:
-        with self.swap(
+        with patch.object(
             user_models, 'UserSettingsModel',
             MockUserSettingsModelWithProfilePicture
         ):

--- a/core/jobs/batch_jobs/topic_migration_jobs_test.py
+++ b/core/jobs/batch_jobs/topic_migration_jobs_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.batch_jobs.topic_migration_jobs."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 
@@ -123,10 +124,10 @@ class MigrateTopicJobTests(job_test_utils.JobTestBase):
         ) -> None:
             versioned_story_references['schema_version'] = current_version + 1
 
-        self.story_reference_schema_version_swap = self.swap(
+        self.story_reference_schema_version_swap = patch.object(
             feconf, 'CURRENT_STORY_REFERENCE_SCHEMA_VERSION',
             mock_story_reference_schema_version)
-        self.update_story_reference_swap = self.swap(
+        self.update_story_reference_swap = patch.object(
             topic_domain.Topic, 'update_story_references_from_model',
             classmethod(mock_update_story_references_from_model))
 
@@ -380,10 +381,10 @@ class AuditTopicMigrateJobTests(job_test_utils.JobTestBase):
         ) -> None:
             versioned_story_references['schema_version'] = current_version + 1
 
-        self.story_reference_schema_version_swap = self.swap(
+        self.story_reference_schema_version_swap = patch.object(
             feconf, 'CURRENT_STORY_REFERENCE_SCHEMA_VERSION',
             mock_story_reference_schema_version)
-        self.update_story_reference_swap = self.swap(
+        self.update_story_reference_swap = patch.object(
             topic_domain.Topic, 'update_story_references_from_model',
             classmethod(mock_update_story_references_from_model))
 

--- a/core/jobs/io/cache_io_test.py
+++ b/core/jobs/io/cache_io_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.io.cache_io."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.domain import caching_services
 from core.jobs import job_test_utils
@@ -39,7 +40,7 @@ class FlushCacheTests(job_test_utils.PipelinedTestBase):
                 """Flush cache."""
                 called_functions['flush_caches'] = True
 
-        with self.swap(
+        with patch.object(
             caching_services, 'memory_cache_services', MockMemoryCachingServices
         ):
             self.assert_pcoll_equal(

--- a/core/jobs/io/gcs_io_test.py
+++ b/core/jobs/io/gcs_io_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.io.gcs_io."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import utils
 from core.domain import user_services
@@ -114,7 +115,7 @@ class DeleteFileTest(job_test_utils.PipelinedTestBase):
         file_path = 'dummy_folder/dummy_subfolder/dummy_file'
         file_paths = [file_path]
 
-        with self.swap(
+        with patch.object(
             gcs_io.DeleteFile,
             '_delete_file',
             lambda self, file_path: file_path
@@ -157,7 +158,7 @@ class GetFilesTest(job_test_utils.PipelinedTestBase):
     def test_check_correct_filepath_is_passing(self) -> None:
         file_paths = ['dummy_folder/dummy_subfolder']
 
-        with self.swap(
+        with patch.object(
             gcs_io.GetFiles,
             '_get_file_with_prefix',
             lambda self, file_path: file_path

--- a/core/jobs/io/job_io_test.py
+++ b/core/jobs/io/job_io_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.io.job_io."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.domain import beam_job_services
 from core.jobs import job_test_utils
@@ -53,7 +54,7 @@ class PutResultsTests(job_test_utils.PipelinedTestBase):
             job_run_result.JobRunResult(stdout='ghi', stderr='789'),
         ]
 
-        with self.swap(job_run_result, 'MAX_OUTPUT_CHARACTERS', 8):
+        with patch.object(job_run_result, 'MAX_OUTPUT_CHARACTERS', 8):
             self.assert_pcoll_empty(
                 self.pipeline
                 | beam.Create(messages)

--- a/core/jobs/registry_test.py
+++ b/core/jobs/registry_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.registry."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.jobs import base_jobs
 from core.jobs import registry
@@ -49,7 +50,7 @@ class RegistryTests(test_utils.TestBase):
         return cls.unique_obj
 
     def test_get_all_jobs_returns_value_from_job_metaclass(self) -> None:
-        get_all_jobs_swap = self.swap(
+        get_all_jobs_swap = patch.object(
             base_jobs.JobMetaclass, 'get_all_jobs', self.get_all_jobs_mock)
 
         with get_all_jobs_swap:
@@ -59,7 +60,7 @@ class RegistryTests(test_utils.TestBase):
         self.assertNotEqual(registry.get_all_jobs(), [])
 
     def test_get_all_job_names_returns_value_from_job_metaclass(self) -> None:
-        get_all_job_names_swap = self.swap(
+        get_all_job_names_swap = patch.object(
             base_jobs.JobMetaclass,
             'get_all_job_names', self.get_all_job_names_mock)
 
@@ -72,7 +73,7 @@ class RegistryTests(test_utils.TestBase):
     def test_get_job_class_by_name_returns_value_from_job_metaclass(
         self
     ) -> None:
-        get_job_class_by_name_swap = self.swap(
+        get_job_class_by_name_swap = patch.object(
             base_jobs.JobMetaclass,
             'get_job_class_by_name', self.get_job_class_by_name_mock)
 

--- a/core/jobs/transforms/validation/base_validation_registry_test.py
+++ b/core/jobs/transforms/validation/base_validation_registry_test.py
@@ -17,6 +17,7 @@
 """Unit tests for jobs.transforms.base_validation_registry."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.jobs.decorators import validation_decorators
 from core.jobs.transforms.validation import base_validation_registry
@@ -35,7 +36,7 @@ class GetAuditsByKindTests(test_utils.TestBase):
         return cls.unique_obj
 
     def test_returns_value_from_decorator(self) -> None:
-        get_audit_do_fn_types_by_kind_swap = self.swap(
+        get_audit_do_fn_types_by_kind_swap = patch.object(
             validation_decorators.AuditsExisting,
             'get_audit_do_fn_types_by_kind',
             self.get_audit_do_fn_types_by_kind_mock)
@@ -59,7 +60,7 @@ class GetIdReferencingPropertiesByKindOfPossessorTests(test_utils.TestBase):
         return cls.unique_obj
 
     def test_returns_value_from_decorator(self) -> None:
-        get_id_referencing_properties_by_kind_of_possessor_swap = self.swap(
+        get_id_referencing_properties_by_kind_of_possessor_swap = patch.object(
             validation_decorators.RelationshipsOf,
             'get_id_referencing_properties_by_kind_of_possessor',
             self.get_id_referencing_properties_by_kind_of_possessor_mock)
@@ -84,7 +85,7 @@ class GetAllModelKindsReferencedByPropertiesTests(test_utils.TestBase):
         return cls.unique_obj
 
     def test_returns_value_from_decorator(self) -> None:
-        get_all_model_kinds_referenced_by_properties_swap = self.swap(
+        get_all_model_kinds_referenced_by_properties_swap = patch.object(
             validation_decorators.RelationshipsOf,
             'get_all_model_kinds_referenced_by_properties',
             self.get_all_model_kinds_referenced_by_properties_mock)

--- a/core/platform/app_identity/gae_app_identity_services_test.py
+++ b/core/platform/app_identity/gae_app_identity_services_test.py
@@ -17,6 +17,7 @@
 """Tests for core.platform.app_identity.gae_app_identity_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.platform.app_identity import gae_app_identity_services
@@ -26,19 +27,19 @@ from core.tests import test_utils
 class GaeAppIdentityServicesTests(test_utils.GenericTestBase):
 
     def test_get_application_id(self) -> None:
-        with self.swap(feconf, 'OPPIA_PROJECT_ID', 'some_id'):
+        with patch.object(feconf, 'OPPIA_PROJECT_ID', 'some_id'):
             self.assertEqual(
                 gae_app_identity_services.get_application_id(), 'some_id')
 
     def test_get_application_id_throws_error(self) -> None:
-        with self.swap(feconf, 'OPPIA_PROJECT_ID', None):
+        with patch.object(feconf, 'OPPIA_PROJECT_ID', None):
             with self.assertRaisesRegex(
                 ValueError, 'Value None for application id is invalid.'
             ):
                 gae_app_identity_services.get_application_id()
 
     def test_get_default_gcs_bucket_name(self) -> None:
-        with self.swap(feconf, 'OPPIA_PROJECT_ID', 'some_id'):
+        with patch.object(feconf, 'OPPIA_PROJECT_ID', 'some_id'):
             self.assertEqual(
                 gae_app_identity_services.get_gcs_resource_bucket_name(),
                 'some_id-resources')

--- a/core/platform/bulk_email/dev_mode_bulk_email_services_test.py
+++ b/core/platform/bulk_email/dev_mode_bulk_email_services_test.py
@@ -15,6 +15,7 @@
 """Tests for dev mode bulk email services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 
@@ -31,7 +32,7 @@ class DevModeBulkEmailServicesUnitTests(test_utils.GenericTestBase):
             """Mocks logging.info()."""
             observed_log_messages.append(msg % args)
 
-        with self.swap(logging, 'info', _mock_logging_function):
+        with patch.object(logging, 'info', _mock_logging_function):
             dev_mode_bulk_email_services.add_or_update_user_status(
                 'test@example.com', {}, 'Web', can_receive_email_updates=True)
             self.assertItemsEqual(
@@ -55,7 +56,7 @@ class DevModeBulkEmailServicesUnitTests(test_utils.GenericTestBase):
             """Mocks logging.info()."""
             observed_log_messages.append(msg % args)
 
-        with self.swap(logging, 'info', _mock_logging_function):
+        with patch.object(logging, 'info', _mock_logging_function):
             dev_mode_bulk_email_services.permanently_delete_user_from_list(
                 'test@example.com')
             self.assertItemsEqual(

--- a/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
@@ -15,6 +15,7 @@
 """Tests for mailchimp services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 
@@ -202,7 +203,7 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
     def test_function_input_validation(self) -> None:
         mailchimp = self.MockMailchimpClass()
         swapped_mailchimp = lambda: mailchimp
-        swap_mailchimp_context = self.swap(
+        swap_mailchimp_context = patch.object(
             mailchimp_bulk_email_services, '_get_mailchimp_class',
             swapped_mailchimp)
         with swap_mailchimp_context:
@@ -241,7 +242,7 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
     def test_get_mailchimp_class_errors_when_username_is_not_available(
         self
     ) -> None:
-        swap_mailchimp_username = self.swap(
+        swap_mailchimp_username = patch.object(
             feconf, 'MAILCHIMP_USERNAME', None
         )
         swap_get_secret = self.swap_with_checks(
@@ -298,11 +299,11 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
     def test_add_or_update_mailchimp_user_status(self) -> None:
         mailchimp = self.MockMailchimpClass()
         swapped_mailchimp = lambda: mailchimp
-        swap_mailchimp_context = self.swap(
+        swap_mailchimp_context = patch.object(
             mailchimp_bulk_email_services, '_get_mailchimp_class',
             swapped_mailchimp)
-        swap_api = self.swap(secrets_services, 'get_secret', lambda _: 'key')
-        swap_username = self.swap(feconf, 'MAILCHIMP_USERNAME', 'username')
+        swap_api = patch.object(secrets_services, 'get_secret', lambda _: 'key')
+        swap_username = patch.object(feconf, 'MAILCHIMP_USERNAME', 'username')
 
         with swap_mailchimp_context, swap_api, swap_username:
             # Tests condition where user was initally unsubscribed in list and
@@ -357,11 +358,11 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
     def test_android_merge_fields(self) -> None:
         mailchimp = self.MockMailchimpClass()
         swapped_mailchimp = lambda: mailchimp
-        swap_mailchimp_context = self.swap(
+        swap_mailchimp_context = patch.object(
             mailchimp_bulk_email_services, '_get_mailchimp_class',
             swapped_mailchimp)
-        swap_api = self.swap(secrets_services, 'get_secret', lambda _: 'key')
-        swap_username = self.swap(feconf, 'MAILCHIMP_USERNAME', 'username')
+        swap_api = patch.object(secrets_services, 'get_secret', lambda _: 'key')
+        swap_username = patch.object(feconf, 'MAILCHIMP_USERNAME', 'username')
 
         with swap_mailchimp_context, swap_api, swap_username:
             # Tests condition where user was initally unsubscribed in list and
@@ -379,11 +380,11 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
     def test_catch_or_raise_errors_when_creating_new_invalid_user(self) -> None:
         mailchimp = self.MockMailchimpClass()
         swapped_mailchimp = lambda: mailchimp
-        swap_mailchimp_context = self.swap(
+        swap_mailchimp_context = patch.object(
             mailchimp_bulk_email_services, '_get_mailchimp_class',
             swapped_mailchimp)
-        swap_api = self.swap(secrets_services, 'get_secret', lambda _: 'key')
-        swap_username = self.swap(feconf, 'MAILCHIMP_USERNAME', 'username')
+        swap_api = patch.object(secrets_services, 'get_secret', lambda _: 'key')
+        swap_username = patch.object(feconf, 'MAILCHIMP_USERNAME', 'username')
 
         with swap_mailchimp_context, swap_api, swap_username:
             # Creates a mailchimp entry for a deleted user.
@@ -405,11 +406,11 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
     def test_permanently_delete_user(self) -> None:
         mailchimp = self.MockMailchimpClass()
         swapped_mailchimp = lambda: mailchimp
-        swap_mailchimp_context = self.swap(
+        swap_mailchimp_context = patch.object(
             mailchimp_bulk_email_services, '_get_mailchimp_class',
             swapped_mailchimp)
-        swap_api = self.swap(secrets_services, 'get_secret', lambda _: 'key')
-        swap_username = self.swap(feconf, 'MAILCHIMP_USERNAME', 'username')
+        swap_api = patch.object(secrets_services, 'get_secret', lambda _: 'key')
+        swap_username = patch.object(feconf, 'MAILCHIMP_USERNAME', 'username')
 
         with swap_mailchimp_context, swap_api, swap_username:
             self.assertEqual(len(mailchimp.lists.members.users_data), 3)

--- a/core/platform/datastore/cloud_datastore_services_test.py
+++ b/core/platform/datastore/cloud_datastore_services_test.py
@@ -15,6 +15,7 @@
 """Unit tests for the cloud_datastore_services.py"""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import logging
@@ -166,7 +167,7 @@ class CloudDatastoreServicesTests(test_utils.GenericTestBase):
             ndb,
             'get_multi',
             Exception('Mock key error')
-        ), self.swap(logging, 'exception', _mock_logging_function):
+        ), patch.object(logging, 'exception', _mock_logging_function):
             with self.assertRaisesRegex(Exception, error_msg):
                 cloud_datastore_services.get_multi(dummy_keys)
         self.assertEqual(

--- a/core/platform/email/dev_mode_email_services_test.py
+++ b/core/platform/email/dev_mode_email_services_test.py
@@ -17,6 +17,7 @@
 """Tests for the email services API wrapper in DEV_MODE."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 import textwrap
@@ -67,9 +68,9 @@ class EmailTests(test_utils.GenericTestBase):
             'dev environment. Emails are sent out in the production' +
             ' environment.')
 
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = patch.object(feconf, 'CAN_SEND_EMAILS', True)
         with allow_emailing, (
-            self.swap(logging, 'info', _mock_logging_function)):
+            patch.object(logging, 'info', _mock_logging_function)):
             dev_mode_email_services.send_email_to_recipients(
                 feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
                 'subject', 'body', 'html')
@@ -124,9 +125,9 @@ class EmailTests(test_utils.GenericTestBase):
             'dev environment. Emails are sent out in the production' +
             ' environment.')
 
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = patch.object(feconf, 'CAN_SEND_EMAILS', True)
         with allow_emailing, (
-            self.swap(logging, 'info', _mock_logging_function)):
+            patch.object(logging, 'info', _mock_logging_function)):
             dev_mode_email_services.send_email_to_recipients(
                 feconf.SYSTEM_EMAIL_ADDRESS,
                 ['a@a.com', 'b@b.com', 'c@c.com', 'd@d.com'],

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -17,6 +17,7 @@
 """Tests for the Mailgun API wrapper."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import urllib
 
@@ -84,11 +85,11 @@ class EmailTests(test_utils.GenericTestBase):
         )
         swapped_urlopen = lambda x: self.Response(x, expected_query_url)
 
-        swap_urlopen_context = self.swap(
+        swap_urlopen_context = patch.object(
             utils, 'url_open', swapped_urlopen)
-        swap_request_context = self.swap(
+        swap_request_context = patch.object(
             urllib.request, 'Request', self.swapped_request)
-        swap_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        swap_domain = patch.object(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         with self.swap_api_key_secrets_return_secret, swap_urlopen_context:
             with swap_request_context, swap_domain:
                 resp = mailgun_email_services.send_email_to_recipients(
@@ -114,11 +115,11 @@ class EmailTests(test_utils.GenericTestBase):
             b'%27%3A+%7B%27first%27%3A+%27Bob%27%2C+%27id%27%3A+1%7D%7D',
             {'Authorization': 'Basic YXBpOmtleQ=='})
         swapped_urlopen = lambda x: self.Response(x, expected_query_url)
-        swap_urlopen_context = self.swap(
+        swap_urlopen_context = patch.object(
             utils, 'url_open', swapped_urlopen)
-        swap_request_context = self.swap(
+        swap_request_context = patch.object(
             urllib.request, 'Request', self.swapped_request)
-        swap_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        swap_domain = patch.object(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         with self.swap_api_key_secrets_return_secret, swap_urlopen_context:
             with swap_request_context, swap_domain:
                 resp = mailgun_email_services.send_email_to_recipients(
@@ -148,11 +149,11 @@ class EmailTests(test_utils.GenericTestBase):
             b'%27%3A+%7B%27first%27%3A+%27Bob%27%2C+%27id%27%3A+1%7D%7D',
             {'Authorization': 'Basic YXBpOmtleQ=='})
         swapped_urlopen = lambda x: self.Response(x, expected_query_url)
-        swap_urlopen_context = self.swap(
+        swap_urlopen_context = patch.object(
             utils, 'url_open', swapped_urlopen)
-        swap_request_context = self.swap(
+        swap_request_context = patch.object(
             urllib.request, 'Request', self.swapped_request)
-        swap_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        swap_domain = patch.object(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         with self.swap_api_key_secrets_return_secret, swap_urlopen_context:
             with swap_request_context, swap_domain:
                 resp = mailgun_email_services.send_email_to_recipients(
@@ -182,11 +183,11 @@ class EmailTests(test_utils.GenericTestBase):
             {'Authorization': 'Basic YXBpOmtleQ=='})
         swapped_urlopen = lambda x: self.Response(x, expected_query_url)
         swapped_request = lambda *args: args
-        swap_urlopen_context = self.swap(
+        swap_urlopen_context = patch.object(
             utils, 'url_open', swapped_urlopen)
-        swap_request_context = self.swap(
+        swap_request_context = patch.object(
             urllib.request, 'Request', swapped_request)
-        swap_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        swap_domain = patch.object(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         with self.swap_api_key_secrets_return_secret, swap_urlopen_context:
             with swap_request_context, swap_domain:
                 resp = mailgun_email_services.send_email_to_recipients(
@@ -246,11 +247,11 @@ class EmailTests(test_utils.GenericTestBase):
             {'Authorization': 'Basic'})
         swapped_request = lambda *args: args
         swapped_urlopen = lambda x: self.Response(x, expected_query_url)
-        swap_urlopen_context = self.swap(
+        swap_urlopen_context = patch.object(
             utils, 'url_open', swapped_urlopen)
-        swap_request_context = self.swap(
+        swap_request_context = patch.object(
             urllib.request, 'Request', swapped_request)
-        swap_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        swap_domain = patch.object(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         with self.swap_api_key_secrets_return_secret, swap_urlopen_context:
             with swap_request_context, swap_domain:
                 resp = mailgun_email_services.send_email_to_recipients(

--- a/core/platform/models_test.py
+++ b/core/platform/models_test.py
@@ -17,6 +17,7 @@
 """Tests interface for storage model switching."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import re
 import sys
@@ -297,10 +298,10 @@ class RegistryUnitTest(test_utils.TestBase):
         """Tests import email services method for when email service provider is
         mailgun.
         """
-        with self.swap(
+        with patch.object(
             feconf, 'EMAIL_SERVICE_PROVIDER',
             feconf.EMAIL_SERVICE_PROVIDER_MAILGUN), (
-                self.swap(constants, 'DEV_MODE', False)):
+                patch.object(constants, 'DEV_MODE', False)):
             from core.platform.email import mailgun_email_services
             self.assertEqual(
                 mailgun_email_services,
@@ -310,10 +311,10 @@ class RegistryUnitTest(test_utils.TestBase):
         """Tests import email services method for when email service provider is
         an invalid option.
         """
-        with self.swap(
+        with patch.object(
             feconf, 'EMAIL_SERVICE_PROVIDER',
             'invalid service provider'), (
-                self.swap(constants, 'DEV_MODE', False)):
+                patch.object(constants, 'DEV_MODE', False)):
             with self.assertRaisesRegex(
                 Exception,
                 'Invalid email service provider: invalid service provider'
@@ -324,10 +325,10 @@ class RegistryUnitTest(test_utils.TestBase):
         """Tests import email services method for when email service provider is
         mailchimp.
         """
-        with self.swap(
+        with patch.object(
             feconf, 'BULK_EMAIL_SERVICE_PROVIDER',
             feconf.BULK_EMAIL_SERVICE_PROVIDER_MAILCHIMP), (
-                self.swap(constants, 'EMULATOR_MODE', False)):
+                patch.object(constants, 'EMULATOR_MODE', False)):
             from core.platform.bulk_email import mailchimp_bulk_email_services
             self.assertEqual(
                 mailchimp_bulk_email_services,
@@ -337,10 +338,10 @@ class RegistryUnitTest(test_utils.TestBase):
         """Tests import email services method for when email service provider is
         an invalid option.
         """
-        with self.swap(
+        with patch.object(
             feconf, 'BULK_EMAIL_SERVICE_PROVIDER',
             'invalid service provider'), (
-                self.swap(constants, 'EMULATOR_MODE', False)):
+                patch.object(constants, 'EMULATOR_MODE', False)):
             with self.assertRaisesRegex(
                 Exception,
                 'Invalid bulk email service provider: invalid service '
@@ -360,7 +361,7 @@ class RegistryUnitTest(test_utils.TestBase):
         class MockCloudTaskqueue():
             pass
 
-        with self.swap(constants, 'EMULATOR_MODE', False):
+        with patch.object(constants, 'EMULATOR_MODE', False):
             # Here we use cast because sys.modules can only accept ModuleTypes
             # but for testing purposes here we are providing MockCloudTaskqueue
             # which is of class type. So because of this MyPy throws an error.
@@ -378,7 +379,7 @@ class RegistryUnitTest(test_utils.TestBase):
 
     def test_import_cloud_translate_services(self) -> None:
         """Tests import cloud translate services function."""
-        with self.swap(constants, 'EMULATOR_MODE', False):
+        with patch.object(constants, 'EMULATOR_MODE', False):
             from core.platform.translate import cloud_translate_services
             self.assertEqual(
                 self.registry_instance.import_translate_services(),
@@ -402,7 +403,7 @@ class RegistryUnitTest(test_utils.TestBase):
         class MockCloudStorage():
             pass
 
-        with self.swap(constants, 'EMULATOR_MODE', False):
+        with patch.object(constants, 'EMULATOR_MODE', False):
             # Here we use cast because sys.modules can only accept ModuleTypes
             # but for testing purposes here we are providing MockCloudStorage
             # which is of class type. So because of this MyPy throws an error.

--- a/core/platform/search/elastic_search_services_test.py
+++ b/core/platform/search/elastic_search_services_test.py
@@ -17,6 +17,7 @@
 """Tests for the python elastic search wrapper."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.domain import search_services
 from core.platform.search import elastic_search_services
@@ -45,7 +46,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                     'failed': 0
                 }
             }
-        with self.swap(elastic_search_services.ES, 'index', mock_index):
+        with patch.object(elastic_search_services.ES, 'index', mock_index):
             elastic_search_services.add_documents_to_index([{
                 'id': correct_id
             }], correct_index_name)
@@ -74,7 +75,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
         assert_raises_ctx = self.assertRaisesRegex(
             Exception,
             'Failed to add document to index.')
-        with assert_raises_ctx, self.swap(
+        with assert_raises_ctx, patch.object(
             elastic_search_services.ES, 'index', mock_index):
             elastic_search_services.add_documents_to_index(
                 documents, correct_index_name)
@@ -119,7 +120,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                     'match_all': {}
                 }
             })
-        swap_delete_by_query = self.swap(
+        swap_delete_by_query = patch.object(
             elastic_search_services.ES, 'delete_by_query', mock_delete_by_query)
 
         with swap_delete_by_query:
@@ -203,7 +204,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 }
             }
 
-        swap_search = self.swap(
+        swap_search = patch.object(
             elastic_search_services.ES, 'search', mock_search)
         with swap_search:
             result, new_offset = (
@@ -262,7 +263,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 }
             }
 
-        swap_search = self.swap(
+        swap_search = patch.object(
             elastic_search_services.ES, 'search', mock_search)
         with swap_search:
             result, new_offset = (
@@ -380,7 +381,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 }
             }
 
-        swap_search = self.swap(
+        swap_search = patch.object(
             elastic_search_services.ES, 'search', mock_search)
         with swap_search:
             result, new_offset = (
@@ -442,7 +443,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 }
             }
 
-        swap_search = self.swap(
+        swap_search = patch.object(
             elastic_search_services.ES, 'search', mock_search)
         with swap_search:
             result, new_offset = (

--- a/core/platform/secrets/dev_mode_secrets_services_test.py
+++ b/core/platform/secrets/dev_mode_secrets_services_test.py
@@ -17,6 +17,7 @@
 """Tests for the Python Cloud Secret services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 
@@ -28,10 +29,10 @@ class DevModeSecretsServicesTests(test_utils.GenericTestBase):
     """Tests for the Python Cloud Secret services."""
 
     def test_get_secret_returns_existing_secret(self) -> None:
-        with self.swap(os, 'environ', {'SECRETS': '{"name": "secret"}'}):
+        with patch.object(os, 'environ', {'SECRETS': '{"name": "secret"}'}):
             self.assertEqual(
                 dev_mode_secrets_services.get_secret('name'), 'secret')
 
     def test_get_secret_returns_none_when_secret_does_not_exist(self) -> None:
-        with self.swap(os, 'environ', {'SECRETS': '{"name": "secret"}'}):
+        with patch.object(os, 'environ', {'SECRETS': '{"name": "secret"}'}):
             self.assertIsNone(dev_mode_secrets_services.get_secret('name2'))

--- a/core/platform/storage/cloud_storage_services_test.py
+++ b/core/platform/storage/cloud_storage_services_test.py
@@ -17,6 +17,7 @@
 """Tests for cloud_storage_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.platform.storage import cloud_storage_services
 from core.tests import test_utils
@@ -155,9 +156,9 @@ class CloudStorageServicesTests(test_utils.TestBase):
         self.bucket_2 = MockBucket()
         self.client.buckets['bucket_1'] = self.bucket_1
         self.client.buckets['bucket_2'] = self.bucket_2
-        self.get_client_swap = self.swap(
+        self.get_client_swap = patch.object(
             storage, 'Client', lambda: self.client)
-        self.get_bucket_swap = self.swap(
+        self.get_bucket_swap = patch.object(
             cloud_storage_services,
             '_get_bucket',
             self.client.get_bucket

--- a/core/platform/taskqueue/cloud_taskqueue_services_test.py
+++ b/core/platform/taskqueue/cloud_taskqueue_services_test.py
@@ -17,6 +17,7 @@
 """Tests for methods in the cloud_taskqueue_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import json
@@ -83,7 +84,7 @@ class CloudTaskqueueServicesUnitTests(test_utils.TestBase):
             )
             return self.Response(task_name)
 
-        with self.swap(
+        with patch.object(
             cloud_taskqueue_services.CLIENT, 'create_task', mock_create_task):
             cloud_taskqueue_services.create_http_task(
                 queue_name, dummy_url, payload=payload, task_name=task_name)
@@ -133,7 +134,7 @@ class CloudTaskqueueServicesUnitTests(test_utils.TestBase):
             )
             return self.Response(task_name)
 
-        with self.swap(
+        with patch.object(
             cloud_taskqueue_services.CLIENT, 'create_task', mock_create_task):
             cloud_taskqueue_services.create_http_task(
                 queue_name, dummy_url, payload=payload,

--- a/core/platform/taskqueue/dev_mode_taskqueue_services_test.py
+++ b/core/platform/taskqueue/dev_mode_taskqueue_services_test.py
@@ -17,6 +17,7 @@
 """Tests for methods in the dev_mode_taskqueue_services."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 
@@ -61,7 +62,7 @@ class DevModeTaskqueueServicesUnitTests(test_utils.TestBase):
             self.assertEqual(payload, correct_payload)
             self.assertEqual(task_name, correct_task_name)
 
-        swap_create_task = self.swap(
+        swap_create_task = patch.object(
             dev_mode_taskqueue_services.CLIENT, 'create_task', mock_create_task)
         with swap_create_task:
             dev_mode_taskqueue_services.create_http_task(
@@ -106,7 +107,7 @@ class DevModeTaskqueueServicesUnitTests(test_utils.TestBase):
             self.assertEqual(headers, correct_headers)
             self.assertEqual(timeout, feconf.DEFAULT_TASKQUEUE_TIMEOUT_SECONDS)
 
-        swap_post = self.swap(requests, 'post', mock_post)
+        swap_post = patch.object(requests, 'post', mock_post)
         with swap_post:
             # I have to test _task_handler by calling it because I cannot
             # surround this task handler in a context manager reliably. The

--- a/core/platform/transactions/cloud_transaction_services_test.py
+++ b/core/platform/transactions/cloud_transaction_services_test.py
@@ -15,6 +15,7 @@
 """Unit tests for the cloud_transaction_services.py"""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.platform.transactions import cloud_transaction_services
 from core.tests import test_utils
@@ -39,7 +40,7 @@ class CloudTransactionServicesTests(test_utils.GenericTestBase):
             def transaction(self) -> MockTransaction: # pylint: disable=missing-docstring
                 return MockTransaction()
 
-        swap_client = self.swap(
+        swap_client = patch.object(
             cloud_transaction_services, 'CLIENT', MockClient())
 
         def add(x: int, y: int) -> int:

--- a/core/storage/app_feedback_report/gae_models_test.py
+++ b/core/storage/app_feedback_report/gae_models_test.py
@@ -15,6 +15,7 @@
 """Tests for core.storage.app_feedback_report.gae_models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import enum
@@ -206,7 +207,7 @@ class AppFeedbackReportModelTests(test_utils.GenericTestBase):
             Exception, 'The id generator for AppFeedbackReportModel is '
             'producing too many collisions.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 app_feedback_report_models.AppFeedbackReportModel,
                 'get_by_id', types.MethodType(
                     lambda x, y: True,
@@ -356,7 +357,7 @@ class AppFeedbackReportModelTests(test_utils.GenericTestBase):
             'The field %s is not a valid field to filter reports on' % (
                 InvalidFilter.INVALID_FIELD.name)
         ):
-            with self.swap(
+            with patch.object(
                 model_class, 'query',
                 self._mock_query_filters_returns_empty_list):
                 # Here we use MyPy ignore because we passes arg of type
@@ -522,7 +523,7 @@ class AppFeedbackReportTicketModelTests(test_utils.GenericTestBase):
             'many collisions.'
         ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(model_class, 'get_by_id', types.MethodType(
+            with patch.object(model_class, 'get_by_id', types.MethodType(
                 lambda x, y: True, model_class)):
                 ticket_id = model_class.generate_id(self.TICKET_NAME)
                 model_class.create(

--- a/core/storage/base_model/gae_models_test.py
+++ b/core/storage/base_model/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for core.storage.base_model.gae_models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import re
@@ -342,7 +343,7 @@ class BaseHumanMaintainedModelTests(test_utils.GenericTestBase):
             # and we do actually want to save the changes in this case.
             base_models.BaseModel.put(self)
 
-        with self.swap(TestBaseHumanMaintainedModel, 'put', mock_put):
+        with patch.object(TestBaseHumanMaintainedModel, 'put', mock_put):
             self.model_instance.put()
 
     def test_put(self) -> None:
@@ -745,7 +746,7 @@ class VersionedModelTests(test_utils.GenericTestBase):
             model_2.get_snapshot_id(model_2.id, version_number)
             for version_number in model_2_version_numbers]
 
-        with self.swap(feconf, 'MAX_NUMBER_OF_OPS_IN_TRANSACTION', 2):
+        with patch.object(feconf, 'MAX_NUMBER_OF_OPS_IN_TRANSACTION', 2):
             TestVersionedModel.delete_multi(
                 [model_1_id, model_2_id],
                 feconf.SYSTEM_COMMITTER_ID,
@@ -872,7 +873,7 @@ class BaseModelTests(test_utils.GenericTestBase):
     def test_create_raises_error_when_many_id_collisions_occur(self) -> None:
 
         # Swap dependent method get_by_id to simulate collision every time.
-        get_by_id_swap = self.swap(
+        get_by_id_swap = patch.object(
             TestBaseModel, 'get_by_id', types.MethodType(
                 lambda _, __: True, TestBaseModel))
 

--- a/core/storage/blog/gae_models_test.py
+++ b/core/storage/blog/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for Blog Post models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import types
@@ -113,7 +114,7 @@ class BlogPostModelTest(test_utils.GenericTestBase):
             'A blog post with the given blog post ID exists already.'):
 
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 blog_post_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,
@@ -126,7 +127,7 @@ class BlogPostModelTest(test_utils.GenericTestBase):
             Exception,
             'New blog post id generator is producing too many collisions.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 blog_post_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,
@@ -466,7 +467,7 @@ class BlogPostRightsModelTest(test_utils.GenericTestBase):
             Exception,
             'Blog Post ID conflict on creating new blog post rights model.'):
             #  Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 blog_post_rights_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,
@@ -549,7 +550,7 @@ class BlogAuthorDetailsModelTest(test_utils.GenericTestBase):
 
             # Swap dependent method get_by_author to simulate collision every
             # time.
-            with self.swap(
+            with patch.object(
                 blog_author_details_model_cls, 'get_by_author',
                 types.MethodType(
                     lambda x, y: True,
@@ -562,7 +563,7 @@ class BlogAuthorDetailsModelTest(test_utils.GenericTestBase):
             Exception,
             'New instance id generator is producing too many collisions.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 blog_author_details_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,

--- a/core/storage/blog_statistics/gae_models_test.py
+++ b/core/storage/blog_statistics/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for Blog Post Statistics Models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import types
 
@@ -102,7 +103,7 @@ class BlogPostViewedEventLogEntryModelUnitTests(test_utils.GenericTestBase):
             Exception, 'The id generator for the model is producing too many'
             ' collisions.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 blog_stats_models.BlogPostViewedEventLogEntryModel,
                 'get_by_id', types.MethodType(
                     lambda x, y: True,
@@ -115,12 +116,12 @@ class BlogPostViewedEventLogEntryModelUnitTests(test_utils.GenericTestBase):
         rand_hash = '123456789123'
         def mock_convert_to_hash(input_string: str, max_length: int) -> str: # pylint: disable=unused-argument
             return rand_hash
-        with self.swap(
+        with patch.object(
             utils,
             'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs
         ):
-            with self.swap(utils, 'convert_to_hash', mock_convert_to_hash):
+            with patch.object(utils, 'convert_to_hash', mock_convert_to_hash):
                 new_id = (
                     blog_stats_models.BlogPostViewedEventLogEntryModel
                         .get_new_event_entity_id('BLOG')
@@ -225,12 +226,12 @@ class BlogPostReadEventLogEntryModelUnitTests(test_utils.GenericTestBase):
         mock_get_current_time_in_millisecs = lambda: time_in_millisecs
         def mock_convert_to_hash(input_string: str, max_length: int) -> str: # pylint: disable=unused-argument
             return rand_hash
-        with self.swap(
+        with patch.object(
             utils,
             'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs
         ):
-            with self.swap(utils, 'convert_to_hash', mock_convert_to_hash):
+            with patch.object(utils, 'convert_to_hash', mock_convert_to_hash):
                 new_id = (
                     blog_stats_models.BlogPostReadEventLogEntryModel
                         .get_new_event_entity_id('BLOG')
@@ -246,7 +247,7 @@ class BlogPostReadEventLogEntryModelUnitTests(test_utils.GenericTestBase):
             Exception, 'The id generator for the model is producing too many'
             ' collisions.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 blog_stats_models.BlogPostReadEventLogEntryModel,
                 'get_by_id', types.MethodType(
                     lambda x, y: True,
@@ -354,12 +355,12 @@ class BlogPostExitedEventLogEntryModelUnitTests(test_utils.GenericTestBase):
         rand_hash = '123456789123'
         def mock_convert_to_hash(input_string: str, max_length: int) -> str: # pylint: disable=unused-argument
             return rand_hash
-        with self.swap(
+        with patch.object(
             utils,
             'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs
         ):
-            with self.swap(utils, 'convert_to_hash', mock_convert_to_hash):
+            with patch.object(utils, 'convert_to_hash', mock_convert_to_hash):
                 new_id = (
                     blog_stats_models.BlogPostExitedEventLogEntryModel
                         .get_new_event_entity_id('BLOG')
@@ -387,7 +388,7 @@ class BlogPostExitedEventLogEntryModelUnitTests(test_utils.GenericTestBase):
             Exception, 'The id generator for the model is producing too many'
             ' collisions.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 blog_stats_models.BlogPostExitedEventLogEntryModel,
                 'get_by_id', types.MethodType(
                     lambda x, y: True,

--- a/core/storage/classifier/gae_models_test.py
+++ b/core/storage/classifier/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for core.storage.classifier.gae_models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import types
@@ -150,7 +151,7 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
     def test_query_new_and_pending_training_jobs_with_non_zero_offset(
         self
     ) -> None:
-        with self.swap(
+        with patch.object(
             classifier_models, 'NEW_AND_PENDING_TRAINING_JOBS_FETCH_LIMIT', 2):
             next_scheduled_check_time = (
                 datetime.datetime.utcnow() - datetime.timedelta(minutes=1))
@@ -315,7 +316,7 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
             'producing too many collisions.'
             ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 classifier_models.ClassifierTrainingJobModel, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,

--- a/core/storage/classroom/gae_models_test.py
+++ b/core/storage/classroom/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for classroom models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import types
 
@@ -128,7 +129,7 @@ class ClassroomModelUnitTest(test_utils.GenericTestBase):
             'A classroom with the given classroom ID already exists.'
         ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 classroom_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,
@@ -147,7 +148,7 @@ class ClassroomModelUnitTest(test_utils.GenericTestBase):
             'New classroom id generator is producing too many collisions.'
         ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 classroom_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for collection models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import copy
 import datetime
@@ -225,7 +226,7 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
         )
 
     def test_has_reference_to_user_id(self) -> None:
-        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+        with patch.object(base_models, 'FETCH_BATCH_SIZE', 1):
             self.assertTrue(
                 collection_models.CollectionRightsModel
                 .has_reference_to_user_id(self.USER_ID_1))
@@ -396,7 +397,7 @@ class CollectionRightsModelRevertUnitTest(test_utils.GenericTestBase):
                 'new_role': rights_domain.ROLE_OWNER
             }]
         )
-        self.allow_revert_swap = self.swap(
+        self.allow_revert_swap = patch.object(
             collection_models.CollectionRightsModel, 'ALLOW_REVERT', True)
 
         collection_rights_allowed_commands = copy.deepcopy(
@@ -409,7 +410,7 @@ class CollectionRightsModelRevertUnitTest(test_utils.GenericTestBase):
             'allowed_values': {},
             'deprecated_values': {}
         })
-        self.allowed_commands_swap = self.swap(
+        self.allowed_commands_swap = patch.object(
             feconf,
             'COLLECTION_RIGHTS_CHANGE_ALLOWED_COMMANDS',
             collection_rights_allowed_commands

--- a/core/storage/email/gae_models_test.py
+++ b/core/storage/email/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for core.storage.email.gae_models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import datetime
 import types
@@ -57,14 +58,14 @@ class SentEmailModelUnitTests(test_utils.GenericTestBase):
         ) -> str:
             return 'Email Hash'
 
-        self.generate_constant_hash_ctx = self.swap(
+        self.generate_constant_hash_ctx = patch.object(
             email_models.SentEmailModel,
             '_generate_hash',
             types.MethodType(mock_generate_hash, email_models.SentEmailModel)
         )
         # Since we cannot reuse swap, we need to duplicate the code so that
         # we can create the intitial model here.
-        with self.swap(
+        with patch.object(
             email_models.SentEmailModel,
             '_generate_hash',
             types.MethodType(mock_generate_hash, email_models.SentEmailModel)
@@ -232,7 +233,7 @@ class SentEmailModelUnitTests(test_utils.GenericTestBase):
     def test_check_duplicate_messages_with_same_hash(self) -> None:
         def mock_convert_to_hash(input_string: str, max_length: int) -> str: # pylint: disable=unused-argument
             return 'some_poor_hash'
-        swap_generate_hash = self.swap(
+        swap_generate_hash = patch.object(
             utils, 'convert_to_hash', mock_convert_to_hash)
         with swap_generate_hash:
             email_models.SentEmailModel.create(
@@ -251,7 +252,7 @@ class SentEmailModelUnitTests(test_utils.GenericTestBase):
             'producing too many collisions.'
         ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 email_models.SentEmailModel, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for Exploration models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import copy
 import datetime
@@ -242,7 +243,7 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
         )
 
     def test_has_reference_to_user_id(self) -> None:
-        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+        with patch.object(base_models, 'FETCH_BATCH_SIZE', 1):
             self.assertTrue(
                 exp_models.ExplorationRightsModel
                 .has_reference_to_user_id(self.USER_ID_1))
@@ -413,7 +414,7 @@ class ExplorationRightsModelRevertUnitTest(test_utils.GenericTestBase):
                 'new_role': rights_domain.ROLE_OWNER
             }]
         )
-        self.allow_revert_swap = self.swap(
+        self.allow_revert_swap = patch.object(
             exp_models.ExplorationRightsModel, 'ALLOW_REVERT', True)
 
         exploration_rights_allowed_commands = copy.deepcopy(
@@ -426,7 +427,7 @@ class ExplorationRightsModelRevertUnitTest(test_utils.GenericTestBase):
             'allowed_values': {},
             'deprecated_values': {}
         })
-        self.allowed_commands_swap = self.swap(
+        self.allowed_commands_swap = patch.object(
             feconf,
             'EXPLORATION_RIGHTS_CHANGE_ALLOWED_COMMANDS',
             exploration_rights_allowed_commands
@@ -1071,7 +1072,7 @@ class TransientCheckpointUrlModelUnitTest(test_utils.GenericTestBase):
             'New id generator is producing too many collisions.'
         ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 transient_checkpoint_progress_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for core.storage.feedback.gae_models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import types
 
@@ -107,7 +108,7 @@ class FeedbackThreadModelTest(test_utils.GenericTestBase):
         with self.assertRaisesRegex(
             Exception, 'Feedback thread ID conflict on create.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 feedback_thread_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,
@@ -120,7 +121,7 @@ class FeedbackThreadModelTest(test_utils.GenericTestBase):
             Exception,
             'New thread id generator is producing too many collisions.'):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 feedback_thread_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,

--- a/core/storage/learner_group/gae_models_test.py
+++ b/core/storage/learner_group/gae_models_test.py
@@ -17,6 +17,7 @@
 """Tests for Learner group models."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import types
 
@@ -98,7 +99,7 @@ class LearnerGroupModelUnitTest(test_utils.GenericTestBase):
             'A learner group with the given group ID exists already.'
         ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 learner_group_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,
@@ -111,7 +112,7 @@ class LearnerGroupModelUnitTest(test_utils.GenericTestBase):
             'New id generator is producing too many collisions.'
         ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 learner_group_model_cls, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -182,7 +182,7 @@ class QuestionModelUnitTests(test_utils.GenericTestBase):
             'many collisions.'
             ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(
+            with patch.object(
                 question_models.QuestionModel, 'get_by_id',
                 types.MethodType(
                     lambda x, y: True,
@@ -604,11 +604,11 @@ class QuestionSkillLinkModelUnitTests(test_utils.GenericTestBase):
             alist.sort(key=k)
             return alist[:num]
 
-        sample_swap = self.swap(random, 'sample', mock_random_sample)
+        sample_swap = patch.object(random, 'sample', mock_random_sample)
 
         def mock_random_int(upper_bound: int) -> int:
             return 1 if upper_bound > 1 else 0
-        random_int_swap = self.swap(utils, 'get_random_int', mock_random_int)
+        random_int_swap = patch.object(utils, 'get_random_int', mock_random_int)
         with sample_swap, random_int_swap:
             question_skill_links_1 = (
                 question_models.QuestionSkillLinkModel.
@@ -814,11 +814,11 @@ class QuestionSkillLinkModelUnitTests(test_utils.GenericTestBase):
             alist.sort(key=k)
             return alist[:num]
 
-        sample_swap = self.swap(random, 'sample', mock_random_sample)
+        sample_swap = patch.object(random, 'sample', mock_random_sample)
 
         def mock_random_int(upper_bound: int) -> int:
             return 1 if upper_bound > 1 else 0
-        random_int_swap = self.swap(utils, 'get_random_int', mock_random_int)
+        random_int_swap = patch.object(utils, 'get_random_int', mock_random_int)
         with sample_swap, random_int_swap:
             question_skill_links_1 = (
                 question_models.QuestionSkillLinkModel.

--- a/core/storage/statistics/gae_models_test.py
+++ b/core/storage/statistics/gae_models_test.py
@@ -807,7 +807,7 @@ class PlaythroughModelUnitTests(test_utils.GenericTestBase):
 
     def test_create_raises_error_when_many_id_collisions_occur(self) -> None:
         # Swap dependent method get_by_id to simulate collision every time.
-        get_by_id_swap = self.swap(
+        get_by_id_swap = patch.object(
             stats_models.PlaythroughModel, 'get_by_id', types.MethodType(
                 lambda _, __: True, stats_models.PlaythroughModel))
 
@@ -1108,7 +1108,7 @@ class StateAnswersModelUnitTests(test_utils.GenericTestBase):
 
         # Use a smaller max answer list size so fewer answers are needed to
         # exceed a shard. This will increase the 'shard_count'.
-        with self.swap(
+        with patch.object(
             stats_models.StateAnswersModel, '_MAX_ANSWER_LIST_BYTE_SIZE', 1):
             stats_models.StateAnswersModel.insert_submitted_answers(
                 'exp_id', 1, 'state_name', 'interaction_id',
@@ -1205,7 +1205,7 @@ class StateAnswersModelUnitTests(test_utils.GenericTestBase):
     def test_get_all_state_answer_models_of_all_shards(self) -> None:
         # Use a smaller max answer list size so fewer answers are needed to
         # exceed a shard. This will increase the 'shard_count'.
-        with self.swap(
+        with patch.object(
             stats_models.StateAnswersModel, '_MAX_ANSWER_LIST_BYTE_SIZE', 1):
             submitted_answer_list1: List[stats_domain.SubmittedAnswerDict] = [{
                 'answer': 'value1',

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -1115,7 +1115,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_7', self.translation_language_code)
 
-        with self.swap(feconf, 'DEFAULT_SUGGESTION_QUERY_LIMIT', 1):
+        with patch.object(feconf, 'DEFAULT_SUGGESTION_QUERY_LIMIT', 1):
             suggestions = (
                 suggestion_models.GeneralSuggestionModel
                 .get_translation_suggestions_in_review_with_exp_id(
@@ -1243,7 +1243,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_10', self.translation_language_code)
 
-        with self.swap(feconf, 'DEFAULT_SUGGESTION_QUERY_LIMIT', 1):
+        with patch.object(feconf, 'DEFAULT_SUGGESTION_QUERY_LIMIT', 1):
             suggestion_model_results = (
                 suggestion_models
                 .GeneralSuggestionModel
@@ -1256,13 +1256,13 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(len(suggestion_model_results), 2)
 
     def test_get_all_stale_suggestion_ids(self) -> None:
-        with self.swap(
+        with patch.object(
             suggestion_models, 'THRESHOLD_TIME_BEFORE_ACCEPT_IN_MSECS', 0):
             self.assertEqual(len(
                 suggestion_models.GeneralSuggestionModel
                 .get_all_stale_suggestion_ids()), 1)
 
-        with self.swap(
+        with patch.object(
             suggestion_models, 'THRESHOLD_TIME_BEFORE_ACCEPT_IN_MSECS',
             7 * 24 * 60 * 60 * 1000):
             self.assertEqual(len(
@@ -1272,7 +1272,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
     def test_get__suggestions_waiting_too_long_raises_if_suggestion_types_empty(
         self
     ) -> None:
-        with self.swap(
+        with patch.object(
             feconf, 'CONTRIBUTOR_DASHBOARD_SUGGESTION_TYPES', []):
             with self.assertRaisesRegex(
                 Exception,
@@ -1297,10 +1297,10 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
         mocked_contributor_dashboard_suggestion_types = [
             feconf.SUGGESTION_TYPE_ADD_QUESTION]
 
-        with self.swap(
+        with patch.object(
             feconf, 'CONTRIBUTOR_DASHBOARD_SUGGESTION_TYPES',
             mocked_contributor_dashboard_suggestion_types):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0):
                 suggestions_waiting_too_long_for_review = (
@@ -1322,7 +1322,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             'exploration.exp1.thread1', self.translation_language_code)
 
         # Make sure the threshold is nonzero.
-        with self.swap(
+        with patch.object(
             suggestion_models,
             'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 1):
             suggestions_waiting_too_long_for_review = (
@@ -1349,7 +1349,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
         with self.mock_datetime_utcnow(
             mocked_datetime_less_than_review_wait_time_threshold):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS',
                 mocked_threshold_review_wait_time_in_days):
@@ -1378,7 +1378,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
         with self.mock_datetime_utcnow(
             mocked_datetime_eq_review_wait_time_threshold):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS',
                 mocked_threshold_review_wait_time_in_days):
@@ -1400,7 +1400,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread1', self.translation_language_code)
 
-        with self.swap(
+        with patch.object(
             suggestion_models,
             'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0):
             suggestions_waiting_too_long_for_review = (
@@ -1436,7 +1436,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
         with self.mock_datetime_utcnow(
             mocked_datetime_past_review_wait_time_threshold):
-            with self.swap(
+            with patch.object(
                 suggestion_models,
                 'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS',
                 mocked_threshold_review_wait_time_in_days):
@@ -1478,7 +1478,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp3.thread1', 'hi')
 
-        with self.swap(
+        with patch.object(
             suggestion_models,
             'SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS', 0):
             suggestions_waiting_too_long_for_review = (
@@ -1719,7 +1719,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp2.thread1', self.translation_language_code)
 
-        with self.swap(
+        with patch.object(
             suggestion_models,
             'MAX_TRANSLATION_SUGGESTIONS_TO_FETCH_FOR_REVIEWER_EMAILS', 1):
             translation_suggestion_models = (
@@ -1752,7 +1752,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             'reviewer_2', self.change_cmd, 'category2',
             'skill2.thread1', self.question_language_code)
 
-        with self.swap(
+        with patch.object(
             suggestion_models,
             'MAX_QUESTION_SUGGESTIONS_TO_FETCH_FOR_REVIEWER_EMAILS', 1):
             question_suggestion_models = (

--- a/core/storage/topic/gae_models_test.py
+++ b/core/storage/topic/gae_models_test.py
@@ -254,7 +254,7 @@ class TopicRightsModelUnitTests(test_utils.GenericTestBase):
             base_models.DELETION_POLICY.LOCALLY_PSEUDONYMIZE)
 
     def test_has_reference_to_user_id(self) -> None:
-        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+        with patch.object(base_models, 'FETCH_BATCH_SIZE', 1):
             topic_rights = topic_models.TopicRightsModel(
                 id=self.TOPIC_1_ID, manager_ids=['manager_id'])
             topic_rights.commit(

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -350,7 +350,7 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
 
     def test_get_new_id_with_deleted_user_model(self) -> None:
         # Swap dependent method get_by_id to simulate collision every time.
-        get_by_id_swap = self.swap(
+        get_by_id_swap = patch.object(
             user_models.DeletedUserModel, 'get_by_id', types.MethodType(
                 lambda _, __: True, user_models.DeletedUserModel))
 
@@ -362,7 +362,7 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
 
     def test_get_new_id_for_too_many_collisions_raises_error(self) -> None:
         # Swap dependent method get_by_id to simulate collision every time.
-        get_by_id_swap = self.swap(
+        get_by_id_swap = patch.object(
             user_models.UserSettingsModel, 'get_by_id', types.MethodType(
                 lambda _, __: True, user_models.UserSettingsModel))
 
@@ -3316,7 +3316,7 @@ class PseudonymizedUserModelTests(test_utils.GenericTestBase):
 
     def test_create_raises_error_when_many_id_collisions_occur(self) -> None:
         # Swap dependent method get_by_id to simulate collision every time.
-        get_by_id_swap = self.swap(
+        get_by_id_swap = patch.object(
             user_models.PseudonymizedUserModel, 'get_by_id', types.MethodType(
                 lambda _, __: True, user_models.PseudonymizedUserModel))
 
@@ -3345,7 +3345,7 @@ class PseudonymizedUserModelTests(test_utils.GenericTestBase):
             ids.add(new_id)
 
     def test_get_new_id_simulate_collisions(self) -> None:
-        get_by_id_swap = self.swap(
+        get_by_id_swap = patch.object(
             user_models.PseudonymizedUserModel, 'get_by_id', types.MethodType(
                 lambda _, __: True, user_models.PseudonymizedUserModel))
 

--- a/core/tests/gae_suite_test.py
+++ b/core/tests/gae_suite_test.py
@@ -15,6 +15,7 @@
 """Tests for gae_suite."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import unittest
 
@@ -48,7 +49,7 @@ class GaeSuiteTests(test_utils.GenericTestBase):
     def test_cannot_add_directory_with_invalid_path(self) -> None:
         """Creates invalid path."""
 
-        dir_to_add_swap = self.swap(
+        dir_to_add_swap = patch.object(
             common, 'DIRS_TO_ADD_TO_SYS_PATH', ['invalid_path'])
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception, 'Directory invalid_path does not exist.')
@@ -65,7 +66,7 @@ class GaeSuiteTests(test_utils.GenericTestBase):
             loader = unittest.TestLoader()
             return [loader.loadTestsFromName('core.tests.data.failing_tests')]
 
-        create_test_suites_swap = self.swap(
+        create_test_suites_swap = patch.object(
             gae_suite, 'create_test_suites', _mock_create_test_suites)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception,
@@ -83,7 +84,7 @@ class GaeSuiteTests(test_utils.GenericTestBase):
             loader = unittest.TestLoader()
             return [loader.loadTestsFromName('invalid_test')]
 
-        create_test_suites_swap = self.swap(
+        create_test_suites_swap = patch.object(
             gae_suite, 'create_test_suites', _mock_create_test_suites)
         assert_raises_regexp_context_manager = self.assertRaisesRegex(
             Exception, 'Test suite failed: 1 tests run, 1 errors, 0 failures.')

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -17,6 +17,7 @@
 """Common utilities for test classes."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import collections
@@ -1410,7 +1411,7 @@ class TestBase(unittest.TestCase):
         Example usage:
 
             import math
-            with self.swap(math, 'sqrt', lambda x: 42):
+            with patch.object(math, 'sqrt', lambda x: 42):
                 print math.sqrt(16.0) # prints 42
             print math.sqrt(16.0) # prints 4 as expected.
 
@@ -1418,7 +1419,7 @@ class TestBase(unittest.TestCase):
         first, for example:
 
             import types
-            with self.swap(
+            with patch.object(
                 SomePythonClass, 'some_classmethod',
                 classmethod(new_classmethod)):
 
@@ -1449,7 +1450,7 @@ class TestBase(unittest.TestCase):
         def function_that_always_returns(*_: str, **__: str) -> Any:
             """Returns the input value."""
             return value
-        with self.swap(obj, attr, function_that_always_returns):
+        with patch.object(obj, attr, function_that_always_returns):
             yield
 
     # Here we use type Any because the argument 'obj' can accept any
@@ -1465,7 +1466,7 @@ class TestBase(unittest.TestCase):
         def function_that_always_raises(*_: str, **__: str) -> None:
             """Raises the input exception."""
             raise error
-        with self.swap(obj, attr, function_that_always_raises):
+        with patch.object(obj, attr, function_that_always_raises):
             yield
 
     # Here we use type Any because argument 'obj' can accept any kind
@@ -1503,7 +1504,7 @@ class TestBase(unittest.TestCase):
                 raise raises # pylint: disable=raising-bad-type
             return returns
         call_counter = CallCounter(impl)
-        with self.swap(obj, attr, call_counter):
+        with patch.object(obj, attr, call_counter):
             yield call_counter
 
     # Here we use type Any because the argument 'obj' can accept any
@@ -1863,7 +1864,7 @@ class AppEngineTestBase(TestBase):
         # Mock set_constans_to_default method to throw an exception.
         # Don't directly change constants file in the test.
         # Mock this method again in your test.
-        self.contextManager = self.swap(
+        self.contextManager = patch.object(
             common, 'set_constants_to_default',
             self.mock_set_constants_to_default)
         self.contextManager.__enter__()
@@ -1890,7 +1891,7 @@ class AppEngineTestBase(TestBase):
                 None, a temporary result object is created (by calling the
                 defaultTestResult() method) and used instead.
         """
-        platform_taskqueue_services_swap = self.swap(
+        platform_taskqueue_services_swap = patch.object(
             platform_taskqueue_services, 'create_http_task',
             self._platform_taskqueue_services_stub.create_http_task)
         with platform_taskqueue_services_swap:
@@ -2322,37 +2323,37 @@ version: 1
 
         with contextlib.ExitStack() as stack:
             stack.callback(AuthServicesStub.install_stub(self))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 elastic_search_services.ES.indices, 'create',
                 es_stub.mock_create_index))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 elastic_search_services.ES, 'index',
                 es_stub.mock_index))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 elastic_search_services.ES, 'exists',
                 es_stub.mock_exists))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 elastic_search_services.ES, 'delete',
                 es_stub.mock_delete))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 elastic_search_services.ES, 'delete_by_query',
                 es_stub.mock_delete_by_query))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 elastic_search_services.ES, 'search',
                 es_stub.mock_search))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 memory_cache_services, 'flush_caches',
                 memory_cache_services_stub.flush_caches))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 memory_cache_services, 'get_multi',
                 memory_cache_services_stub.get_multi))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 memory_cache_services, 'set_multi',
                 memory_cache_services_stub.set_multi))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 memory_cache_services, 'get_memory_cache_stats',
                 memory_cache_services_stub.get_memory_cache_stats))
-            stack.enter_context(self.swap(
+            stack.enter_context(patch.object(
                 memory_cache_services, 'delete_multi',
                 memory_cache_services_stub.delete_multi))
 
@@ -2724,7 +2725,7 @@ version: 1
         # source directory instead of webpack_bundles since webpack_bundles is
         # only produced after webpack compilation which is not performed during
         # backend tests.
-        with self.swap(base, 'load_template', mock_load_template):
+        with patch.object(base, 'load_template', mock_load_template):
             response = self.testapp.get(
                 url,
                 params=params,
@@ -2823,7 +2824,7 @@ version: 1
         # source directory instead of webpack_bundles since webpack_bundles is
         # only produced after webpack compilation which is not performed during
         # backend tests.
-        with self.swap(base, 'load_template', mock_load_template):
+        with patch.object(base, 'load_template', mock_load_template):
             response = self.testapp.get(url, params=params, expect_errors=True)
 
         self.assertIn(response.status_int, expected_status_int_list)
@@ -3997,7 +3998,7 @@ class LinterTestBase(GenericTestBase):
             """
             self.linter_stdout.append(' '.join(str(arg) for arg in args))
 
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
     def assert_same_list_elements(
         self, phrases: List[str], stdout: List[str]
@@ -4100,7 +4101,7 @@ class GenericEmailTestBase(GenericTestBase):
         mailgun api key, mailgun domain name and mocked version of
         send_email_to_recipients().
         """
-        with self.swap(
+        with patch.object(
             email_services, 'send_email_to_recipients',
             self._send_email_to_recipients):
             super().run(result=result)

--- a/core/tests/test_utils_test.py
+++ b/core/tests/test_utils_test.py
@@ -17,6 +17,7 @@
 """Tests for test_utils, mainly for the FunctionWrapper."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import logging
 import os
@@ -109,7 +110,7 @@ class FunctionWrapperTests(test_utils.GenericTestBase):
 
         wrapped = test_utils.FunctionWrapper(MockClass.mock_method)
 
-        with self.swap(MockClass, 'mock_method', wrapped):
+        with patch.object(MockClass, 'mock_method', wrapped):
             val = MockClass('foo').mock_method('bar')
             self.assertEqual(val, 'foobarfoobar')
             self.assertEqual(data.get('value'), 'foobar')
@@ -127,7 +128,7 @@ class FunctionWrapperTests(test_utils.GenericTestBase):
                 return (cls.str_attr + string) * 2
 
         wrapped = test_utils.FunctionWrapper(MockClass.mock_classmethod)
-        with self.swap(MockClass, 'mock_classmethod', wrapped):
+        with patch.object(MockClass, 'mock_classmethod', wrapped):
             val = MockClass.mock_classmethod('bar')
             self.assertEqual(val, 'foobarfoobar')
             self.assertEqual(data.get('value'), 'foobar')
@@ -143,7 +144,7 @@ class FunctionWrapperTests(test_utils.GenericTestBase):
                 return string * 2
 
         wrapped = test_utils.FunctionWrapper(MockClass.mock_staticmethod)
-        with self.swap(MockClass, 'mock_staticmethod', wrapped):
+        with patch.object(MockClass, 'mock_staticmethod', wrapped):
             val = MockClass.mock_staticmethod('foobar')
             self.assertEqual(val, 'foobarfoobar')
             self.assertEqual(data.get('value'), 'foobar')
@@ -363,7 +364,7 @@ class TestUtilsTests(test_utils.GenericTestBase):
         self.assertEqual(asset_url, '/assets/images/subjects/Lightbulb.svg')
 
     def test_get_static_asset_filepath_with_prod_mode_on(self) -> None:
-        with self.swap(constants, 'DEV_MODE', False):
+        with patch.object(constants, 'DEV_MODE', False):
             filepath = self.get_static_asset_filepath()
             self.assertEqual(filepath, 'build')
 

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -17,6 +17,7 @@
 """Unit tests for utils.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import base64
 import copy
@@ -294,7 +295,7 @@ class UtilsTests(test_utils.GenericTestBase):
 
     def test_are_datetimes_close(self) -> None:
         initial_time = datetime.datetime(2016, 12, 1, 0, 0, 0)
-        with self.swap(feconf, 'PROXIMAL_TIMEDELTA_SECS', 2):
+        with patch.object(feconf, 'PROXIMAL_TIMEDELTA_SECS', 2):
             self.assertTrue(utils.are_datetimes_close(
                 datetime.datetime(2016, 12, 1, 0, 0, 1),
                 initial_time))
@@ -646,7 +647,7 @@ class UtilsTests(test_utils.GenericTestBase):
                 'core/tests/data/dummy_assets/')
 
     def test_get_asset_dir_prefix_with_prod_mode(self) -> None:
-        with self.swap(constants, 'DEV_MODE', False):
+        with patch.object(constants, 'DEV_MODE', False):
             self.assertEqual(utils.get_asset_dir_prefix(), '/build')
 
     def test_base64_from_int(self) -> None:

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -17,6 +17,7 @@
 """Tests for typed object classes (mostly normalization)."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import inspect
 import json
@@ -1056,7 +1057,7 @@ class BaseTranslatableObjectTests(test_utils.GenericTestBase):
             'be set'):
             objects.BaseTranslatableObject.get_schema()
 
-        with self.swap(objects.BaseTranslatableObject, '_value_key_name', 'a'):
+        with patch.object(objects.BaseTranslatableObject, '_value_key_name', 'a'):
             with self.assertRaisesRegex(
                 NotImplementedError,
                 'The _value_key_name and _value_schema for this class must '

--- a/main_test.py
+++ b/main_test.py
@@ -15,6 +15,7 @@
 """Tests for generic controller behavior."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import contextlib
 import importlib
@@ -52,7 +53,7 @@ class CloudLoggingTests(test_utils.GenericTestBase):
             def setup_logging(self) -> None:
                 function_calls['setup_logging'] = True
 
-        emulator_mode_swap = self.swap(constants, 'EMULATOR_MODE', False)
+        emulator_mode_swap = patch.object(constants, 'EMULATOR_MODE', False)
         logging_client_swap = self.swap_with_checks(
             google.cloud.logging, 'Client', MockClient)
         with emulator_mode_swap, logging_client_swap:

--- a/scripts/check_backend_associated_test_file_test.py
+++ b/scripts/check_backend_associated_test_file_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/check_backend_associated_test_file.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import logging
@@ -39,9 +40,9 @@ class CheckBackendAssociatedTestFileTests(test_utils.GenericTestBase):
         def mock_error(msg: str) -> None:
             self.error_arr.append(msg)
 
-        self.print_swap = self.swap(builtins, 'print', mock_print)
-        self.swap_logging = self.swap(logging, 'error', mock_error)
-        self.swap_exit = self.swap(sys, 'exit', lambda _: None)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
+        self.swap_logging = patch.object(logging, 'error', mock_error)
+        self.swap_exit = patch.object(sys, 'exit', lambda _: None)
 
     def test_checks_fail_when_a_backend_file_lacks_associated_test_file(
             self) -> None:

--- a/scripts/check_e2e_tests_are_captured_in_ci_test.py
+++ b/scripts/check_e2e_tests_are_captured_in_ci_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/check_e2e_tests_are_captured_in_ci.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 import re
@@ -41,7 +42,7 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
     def test_read_ci_file(self) -> None:
         ci_filepath = os.path.join(DUMMY_CONF_FILES)
 
-        ci_filepath_swap = self.swap(
+        ci_filepath_swap = patch.object(
             check_e2e_tests_are_captured_in_ci, 'CI_PATH',
             ci_filepath)
         with ci_filepath_swap:
@@ -54,7 +55,7 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
         webdriverio_config_file = os.path.join(
             DUMMY_CONF_FILES, 'dummy_webdriverio.conf.js')
 
-        webdriverio_config_file_swap = self.swap(
+        webdriverio_config_file_swap = patch.object(
             check_e2e_tests_are_captured_in_ci, 'WEBDRIVERIO_CONF_FILE_PATH',
             webdriverio_config_file)
         with webdriverio_config_file_swap:
@@ -67,7 +68,7 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
         def mock_read_ci_config_file() -> List[str]:
             return EXPECTED_CI_LIST
 
-        dummy_path = self.swap(
+        dummy_path = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'read_and_parse_ci_config_files',
             mock_read_ci_config_file)
@@ -84,7 +85,7 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
                     DUMMY_CONF_FILES, 'dummy_webdriverio.conf.js'), 'r').read()
             return webdriverio_config_file
 
-        dummy_path = self.swap(
+        dummy_path = patch.object(
             check_e2e_tests_are_captured_in_ci, 'read_webdriverio_conf_file',
             mock_read_webdriverio_conf_file)
         with dummy_path:
@@ -101,21 +102,21 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
         def mock_get_e2e_suite_names_from_ci() -> List[str]:
             return ['oneword', 'twoWords']
 
-        mock_webdriverio_test_suites = self.swap(
+        mock_webdriverio_test_suites = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'get_e2e_suite_names_from_webdriverio_file',
             mock_get_e2e_suite_names_from_webdriverio_file)
 
-        mock_ci_scripts = self.swap(
+        mock_ci_scripts = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'get_e2e_suite_names_from_ci_config_file',
             mock_get_e2e_suite_names_from_ci)
 
-        mock_tests_to_remove = self.swap(
+        mock_tests_to_remove = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'TEST_SUITES_NOT_RUN_IN_CI', ['fourWord'])
 
-        common_test_swap = self.swap(
+        common_test_swap = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'SAMPLE_TEST_SUITE_THAT_IS_KNOWN_TO_EXIST',
             'oneword')
@@ -141,16 +142,16 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
         def mock_return_empty_list() -> List[str]:
             return []
 
-        ci_path_swap = self.swap(
+        ci_path_swap = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'read_and_parse_ci_config_files',
             mock_read_ci_config_file)
 
-        mock_tests_to_remove = self.swap(
+        mock_tests_to_remove = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'TEST_SUITES_NOT_RUN_IN_CI', [])
 
-        mock_get_e2e_suite_names_from_ci_config_file = self.swap(
+        mock_get_e2e_suite_names_from_ci_config_file = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'get_e2e_suite_names_from_ci_config_file',
             mock_return_empty_list)
@@ -176,20 +177,20 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
         def mock_get_e2e_test_filenames_from_webdriverio_dir() -> List[str]:
             return ['fourWords.js', 'threeWords.js']
 
-        webdriverio_test_suite_files_swap = self.swap(
+        webdriverio_test_suite_files_swap = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'get_e2e_test_filenames_from_webdriverio_dir',
             mock_get_e2e_test_filenames_from_webdriverio_dir)
 
-        webdriverio_path_swap = self.swap(
+        webdriverio_path_swap = patch.object(
             check_e2e_tests_are_captured_in_ci, 'read_webdriverio_conf_file',
             mock_read_webdriverio_conf_file)
 
-        mock_tests_to_remove = self.swap(
+        mock_tests_to_remove = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'TEST_SUITES_NOT_RUN_IN_CI', [])
 
-        mock_e2e_test_suites = self.swap(
+        mock_e2e_test_suites = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'get_e2e_suite_names_from_webdriverio_file',
             mock_return_empty_list)
@@ -208,7 +209,7 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
         def mock_get_e2e_test_filenames_from_webdriverio_dir() -> List[str]:
             return ['fourWords.js', 'threeWords.js']
 
-        webdriverio_test_suite_files_swap = self.swap(
+        webdriverio_test_suite_files_swap = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'get_e2e_test_filenames_from_webdriverio_dir',
             mock_get_e2e_test_filenames_from_webdriverio_dir)
@@ -234,22 +235,22 @@ class CheckE2eTestsCapturedInCITests(test_utils.GenericTestBase):
         def mock_read_ci_config() -> List[str]:
             return EXPECTED_CI_LIST
 
-        webdriverio_test_suite_files_swap = self.swap(
+        webdriverio_test_suite_files_swap = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'get_e2e_test_filenames_from_webdriverio_dir',
             mock_get_e2e_test_filenames_from_webdriverio_dir)
-        webdriverio_path_swap = self.swap(
+        webdriverio_path_swap = patch.object(
             check_e2e_tests_are_captured_in_ci, 'read_webdriverio_conf_file',
             mock_read_webdriverio_conf_file)
-        ci_path_swap = self.swap(
+        ci_path_swap = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'read_and_parse_ci_config_files', mock_read_ci_config)
-        common_test_swap = self.swap(
+        common_test_swap = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'SAMPLE_TEST_SUITE_THAT_IS_KNOWN_TO_EXIST',
             'threeWords')
 
-        mock_tests_to_remove = self.swap(
+        mock_tests_to_remove = patch.object(
             check_e2e_tests_are_captured_in_ci,
             'TEST_SUITES_NOT_RUN_IN_CI', [])
 

--- a/scripts/check_frontend_test_coverage_test.py
+++ b/scripts/check_frontend_test_coverage_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/check_frontend_test_coverage.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -66,12 +67,12 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
         def mock_check_call(command: str) -> None:  # pylint: disable=unused-argument
             self.check_function_calls['check_call_is_called'] = True
 
-        self.open_file_swap = self.swap(
+        self.open_file_swap = patch.object(
             utils, 'open_file', mock_open_file
         )
-        self.exists_swap = self.swap(os.path, 'exists', mock_exists)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
-        self.check_call_swap = self.swap(
+        self.exists_swap = patch.object(os.path, 'exists', mock_exists)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
+        self.check_call_swap = patch.object(
             subprocess, 'check_call', mock_check_call
         )
 
@@ -158,7 +159,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
             'LH:9\n'
             'end_of_record\n'
         )
-        not_fully_covered_files_swap = self.swap(
+        not_fully_covered_files_swap = patch.object(
             check_frontend_test_coverage,
             'NOT_FULLY_COVERED_FILENAMES',
             ['file.ts', 'file2.ts'],
@@ -170,7 +171,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
         def mock_sys_exit(error_message: str) -> None:  # pylint: disable=unused-argument
             check_function_calls['sys_exit_is_called'] = True
 
-        sys_exit_swap = self.swap(sys, 'exit', mock_sys_exit)
+        sys_exit_swap = patch.object(sys, 'exit', mock_sys_exit)
         with sys_exit_swap, self.exists_swap, self.open_file_swap, self.print_swap:  # pylint: disable=line-too-long
             with not_fully_covered_files_swap:
                 check_frontend_test_coverage.check_coverage_changes()
@@ -182,7 +183,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
         def mock_exists(unused_path: str) -> Literal[False]:
             return False
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
         with exists_swap:
             with self.assertRaisesRegex(
                 Exception,
@@ -206,7 +207,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
             'LH:9\n'
             'end_of_record\n'
         )
-        not_fully_covered_files_swap = self.swap(
+        not_fully_covered_files_swap = patch.object(
             check_frontend_test_coverage, 'NOT_FULLY_COVERED_FILENAMES', []
         )
 
@@ -229,7 +230,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
             'LH:10\n'
             'end_of_record\n'
         )
-        not_fully_covered_files_swap = self.swap(
+        not_fully_covered_files_swap = patch.object(
             check_frontend_test_coverage,
             'NOT_FULLY_COVERED_FILENAMES',
             ['file.ts'],
@@ -260,7 +261,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
             'LH:9\n'
             'end_of_record\n'
         )
-        not_fully_covered_files_swap = self.swap(
+        not_fully_covered_files_swap = patch.object(
             check_frontend_test_coverage,
             'NOT_FULLY_COVERED_FILENAMES',
             ['file.ts'],
@@ -299,7 +300,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
             'LH:9\n'
             'end_of_record\n'
         )
-        not_fully_covered_files_swap = self.swap(
+        not_fully_covered_files_swap = patch.object(
             check_frontend_test_coverage,
             'NOT_FULLY_COVERED_FILENAMES',
             ['anotherfile.tsfile.ts'],
@@ -311,7 +312,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
         def mock_sys_exit(error_message: str) -> None:  # pylint: disable=unused-argument
             check_function_calls['sys_exit_is_called'] = True
 
-        sys_exit_swap = self.swap(sys, 'exit', mock_sys_exit)
+        sys_exit_swap = patch.object(sys, 'exit', mock_sys_exit)
         with sys_exit_swap, self.exists_swap, self.open_file_swap:
             with self.print_swap, not_fully_covered_files_swap:
                 (
@@ -333,7 +334,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
             'LH:9\n'
             'end_of_record\n'
         )
-        not_fully_covered_files_swap = self.swap(
+        not_fully_covered_files_swap = patch.object(
             check_frontend_test_coverage,
             'NOT_FULLY_COVERED_FILENAMES',
             ['file.ts', 'anotherfile.ts'],
@@ -361,7 +362,7 @@ class CheckFrontendCoverageTests(test_utils.GenericTestBase):
             'LH:9\n'
             'end_of_record\n'
         )
-        not_fully_covered_files_swap = self.swap(
+        not_fully_covered_files_swap = patch.object(
             check_frontend_test_coverage,
             'NOT_FULLY_COVERED_FILENAMES',
             ['file.ts'],

--- a/scripts/check_overall_backend_test_coverage_test.py
+++ b/scripts/check_overall_backend_test_coverage_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/check_overall_backend_test_coverage.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -35,7 +36,7 @@ class CheckOverallBackendTestCoverageTests(test_utils.GenericTestBase):
         self.print_arr: list[str] = []
         def mock_print(msg: str, end: str = '\n') -> None:  # pylint: disable=unused-argument
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
         self.env = os.environ.copy()
         self.cmd = [
             sys.executable, '-m', 'coverage', 'report',

--- a/scripts/clean_test.py
+++ b/scripts/clean_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/clean_test.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 import shutil
@@ -43,8 +44,8 @@ class CleanTests(test_utils.GenericTestBase):
         def mock_exists(unused_path: str) -> Literal[False]:
             return False
 
-        rmtree_swap = self.swap(shutil, 'rmtree', mock_rmtree)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        rmtree_swap = patch.object(shutil, 'rmtree', mock_rmtree)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
         with rmtree_swap, exists_swap:
             clean.delete_directory_tree('dir_path')
         self.assertEqual(check_function_calls, expected_check_function_calls)
@@ -61,8 +62,8 @@ class CleanTests(test_utils.GenericTestBase):
         def mock_exists(unused_path: str) -> Literal[True]:
             return True
 
-        rmtree_swap = self.swap(shutil, 'rmtree', mock_rmtree)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        rmtree_swap = patch.object(shutil, 'rmtree', mock_rmtree)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
         with rmtree_swap, exists_swap:
             clean.delete_directory_tree('dir_path')
         self.assertEqual(check_function_calls, expected_check_function_calls)
@@ -79,8 +80,8 @@ class CleanTests(test_utils.GenericTestBase):
         def mock_isfile(unused_path: str) -> Literal[False]:
             return False
 
-        remove_swap = self.swap(os, 'remove', mock_remove)
-        isfile_swap = self.swap(os.path, 'isfile', mock_isfile)
+        remove_swap = patch.object(os, 'remove', mock_remove)
+        isfile_swap = patch.object(os.path, 'isfile', mock_isfile)
         with remove_swap, isfile_swap:
             clean.delete_file('file_path')
         self.assertEqual(check_function_calls, expected_check_function_calls)
@@ -97,8 +98,8 @@ class CleanTests(test_utils.GenericTestBase):
         def mock_isfile(unused_path: str) -> Literal[True]:
             return True
 
-        remove_swap = self.swap(os, 'remove', mock_remove)
-        isfile_swap = self.swap(os.path, 'isfile', mock_isfile)
+        remove_swap = patch.object(os, 'remove', mock_remove)
+        isfile_swap = patch.object(os.path, 'isfile', mock_isfile)
         with remove_swap, isfile_swap:
             clean.delete_file('file_path')
         self.assertEqual(check_function_calls, expected_check_function_calls)
@@ -118,10 +119,10 @@ class CleanTests(test_utils.GenericTestBase):
             check_function_calls['delete_file_is_called'] += 1
         def mock_listdir(unused_path: str) -> List[str]:
             return ['some_dir', 'tmpcompiledjs_dir']
-        delete_dir_swap = self.swap(
+        delete_dir_swap = patch.object(
             clean, 'delete_directory_tree', mock_delete_dir)
-        delete_file_swap = self.swap(clean, 'delete_file', mock_delete_file)
-        listdir_swap = self.swap(os, 'listdir', mock_listdir)
+        delete_file_swap = patch.object(clean, 'delete_file', mock_delete_file)
+        listdir_swap = patch.object(os, 'listdir', mock_listdir)
 
         with delete_dir_swap, delete_file_swap, listdir_swap:
             clean.main(args=[])

--- a/scripts/common_test.py
+++ b/scripts/common_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/common.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import contextlib
@@ -90,7 +91,7 @@ class CommonTests(test_utils.GenericTestBase):
         self.print_arr: list[str] = []
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
     def test_run_ng_compilation_successfully(self) -> None:
         swap_isdir = self.swap_with_checks(
@@ -201,25 +202,25 @@ class CommonTests(test_utils.GenericTestBase):
         self.assertEqual(common.PROTOC_VERSION, protobuf_version)
 
     def test_is_x64_architecture_in_x86(self) -> None:
-        maxsize_swap = self.swap(sys, 'maxsize', 1)
+        maxsize_swap = patch.object(sys, 'maxsize', 1)
         with maxsize_swap:
             self.assertFalse(common.is_x64_architecture())
 
     def test_is_x64_architecture_in_x64(self) -> None:
-        maxsize_swap = self.swap(sys, 'maxsize', 2**32 + 1)
+        maxsize_swap = patch.object(sys, 'maxsize', 2**32 + 1)
         with maxsize_swap:
             self.assertTrue(common.is_x64_architecture())
 
     def test_is_mac_os(self) -> None:
-        with self.swap(common, 'OS_NAME', 'Darwin'):
+        with patch.object(common, 'OS_NAME', 'Darwin'):
             self.assertTrue(common.is_mac_os())
-        with self.swap(common, 'OS_NAME', 'Linux'):
+        with patch.object(common, 'OS_NAME', 'Linux'):
             self.assertFalse(common.is_mac_os())
 
     def test_is_linux_os(self) -> None:
-        with self.swap(common, 'OS_NAME', 'Linux'):
+        with patch.object(common, 'OS_NAME', 'Linux'):
             self.assertTrue(common.is_linux_os())
-        with self.swap(common, 'OS_NAME', 'Windows'):
+        with patch.object(common, 'OS_NAME', 'Windows'):
             self.assertFalse(common.is_linux_os())
 
     def test_run_cmd(self) -> None:
@@ -233,7 +234,7 @@ class CommonTests(test_utils.GenericTestBase):
         }
         def mock_makedirs(unused_dirpath: str) -> None:
             check_function_calls['makedirs_gets_called'] = True
-        with self.swap(os, 'makedirs', mock_makedirs):
+        with patch.object(os, 'makedirs', mock_makedirs):
             common.ensure_directory_exists('assets')
         self.assertEqual(check_function_calls, {'makedirs_gets_called': False})
 
@@ -243,7 +244,7 @@ class CommonTests(test_utils.GenericTestBase):
         }
         def mock_makedirs(unused_dirpath: str) -> None:
             check_function_calls['makedirs_gets_called'] = True
-        with self.swap(os, 'makedirs', mock_makedirs):
+        with patch.object(os, 'makedirs', mock_makedirs):
             common.ensure_directory_exists('test-dir')
         self.assertEqual(check_function_calls, {'makedirs_gets_called': True})
 
@@ -262,7 +263,7 @@ class CommonTests(test_utils.GenericTestBase):
     ) -> None:
         def mock_getcwd() -> str:
             return 'invalid'
-        getcwd_swap = self.swap(os, 'getcwd', mock_getcwd)
+        getcwd_swap = patch.object(os, 'getcwd', mock_getcwd)
         with getcwd_swap, self.assertRaisesRegex(
             Exception, 'Please run this script from the oppia/ directory.'):
             common.require_cwd_to_be_oppia()
@@ -278,9 +279,9 @@ class CommonTests(test_utils.GenericTestBase):
 
         def mock_isdir(unused_dirpath: str) -> Literal[True]:
             return True
-        getcwd_swap = self.swap(os, 'getcwd', mock_getcwd)
-        basename_swap = self.swap(os.path, 'basename', mock_basename)
-        isdir_swap = self.swap(os.path, 'isdir', mock_isdir)
+        getcwd_swap = patch.object(os, 'getcwd', mock_getcwd)
+        basename_swap = patch.object(os.path, 'basename', mock_basename)
+        isdir_swap = patch.object(os.path, 'isdir', mock_isdir)
         with getcwd_swap, basename_swap, isdir_swap:
             common.require_cwd_to_be_oppia(allow_deploy_dir=True)
 
@@ -306,10 +307,10 @@ class CommonTests(test_utils.GenericTestBase):
             def mock_input() -> str:
                 check_function_calls['input_gets_called'] += 1
                 return 'n'
-            call_swap = self.swap(subprocess, 'call', mock_call)
-            check_call_swap = self.swap(
+            call_swap = patch.object(subprocess, 'call', mock_call)
+            check_call_swap = patch.object(
                 subprocess, 'check_call', mock_check_call)
-            input_swap = self.swap(builtins, 'input', mock_input)
+            input_swap = patch.object(builtins, 'input', mock_input)
             with call_swap, check_call_swap, input_swap:
                 common.open_new_tab_in_browser_if_possible('test-url')
             self.assertEqual(
@@ -341,10 +342,10 @@ class CommonTests(test_utils.GenericTestBase):
                 if check_function_calls['input_gets_called'] == 2:
                     return '1'
                 return 'y'
-            call_swap = self.swap(subprocess, 'call', mock_call)
-            check_call_swap = self.swap(
+            call_swap = patch.object(subprocess, 'call', mock_call)
+            check_call_swap = patch.object(
                 subprocess, 'check_call', mock_check_call)
-            input_swap = self.swap(builtins, 'input', mock_input)
+            input_swap = patch.object(builtins, 'input', mock_input)
             with call_swap, check_call_swap, input_swap:
                 common.open_new_tab_in_browser_if_possible('test-url')
             self.assertEqual(
@@ -376,10 +377,10 @@ class CommonTests(test_utils.GenericTestBase):
                 if check_function_calls['input_gets_called'] == 2:
                     return '1'
                 return 'y'
-            call_swap = self.swap(subprocess, 'call', mock_call)
-            check_call_swap = self.swap(
+            call_swap = patch.object(subprocess, 'call', mock_call)
+            check_call_swap = patch.object(
                 subprocess, 'check_call', mock_check_call)
-            input_swap = self.swap(builtins, 'input', mock_input)
+            input_swap = patch.object(builtins, 'input', mock_input)
             with call_swap, check_call_swap, input_swap:
                 common.open_new_tab_in_browser_if_possible('test-url')
             self.assertEqual(
@@ -392,7 +393,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'remote1 url1\nremote2 url2'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output
         ):
             self.assertEqual(common.get_remote_alias(['url1']), 'remote1')
@@ -402,7 +403,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'remote1 url1\nremote2 url2'
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
         with check_output_swap, self.assertRaisesRegex(
             Exception,
@@ -413,7 +414,7 @@ class CommonTests(test_utils.GenericTestBase):
     def test_verify_local_repo_is_clean_with_clean_repo(self) -> None:
         def mock_check_output(unused_cmd_tokens: List[str]) -> bytes:
             return b'nothing to commit, working directory clean'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output
         ):
             common.verify_local_repo_is_clean()
@@ -421,7 +422,7 @@ class CommonTests(test_utils.GenericTestBase):
     def test_verify_local_repo_is_clean_with_unclean_repo(self) -> None:
         def mock_check_output(unused_cmd_tokens: List[str]) -> bytes:
             return b'invalid'
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
         with check_output_swap, self.assertRaisesRegex(
             Exception, 'ERROR: This script should be run from a clean branch.'
@@ -433,7 +434,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch test'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.get_current_branch_name(), 'test')
 
@@ -446,8 +447,8 @@ class CommonTests(test_utils.GenericTestBase):
         def mock_run_cmd(cmd: str) -> str:
             return cmd
 
-        with self.swap(subprocess, 'check_output', mock_check_output):
-            with self.swap(common, 'run_cmd', mock_run_cmd):
+        with patch.object(subprocess, 'check_output', mock_check_output):
+            with patch.object(common, 'run_cmd', mock_run_cmd):
                 common.update_branch_with_upstream()
 
     def test_get_current_release_version_number_with_non_hotfix_branch(
@@ -484,7 +485,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch release-1.2.3'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_hotfix_branch(), False)
 
@@ -493,7 +494,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch release-1.2.3-hotfix-1'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_hotfix_branch(), True)
 
@@ -504,7 +505,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch release-1.2.3'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_release_branch(), True)
 
@@ -515,7 +516,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch release-1.2.3-hotfix-1'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_release_branch(), True)
 
@@ -526,7 +527,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch release-maintenance-1.2.3'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_release_branch(), True)
 
@@ -537,7 +538,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch test'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_release_branch(), False)
 
@@ -546,7 +547,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch test-common'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_test_branch(), True)
 
@@ -555,7 +556,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch invalid-test'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             self.assertEqual(common.is_current_branch_a_test_branch(), False)
 
@@ -564,7 +565,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch test'
-        with self.swap(
+        with patch.object(
             subprocess, 'check_output', mock_check_output):
             common.verify_current_branch_name('test')
 
@@ -573,7 +574,7 @@ class CommonTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'On branch invalid'
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
         with check_output_swap, self.assertRaisesRegex(
             Exception,
@@ -594,7 +595,7 @@ class CommonTests(test_utils.GenericTestBase):
 
         sleep_swap = self.swap_with_checks(
             time, 'sleep', mock_sleep, expected_args=[(1,)] * 60)
-        is_port_in_use_swap = self.swap(
+        is_port_in_use_swap = patch.object(
             common, 'is_port_in_use', mock_is_port_in_use)
 
         with sleep_swap, is_port_in_use_swap:
@@ -607,9 +608,9 @@ class CommonTests(test_utils.GenericTestBase):
         def mock_is_port_in_use(unused_port_number: int) -> Literal[False]:
             return False
 
-        sleep_swap = self.swap(
+        sleep_swap = patch.object(
             time, 'sleep', mock_sleep)
-        is_port_in_use_swap = self.swap(
+        is_port_in_use_swap = patch.object(
             common, 'is_port_in_use', mock_is_port_in_use)
 
         with sleep_swap, is_port_in_use_swap:
@@ -626,7 +627,7 @@ class CommonTests(test_utils.GenericTestBase):
 
         sleep_swap = self.swap_with_checks(
             time, 'sleep', mock_sleep, expected_args=[(1,)] * 60 * 5)
-        is_port_in_use_swap = self.swap(
+        is_port_in_use_swap = patch.object(
             common, 'is_port_in_use', mock_is_port_in_use)
         exit_swap = self.swap_with_checks(
             sys, 'exit', mock_exit, expected_args=[(1,)])
@@ -642,10 +643,10 @@ class CommonTests(test_utils.GenericTestBase):
         def mock_exit(unused_code: str) -> NoReturn:
             raise AssertionError('mock_exit should not be called.')
 
-        sleep_swap = self.swap(time, 'sleep', mock_sleep)
-        is_port_in_use_swap = self.swap(
+        sleep_swap = patch.object(time, 'sleep', mock_sleep)
+        is_port_in_use_swap = patch.object(
             common, 'is_port_in_use', mock_is_port_in_use)
-        exit_swap = self.swap(sys, 'exit', mock_exit)
+        exit_swap = patch.object(sys, 'exit', mock_exit)
 
         with sleep_swap, is_port_in_use_swap, exit_swap:
             common.wait_for_port_to_be_in_use(9999)
@@ -739,7 +740,7 @@ class CommonTests(test_utils.GenericTestBase):
 
         self.assertFalse(os.path.exists('temp_file'))
 
-        with self.swap(subprocess, 'check_call', _mock_subprocess_check_call):
+        with patch.object(subprocess, 'check_call', _mock_subprocess_check_call):
             common.install_npm_library('library_name', 'version', 'path')
 
         self.assertFalse(os.path.exists('temp_file'))
@@ -747,19 +748,19 @@ class CommonTests(test_utils.GenericTestBase):
     def test_ask_user_to_confirm(self) -> None:
         def mock_input() -> str:
             return 'Y'
-        with self.swap(builtins, 'input', mock_input):
+        with patch.object(builtins, 'input', mock_input):
             common.ask_user_to_confirm('Testing')
 
     def test_get_personal_access_token_with_valid_token(self) -> None:
         def mock_getpass(prompt: str) -> str:  # pylint: disable=unused-argument
             return 'token'
-        with self.swap(getpass, 'getpass', mock_getpass):
+        with patch.object(getpass, 'getpass', mock_getpass):
             self.assertEqual(common.get_personal_access_token(), 'token')
 
     def test_get_personal_access_token_with_token_as_none(self) -> None:
         def mock_getpass(prompt: str) -> None:  # pylint: disable=unused-argument
             return None
-        getpass_swap = self.swap(getpass, 'getpass', mock_getpass)
+        getpass_swap = patch.object(getpass, 'getpass', mock_getpass)
         with getpass_swap, self.assertRaisesRegex(
             Exception,
             'No personal access token provided, please set up a personal '
@@ -807,9 +808,9 @@ class CommonTests(test_utils.GenericTestBase):
         ) -> List[github.Label.Label]:
             return [label]
 
-        get_issues_swap = self.swap(
+        get_issues_swap = patch.object(
             github.Repository.Repository, 'get_issues', mock_get_issues)
-        get_label_swap = self.swap(
+        get_label_swap = patch.object(
             github.Repository.Repository, 'get_label', mock_get_label)
         with get_issues_swap, get_label_swap:
             common.check_prs_for_current_release_are_released(mock_repo)
@@ -856,11 +857,11 @@ class CommonTests(test_utils.GenericTestBase):
         ) -> List[github.Label.Label]:
             return [label]
 
-        get_issues_swap = self.swap(
+        get_issues_swap = patch.object(
             github.Repository.Repository, 'get_issues', mock_get_issues)
-        get_label_swap = self.swap(
+        get_label_swap = patch.object(
             github.Repository.Repository, 'get_label', mock_get_label)
-        open_tab_swap = self.swap(
+        open_tab_swap = patch.object(
             common, 'open_new_tab_in_browser_if_possible', mock_open_tab)
         with get_issues_swap, get_label_swap, open_tab_swap:
             with self.assertRaisesRegex(
@@ -966,7 +967,7 @@ class CommonTests(test_utils.GenericTestBase):
         def mock_is_windows() -> Literal[True]:
             return True
 
-        is_windows_swap = self.swap(common, 'is_windows_os', mock_is_windows)
+        is_windows_swap = patch.object(common, 'is_windows_os', mock_is_windows)
         original_filepath = 'c:\\path\\to\\a\\file.js'
         with is_windows_swap:
             actual_file_path = common.convert_to_posixpath(original_filepath)
@@ -976,7 +977,7 @@ class CommonTests(test_utils.GenericTestBase):
         def mock_is_windows() -> Literal[False]:
             return False
 
-        is_windows_swap = self.swap(common, 'is_windows_os', mock_is_windows)
+        is_windows_swap = patch.object(common, 'is_windows_os', mock_is_windows)
         original_filepath = 'c:\\path\\to\\a\\file.js'
         with is_windows_swap:
             actual_file_path = common.convert_to_posixpath(original_filepath)
@@ -1003,7 +1004,7 @@ class CommonTests(test_utils.GenericTestBase):
                 ('/new/path',),
                 ('/old/path',),
             ])
-        getcwd_swap = self.swap(os, 'getcwd', mock_getcwd)
+        getcwd_swap = patch.object(os, 'getcwd', mock_getcwd)
 
         with chdir_swap, getcwd_swap:
             with common.CD('/new/path'):
@@ -1067,7 +1068,7 @@ class CommonTests(test_utils.GenericTestBase):
         write_swap = self.swap_to_always_raise(
             os, 'write',
             io.UnsupportedOperation('unsupported operation'))
-        stdout_write_swap = self.swap(sys, 'stdout', mock_stdout)
+        stdout_write_swap = patch.object(sys, 'stdout', mock_stdout)
 
         with write_swap, stdout_write_swap:
             common.write_stdout_safe('test')
@@ -1119,7 +1120,7 @@ class CommonTests(test_utils.GenericTestBase):
                 self._assert_ssl_context_matches_default(context)
                 return io.BytesIO(b'content')
 
-            urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+            urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
             with urlopen_swap:
                 common.url_retrieve('https://example.com', output_path)
@@ -1141,7 +1142,7 @@ class CommonTests(test_utils.GenericTestBase):
                     raise ssl.SSLError()
                 return io.BytesIO(b'content')
 
-            urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+            urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
             with urlopen_swap:
                 common.url_retrieve('https://example.com', output_path)
@@ -1161,8 +1162,8 @@ class CommonTests(test_utils.GenericTestBase):
             self._assert_ssl_context_matches_default(context)
             raise ssl.SSLError('test_error')
 
-        open_swap = self.swap(builtins, 'open', mock_open)
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        open_swap = patch.object(builtins, 'open', mock_open)
+        urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
         with open_swap, urlopen_swap:
             with self.assertRaisesRegex(ssl.SSLError, 'test_error'):
@@ -1174,8 +1175,8 @@ class CommonTests(test_utils.GenericTestBase):
         def mock_urlopen(url: str, context: ssl.SSLContext) -> NoReturn:  # pylint: disable=unused-argument
             raise AssertionError('urlopen() should not be called')
 
-        open_swap = self.swap(builtins, 'open', mock_open)
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        open_swap = patch.object(builtins, 'open', mock_open)
+        urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
         with open_swap, urlopen_swap:
             with self.assertRaisesRegex(
@@ -1196,7 +1197,7 @@ class CommonTests(test_utils.GenericTestBase):
                 self._assert_ssl_context_matches_default(context)
                 return io.BytesIO(b'content')
 
-            urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+            urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
             with urlopen_swap:
                 common.url_retrieve(
@@ -1205,7 +1206,7 @@ class CommonTests(test_utils.GenericTestBase):
                 self.assertEqual(buffer.read(), b'content')
 
     def test_chrome_bin_setup_with_google_chrome(self) -> None:
-        isfile_swap = self.swap(
+        isfile_swap = patch.object(
             os.path, 'isfile', lambda path: path == '/usr/bin/google-chrome'
         )
         with isfile_swap:
@@ -1213,7 +1214,7 @@ class CommonTests(test_utils.GenericTestBase):
         self.assertEqual(os.environ['CHROME_BIN'], '/usr/bin/google-chrome')
 
     def test_chrome_bin_setup_with_wsl_chrome_browser(self) -> None:
-        isfile_swap = self.swap(
+        isfile_swap = patch.object(
             os.path,
             'isfile',
             lambda path: path == (
@@ -1234,8 +1235,8 @@ class CommonTests(test_utils.GenericTestBase):
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
 
-        isfile_swap = self.swap(os.path, 'isfile', lambda _: False)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        isfile_swap = patch.object(os.path, 'isfile', lambda _: False)
+        print_swap = patch.object(builtins, 'print', mock_print)
 
         with print_swap, isfile_swap, self.assertRaisesRegex(
             Exception, 'Chrome not found.'
@@ -1246,16 +1247,16 @@ class CommonTests(test_utils.GenericTestBase):
     def test_modify_constants_under_docker_env(self) -> None:
         mock_constants_path = 'mock_app_dev.yaml'
         mock_feconf_path = 'mock_app.yaml'
-        constants_path_swap = self.swap(
+        constants_path_swap = patch.object(
             common, 'CONSTANTS_FILE_PATH', mock_constants_path)
-        feconf_path_swap = self.swap(common, 'FECONF_PATH', mock_feconf_path)
+        feconf_path_swap = patch.object(common, 'FECONF_PATH', mock_feconf_path)
 
-        with self.swap(feconf, 'OPPIA_IS_DOCKERIZED', True):
+        with patch.object(feconf, 'OPPIA_IS_DOCKERIZED', True):
             def mock_check_output(
                 unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
             ) -> str:
                 return 'test'
-            check_output_swap = self.swap(
+            check_output_swap = patch.object(
                 subprocess, 'check_output', mock_check_output
             )
 
@@ -1316,15 +1317,15 @@ class CommonTests(test_utils.GenericTestBase):
     def test_modify_constants(self) -> None:
         mock_constants_path = 'mock_app_dev.yaml'
         mock_feconf_path = 'mock_app.yaml'
-        constants_path_swap = self.swap(
+        constants_path_swap = patch.object(
             common, 'CONSTANTS_FILE_PATH', mock_constants_path)
-        feconf_path_swap = self.swap(common, 'FECONF_PATH', mock_feconf_path)
+        feconf_path_swap = patch.object(common, 'FECONF_PATH', mock_feconf_path)
 
         def mock_check_output(
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'test'
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output
         )
 
@@ -1389,9 +1390,9 @@ class CommonTests(test_utils.GenericTestBase):
     def test_set_constants_to_default(self) -> None:
         mock_constants_path = 'mock_app_dev.yaml'
         mock_feconf_path = 'mock_app.yaml'
-        constants_path_swap = self.swap(
+        constants_path_swap = patch.object(
             common, 'CONSTANTS_FILE_PATH', mock_constants_path)
-        feconf_path_swap = self.swap(common, 'FECONF_PATH', mock_feconf_path)
+        feconf_path_swap = patch.object(common, 'FECONF_PATH', mock_feconf_path)
 
         constants_temp_file = tempfile.NamedTemporaryFile()
         # Here MyPy assumes that the 'name' attribute is read-only. In order to

--- a/scripts/concurrent_task_utils_test.py
+++ b/scripts/concurrent_task_utils_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/concurrent_task_utils.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import threading
@@ -52,7 +53,7 @@ class ConcurrentTaskUtilsTests(test_utils.GenericTestBase):
                     in the same line of output.
             """
             self.task_stdout.append(' '.join(str(arg) for arg in args))
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
 
 class TaskResultTests(ConcurrentTaskUtilsTests):

--- a/scripts/create_expression_parser_test.py
+++ b/scripts/create_expression_parser_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/create_expression_parser.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 import subprocess
@@ -45,10 +46,10 @@ class CreateExpressionParserTests(test_utils.GenericTestBase):
             library_name: str, library_version: str, path: str) -> None:
             libraries_installed.append([library_name, library_version, path])
 
-        swap_check_call = self.swap(
+        swap_check_call = patch.object(
             subprocess, 'check_call', mock_check_call)
-        swap_setup = self.swap(setup, 'main', mock_setup)
-        swap_install_npm_library = self.swap(
+        swap_setup = patch.object(setup, 'main', mock_setup)
+        swap_install_npm_library = patch.object(
             common, 'install_npm_library', mock_install_npm_library)
 
         expression_parser_definition = os.path.join(

--- a/scripts/create_topological_sort_of_all_services_test.py
+++ b/scripts/create_topological_sort_of_all_services_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/create_topological_sort_of_all_services.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import collections
@@ -46,7 +47,7 @@ class TopologicalSortTests(test_utils.GenericTestBase):
         self.assertEqual(visit_stack, ['A', 'B', 'C', 'D'])
 
     def test_make_graph(self) -> None:
-        with self.swap(
+        with patch.object(
             create_topological_sort_of_all_services, 'DIRECTORY_NAMES',
             MOCK_DIRECTORY_NAMES):
             adj_list, node_list = (
@@ -79,8 +80,8 @@ class TopologicalSortTests(test_utils.GenericTestBase):
         def mock_print(val: str) -> None:
             actual_output.append(val)
 
-        print_swap = self.swap(builtins, 'print', mock_print)
-        dir_names_swap = self.swap(
+        print_swap = patch.object(builtins, 'print', mock_print)
+        dir_names_swap = patch.object(
             create_topological_sort_of_all_services, 'DIRECTORY_NAMES',
             MOCK_DIRECTORY_NAMES)
         with print_swap, dir_names_swap:

--- a/scripts/docstrings_checker_test.py
+++ b/scripts/docstrings_checker_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/docstrings_checker."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core.tests import test_utils
 from . import docstrings_checker  # isort:skip
@@ -239,7 +240,7 @@ class DocstringsCheckerTest(test_utils.GenericTestBase):
         def func():
             raise Exception('An exception.') #@
         """)
-        node_ignores_exception_swap = self.swap(
+        node_ignores_exception_swap = patch.object(
             utils, 'node_ignores_exception',
             lambda _, __: (_ for _ in ()).throw(astroid.InferenceError())
         )

--- a/scripts/extend_index_yaml_test.py
+++ b/scripts/extend_index_yaml_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/extend_index_yaml.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import tempfile
 
@@ -177,10 +178,10 @@ class ExtendIndexYamlTests(test_utils.GenericTestBase):
         self.web_inf_index_xml_file = tempfile.NamedTemporaryFile()
         self.index_yaml_file_name = self.index_yaml_file.name
         self.web_inf_index_xml_file_name = self.web_inf_index_xml_file.name
-        self.index_yaml_swap = self.swap(
+        self.index_yaml_swap = patch.object(
             extend_index_yaml, 'INDEX_YAML_PATH',
             self.index_yaml_file.name)
-        self.web_inf_index_xml_swap = self.swap(
+        self.web_inf_index_xml_swap = patch.object(
             extend_index_yaml, 'WEB_INF_INDEX_XML_PATH',
             self.web_inf_index_xml_file.name)
         self.open_index_yaml_r = open(

--- a/scripts/generate_build_directory_test.py
+++ b/scripts/generate_build_directory_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/generate_build_directory.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 
@@ -37,5 +38,5 @@ class GenerateBuildDirectoryTests(test_utils.GenericTestBase):
 
     def test_generate_build_dir_under_docker(self) -> None:
         with self.assertRaisesRegex(KeyError, 'js/third_party.min.js'):
-            with self.swap(feconf, 'OPPIA_IS_DOCKERIZED', True):
+            with patch.object(feconf, 'OPPIA_IS_DOCKERIZED', True):
                 generate_build_directory.main()

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/install_dependencies_json_packages.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import io
@@ -76,19 +77,19 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_extractall(_self: zipfile.ZipFile, path: str) -> None:  # pylint: disable=unused-argument
             self.check_function_calls['extractall_is_called'] = True
 
-        self.unzip_swap = self.swap(
+        self.unzip_swap = patch.object(
             install_dependencies_json_packages, 'TMP_UNZIP_PATH',
             MOCK_TMP_UNZIP_PATH)
-        self. dir_exists_swap = self.swap(
+        self. dir_exists_swap = patch.object(
             install_dependencies_json_packages,
             'ensure_directory_exists', mock_ensure_directory_exists)
-        self.exists_swap = self.swap(os.path, 'exists', mock_exists)
-        self.remove_swap = self.swap(os, 'remove', mock_remove)
-        self.rename_swap = self.swap(os, 'rename', mock_rename)
-        self.url_retrieve_swap = self.swap(
+        self.exists_swap = patch.object(os.path, 'exists', mock_exists)
+        self.remove_swap = patch.object(os, 'remove', mock_remove)
+        self.rename_swap = patch.object(os, 'rename', mock_rename)
+        self.url_retrieve_swap = patch.object(
             install_dependencies_json_packages, 'url_retrieve',
             mock_url_retrieve)
-        self.extract_swap = self.swap(
+        self.extract_swap = patch.object(
             zipfile.ZipFile, 'extractall', mock_extractall)
 
     def test_download_files_with_invalid_source_filenames(self) -> None:
@@ -118,8 +119,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_url_retrieve(_url: str, filename: str) -> None:
             check_file_downloads[filename] = True
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        url_retrieve_swap = self.swap(
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        url_retrieve_swap = patch.object(
             install_dependencies_json_packages, 'url_retrieve',
             mock_url_retrieve)
         with self.dir_exists_swap, exists_swap, url_retrieve_swap:
@@ -135,7 +136,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             exists_arr.append(False)
             return False
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
 
         with exists_swap, self.dir_exists_swap, self.url_retrieve_swap:
             with self.remove_swap, self.rename_swap, self.unzip_swap:
@@ -166,8 +167,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                 MOCK_TMP_UNZIP_PATH, 'rb', None)
             return file_obj
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        url_open_swap = self.swap(
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        url_open_swap = patch.object(
             install_dependencies_json_packages, 'url_open',
             mock_url_open)
         with exists_swap, self.dir_exists_swap, self.url_retrieve_swap:
@@ -187,10 +188,10 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_extractall(_self: zipfile.ZipFile, _path: str) -> None:
             self.check_function_calls['extractall_is_called'] = True
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        extract_swap = self.swap(
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        extract_swap = patch.object(
             tarfile.TarFile, 'extractall', mock_extractall)
-        unzip_swap = self.swap(
+        unzip_swap = patch.object(
             install_dependencies_json_packages, 'TMP_UNZIP_PATH', os.path.join(
                 RELEASE_TEST_DIR, 'tmp_unzip.tar.gz'))
 
@@ -237,7 +238,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         print_arr = []
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
         with print_swap, self.assertRaisesRegex(SystemExit, '1'):
             install_dependencies_json_packages.test_dependencies_syntax(
                 'files', {
@@ -254,7 +255,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         print_arr = []
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
         with print_swap, self.assertRaisesRegex(SystemExit, '1'):
             install_dependencies_json_packages.test_dependencies_syntax(
                 'zip', {
@@ -272,7 +273,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         print_arr = []
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
         with print_swap, self.assertRaisesRegex(SystemExit, '1'):
             install_dependencies_json_packages.test_dependencies_syntax(
                 'tar', {
@@ -306,7 +307,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                 }
             }
 
-        return_json_swap = self.swap(
+        return_json_swap = patch.object(
             install_dependencies_json_packages, 'return_json', mock_return_json)
         with return_json_swap:
             install_dependencies_json_packages.validate_dependencies('filepath')
@@ -326,7 +327,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     }
                 }
             }
-        return_json_swap = self.swap(
+        return_json_swap = patch.object(
             install_dependencies_json_packages, 'return_json', mock_return_json)
         with return_json_swap, self.assertRaisesRegex(
             Exception,
@@ -412,20 +413,20 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             unused_target_root_name: str
         ) -> None:
             check_function_calls['download_and_untar_files_is_called'] = True
-        return_json_swap = self.swap(
+        return_json_swap = patch.object(
             install_dependencies_json_packages, 'return_json', mock_return_json)
-        validate_swap = self.swap(
+        validate_swap = patch.object(
             install_dependencies_json_packages,
             'validate_dependencies',
             mock_validate_dependencies
         )
-        download_files_swap = self.swap(
+        download_files_swap = patch.object(
             install_dependencies_json_packages, 'download_files',
             mock_download_files)
-        unzip_files_swap = self.swap(
+        unzip_files_swap = patch.object(
             install_dependencies_json_packages, 'download_and_unzip_files',
             mock_download_and_unzip_files)
-        untar_files_swap = self.swap(
+        untar_files_swap = patch.object(
             install_dependencies_json_packages, 'download_and_untar_files',
             mock_download_and_untar_files)
 
@@ -487,7 +488,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                 self._assert_ssl_context_matches_default(context)
                 return io.BytesIO(b'content')
 
-            urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+            urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
             with urlopen_swap:
                 install_dependencies_json_packages.url_retrieve(
@@ -510,7 +511,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     raise ssl.SSLError()
                 return io.BytesIO(b'content')
 
-            urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+            urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
             with urlopen_swap:
                 install_dependencies_json_packages.url_retrieve(
@@ -531,8 +532,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             self._assert_ssl_context_matches_default(context)
             raise ssl.SSLError('test_error')
 
-        open_swap = self.swap(builtins, 'open', mock_open)
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        open_swap = patch.object(builtins, 'open', mock_open)
+        urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
         with open_swap, urlopen_swap:
             with self.assertRaisesRegex(ssl.SSLError, 'test_error'):
@@ -545,8 +546,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_urlopen(url: str, context: ssl.SSLContext) -> NoReturn:  # pylint: disable=unused-argument
             raise AssertionError('urlopen() should not be called')
 
-        open_swap = self.swap(builtins, 'open', mock_open)
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        open_swap = patch.object(builtins, 'open', mock_open)
+        urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
         with open_swap, urlopen_swap:
             with self.assertRaisesRegex(
@@ -568,7 +569,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                 self._assert_ssl_context_matches_default(context)
                 return io.BytesIO(b'content')
 
-            urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+            urlopen_swap = patch.object(urlrequest, 'urlopen', mock_urlopen)
 
             with urlopen_swap:
                 install_dependencies_json_packages.url_retrieve(
@@ -582,7 +583,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         }
         def mock_makedirs(unused_dirpath: str) -> None:
             check_function_calls['makedirs_gets_called'] = True
-        with self.swap(os, 'makedirs', mock_makedirs):
+        with patch.object(os, 'makedirs', mock_makedirs):
             install_dependencies_json_packages.ensure_directory_exists(
                 'assets')
         self.assertEqual(
@@ -594,7 +595,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         }
         def mock_makedirs(unused_dirpath: str) -> None:
             check_function_calls['makedirs_gets_called'] = True
-        with self.swap(os, 'makedirs', mock_makedirs):
+        with patch.object(os, 'makedirs', mock_makedirs):
             install_dependencies_json_packages.ensure_directory_exists(
                 'test-dir')
         self.assertEqual(

--- a/scripts/install_python_dev_dependencies_test.py
+++ b/scripts/install_python_dev_dependencies_test.py
@@ -17,6 +17,7 @@
 """Tests for install_python_dev_dependencies.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import contextlib
@@ -61,35 +62,35 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
                 delattr(sys, 'real_prefix')
 
     def test_check_python_env_is_suitable_passes_when_in_venv(self) -> None:
-        prefix_swap = self.swap(
+        prefix_swap = patch.object(
             sys, 'prefix', '/home/user/.pyenv/versions/3.7.10')
-        base_prefix_swap = self.swap(
+        base_prefix_swap = patch.object(
             sys, 'base_prefix', '/home/user/.pyenv/versions/oppia')
         real_prefix_manager = self.sys_real_prefix_context('')
-        environ_swap = self.swap(os, 'environ', {})
+        environ_swap = patch.object(os, 'environ', {})
         with prefix_swap, base_prefix_swap, real_prefix_manager, environ_swap:
             install_python_dev_dependencies.check_python_env_is_suitable()
 
     def test_check_python_env_is_suitable_passes_when_in_venv_real_prefix(
         self
     ) -> None:
-        prefix_swap = self.swap(
+        prefix_swap = patch.object(
             sys, 'prefix', '/home/user/.pyenv/versions/3.7.10')
-        base_prefix_swap = self.swap(
+        base_prefix_swap = patch.object(
             sys, 'base_prefix', '/home/user/.pyenv/versions/3.7.10')
         real_prefix_manager = self.sys_real_prefix_context(
             '/home/user/.pyenv/versions/oppia')
-        environ_swap = self.swap(os, 'environ', {})
+        environ_swap = patch.object(os, 'environ', {})
         with prefix_swap, base_prefix_swap, real_prefix_manager, environ_swap:
             install_python_dev_dependencies.check_python_env_is_suitable()
 
     def test_check_python_env_is_suitable_fails_when_out_of_venv(self) -> None:
-        prefix_swap = self.swap(
+        prefix_swap = patch.object(
             sys, 'prefix', '/home/user/.pyenv/versions/3.7.10')
-        base_prefix_swap = self.swap(
+        base_prefix_swap = patch.object(
             sys, 'base_prefix', '/home/user/.pyenv/versions/3.7.10')
         real_prefix_manager = self.sys_real_prefix_context('')
-        environ_swap = self.swap(os, 'environ', {})
+        environ_swap = patch.object(os, 'environ', {})
         expected_error = (
             'Oppia must be developed within a virtual environment.')
         with self.assertRaisesRegex(
@@ -103,12 +104,12 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
                     )
 
     def test_check_python_env_is_suitable_passes_when_on_ci(self) -> None:
-        prefix_swap = self.swap(
+        prefix_swap = patch.object(
             sys, 'prefix', '/home/user/.pyenv/versions/3.7.10')
-        base_prefix_swap = self.swap(
+        base_prefix_swap = patch.object(
             sys, 'base_prefix', '/home/user/.pyenv/versions/3.7.10')
         real_prefix_manager = self.sys_real_prefix_context('')
-        environ_swap = self.swap(os, 'environ', {'GITHUB_ACTION': '1'})
+        environ_swap = patch.object(os, 'environ', {'GITHUB_ACTION': '1'})
         with prefix_swap, base_prefix_swap, real_prefix_manager, environ_swap:
             install_python_dev_dependencies.check_python_env_is_suitable()
 
@@ -136,7 +137,7 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             self.assertTrue(check)
             self.assertEqual(encoding, 'utf-8')
 
-        run_swap = self.swap(subprocess, 'run', mock_run)
+        run_swap = patch.object(subprocess, 'run', mock_run)
 
         with run_swap:
             install_python_dev_dependencies.install_installation_tools()

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -17,6 +17,7 @@
 """Unit tests for 'scripts/install_python_prod_dependencies.py'."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import itertools
@@ -101,7 +102,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
         self.file_arr: List[str] = []
         def mock_write(msg: str) -> None:
@@ -128,7 +129,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             def __exit__(self, *args: int) -> None:
                 pass
 
-        self.open_file_swap = self.swap(
+        self.open_file_swap = patch.object(
             utils, 'open_file', MockOpenFile)
 
         self.cmd_token_list: List[List[str]] = []
@@ -154,11 +155,11 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             self.cmd_token_list.append(cmd_tokens)
             return ''
 
-        self.swap_check_call = self.swap(
+        self.swap_check_call = patch.object(
             subprocess, 'check_call', mock_check_call)
-        self.swap_Popen = self.swap(
+        self.swap_Popen = patch.object(
             subprocess, 'Popen', mock_check_call)
-        self.swap_run = self.swap(subprocess, 'run', mock_run)
+        self.swap_run = patch.object(subprocess, 'run', mock_run)
 
         class MockErrorProcess:
 
@@ -178,7 +179,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     'Popen should have been called with encoding="utf-8"')
             return MockErrorProcess()
 
-        self.swap_Popen_error = self.swap(
+        self.swap_Popen_error = patch.object(
             subprocess, 'Popen', mock_check_call_error)
 
     def get_git_version_string(self, name: str, sha1_piece: str) -> str:
@@ -196,7 +197,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         return 'git+git://github.com/oppia/%s@%s' % (name, sha1)
 
     def test_invalid_git_dependency_raises_an_exception(self) -> None:
-        swap_requirements = self.swap(
+        swap_requirements = patch.object(
             common, 'COMPILED_REQUIREMENTS_FILE_PATH',
             self.INVALID_GIT_REQUIREMENTS_TEST_TXT_FILE_PATH)
 
@@ -207,7 +208,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 install_python_prod_dependencies.get_mismatches()
 
     def test_multiple_discrepancies_returns_correct_mismatches(self) -> None:
-        swap_requirements = self.swap(
+        swap_requirements = patch.object(
             common, 'COMPILED_REQUIREMENTS_FILE_PATH',
             self.REQUIREMENTS_TEST_TXT_FILE_PATH)
 
@@ -229,7 +230,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 })
             ]
 
-        swap_find_distributions = self.swap(
+        swap_find_distributions = patch.object(
             pkg_resources, 'find_distributions', mock_find_distributions)
         with swap_requirements, swap_find_distributions:
             self.assertEqual(
@@ -267,14 +268,14 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         def mock_validate_metadata_directories() -> None:
             pass
 
-        swap_validate_metadata_directories = self.swap(
+        swap_validate_metadata_directories = patch.object(
             install_python_prod_dependencies, 'validate_metadata_directories',
             mock_validate_metadata_directories)
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies,
             'get_mismatches',
             mock_get_mismatches)
-        swap_remove_dir = self.swap(shutil, 'rmtree', mock_remove_dir)
+        swap_remove_dir = patch.object(shutil, 'rmtree', mock_remove_dir)
 
         with self.swap_check_call, self.swap_Popen, swap_remove_dir:
             with self.open_file_swap, swap_get_mismatches:
@@ -320,11 +321,11 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
         def mock_validate_metadata_directories() -> None:
             pass
-        swap_validate_metadata_directories = self.swap(
+        swap_validate_metadata_directories = patch.object(
             install_python_prod_dependencies, 'validate_metadata_directories',
             mock_validate_metadata_directories)
 
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies,
             'get_mismatches',
             mock_get_mismatches)
@@ -394,15 +395,15 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
         def mock_validate_metadata_directories() -> None:
             pass
-        swap_validate_metadata_directories = self.swap(
+        swap_validate_metadata_directories = patch.object(
             install_python_prod_dependencies, 'validate_metadata_directories',
             mock_validate_metadata_directories)
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies,
             'get_mismatches',
             mock_get_mismatches)
 
-        swap_remove_dir = self.swap(shutil, 'rmtree', mock_remove_dir)
+        swap_remove_dir = patch.object(shutil, 'rmtree', mock_remove_dir)
         with self.swap_check_call, self.swap_Popen, swap_remove_dir:
             with self.open_file_swap, swap_get_mismatches:
                 with swap_validate_metadata_directories, self.swap_run:
@@ -440,10 +441,10 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             return {}
         def mock_validate_metadata_directories() -> None:
             pass
-        swap_validate_metadata_directories = self.swap(
+        swap_validate_metadata_directories = patch.object(
             install_python_prod_dependencies, 'validate_metadata_directories',
             mock_validate_metadata_directories)
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies,
             'get_mismatches',
             mock_get_mismatches)
@@ -488,13 +489,13 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
         def mock_validate_metadata_directories() -> None:
             pass
-        swap_validate_metadata_directories = self.swap(
+        swap_validate_metadata_directories = patch.object(
             install_python_prod_dependencies, 'validate_metadata_directories',
             mock_validate_metadata_directories)
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies, 'get_mismatches',
             mock_get_mismatches)
-        swap_print = self.swap(builtins, 'print', mock_print)
+        swap_print = patch.object(builtins, 'print', mock_print)
         with self.swap_run, swap_get_mismatches, swap_print:
             with swap_validate_metadata_directories, self.open_file_swap:
                 install_python_prod_dependencies.main()
@@ -550,16 +551,16 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         def mock_validate_metadata_directories() -> None:
             pass
 
-        swap_validate_metadata_directories = self.swap(
+        swap_validate_metadata_directories = patch.object(
             install_python_prod_dependencies, 'validate_metadata_directories',
             mock_validate_metadata_directories)
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies,
             'get_mismatches',
             mock_get_mismatches)
-        swap_rm_tree = self.swap(shutil, 'rmtree', mock_rm)
-        swap_list_dir = self.swap(os, 'listdir', mock_list_dir)
-        swap_is_dir = self.swap(os.path, 'isdir', mock_is_dir)
+        swap_rm_tree = patch.object(shutil, 'rmtree', mock_rm)
+        swap_list_dir = patch.object(os, 'listdir', mock_list_dir)
+        swap_is_dir = patch.object(os.path, 'isdir', mock_is_dir)
 
         with self.swap_check_call, self.swap_Popen, swap_get_mismatches:
             with swap_validate_metadata_directories, self.open_file_swap:
@@ -636,10 +637,10 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         def mock_is_dir(unused_path: str) -> bool:
             return True
 
-        swap_find_distributions = self.swap(
+        swap_find_distributions = patch.object(
             pkg_resources, 'find_distributions', mock_find_distributions)
-        swap_list_dir = self.swap(os, 'listdir', mock_list_dir)
-        swap_is_dir = self.swap(os.path, 'isdir', mock_is_dir)
+        swap_list_dir = patch.object(os, 'listdir', mock_list_dir)
+        swap_is_dir = patch.object(os.path, 'isdir', mock_is_dir)
 
         with swap_find_distributions, swap_list_dir, swap_is_dir:
             install_python_prod_dependencies.validate_metadata_directories()
@@ -674,11 +675,11 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
         def mock_is_dir(unused_path: str) -> bool:
             return True
-        swap_find_distributions = self.swap(
+        swap_find_distributions = patch.object(
             pkg_resources, 'find_distributions', mock_find_distributions)
-        swap_list_dir = self.swap(
+        swap_list_dir = patch.object(
             os, 'listdir', mock_list_dir)
-        swap_is_dir = self.swap(
+        swap_is_dir = patch.object(
             os.path, 'isdir', mock_is_dir
         )
 
@@ -733,7 +734,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 'package==version', 'path')
 
     def test_pip_install_with_import_error_and_darwin_os(self) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Darwin')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Darwin')
 
         import pip
         try:
@@ -755,7 +756,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             'OS%29' in self.print_arr)
 
     def test_pip_install_with_import_error_and_linux_os(self) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Linux')
 
         import pip
         try:
@@ -777,7 +778,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             '%29' in self.print_arr)
 
     def test_pip_install_with_import_error_and_windows_os(self) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Windows')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Windows')
         import pip
         try:
             # Here we use MyPy ignore because to test the case where pip

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/install_third_party_libs.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -90,29 +91,29 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
 
-        self.check_call_swap = self.swap(
+        self.check_call_swap = patch.object(
             subprocess, 'check_call', mock_check_call)
-        self.Popen_swap = self.swap(
+        self.Popen_swap = patch.object(
             subprocess, 'Popen', mock_check_call)
-        self.check_call_error_swap = self.swap(
+        self.check_call_error_swap = patch.object(
             subprocess, 'check_call', mock_check_call_error)
-        self.Popen_error_swap = self.swap(
+        self.Popen_error_swap = patch.object(
             subprocess, 'Popen', mock_popen_error_call)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
         def mock_ensure_directory_exists(unused_path: str) -> None:
             pass
 
-        self.dir_exists_swap = self.swap(
+        self.dir_exists_swap = patch.object(
             common, 'ensure_directory_exists', mock_ensure_directory_exists)
 
     def test_install_third_party_main_under_docker(self) -> None:
-        with self.swap(feconf, 'OPPIA_IS_DOCKERIZED', True):
+        with patch.object(feconf, 'OPPIA_IS_DOCKERIZED', True):
             with self.check_call_swap:
                 install_third_party_libs.main()
 
     def test_install_third_party_main(self) -> None:
-        with self.swap(feconf, 'OPPIA_IS_DOCKERIZED', False):
+        with patch.object(feconf, 'OPPIA_IS_DOCKERIZED', False):
             with self.check_call_swap:
                 install_third_party_libs.main()
 
@@ -127,8 +128,8 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
             self.assertEqual(origin_name + '.sh', new_name)
             check_function_calls['mock_rename'] = True
         check_function_calls['mock_rename'] = False
-        isfile_swap = self.swap(os.path, 'isfile', mock_is_file)
-        rename_swap = self.swap(os, 'rename', mock_rename)
+        isfile_swap = patch.object(os.path, 'isfile', mock_is_file)
+        rename_swap = patch.object(os, 'rename', mock_rename)
         with isfile_swap, rename_swap:
             install_third_party_libs.tweak_yarn_executable()
         self.assertTrue(check_function_calls['mock_rename'])
@@ -146,26 +147,26 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
             self.assertEqual(origin_name + '.sh', new_name)
             check_function_calls['mock_rename'] = True
         check_function_calls['mock_rename'] = False
-        isfile_swap = self.swap(os.path, 'isfile', mock_is_file)
-        rename_swap = self.swap(os, 'rename', mock_rename)
+        isfile_swap = patch.object(os.path, 'isfile', mock_is_file)
+        rename_swap = patch.object(os, 'rename', mock_rename)
         with isfile_swap, rename_swap:
             install_third_party_libs.tweak_yarn_executable()
         self.assertFalse(check_function_calls['mock_rename'])
 
     def test_get_yarn_command_on_windows(self) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Windows')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Windows')
         with os_name_swap:
             command = install_third_party_libs.get_yarn_command()
             self.assertEqual(command, 'yarn.cmd')
 
     def test_get_yarn_command_on_linux(self) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Linux')
         with os_name_swap:
             command = install_third_party_libs.get_yarn_command()
             self.assertEqual(command, 'yarn')
 
     def test_get_yarn_command_on_mac(self) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Darwin')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Darwin')
         with os_name_swap:
             command = install_third_party_libs.get_yarn_command()
             self.assertEqual(command, 'yarn')
@@ -210,14 +211,14 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_remove(unused_path: str) -> None:  # pylint: disable=unused-argument
             return
 
-        url_retrieve_swap = self.swap(
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        recursive_chmod_swap = self.swap(
+        recursive_chmod_swap = patch.object(
             common, 'recursive_chmod', mock_recursive_chmod)
-        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
-        isfile_swap = self.swap(os.path, 'isfile', mock_isfile)
-        zipfile_swap = self.swap(zipfile, 'ZipFile', MockZipFile)
-        remove_swap = self.swap(os, 'remove', mock_remove)
+        os_name_swap = patch.object(common, 'OS_NAME', 'Linux')
+        isfile_swap = patch.object(os.path, 'isfile', mock_isfile)
+        zipfile_swap = patch.object(zipfile, 'ZipFile', MockZipFile)
+        remove_swap = patch.object(os, 'remove', mock_remove)
 
         with os_name_swap, url_retrieve_swap, recursive_chmod_swap:
             with self.dir_exists_swap, isfile_swap, zipfile_swap, remove_swap:
@@ -268,14 +269,14 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_remove(unused_path: str) -> None:  # pylint: disable=unused-argument
             return
 
-        url_retrieve_swap = self.swap(
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        recursive_chmod_swap = self.swap(
+        recursive_chmod_swap = patch.object(
             common, 'recursive_chmod', mock_recursive_chmod)
-        os_name_swap = self.swap(common, 'OS_NAME', 'Darwin')
-        isfile_swap = self.swap(os.path, 'isfile', mock_isfile)
-        zipfile_swap = self.swap(zipfile, 'ZipFile', MockZipFile)
-        remove_swap = self.swap(os, 'remove', mock_remove)
+        os_name_swap = patch.object(common, 'OS_NAME', 'Darwin')
+        isfile_swap = patch.object(os.path, 'isfile', mock_isfile)
+        zipfile_swap = patch.object(zipfile, 'ZipFile', MockZipFile)
+        remove_swap = patch.object(os, 'remove', mock_remove)
 
         with os_name_swap, url_retrieve_swap, recursive_chmod_swap:
             with self.dir_exists_swap, isfile_swap, zipfile_swap, remove_swap:
@@ -302,11 +303,11 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_exists(unused_fname: str) -> bool:
             return True
 
-        url_retrieve_swap = self.swap(
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        recursive_chmod_swap = self.swap(
+        recursive_chmod_swap = patch.object(
             common, 'recursive_chmod', mock_recursive_chmod)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
 
         with url_retrieve_swap, recursive_chmod_swap:
             with self.dir_exists_swap, exists_swap:
@@ -349,11 +350,11 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_isfile(unused_fname: str) -> bool:
             return False
 
-        url_retrieve_swap = self.swap(
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
-        isfile_swap = self.swap(os.path, 'isfile', mock_isfile)
-        zipfile_swap = self.swap(zipfile, 'ZipFile', MockZipFile)
+        os_name_swap = patch.object(common, 'OS_NAME', 'Linux')
+        isfile_swap = patch.object(os.path, 'isfile', mock_isfile)
+        zipfile_swap = patch.object(zipfile, 'ZipFile', MockZipFile)
 
         with os_name_swap, url_retrieve_swap:
             with self.dir_exists_swap, isfile_swap, zipfile_swap:
@@ -446,20 +447,20 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
                 os.path.join(correct_google_path, 'pyglib'))
         ]
 
-        swap_isdir = self.swap(os.path, 'isdir', mock_isdir)
-        swap_mkdir = self.swap(os, 'mkdir', mock_mkdir)
-        swap_copytree = self.swap(shutil, 'copytree', mock_copytree)
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
-        install_third_party_main_swap = self.swap(
+        swap_isdir = patch.object(os.path, 'isdir', mock_isdir)
+        swap_mkdir = patch.object(os, 'mkdir', mock_mkdir)
+        swap_copytree = patch.object(shutil, 'copytree', mock_copytree)
+        check_call_swap = patch.object(subprocess, 'check_call', mock_check_call)
+        install_third_party_main_swap = patch.object(
             install_third_party, 'main', mock_main_for_install_third_party)
-        setup_main_swap = self.swap(setup, 'main', mock_main_for_setup)
-        setup_gae_main_swap = self.swap(
+        setup_main_swap = patch.object(setup, 'main', mock_main_for_setup)
+        setup_gae_main_swap = patch.object(
             setup_gae, 'main', mock_main_for_setup_gae)
-        pre_commit_hook_main_swap = self.swap(
+        pre_commit_hook_main_swap = patch.object(
             pre_commit_hook, 'main', mock_main_for_pre_commit_hook)
-        pre_push_hook_main_swap = self.swap(
+        pre_push_hook_main_swap = patch.object(
             pre_push_hook, 'main', mock_main_for_pre_push_hook)
-        tweak_yarn_executable_swap = self.swap(
+        tweak_yarn_executable_swap = patch.object(
             install_third_party_libs, 'tweak_yarn_executable',
             mock_tweak_yarn_executable)
 
@@ -510,20 +511,20 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_tweak_yarn_executable() -> None:
             check_function_calls['tweak_yarn_executable_is_called'] = True
 
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
-        install_third_party_main_swap = self.swap(
+        check_call_swap = patch.object(subprocess, 'check_call', mock_check_call)
+        install_third_party_main_swap = patch.object(
             install_third_party, 'main', mock_main_for_install_third_party)
-        setup_main_swap = self.swap(setup, 'main', mock_main_for_setup)
-        setup_gae_main_swap = self.swap(
+        setup_main_swap = patch.object(setup, 'main', mock_main_for_setup)
+        setup_gae_main_swap = patch.object(
             setup_gae, 'main', mock_main_for_setup_gae)
-        pre_commit_hook_main_swap = self.swap(
+        pre_commit_hook_main_swap = patch.object(
             pre_commit_hook, 'main', mock_main_for_pre_commit_hook)
-        pre_push_hook_main_swap = self.swap(
+        pre_push_hook_main_swap = patch.object(
             pre_push_hook, 'main', mock_main_for_pre_push_hook)
-        tweak_yarn_executable_swap = self.swap(
+        tweak_yarn_executable_swap = patch.object(
             install_third_party_libs, 'tweak_yarn_executable',
             mock_tweak_yarn_executable)
-        os_name_swap = self.swap(common, 'OS_NAME', 'Windows')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Windows')
 
         py_actual_text = (
             'ConverterMapping,\nLine ending with '

--- a/scripts/install_third_party_test.py
+++ b/scripts/install_third_party_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/install_third_party.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -77,16 +78,16 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_extractall(_self: zipfile.ZipFile, path: str) -> None:  # pylint: disable=unused-argument
             self.check_function_calls['extractall_is_called'] = True
 
-        self.unzip_swap = self.swap(
+        self.unzip_swap = patch.object(
             install_third_party, 'TMP_UNZIP_PATH', MOCK_TMP_UNZIP_PATH)
-        self. dir_exists_swap = self.swap(
+        self. dir_exists_swap = patch.object(
             common, 'ensure_directory_exists', mock_ensure_directory_exists)
-        self.exists_swap = self.swap(os.path, 'exists', mock_exists)
-        self.remove_swap = self.swap(os, 'remove', mock_remove)
-        self.rename_swap = self.swap(os, 'rename', mock_rename)
-        self.url_retrieve_swap = self.swap(
+        self.exists_swap = patch.object(os.path, 'exists', mock_exists)
+        self.remove_swap = patch.object(os, 'remove', mock_remove)
+        self.rename_swap = patch.object(os, 'rename', mock_rename)
+        self.url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        self.extract_swap = self.swap(
+        self.extract_swap = patch.object(
             zipfile.ZipFile, 'extractall', mock_extractall)
 
     def test_download_files_with_invalid_source_filenames(self) -> None:
@@ -116,8 +117,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_url_retrieve(_url: str, filename: str) -> None:
             check_file_downloads[filename] = True
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        url_retrieve_swap = self.swap(
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
         with self.dir_exists_swap, exists_swap, url_retrieve_swap:
             install_third_party.download_files(
@@ -132,7 +133,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             exists_arr.append(False)
             return False
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
 
         with exists_swap, self.dir_exists_swap, self.url_retrieve_swap:
             with self.remove_swap, self.rename_swap, self.unzip_swap:
@@ -162,8 +163,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             file_obj = utils.open_file(MOCK_TMP_UNZIP_PATH, 'rb', None)
             return file_obj
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        url_open_swap = self.swap(utils, 'url_open', mock_url_open)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        url_open_swap = patch.object(utils, 'url_open', mock_url_open)
         with exists_swap, self.dir_exists_swap, self.url_retrieve_swap:
             with self.remove_swap, self.rename_swap, self.extract_swap:
                 with url_open_swap:
@@ -181,10 +182,10 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_extractall(_self: zipfile.ZipFile, _path: str) -> None:
             self.check_function_calls['extractall_is_called'] = True
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        extract_swap = self.swap(
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        extract_swap = patch.object(
             tarfile.TarFile, 'extractall', mock_extractall)
-        unzip_swap = self.swap(
+        unzip_swap = patch.object(
             install_third_party, 'TMP_UNZIP_PATH', os.path.join(
                 RELEASE_TEST_DIR, 'tmp_unzip.tar.gz'))
 
@@ -228,7 +229,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         print_arr = []
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
         with print_swap, self.assertRaisesRegex(SystemExit, '1'):
             install_third_party.test_dependencies_syntax(
                 'files', {
@@ -245,7 +246,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         print_arr = []
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
         with print_swap, self.assertRaisesRegex(SystemExit, '1'):
             install_third_party.test_dependencies_syntax(
                 'zip', {
@@ -263,7 +264,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         print_arr = []
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
         with print_swap, self.assertRaisesRegex(SystemExit, '1'):
             install_third_party.test_dependencies_syntax(
                 'tar', {
@@ -297,7 +298,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                 }
             }
 
-        return_json_swap = self.swap(
+        return_json_swap = patch.object(
             install_third_party, 'return_json', mock_return_json)
         with return_json_swap:
             install_third_party.validate_dependencies('filepath')
@@ -317,7 +318,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     }
                 }
             }
-        return_json_swap = self.swap(
+        return_json_swap = patch.object(
             install_third_party, 'return_json', mock_return_json)
         with return_json_swap, self.assertRaisesRegex(
             Exception,
@@ -400,22 +401,22 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         def mock_install_python_prod_dependencies() -> None:
             check_function_calls[
                 'install_python_prod_dependencies_is_called'] = True
-        return_json_swap = self.swap(
+        return_json_swap = patch.object(
             install_third_party, 'return_json', mock_return_json)
-        validate_swap = self.swap(
+        validate_swap = patch.object(
             install_third_party,
             'validate_dependencies',
             mock_validate_dependencies
         )
-        download_files_swap = self.swap(
+        download_files_swap = patch.object(
             install_third_party, 'download_files', mock_download_files)
-        unzip_files_swap = self.swap(
+        unzip_files_swap = patch.object(
             install_third_party, 'download_and_unzip_files',
             mock_download_and_unzip_files)
-        untar_files_swap = self.swap(
+        untar_files_swap = patch.object(
             install_third_party, 'download_and_untar_files',
             mock_download_and_untar_files)
-        mock_install_python_prod_dependencies_swap = self.swap(
+        mock_install_python_prod_dependencies_swap = patch.object(
             install_python_prod_dependencies, 'main',
             mock_install_python_prod_dependencies)
 
@@ -433,7 +434,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             'The redis command line interface will not be installed because '
             'your machine is on the Windows operating system.')
 
-        with self.swap(common, 'is_windows_os', mock_is_windows_os), (
+        with patch.object(common, 'is_windows_os', mock_is_windows_os), (
             windows_not_supported_exception):
             install_third_party.main(args=[])
 
@@ -464,9 +465,9 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
             return Ret()
 
-        swap_call = self.swap(
+        swap_call = patch.object(
             subprocess, 'call', mock_call)
-        untar_files_swap = self.swap(
+        untar_files_swap = patch.object(
             install_third_party, 'download_and_untar_files',
             mock_download_and_untar_files)
         with swap_call, untar_files_swap:
@@ -510,15 +511,15 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
             return Ret()
 
-        swap_call = self.swap(
+        swap_call = patch.object(
             subprocess, 'call', mock_call)
-        unzip_files_swap = self.swap(
+        unzip_files_swap = patch.object(
             install_third_party, 'download_and_unzip_files',
             mock_download_and_unzip_files)
 
-        mac_swap = self.swap(common, 'is_mac_os', mock_is_mac_os)
-        linux_swap = self.swap(common, 'is_linux_os', mock_is_linux_os)
-        windows_swap = self.swap(common, 'is_windows_os', mock_is_windows_os)
+        mac_swap = patch.object(common, 'is_mac_os', mock_is_mac_os)
+        linux_swap = patch.object(common, 'is_linux_os', mock_is_linux_os)
+        windows_swap = patch.object(common, 'is_windows_os', mock_is_windows_os)
         with swap_call, unzip_files_swap, mac_swap, linux_swap, windows_swap:
             install_third_party.install_elasticsearch_dev_server()
         self.assertEqual(check_function_calls, expected_check_function_calls)
@@ -555,9 +556,9 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
             return Ret()
 
-        swap_call = self.swap(
+        swap_call = patch.object(
             subprocess, 'call', mock_call)
-        untar_files_swap = self.swap(
+        untar_files_swap = patch.object(
             install_third_party, 'download_and_untar_files',
             mock_download_and_untar_files)
 
@@ -567,8 +568,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             'download_and_unzip_files_is_called': False
         }
 
-        mac_os_swap = self.swap(common, 'is_mac_os', mock_is_mac_os)
-        linux_os_swap = self.swap(common, 'is_linux_os', mock_is_linux_os)
+        mac_os_swap = patch.object(common, 'is_mac_os', mock_is_mac_os)
+        linux_os_swap = patch.object(common, 'is_linux_os', mock_is_linux_os)
         with swap_call, untar_files_swap, mac_os_swap, linux_os_swap:
             install_third_party.install_elasticsearch_dev_server()
         self.assertEqual(check_function_calls, expected_check_function_calls)
@@ -595,14 +596,14 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
             return Ret()
 
-        swap_call = self.swap(
+        swap_call = patch.object(
             subprocess, 'call', mock_call)
 
         os_not_supported_exception = self.assertRaisesRegex(
             Exception, 'Unrecognized or unsupported operating system.')
-        mac_swap = self.swap(common, 'is_mac_os', mock_is_mac_os)
-        linux_swap = self.swap(common, 'is_linux_os', mock_is_linux_os)
-        windows_swap = self.swap(common, 'is_windows_os', mock_is_windows_os)
+        mac_swap = patch.object(common, 'is_mac_os', mock_is_mac_os)
+        linux_swap = patch.object(common, 'is_linux_os', mock_is_linux_os)
+        windows_swap = patch.object(common, 'is_windows_os', mock_is_windows_os)
         with mac_swap, linux_swap, windows_swap, swap_call, (
             os_not_supported_exception):
             install_third_party.install_elasticsearch_dev_server()
@@ -623,7 +624,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
             return Ret()
 
-        swap_call = self.swap(
+        swap_call = patch.object(
             subprocess, 'call', mock_call)
 
         expected_check_function_calls = {

--- a/scripts/linters/codeowner_linter_test.py
+++ b/scripts/linters/codeowner_linter_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/linters/codeowner_linter.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import multiprocessing
 import os
@@ -94,9 +95,9 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
                 '.github/stale.yml',
                 'core/domain/new_file.py']
 
-        self.listdir_swap = self.swap(os, 'listdir', mock_listdir)
+        self.listdir_swap = patch.object(os, 'listdir', mock_listdir)
         self.listdir_swap_file_with_blanket_codeowner_only = (
-            self.swap(
+            patch.object(
                 os, 'listdir', mock_listdir_with_blanket_codeowner_only_file)
         )
 
@@ -105,11 +106,11 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         # for testing purpose.
         mock_codeowner_important_paths = CODEOWNER_IMPORTANT_PATHS[:-1]
 
-        codeowner_important_paths_swap = self.swap(
+        codeowner_important_paths_swap = patch.object(
             codeowner_linter, 'CODEOWNER_IMPORTANT_PATHS',
             mock_codeowner_important_paths)
 
-        codeowner_filepath_swap = self.swap(
+        codeowner_filepath_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             VALID_CODEOWNER_FILEPATH)
 
@@ -129,7 +130,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
     def test_duplicate_important_patterns_at_the_bottom_of_codeowners(
         self
     ) -> None:
-        codeowner_path_swap = self.swap(
+        codeowner_path_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_DUPLICATE_CODEOWNER_FILEPATH)
 
@@ -145,10 +146,10 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
     def test_duplicate_important_patterns_in_list(self) -> None:
         mock_codeowner_important_paths = (
             CODEOWNER_IMPORTANT_PATHS + ['/.github/stale.yml'])
-        codeowner_path_swap = self.swap(
+        codeowner_path_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH', VALID_CODEOWNER_FILEPATH)
 
-        codeowner_important_paths_swap = self.swap(
+        codeowner_important_paths_swap = patch.object(
             codeowner_linter, 'CODEOWNER_IMPORTANT_PATHS',
             mock_codeowner_important_paths)
 
@@ -166,7 +167,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
     def test_missing_important_codeowner_path_from_critical_section(
         self
     ) -> None:
-        codeowner_path_swap = self.swap(
+        codeowner_path_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_MISSING_IMPORTANT_PATTERN_CODEOWNER_FILEPATH)
 
@@ -185,10 +186,10 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         self.assertTrue(lint_task_report.failed)
 
     def test_check_codeowner_file_with_success_message(self) -> None:
-        codeowner_path_swap = self.swap(
+        codeowner_path_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH', VALID_CODEOWNER_FILEPATH)
 
-        codeowner_important_paths_swap = self.swap(
+        codeowner_important_paths_swap = patch.object(
             codeowner_linter, 'CODEOWNER_IMPORTANT_PATHS',
             CODEOWNER_IMPORTANT_PATHS)
 
@@ -202,7 +203,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         self.assertFalse(lint_task_report.failed)
 
     def test_check_file_with_only_blanket_codeowner_defined_fails(self) -> None:
-        codeowner_swap = self.swap(
+        codeowner_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_FILEPATH_WITH_BLANKET_CODEOWNER_ONLY)
 
@@ -220,7 +221,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         self.assertTrue(lint_task_report.failed)
 
     def test_check_invalid_inline_comment_codeowner_filepath(self) -> None:
-        codeowner_swap = self.swap(
+        codeowner_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_INLINE_COMMENT_CODEOWNER_FILEPATH)
 
@@ -234,7 +235,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         self.assertTrue(lint_task_report.failed)
 
     def test_check_codeowner_file_without_codeowner_name(self) -> None:
-        codeowner_swap = self.swap(
+        codeowner_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_MISSING_CODEOWNER_NAME_FILEPATH)
 
@@ -248,7 +249,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         self.assertTrue(lint_task_report.failed)
 
     def test_check_codeowner_file_without_full_file_path(self) -> None:
-        codeowner_swap = self.swap(
+        codeowner_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_FULL_FILEPATH_CODEOWNER_FILEPATH)
 
@@ -263,7 +264,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         self.assertTrue(lint_task_report.failed)
 
     def test_check_codeowner_file_with_wildcard(self) -> None:
-        codeowner_swap = self.swap(
+        codeowner_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_WILDCARD_IN_FILEPATH)
 
@@ -277,7 +278,7 @@ class CodeownerLinterTests(test_utils.LinterTestBase):
         self.assertTrue(lint_task_report.failed)
 
     def test_check_codeowner_file_with_no_valid_match(self) -> None:
-        codeowner_swap = self.swap(
+        codeowner_swap = patch.object(
             codeowner_linter, 'CODEOWNER_FILEPATH',
             INVALID_FILEPATH_MISSING_FROM_DIRECTORY)
 

--- a/scripts/linters/css_linter_test.py
+++ b/scripts/linters/css_linter_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/linters/css_linter.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 import subprocess
@@ -59,7 +60,7 @@ class ThirdPartyCSSLintChecksManagerTests(test_utils.LinterTestBase):
         def mock_join(*unused_args: str) -> str:
             return 'node_modules/stylelint/bin/stylelinter.js'
 
-        join_swap = self.swap(os.path, 'join', mock_join)
+        join_swap = patch.object(os.path, 'join', mock_join)
 
         third_party_linter = css_linter.ThirdPartyCSSLintChecksManager(
             [INVALID_CSS_FILEPATH])

--- a/scripts/linters/general_purpose_linter_test.py
+++ b/scripts/linters/general_purpose_linter_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/linters/js_ts_linter.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import multiprocessing
 import os
@@ -233,7 +234,7 @@ class GeneralLintTests(test_utils.LinterTestBase):
         def _mock_readlines_error(unused_self: str) -> None:
             raise Exception('filecache error')
 
-        with self.swap(FILE_CACHE, 'readlines', _mock_readlines_error):
+        with patch.object(FILE_CACHE, 'readlines', _mock_readlines_error):
             linter = general_purpose_linter.GeneralPurposeLinter(
                 [INVALID_ANNOTATIONS_FILEPATH], FILE_CACHE)
             with self.assertRaisesRegex(
@@ -281,7 +282,7 @@ class GeneralLintTests(test_utils.LinterTestBase):
                 '"DEV_MODE": false,\n'
                 '"EMULATOR_MODE": true\n')
 
-        with self.swap(FILE_CACHE, 'readlines', mock_readlines):
+        with patch.object(FILE_CACHE, 'readlines', mock_readlines):
             linter = general_purpose_linter.GeneralPurposeLinter(
                 [CONSTANTS_FILEPATH], FILE_CACHE)
             lint_task_report = linter.check_bad_patterns()
@@ -302,7 +303,7 @@ class GeneralLintTests(test_utils.LinterTestBase):
                 '"DEV_MODE": true,\n'
                 '"EMULATOR_MODE": false\n')
 
-        with self.swap(FILE_CACHE, 'readlines', mock_readlines):
+        with patch.object(FILE_CACHE, 'readlines', mock_readlines):
             linter = general_purpose_linter.GeneralPurposeLinter(
                 [CONSTANTS_FILEPATH], FILE_CACHE)
             lint_task_report = linter.check_bad_patterns()
@@ -357,7 +358,7 @@ class GeneralLintTests(test_utils.LinterTestBase):
     def test_excluded_file_with_disallow_flags_raise_no_message(self) -> None:
         linter = general_purpose_linter.GeneralPurposeLinter(
             [INVALID_BYPASS_FLAG], FILE_CACHE)
-        excluded_files_swap = self.swap(
+        excluded_files_swap = patch.object(
             warranted_angular_security_bypasses,
             'EXCLUDED_BYPASS_SECURITY_TRUST_FILES',
             [INVALID_BYPASS_FLAG])
@@ -386,7 +387,7 @@ class GeneralLintTests(test_utils.LinterTestBase):
         ) -> bool:
             return True
 
-        filepath_excluded_swap = self.swap(
+        filepath_excluded_swap = patch.object(
             general_purpose_linter,
             'is_filepath_excluded_for_bad_patterns_check',
             mock_is_filepath_excluded_for_bad_patterns_check)

--- a/scripts/linters/js_ts_linter_test.py
+++ b/scripts/linters/js_ts_linter_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/linters/js_ts_linter.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import multiprocessing
 import os
@@ -102,7 +103,7 @@ class JsTsLintTests(test_utils.LinterTestBase):
         ) -> Ret:
             return Ret()
 
-        popen_error_swap = self.swap(
+        popen_error_swap = patch.object(
             subprocess, 'Popen', mock_popen_error_call)
         with popen_error_swap:
             with self.assertRaisesRegex(Exception, 'Some error'):
@@ -112,9 +113,9 @@ class JsTsLintTests(test_utils.LinterTestBase):
         def mock_parse_script(unused_file_content: str, comment: str) -> None:  # pylint: disable=unused-argument
             raise Exception('Exception raised from parse_script()')
 
-        compile_all_ts_files_swap = self.swap(
+        compile_all_ts_files_swap = patch.object(
             js_ts_linter, 'compile_all_ts_files', lambda: None)
-        esprima_swap = self.swap(esprima, 'parseScript', mock_parse_script)
+        esprima_swap = patch.object(esprima, 'parseScript', mock_parse_script)
 
         with esprima_swap, compile_all_ts_files_swap, self.assertRaisesRegex(
             Exception, re.escape('Exception raised from parse_script()')
@@ -135,7 +136,7 @@ class JsTsLintTests(test_utils.LinterTestBase):
                     INVALID_CONSTANT_FILEPATH)
             subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
 
-        compile_all_ts_files_swap = self.swap(
+        compile_all_ts_files_swap = patch.object(
             js_ts_linter, 'compile_all_ts_files', mock_compile_all_ts_files)
 
         with compile_all_ts_files_swap:
@@ -166,7 +167,7 @@ class JsTsLintTests(test_utils.LinterTestBase):
                     INVALID_CONSTANT_IN_TS_FILEPATH)
             subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
 
-        compile_all_ts_files_swap = self.swap(
+        compile_all_ts_files_swap = patch.object(
             js_ts_linter, 'compile_all_ts_files', mock_compile_all_ts_files)
 
         with compile_all_ts_files_swap:
@@ -197,8 +198,8 @@ class JsTsLintTests(test_utils.LinterTestBase):
             return process
         def mock_communicate(unused_self: str) -> Tuple[bytes, bytes]:
             return (b'Output', b'Invalid')
-        popen_swap = self.swap(subprocess, 'Popen', mock_popen)
-        communicate_swap = self.swap(
+        popen_swap = patch.object(subprocess, 'Popen', mock_popen)
+        communicate_swap = patch.object(
             subprocess.Popen, 'communicate', mock_communicate)
         with popen_swap, communicate_swap:
             with self.assertRaisesRegex(Exception, 'Invalid'):
@@ -210,7 +211,7 @@ class JsTsLintTests(test_utils.LinterTestBase):
         def mock_exists(unused_path: str) -> bool:
             return False
 
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
 
         with exists_swap, self.assertRaisesRegex(
             Exception,
@@ -261,7 +262,7 @@ class JsTsLintTests(test_utils.LinterTestBase):
                     VALID_UNLISTED_SERVICE_PATH)
             subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
 
-        compile_all_ts_files_swap = self.swap(
+        compile_all_ts_files_swap = patch.object(
             js_ts_linter, 'compile_all_ts_files', mock_compile_all_ts_files)
 
         with compile_all_ts_files_swap:
@@ -300,7 +301,7 @@ class JsTsLintTests(test_utils.LinterTestBase):
                     VALID_IGNORED_SERVICE_PATH)
             subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
 
-        compile_all_ts_files_swap = self.swap(
+        compile_all_ts_files_swap = patch.object(
             js_ts_linter, 'compile_all_ts_files', mock_compile_all_ts_files)
         with compile_all_ts_files_swap:
             lint_task_report = js_ts_linter.JsTsLintChecksManager(

--- a/scripts/linters/linter_utils_test.py
+++ b/scripts/linters/linter_utils_test.py
@@ -17,6 +17,7 @@
 """Unit tests for linter_utils.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -99,7 +100,7 @@ class ColorMessagePrintTest(test_utils.GenericTestBase):
             """Mock for print."""
             self.log = ' '.join(str(arg) for arg in args)
 
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
     def test_print_failure_message_prints_in_red_color(self) -> None:
         message = 'Failure Message'

--- a/scripts/linters/other_files_linter_test.py
+++ b/scripts/linters/other_files_linter_test.py
@@ -17,6 +17,7 @@
 """Unit tests for app_dev_linter.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import io
 import multiprocessing
@@ -70,9 +71,9 @@ class CustomLintChecksManagerTests(test_utils.LinterTestBase):
             return file
         def mock_listdir(unused_path: str) -> List[str]:
             return self.files_in_typings_dir
-        self.open_file_swap = self.swap(
+        self.open_file_swap = patch.object(
             utils, 'open_file', mock_open_file)
-        self.listdir_swap = self.swap(os, 'listdir', mock_listdir)
+        self.listdir_swap = patch.object(os, 'listdir', mock_listdir)
 
     def test_check_valid_pattern_in_app_dev_yaml(self) -> None:
         def mock_readlines(
@@ -83,7 +84,7 @@ class CustomLintChecksManagerTests(test_utils.LinterTestBase):
                 '# Third party files:',
                 '- third_party/static/bootstrap-4.3.1/')
 
-        readlines_swap = self.swap(
+        readlines_swap = patch.object(
             pre_commit_linter.FileCache, 'readlines', mock_readlines)
         with readlines_swap:
             error_messages = other_files_linter.CustomLintChecksManager(
@@ -101,7 +102,7 @@ class CustomLintChecksManagerTests(test_utils.LinterTestBase):
             return (
                 '# Third party files:', '- third_party/static/bootstrap-4.3/')
 
-        readlines_swap = self.swap(
+        readlines_swap = patch.object(
             pre_commit_linter.FileCache, 'readlines', mock_readlines)
         with readlines_swap:
             error_messages = other_files_linter.CustomLintChecksManager(
@@ -130,7 +131,7 @@ class CustomLintChecksManagerTests(test_utils.LinterTestBase):
                 '       inject: false', '}),]'
             )
 
-        readlines_swap = self.swap(
+        readlines_swap = patch.object(
             pre_commit_linter.FileCache, 'readlines', mock_readlines)
         with readlines_swap:
             error_messages = other_files_linter.CustomLintChecksManager(
@@ -155,7 +156,7 @@ class CustomLintChecksManagerTests(test_utils.LinterTestBase):
                 '       inject: false', '}),]'
             )
 
-        readlines_swap = self.swap(
+        readlines_swap = patch.object(
             pre_commit_linter.FileCache, 'readlines', mock_readlines)
         with readlines_swap:
             error_messages = other_files_linter.CustomLintChecksManager(
@@ -179,7 +180,7 @@ class CustomLintChecksManagerTests(test_utils.LinterTestBase):
                 '}),]'
             )
 
-        readlines_swap = self.swap(
+        readlines_swap = patch.object(
             pre_commit_linter.FileCache, 'readlines', mock_readlines)
         with readlines_swap:
             error_messages = other_files_linter.CustomLintChecksManager(
@@ -312,7 +313,7 @@ class CustomLintChecksManagerTests(test_utils.LinterTestBase):
         listdir_swap = self.swap_with_checks(
             os, 'listdir', mock_listdir,
             expected_args=[(other_files_linter.WORKFLOWS_DIR,)])
-        read_swap = self.swap(FILE_CACHE, 'read', mock_read)
+        read_swap = patch.object(FILE_CACHE, 'read', mock_read)
 
         expected = [
             '%s --> Job run does not use the .github/actions/merge action.' %

--- a/scripts/linters/pre_commit_linter_test.py
+++ b/scripts/linters/pre_commit_linter_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/pre_commit_linter.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import multiprocessing
 import os
@@ -76,7 +77,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.sys_swap = self.swap(sys, 'exit', mock_exit)
+        self.sys_swap = patch.object(sys, 'exit', mock_exit)
         self.install_swap = self.swap_with_checks(
             install_third_party_libs, 'main',
             mock_install_third_party_libs_main)
@@ -90,7 +91,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
         ) -> List[str]:
             return []
 
-        all_filepath_swap = self.swap(
+        all_filepath_swap = patch.object(
             pre_commit_linter, '_get_all_filepaths', mock_get_all_filepaths)
 
         with self.print_swap, self.sys_swap:
@@ -104,7 +105,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
         def mock_get_changed_filepaths() -> List[str]:
             return []
 
-        get_changed_filepaths_swap = self.swap(
+        get_changed_filepaths_swap = patch.object(
             pre_commit_linter, '_get_changed_filepaths',
             mock_get_changed_filepaths)
 
@@ -131,7 +132,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
                 return [VALID_PY_FILEPATH]
             return []
 
-        shards_swap = self.swap(
+        shards_swap = patch.object(
             pre_commit_linter, 'SHARDS', mock_shards)
 
         get_filenames_from_path_swap = self.swap_with_checks(
@@ -164,7 +165,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
             ],
         }
 
-        shards_swap = self.swap(
+        shards_swap = patch.object(
             pre_commit_linter, 'SHARDS', mock_shards)
 
         get_filenames_from_path_swap = self.swap_with_checks(
@@ -174,7 +175,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
                 (prefix,)
                 for prefix in mock_shards['1']
             ])
-        install_swap = self.swap(
+        install_swap = patch.object(
             install_third_party_libs, 'main',
             mock_install_third_party_main)
 
@@ -206,7 +207,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
             ],
         }
 
-        shards_swap = self.swap(
+        shards_swap = patch.object(
             pre_commit_linter, 'SHARDS', mock_shards)
 
         filenames_from_path_expected_args = [(os.getcwd(),)] + [
@@ -233,7 +234,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
         self.assertTrue(all_checks_passed(self.linter_stdout))
 
     def test_main_with_error_message(self) -> None:
-        all_errors_swap = self.swap(
+        all_errors_swap = patch.object(
             concurrent_task_utils, 'ALL_ERRORS', ['This is an error.'])
 
         with self.print_swap, self.sys_swap:
@@ -271,7 +272,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
         ) -> List[str]:
             return [VALID_PY_FILEPATH]
 
-        get_all_files_swap = self.swap(
+        get_all_files_swap = patch.object(
             pre_commit_linter, '_get_all_files_in_directory',
             mock_get_all_files_in_directory)
 
@@ -318,7 +319,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
     def test_get_changed_filepaths(self) -> None:
         def mock_check_output(unused_list: List[str]) -> Optional[str]:
             return ''
-        subprocess_swap = self.swap(
+        subprocess_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
 
         with self.print_swap, self.sys_swap:

--- a/scripts/populate_sample_contributor_data_test.py
+++ b/scripts/populate_sample_contributor_data_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/populate_sample_data.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 from core import feconf
 from core.controllers import base
@@ -78,7 +79,7 @@ class SampleDataInitializerTests(test_utils.GenericTestBase):
 
         self.initializer.csrf_token = self.get_new_csrf_token()
 
-        self.request_swap = self.swap(
+        self.request_swap = patch.object(
             self.initializer.session,
             'request',
             self._mock_request)
@@ -114,7 +115,7 @@ class SampleDataInitializerTests(test_utils.GenericTestBase):
                     if token == cur_token:
                         self._mock_login_as_admin(email)
                         break
-            with self.swap(
+            with patch.object(
                 base, 'load_template', test_utils.mock_load_template
             ):
                 return self.testapp.get(url, params=params, headers=headers)

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/pre_commit_hook.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -43,7 +44,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
 
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
     def test_install_hook_with_existing_symlink(self) -> None:
         def mock_islink(unused_file: str) -> bool:
@@ -55,9 +56,9 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         ) -> Tuple[str, None]:
             return ('Output', None)
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -84,7 +85,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         exists_swap = self.swap_with_checks(
             os.path, 'exists', mock_exists,
             expected_args=((pre_commit_file,),))
-        is_windows_swap = self.swap(common, 'is_windows_os', mock_is_windows)
+        is_windows_swap = patch.object(common, 'is_windows_os', mock_is_windows)
 
         with islink_swap, exists_swap, self.print_swap, is_windows_swap:
             pre_commit_hook.install_hook()
@@ -107,9 +108,9 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         ) -> Tuple[str, str]:
             return ('Output', 'Error')
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -135,12 +136,12 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         def mock_symlink(unused_path: str, unused_file: str) -> None:
             check_function_calls['symlink_is_called'] = True
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
-        symlink_swap = self.swap(os, 'symlink', mock_symlink)
+        symlink_swap = patch.object(os, 'symlink', mock_symlink)
 
         with islink_swap, exists_swap, subprocess_swap, self.print_swap, (
             symlink_swap):
@@ -174,13 +175,13 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         def mock_copy(unused_type: str, unused_file: str) -> None:
             check_function_calls['copy_is_called'] = True
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
-        symlink_swap = self.swap(os, 'symlink', mock_symlink)
-        copy_swap = self.swap(shutil, 'copy', mock_copy)
+        symlink_swap = patch.object(os, 'symlink', mock_symlink)
+        copy_swap = patch.object(shutil, 'copy', mock_copy)
 
         with islink_swap, exists_swap, subprocess_swap, symlink_swap, copy_swap:
             with self.print_swap:
@@ -208,13 +209,13 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         def mock_symlink(unused_path: str, unused_file: str) -> None:
             check_function_calls['symlink_is_called'] = True
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
-        unlink_swap = self.swap(os, 'unlink', mock_unlink)
-        symlink_swap = self.swap(os, 'symlink', mock_symlink)
+        unlink_swap = patch.object(os, 'unlink', mock_unlink)
+        symlink_swap = patch.object(os, 'symlink', mock_symlink)
 
         with islink_swap, exists_swap, subprocess_swap, self.print_swap:
             with unlink_swap, symlink_swap:
@@ -235,7 +236,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         ) -> psutil.Popen:
             return process
 
-        with self.swap(subprocess, 'Popen', mock_popen):
+        with patch.object(subprocess, 'Popen', mock_popen):
             self.assertEqual(
                 pre_commit_hook.start_subprocess_for_result(['cmd']),
                 (b'test\n', b''))
@@ -248,7 +249,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         ) -> Tuple[bytes, None]:
             return (b'package-lock.json\nfile.1py\nfile2.ts', None)
 
-        with self.swap(
+        with patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result
         ):
@@ -263,7 +264,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         ) -> Tuple[bytes, None]:
             return (b'file.1py\nfile2.ts', None)
 
-        with self.swap(
+        with patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result):
             self.assertFalse(
@@ -275,7 +276,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         ) -> Tuple[bytes, bytes]:
             return (b'file.1py\nfile2.ts', b'Error')
 
-        subprocess_swap = self.swap(
+        subprocess_swap = patch.object(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
         with subprocess_swap, self.assertRaisesRegex(ValueError, 'Error'):
@@ -284,7 +285,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
     def test_does_current_folder_contain_have_package_lock_file(self) -> None:
         def mock_isfile(unused_path: str) -> bool:
             return True
-        with self.swap(os.path, 'isfile', mock_isfile):
+        with patch.object(os.path, 'isfile', mock_isfile):
             self.assertTrue(
                 pre_commit_hook
                 .does_current_folder_contain_have_package_lock_file())
@@ -298,7 +299,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             return (
                 b'-  "DASHBOARD_TYPE_CREATOR": "creator",\n'
                 b'+  "DASHBOARD_TYPE_CREATOR": "creator-change",\n')
-        with self.swap(subprocess, 'check_output', mock_check_output):
+        with patch.object(subprocess, 'check_output', mock_check_output):
             pre_commit_hook.check_changes_in_config()
 
     def test_check_changes_with_no_config_file_changed(self) -> None:
@@ -315,7 +316,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             return (
                 b'-  "DASHBOARD_TYPE_CREATOR": "creator",\n'
                 b'+  "DASHBOARD_TYPE_CREATOR": "creator-change",\n')
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
         with check_output_swap, self.assertRaisesRegex(
             Exception,
@@ -334,7 +335,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             return (
                 b'-  "FIREBASE_CONFIG_API_KEY": "fake-api-key",\n'
                 b'+  "FIREBASE_CONFIG_API_KEY": "changed-api-key",\n')
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
         with check_output_swap, self.assertRaisesRegex(
             Exception,
@@ -350,13 +351,13 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             return True
         def mock_check_changes_in_config() -> None:
             check_function_calls['check_changes_in_config_is_called'] = True
-        package_lock_swap = self.swap(
+        package_lock_swap = patch.object(
             pre_commit_hook, 'does_diff_include_package_lock_file', mock_func)
-        package_lock_in_current_folder_swap = self.swap(
+        package_lock_in_current_folder_swap = patch.object(
             pre_commit_hook,
             'does_current_folder_contain_have_package_lock_file',
             mock_func)
-        check_config_swap = self.swap(
+        check_config_swap = patch.object(
             pre_commit_hook, 'check_changes_in_config',
             mock_check_changes_in_config)
         with package_lock_swap, package_lock_in_current_folder_swap:
@@ -374,7 +375,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         }
         def mock_install_hook() -> None:
             check_function_calls['install_hook_is_called'] = True
-        with self.swap(
+        with patch.object(
             pre_commit_hook, 'install_hook', mock_install_hook):
             pre_commit_hook.main(args=['--install'])
 
@@ -386,13 +387,13 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             return False
         def mock_check_changes_in_config() -> None:
             check_function_calls['check_changes_in_config_is_called'] = True
-        package_lock_swap = self.swap(
+        package_lock_swap = patch.object(
             pre_commit_hook, 'does_diff_include_package_lock_file', mock_func)
-        package_lock_in_current_folder_swap = self.swap(
+        package_lock_in_current_folder_swap = patch.object(
             pre_commit_hook,
             'does_current_folder_contain_have_package_lock_file',
             mock_func)
-        check_config_swap = self.swap(
+        check_config_swap = patch.object(
             pre_commit_hook, 'check_changes_in_config',
             mock_check_changes_in_config)
         with package_lock_swap, package_lock_in_current_folder_swap:
@@ -410,7 +411,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         temp_file.name = temp_file_name  # type: ignore[misc]
         with utils.open_file(temp_file_name, 'w') as tmp:
             tmp.write('{"GCLOUD_PATH": "%s"}' % common.GCLOUD_PATH)
-        with self.swap(
+        with patch.object(
             pre_commit_hook, 'RELEASE_CONSTANTS_FILEPATH', temp_file_name):
             pre_commit_hook.check_changes_in_gcloud_path()
         temp_file.close()
@@ -430,7 +431,7 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             'bin/gcloud')
         with utils.open_file(temp_file_name, 'w') as tmp:
             tmp.write('{"GCLOUD_PATH": "%s"}' % incorrect_gcloud_path)
-        constants_file_swap = self.swap(
+        constants_file_swap = patch.object(
             pre_commit_hook, 'RELEASE_CONSTANTS_FILEPATH', temp_file_name)
         with constants_file_swap, self.assertRaisesRegex(
             Exception, (

--- a/scripts/pre_push_hook_test.py
+++ b/scripts/pre_push_hook_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/pre_push_hook.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -94,33 +95,33 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_check_backend_python_library_for_inconsistencies() -> None:
             return
 
-        self.swap_check_backend_python_libs = self.swap(
+        self.swap_check_backend_python_libs = patch.object(
             pre_push_hook,
             'check_for_backend_python_library_inconsistencies',
             mock_check_backend_python_library_for_inconsistencies)
-        self.popen_swap = self.swap(subprocess, 'Popen', mock_popen)
-        self.get_remote_name_swap = self.swap(
+        self.popen_swap = patch.object(subprocess, 'Popen', mock_popen)
+        self.get_remote_name_swap = patch.object(
             pre_push_hook, 'get_remote_name', mock_get_remote_name)
-        self.get_refs_swap = self.swap(pre_push_hook, 'get_refs', mock_get_refs)
-        self.collect_files_swap = self.swap(
+        self.get_refs_swap = patch.object(pre_push_hook, 'get_refs', mock_get_refs)
+        self.collect_files_swap = patch.object(
             pre_push_hook, 'collect_files_being_pushed',
             mock_collect_files_being_pushed)
-        self.uncommitted_files_swap = self.swap(
+        self.uncommitted_files_swap = patch.object(
             pre_push_hook, 'has_uncommitted_files', mock_has_uncommitted_files)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
-        self.check_output_swap = self.swap(
+        self.print_swap = patch.object(builtins, 'print', mock_print)
+        self.check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
-        self.start_linter_swap = self.swap(
+        self.start_linter_swap = patch.object(
             pre_push_hook, 'start_linter', mock_start_linter)
-        self.execute_mypy_checks_swap = self.swap(
+        self.execute_mypy_checks_swap = patch.object(
             pre_push_hook, 'execute_mypy_checks', mock_execute_mypy_checks)
-        self.js_or_ts_swap = self.swap(
+        self.js_or_ts_swap = patch.object(
             pre_push_hook, 'does_diff_include_js_or_ts_files',
             mock_does_diff_include_js_or_ts_files)
-        self.ts_swap = self.swap(
+        self.ts_swap = patch.object(
             pre_push_hook, 'does_diff_include_ts_files',
             mock_does_diff_include_ts_files)
-        self.ci_config_or_js_files_swap = self.swap(
+        self.ci_config_or_js_files_swap = patch.object(
             pre_push_hook,
             'does_diff_include_ci_config_or_js_files',
             mock_does_diff_include_ci_config_or_js_files)
@@ -150,7 +151,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
                 return process_for_upstream_url
             else:
                 return process_for_remote
-        popen_swap = self.swap(subprocess, 'Popen', mock_popen)
+        popen_swap = patch.object(subprocess, 'Popen', mock_popen)
         with popen_swap:
             self.assertEqual(pre_push_hook.get_remote_name(), b'upstream')
 
@@ -168,7 +169,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         ) -> subprocess.Popen[bytes]:  # pylint: disable=unsubscriptable-object
             return process
 
-        popen_swap = self.swap(subprocess, 'Popen', mock_popen)
+        popen_swap = patch.object(subprocess, 'Popen', mock_popen)
         with popen_swap, self.assertRaisesRegex(ValueError, 'test_oppia_error'):
             pre_push_hook.get_remote_name()
 
@@ -188,10 +189,10 @@ class PrePushHookTests(test_utils.GenericTestBase):
             else:
                 return process_for_remote
 
-        communicate_swap = self.swap(
+        communicate_swap = patch.object(
             process_for_remote_url, 'communicate', mock_communicate
         )
-        popen_swap = self.swap(subprocess, 'Popen', mock_popen)
+        popen_swap = patch.object(subprocess, 'Popen', mock_popen)
         with communicate_swap:
             with popen_swap:
                 with self.assertRaisesRegex(ValueError, 'test_oppia_error'):
@@ -216,7 +217,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
                 return process_for_upstream_url
             else:
                 return process_for_remote
-        popen_swap = self.swap(subprocess, 'Popen', mock_popen)
+        popen_swap = patch.object(subprocess, 'Popen', mock_popen)
         with popen_swap, self.assertRaisesRegex(
             Exception,
             'Error: Please set upstream for the lint checks to run '
@@ -249,7 +250,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
                 return process_for_upstream_url
             else:
                 return process_for_remote
-        popen_swap = self.swap(subprocess, 'Popen', mock_popen)
+        popen_swap = patch.object(subprocess, 'Popen', mock_popen)
         with popen_swap, self.print_swap:
             self.assertIsNone(pre_push_hook.get_remote_name())
         self.assertTrue(
@@ -261,7 +262,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str]
         ) -> Tuple[bytes, None]:
             return (b'M\tfile1\nA\tfile2', None)
-        subprocess_swap = self.swap(
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -278,7 +279,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str]
         ) -> Tuple[str, str]:
             return ('M\tfile1\nA\tfile2', 'test_oppia_error')
-        subprocess_swap = self.swap(
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -311,12 +312,12 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_get_merge_base(unused_left: str, unused_right: str) -> str:
             check_function_calls['get_merge_base_is_called'] = True
             return 'Merge Base'
-        subprocess_swap = self.swap(
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
-        git_diff_swap = self.swap(
+        git_diff_swap = patch.object(
             pre_push_hook, 'git_diff_name_status', mock_git_diff_name_status)
-        get_merge_base_swap = self.swap(
+        get_merge_base_swap = patch.object(
             pre_push_hook, 'get_merge_base', mock_get_merge_base)
 
         with subprocess_swap, git_diff_swap, get_merge_base_swap:
@@ -331,7 +332,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str]
         ) -> Tuple[None, str]:
             return None, 'Test'
-        subprocess_swap = self.swap(
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -350,7 +351,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         ) -> Tuple[bytes, None]:
             check_function_calls['start_subprocess_for_result_is_called'] = True
             return b'Test', None
-        subprocess_swap = self.swap(
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -373,7 +374,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
     def test_get_parent_branch_name_for_diff_with_hotfix_branch(self) -> None:
         def mock_get_branch() -> str:
             return 'release-1.2.3-hotfix-1'
-        get_branch_swap = self.swap(
+        get_branch_swap = patch.object(
             common, 'get_current_branch_name', mock_get_branch)
         with get_branch_swap:
             self.assertEqual(
@@ -383,7 +384,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
     def test_get_parent_branch_name_for_diff_with_release_branch(self) -> None:
         def mock_get_branch() -> str:
             return 'release-1.2.3'
-        get_branch_swap = self.swap(
+        get_branch_swap = patch.object(
             common, 'get_current_branch_name', mock_get_branch)
         with get_branch_swap:
             self.assertEqual(
@@ -394,7 +395,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
     ) -> None:
         def mock_get_branch() -> str:
             return 'branch-1'
-        get_branch_swap = self.swap(
+        get_branch_swap = patch.object(
             common, 'get_current_branch_name', mock_get_branch)
         with get_branch_swap:
             self.assertEqual(
@@ -403,7 +404,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
     def test_collect_files_being_pushed_with_empty_ref_list(self) -> None:
         def mock_get_branch() -> str:
             return 'branch-1'
-        get_branch_swap = self.swap(
+        get_branch_swap = patch.object(
             common, 'get_current_branch_name', mock_get_branch)
         with get_branch_swap:
             self.assertEqual(
@@ -423,11 +424,11 @@ class PrePushHookTests(test_utils.GenericTestBase):
         ) -> List[str]:
             return ['file1', 'file2']
 
-        get_branch_swap = self.swap(
+        get_branch_swap = patch.object(
             common, 'get_current_branch_name', mock_get_branch)
-        compare_to_remote_swap = self.swap(
+        compare_to_remote_swap = patch.object(
             pre_push_hook, 'compare_to_remote', mock_compare_to_remote)
-        extract_files_swap = self.swap(
+        extract_files_swap = patch.object(
             pre_push_hook, 'extract_files_to_lint', mock_extract_files_to_lint)
 
         with compare_to_remote_swap, extract_files_swap, get_branch_swap:
@@ -447,7 +448,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         with utils.open_file(temp_stdin_file, 'w') as f:
             f.write('local_ref local_sha1 remote_ref remote_sha1')
         with utils.open_file(temp_stdin_file, 'r') as f:
-            with self.swap(sys, 'stdin', f):
+            with patch.object(sys, 'stdin', f):
                 self.assertEqual(
                     pre_push_hook.get_refs(),
                     [
@@ -474,7 +475,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             unused_cmd_tokens: List[str], encoding: str = 'utf-8'  # pylint: disable=unused-argument
         ) -> str:
             return 'file1'
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
         with check_output_swap:
             self.assertTrue(pre_push_hook.has_uncommitted_files())
@@ -489,9 +490,9 @@ class PrePushHookTests(test_utils.GenericTestBase):
         ) -> Tuple[str, None]:
             return ('Output', None)
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -516,9 +517,9 @@ class PrePushHookTests(test_utils.GenericTestBase):
         ) -> Tuple[str, str]:
             return ('Output', 'test_oppia_error')
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
@@ -544,12 +545,12 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_symlink(unused_path: str, unused_file: str) -> None:
             check_function_calls['symlink_is_called'] = True
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
-        symlink_swap = self.swap(os, 'symlink', mock_symlink)
+        symlink_swap = patch.object(os, 'symlink', mock_symlink)
 
         with islink_swap, exists_swap, subprocess_swap, symlink_swap, (
             self.print_swap):
@@ -583,13 +584,13 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_copy(unused_type: str, unused_file: str) -> None:
             check_function_calls['copy_is_called'] = True
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
-        symlink_swap = self.swap(os, 'symlink', mock_symlink)
-        copy_swap = self.swap(shutil, 'copy', mock_copy)
+        symlink_swap = patch.object(os, 'symlink', mock_symlink)
+        copy_swap = patch.object(shutil, 'copy', mock_copy)
 
         with islink_swap, exists_swap, subprocess_swap, symlink_swap, copy_swap:
             with self.print_swap:
@@ -617,13 +618,13 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_symlink(unused_path: str, unused_file: str) -> None:
             check_function_calls['symlink_is_called'] = True
 
-        islink_swap = self.swap(os.path, 'islink', mock_islink)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        subprocess_swap = self.swap(
+        islink_swap = patch.object(os.path, 'islink', mock_islink)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        subprocess_swap = patch.object(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
-        unlink_swap = self.swap(os, 'unlink', mock_unlink)
-        symlink_swap = self.swap(os, 'symlink', mock_symlink)
+        unlink_swap = patch.object(os, 'unlink', mock_unlink)
+        symlink_swap = patch.object(os, 'symlink', mock_symlink)
 
         with islink_swap, exists_swap, subprocess_swap, self.print_swap:
             with unlink_swap, symlink_swap:
@@ -668,7 +669,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_has_uncommitted_files() -> bool:
             return True
 
-        uncommitted_files_swap = self.swap(
+        uncommitted_files_swap = patch.object(
             pre_push_hook, 'has_uncommitted_files', mock_has_uncommitted_files)
         with self.get_remote_name_swap, self.get_refs_swap, self.print_swap:
             with self.collect_files_swap, uncommitted_files_swap:
@@ -687,7 +688,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
                 return 'old-branch'
             raise subprocess.CalledProcessError(1, 'cmd', output='Output')
 
-        check_output_swap = self.swap(
+        check_output_swap = patch.object(
             subprocess, 'check_output', mock_check_output)
         with self.get_remote_name_swap, self.get_refs_swap, self.print_swap:
             with self.collect_files_swap, self.uncommitted_files_swap:
@@ -735,7 +736,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             if script == pre_push_hook.TYPESCRIPT_CHECKS_CMDS:
                 return 1
             return 0
-        run_script_and_get_returncode_swap = self.swap(
+        run_script_and_get_returncode_swap = patch.object(
             pre_push_hook, 'run_script_and_get_returncode',
             mock_run_script_and_get_returncode)
         with self.get_remote_name_swap, self.get_refs_swap, self.print_swap:
@@ -756,7 +757,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
                 return 1
             return 0
 
-        run_script_and_get_returncode_swap = self.swap(
+        run_script_and_get_returncode_swap = patch.object(
             pre_push_hook, 'run_script_and_get_returncode',
             mock_run_script_and_get_returncode)
         with self.get_remote_name_swap, self.get_refs_swap, self.print_swap:
@@ -776,7 +777,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             if script == pre_push_hook.BACKEND_ASSOCIATED_TEST_FILE_CHECK_CMD:
                 return 1
             return 0
-        run_script_and_get_returncode_swap = self.swap(
+        run_script_and_get_returncode_swap = patch.object(
             pre_push_hook, 'run_script_and_get_returncode',
             mock_run_script_and_get_returncode)
 
@@ -798,7 +799,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             if script == pre_push_hook.FRONTEND_TEST_CMDS:
                 return 1
             return 0
-        run_script_and_get_returncode_swap = self.swap(
+        run_script_and_get_returncode_swap = patch.object(
             pre_push_hook, 'run_script_and_get_returncode',
             mock_run_script_and_get_returncode)
         with self.get_remote_name_swap, self.get_refs_swap, self.print_swap:
@@ -819,7 +820,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             if script == pre_push_hook.CI_PROTRACTOR_CHECK_CMDS:
                 return 1
             return 0
-        run_script_and_get_returncode_swap = self.swap(
+        run_script_and_get_returncode_swap = patch.object(
             pre_push_hook, 'run_script_and_get_returncode',
             mock_run_script_and_get_returncode)
         with self.get_remote_name_swap, self.get_refs_swap, self.print_swap:
@@ -841,7 +842,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         }
         def mock_install_hook() -> None:
             check_function_calls['install_hook_is_called'] = True
-        with self.swap(
+        with patch.object(
             pre_push_hook, 'install_hook', mock_install_hook), (
                 self.swap_check_backend_python_libs):
             pre_push_hook.main(args=['--install'])
@@ -849,7 +850,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
     def test_main_without_install_arg_and_errors(self) -> None:
         def mock_run_script_and_get_returncode(unused_script: List[str]) -> int:
             return 0
-        run_script_and_get_returncode_swap = self.swap(
+        run_script_and_get_returncode_swap = patch.object(
             pre_push_hook, 'run_script_and_get_returncode',
             mock_run_script_and_get_returncode)
         with self.get_remote_name_swap, self.get_refs_swap, self.print_swap:
@@ -876,10 +877,10 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_exit_error(error_code: int) -> None:
             self.assertEqual(error_code, 1)
 
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies, 'get_mismatches',
             mock_get_mismatches)
-        swap_sys_exit = self.swap(sys, 'exit', mock_exit_error)
+        swap_sys_exit = patch.object(sys, 'exit', mock_exit_error)
         with self.print_swap, swap_sys_exit, swap_get_mismatches:
             pre_push_hook.check_for_backend_python_library_inconsistencies()
 
@@ -913,10 +914,10 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_exit_error(error_code: int) -> None:
             self.assertEqual(error_code, 1)
 
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies, 'get_mismatches',
             mock_get_mismatches)
-        swap_sys_exit = self.swap(sys, 'exit', mock_exit_error)
+        swap_sys_exit = patch.object(sys, 'exit', mock_exit_error)
         with self.print_swap, swap_sys_exit, swap_get_mismatches:
             pre_push_hook.check_for_backend_python_library_inconsistencies()
 
@@ -940,7 +941,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
     def test_main_with_no_inconsistencies_in_backend_python_libs(self) -> None:
         def mock_get_mismatches() -> Dict[str, Tuple[str, str]]:
             return {}
-        swap_get_mismatches = self.swap(
+        swap_get_mismatches = patch.object(
             install_python_prod_dependencies,
             'get_mismatches',
             mock_get_mismatches)

--- a/scripts/release_scripts/repo_specific_changes_fetcher_test.py
+++ b/scripts/release_scripts/repo_specific_changes_fetcher_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/release_scripts/repo_specific_changes_fetcher.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -40,8 +41,8 @@ class GetRepoSpecificChangesTest(test_utils.GenericTestBase):
             return (
                 'CURRENT_STATE_SCHEMA_VERSION = 3'
                 '\nCURRENT_COLLECTION_SCHEMA_VERSION = 4\n')
-        run_cmd_swap = self.swap(common, 'run_cmd', mock_run_cmd)
-        feconf_swap = self.swap(
+        run_cmd_swap = patch.object(common, 'run_cmd', mock_run_cmd)
+        feconf_swap = patch.object(
             repo_specific_changes_fetcher, 'FECONF_FILEPATH',
             MOCK_FECONF_FILEPATH)
         with run_cmd_swap, feconf_swap:
@@ -55,8 +56,8 @@ class GetRepoSpecificChangesTest(test_utils.GenericTestBase):
             return (
                 'CURRENT_STATE_SCHEMA_VERSION = 8'
                 '\nCURRENT_COLLECTION_SCHEMA_VERSION = 4\n')
-        run_cmd_swap = self.swap(common, 'run_cmd', mock_run_cmd)
-        feconf_swap = self.swap(
+        run_cmd_swap = patch.object(common, 'run_cmd', mock_run_cmd)
+        feconf_swap = patch.object(
             repo_specific_changes_fetcher, 'FECONF_FILEPATH',
             MOCK_FECONF_FILEPATH)
         with run_cmd_swap, feconf_swap:
@@ -71,7 +72,7 @@ class GetRepoSpecificChangesTest(test_utils.GenericTestBase):
     ) -> None:
         def mock_run_cmd(unused_cmd: str) -> str:
             return 'scripts/setup.py\nscripts/setup_gae.py'
-        with self.swap(common, 'run_cmd', mock_run_cmd):
+        with patch.object(common, 'run_cmd', mock_run_cmd):
             actual_scripts = (
                 repo_specific_changes_fetcher.get_setup_scripts_changes_status(
                     'release_tag'))
@@ -89,7 +90,7 @@ class GetRepoSpecificChangesTest(test_utils.GenericTestBase):
                 'scripts/setup.py\nextensions/test.ts\n'
                 'core/storage/activity/gae_models.py\n'
                 'core/storage/user/gae_models.py')
-        with self.swap(common, 'run_cmd', mock_run_cmd):
+        with patch.object(common, 'run_cmd', mock_run_cmd):
             actual_storgae_models = (
                 repo_specific_changes_fetcher
                 .get_changed_storage_models_filenames('release_tag'))
@@ -112,14 +113,14 @@ class GetRepoSpecificChangesTest(test_utils.GenericTestBase):
         ) -> None:
             return None
 
-        versions_swap = self.swap(
+        versions_swap = patch.object(
             repo_specific_changes_fetcher,
             'get_changed_schema_version_constant_names',
             mock_get_changed_schema_version_constant_names)
-        setup_scripts_swap = self.swap(
+        setup_scripts_swap = patch.object(
             repo_specific_changes_fetcher, 'get_setup_scripts_changes_status',
             mock_get_setup_scripts_changes_status)
-        storage_models_swap = self.swap(
+        storage_models_swap = patch.object(
             repo_specific_changes_fetcher,
             'get_changed_storage_models_filenames',
             mock_get_changed_storage_models_filenames)
@@ -144,14 +145,14 @@ class GetRepoSpecificChangesTest(test_utils.GenericTestBase):
         ) -> List[str]:
             return ['storage_changes']
 
-        versions_swap = self.swap(
+        versions_swap = patch.object(
             repo_specific_changes_fetcher,
             'get_changed_schema_version_constant_names',
             mock_get_changed_schema_version_constant_names)
-        setup_scripts_swap = self.swap(
+        setup_scripts_swap = patch.object(
             repo_specific_changes_fetcher, 'get_setup_scripts_changes_status',
             mock_get_setup_scripts_changes_status)
-        storage_models_swap = self.swap(
+        storage_models_swap = patch.object(
             repo_specific_changes_fetcher,
             'get_changed_storage_models_filenames',
             mock_get_changed_storage_models_filenames)
@@ -176,9 +177,9 @@ class GetRepoSpecificChangesTest(test_utils.GenericTestBase):
         def mock_print(text_to_print: str) -> None:
             printed_lines.append(text_to_print)
 
-        get_changes_swap = self.swap(
+        get_changes_swap = patch.object(
             repo_specific_changes_fetcher, 'get_changes', mock_get_changes)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
 
         with get_changes_swap, print_swap:
             repo_specific_changes_fetcher.main(args=['--release_tag', 'tag'])

--- a/scripts/release_scripts/update_configs_test.py
+++ b/scripts/release_scripts/update_configs_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/release_scripts/update_configs.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import getpass
 import os
@@ -90,14 +91,14 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
         def mock_url_open(unused_url: str) -> None:
             pass
 
-        self.get_org_swap = self.swap(
+        self.get_org_swap = patch.object(
             github.Github, 'get_organization', mock_get_organization)
-        self.get_repo_swap = self.swap(
+        self.get_repo_swap = patch.object(
             github.Organization.Organization, 'get_repo', mock_get_repo)
-        self.open_tab_swap = self.swap(
+        self.open_tab_swap = patch.object(
             common, 'open_new_tab_in_browser_if_possible', mock_open_tab)
-        self.getpass_swap = self.swap(getpass, 'getpass', mock_getpass)
-        self.url_open_swap = self.swap(utils, 'url_open', mock_url_open)
+        self.getpass_swap = patch.object(getpass, 'getpass', mock_getpass)
+        self.url_open_swap = patch.object(utils, 'url_open', mock_url_open)
 
     def test_feconf_verification_with_correct_config(self) -> None:
         mailgun_api_key = ('key-%s' % ('').join(['1'] * 32))
@@ -341,13 +342,13 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
                 'update_analytics_constants_based_on_config'
             ] = True
 
-        apply_changes_swap = self.swap(
+        apply_changes_swap = patch.object(
             update_configs, 'apply_changes_based_on_config', mock_apply_changes)
-        verify_config_files_swap = self.swap(
+        verify_config_files_swap = patch.object(
             update_configs, 'verify_config_files', mock_verify_config_files)
-        update_app_yaml_swap = self.swap(
+        update_app_yaml_swap = patch.object(
             update_configs, 'update_app_yaml', mock_update_app_yaml)
-        update_analytics_constants_based_on_config_swap = self.swap(
+        update_analytics_constants_based_on_config_swap = patch.object(
             update_configs,
             'update_analytics_constants_based_on_config',
             mock_update_analytics_constants_based_on_config)

--- a/scripts/run_acceptance_tests_test.py
+++ b/scripts/run_acceptance_tests_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/run_acceptance_tests.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import contextlib
 import subprocess
@@ -81,7 +82,7 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
 
         def mock_constants() -> None:
             print('mock_set_constants_to_default')
-        self.swap_mock_set_constants_to_default = self.swap(
+        self.swap_mock_set_constants_to_default = patch.object(
             common, 'set_constants_to_default', mock_constants)
 
     def tearDown(self) -> None:
@@ -278,7 +279,7 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
             sys, 'exit', lambda _: None, expected_args=[(0,)]))
 
         with self.swap_mock_set_constants_to_default:
-            with self.swap(constants, 'EMULATOR_MODE', False):
+            with patch.object(constants, 'EMULATOR_MODE', False):
                 run_acceptance_tests.main(args=['--suite', 'testSuite'])
 
     def test_start_tests_for_long_lived_process(self) -> None:
@@ -312,5 +313,5 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
             sys, 'exit', lambda _: None, expected_args=[(0,)]))
 
         with self.swap_mock_set_constants_to_default:
-            with self.swap(constants, 'EMULATOR_MODE', True):
+            with patch.object(constants, 'EMULATOR_MODE', True):
                 run_acceptance_tests.main(args=['--suite', 'testSuite'])

--- a/scripts/run_custom_eslint_tests_test.py
+++ b/scripts/run_custom_eslint_tests_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/run_custom_eslint_tests.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -35,7 +36,7 @@ class RunCustomEslintTestsTests(test_utils.GenericTestBase):
         self.print_arr: list[str] = []
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
         node_path = os.path.join(common.NODE_PATH, 'bin', 'node')
         nyc_path = os.path.join('node_modules', 'nyc', 'bin', 'nyc.js')
@@ -48,7 +49,7 @@ class RunCustomEslintTestsTests(test_utils.GenericTestBase):
         self.sys_exit_code: int = 0
         def mock_sys_exit(err_code: int) -> None:
             self.sys_exit_code = err_code
-        self.swap_sys_exit = self.swap(sys, 'exit', mock_sys_exit)
+        self.swap_sys_exit = patch.object(sys, 'exit', mock_sys_exit)
 
     def test_custom_eslint_tests_failed_due_to_internal_error(self) -> None:
         class MockTask:
@@ -62,7 +63,7 @@ class RunCustomEslintTestsTests(test_utils.GenericTestBase):
         ) -> MockTask:  # pylint: disable=unused-argument
             self.cmd_token_list.append(cmd_tokens)
             return MockTask()
-        swap_popen = self.swap(subprocess, 'Popen', mock_popen)
+        swap_popen = patch.object(subprocess, 'Popen', mock_popen)
 
         with swap_popen, self.print_swap, self.swap_sys_exit:
             run_custom_eslint_tests.main()
@@ -83,7 +84,7 @@ class RunCustomEslintTestsTests(test_utils.GenericTestBase):
         ) -> MockTask:  # pylint: disable=unused-argument
             self.cmd_token_list.append(cmd_tokens)
             return MockTask()
-        swap_popen = self.swap(subprocess, 'Popen', mock_popen)
+        swap_popen = patch.object(subprocess, 'Popen', mock_popen)
 
         with swap_popen, self.print_swap, self.swap_sys_exit:
             run_custom_eslint_tests.main()
@@ -104,7 +105,7 @@ class RunCustomEslintTestsTests(test_utils.GenericTestBase):
         ) -> MockTask:  # pylint: disable=unused-argument
             self.cmd_token_list.append(cmd_tokens)
             return MockTask()
-        swap_popen = self.swap(subprocess, 'Popen', mock_popen)
+        swap_popen = patch.object(subprocess, 'Popen', mock_popen)
 
         with swap_popen, self.print_swap, self.swap_sys_exit:
             run_custom_eslint_tests.main()
@@ -125,7 +126,7 @@ class RunCustomEslintTestsTests(test_utils.GenericTestBase):
         ) -> MockTask:  # pylint: disable=unused-argument
             self.cmd_token_list.append(cmd_tokens)
             return MockTask()
-        swap_popen = self.swap(subprocess, 'Popen', mock_popen)
+        swap_popen = patch.object(subprocess, 'Popen', mock_popen)
         error_msg = 'Eslint test coverage is not 100%'
 
         with swap_popen, self.print_swap, self.swap_sys_exit:

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -16,6 +16,7 @@
 """Unit tests for scripts/run_e2e_tests.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import contextlib
 import subprocess
@@ -57,7 +58,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
         def mock_constants() -> None:
             print('mock_set_constants_to_default')
-        self.swap_mock_set_constants_to_default = self.swap(
+        self.swap_mock_set_constants_to_default = patch.object(
             common, 'set_constants_to_default', mock_constants)
 
     def tearDown(self) -> None:
@@ -89,7 +90,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
     def test_wait_for_port_to_be_in_use_when_port_failed_to_open(self) -> None:
         mock_sleep = self.exit_stack.enter_context(self.swap_with_call_counter(
             time, 'sleep'))
-        self.exit_stack.enter_context(self.swap(
+        self.exit_stack.enter_context(patch.object(
             common, 'is_port_in_use', lambda _: False))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None))
@@ -217,7 +218,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
         self.exit_stack.enter_context(self.swap_with_checks(
             servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
+        self.exit_stack.enter_context(patch.object(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
@@ -228,7 +229,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         def mock_run_tests(unused_args: str) -> Tuple[str, int]:
             return 'sample\noutput', 1
 
-        self.exit_stack.enter_context(self.swap(
+        self.exit_stack.enter_context(patch.object(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
@@ -241,7 +242,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         def mock_run_tests(unused_args: str) -> Tuple[str, int]:
             return 'sample\noutput', 1
 
-        self.exit_stack.enter_context(self.swap(
+        self.exit_stack.enter_context(patch.object(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
@@ -256,7 +257,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
         self.exit_stack.enter_context(self.swap_with_checks(
             servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
+        self.exit_stack.enter_context(patch.object(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
@@ -269,7 +270,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
         self.exit_stack.enter_context(self.swap_with_checks(
             servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
+        self.exit_stack.enter_context(patch.object(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(0,)]))

--- a/scripts/run_frontend_tests_test.py
+++ b/scripts/run_frontend_tests_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/run_frontend_tests.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -39,7 +40,7 @@ class RunFrontendTestsTests(test_utils.GenericTestBase):
         self.print_arr: list[str] = []
         def mock_print(msg: str, end: str = '\n') -> None:  # pylint: disable=unused-argument
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
         class MockFile:
             def __init__(self, flakes: int = 0) -> None:
@@ -124,21 +125,21 @@ class RunFrontendTestsTests(test_utils.GenericTestBase):
         def mock_check_frontend_coverage() -> None:
             self.frontend_coverage_checks_called = True
 
-        self.swap_success_Popen = self.swap(
+        self.swap_success_Popen = patch.object(
             subprocess, 'Popen', mock_success_check_call)
-        self.swap_flaky_Popen = self.swap(
+        self.swap_flaky_Popen = patch.object(
             subprocess, 'Popen', mock_flaky_check_call)
-        self.swap_very_flaky_Popen = self.swap(
+        self.swap_very_flaky_Popen = patch.object(
             subprocess, 'Popen', mock_very_flaky_check_call)
-        self.swap_failed_Popen = self.swap(
+        self.swap_failed_Popen = patch.object(
             subprocess, 'Popen', mock_failed_check_call)
-        self.swap_sys_exit = self.swap(sys, 'exit', mock_sys_exit)
-        self.swap_build = self.swap(build, 'main', mock_build)
-        self.swap_common = self.swap(
+        self.swap_sys_exit = patch.object(sys, 'exit', mock_sys_exit)
+        self.swap_build = patch.object(build, 'main', mock_build)
+        self.swap_common = patch.object(
             common, 'print_each_string_after_two_new_lines', lambda _: None)
-        self.swap_install_third_party_libs = self.swap(
+        self.swap_install_third_party_libs = patch.object(
             install_third_party_libs, 'main', lambda: None)
-        self.swap_check_frontend_coverage = self.swap(
+        self.swap_check_frontend_coverage = patch.object(
             check_frontend_test_coverage, 'main', mock_check_frontend_coverage)
 
     def test_run_dtslint_type_tests_passed(self) -> None:

--- a/scripts/run_lighthouse_tests_test.py
+++ b/scripts/run_lighthouse_tests_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/run_lighthouse_tests.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -67,9 +68,9 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
         self.print_arr: list[str] = []
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
-        self.swap_sys_exit = self.swap(sys, 'exit', lambda _: None)
+        self.swap_sys_exit = patch.object(sys, 'exit', lambda _: None)
         puppeteer_path = (
             os.path.join('core', 'tests', 'puppeteer', 'lighthouse_setup.js'))
         self.puppeteer_bash_command = [common.NODE_BIN_PATH, puppeteer_path]
@@ -91,17 +92,17 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
             return MockCompilerContextManager()
         env = os.environ.copy()
         env['PIP_NO_DEPS'] = 'True'
-        self.swap_ng_build = self.swap(
+        self.swap_ng_build = patch.object(
             servers, 'managed_ng_build', mock_context_manager)
-        self.swap_webpack_compiler = self.swap(
+        self.swap_webpack_compiler = patch.object(
             servers, 'managed_webpack_compiler', mock_context_manager)
-        self.swap_redis_server = self.swap(
+        self.swap_redis_server = patch.object(
             servers, 'managed_redis_server', mock_context_manager)
-        self.swap_elasticsearch_dev_server = self.swap(
+        self.swap_elasticsearch_dev_server = patch.object(
             servers, 'managed_elasticsearch_dev_server', mock_context_manager)
-        self.swap_firebase_auth_emulator = self.swap(
+        self.swap_firebase_auth_emulator = patch.object(
             servers, 'managed_firebase_auth_emulator', mock_context_manager)
-        self.swap_cloud_datastore_emulator = self.swap(
+        self.swap_cloud_datastore_emulator = patch.object(
             servers, 'managed_cloud_datastore_emulator', mock_context_manager)
         self.swap_dev_appserver = self.swap_with_checks(
             servers, 'managed_dev_appserver',
@@ -177,7 +178,7 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
         def mock_popen(*unused_args: str, **unused_kwargs: str) -> MockTask:  # pylint: disable=unused-argument
             return MockTask()
 
-        swap_isfile = self.swap(os.path, 'isfile', lambda _: True)
+        swap_isfile = patch.object(os.path, 'isfile', lambda _: True)
         swap_popen = self.swap_with_checks(
             subprocess, 'Popen', mock_popen,
             expected_args=((self.puppeteer_bash_command + self.extra_args,),))
@@ -207,7 +208,7 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
         def mock_popen(*unused_args: str, **unused_kwargs: str) -> MockTask:  # pylint: disable=unused-argument
             return MockTask()
 
-        swap_isfile = self.swap(os.path, 'isfile', lambda _: True)
+        swap_isfile = patch.object(os.path, 'isfile', lambda _: True)
         swap_popen = self.swap_with_checks(
             subprocess, 'Popen', mock_popen,
             expected_args=((self.puppeteer_bash_command + self.extra_args,),))
@@ -334,17 +335,17 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
         def mock_popen(*unused_args: str, **unused_kwargs: str) -> MockTask:  # pylint: disable=unused-argument
             return MockTask()
 
-        swap_popen = self.swap(
+        swap_popen = patch.object(
             subprocess, 'Popen', mock_popen)
         swap_run_lighthouse_tests = self.swap_with_checks(
             run_lighthouse_tests, 'run_lighthouse_checks',
             lambda *unused_args: None, expected_args=(('accessibility', '1'),))
-        swap_isdir = self.swap(
+        swap_isdir = patch.object(
             os.path, 'isdir', lambda _: True)
         swap_build = self.swap_with_checks(
             build, 'main', lambda args: None,
             expected_kwargs=[{'args': []}])
-        swap_emulator_mode = self.swap(constants, 'EMULATOR_MODE', False)
+        swap_emulator_mode = patch.object(constants, 'EMULATOR_MODE', False)
 
         with swap_popen, self.swap_webpack_compiler, swap_isdir, swap_build:
             with self.swap_elasticsearch_dev_server, self.swap_dev_appserver:
@@ -369,9 +370,9 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
             lambda *unused_args: None, expected_args=(('performance', '1'),))
         def mock_popen(*unused_args: str, **unused_kwargs: str) -> MockTask:  # pylint: disable=unused-argument
             return MockTask()
-        swap_popen = self.swap(
+        swap_popen = patch.object(
             subprocess, 'Popen', mock_popen)
-        swap_isdir = self.swap(
+        swap_isdir = patch.object(
             os.path, 'isdir', lambda _: True)
         swap_build = self.swap_with_checks(
             build, 'main', lambda args: None,
@@ -404,14 +405,14 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
             expected_args=(('performance', '1'),))
         def mock_popen(*unused_args: str, **unused_kwargs: str) -> MockTask:  # pylint: disable=unused-argument
             return MockTask()
-        swap_popen = self.swap(
+        swap_popen = patch.object(
             subprocess, 'Popen', mock_popen)
-        swap_isdir = self.swap(
+        swap_isdir = patch.object(
             os.path, 'isdir', lambda _: True)
         swap_build = self.swap_with_checks(
                     build, 'main', lambda args: None,
                     expected_kwargs=[{'args': []}])
-        swap_emulator_mode = self.swap(constants, 'EMULATOR_MODE', False)
+        swap_emulator_mode = patch.object(constants, 'EMULATOR_MODE', False)
 
         with swap_popen, self.swap_webpack_compiler, swap_isdir, swap_build:
             with self.swap_elasticsearch_dev_server, self.swap_dev_appserver:
@@ -459,17 +460,17 @@ class RunLighthouseTestsTests(test_utils.GenericTestBase):
             lambda *unused_args: None, expected_args=(('performance', '1'),))
         def mock_popen(*unused_args: str, **unused_kwargs: str) -> MockTask:  # pylint: disable=unused-argument
             return MockTask()
-        swap_popen = self.swap(
+        swap_popen = patch.object(
             subprocess, 'Popen', mock_popen)
-        swap_isdir = self.swap(
+        swap_isdir = patch.object(
             os.path, 'isdir', lambda _: True)
         swap_build = self.swap_with_checks(
             build, 'main', lambda args: None,
             expected_kwargs=[{'args': []}])
-        swap_emulator_mode = self.swap(constants, 'EMULATOR_MODE', False)
-        swap_popen = self.swap(
+        swap_emulator_mode = patch.object(constants, 'EMULATOR_MODE', False)
+        swap_popen = patch.object(
             subprocess, 'Popen', mock_popen)
-        swap_isdir = self.swap(
+        swap_isdir = patch.object(
             os.path, 'isdir', lambda _: True)
 
         with swap_popen, self.swap_webpack_compiler, swap_isdir, swap_build:

--- a/scripts/run_mypy_checks_test.py
+++ b/scripts/run_mypy_checks_test.py
@@ -17,6 +17,7 @@
 """Tests for MyPy type check runner script."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import os
 import site
@@ -83,23 +84,23 @@ class MypyScriptChecks(test_utils.GenericTestBase):
         ) -> subprocess.Popen[bytes]:  # pylint: disable=unsubscriptable-object
             return process_failure
 
-        self.popen_swap_success = self.swap(
+        self.popen_swap_success = patch.object(
             subprocess, 'Popen', mock_popen_success)
-        self.popen_swap_failure = self.swap(
+        self.popen_swap_failure = patch.object(
             subprocess, 'Popen', mock_popen_failure)
 
-        self.install_mypy_prereq_swap_success = self.swap(
+        self.install_mypy_prereq_swap_success = patch.object(
             run_mypy_checks,
             'install_mypy_prerequisites',
             lambda _: (0, 'exec')
         )
-        self.install_mypy_prereq_swap_failure = self.swap(
+        self.install_mypy_prereq_swap_failure = patch.object(
             run_mypy_checks,
             'install_mypy_prerequisites',
             lambda _: (1, 'exec')
         )
 
-        self.directories_swap = self.swap(
+        self.directories_swap = patch.object(
             run_mypy_checks, 'EXCLUDED_DIRECTORIES',
             ['dir1/', 'dir2/'])
 
@@ -107,7 +108,7 @@ class MypyScriptChecks(test_utils.GenericTestBase):
             unused_ci: bool
         ) -> Tuple[int, str]:
             return (0, self.mypy_cmd_path)
-        self.swap_install_success = self.swap(
+        self.swap_install_success = patch.object(
             run_mypy_checks, 'install_mypy_prerequisites',
             mock_install_mypy_prerequisites_success)
 
@@ -116,7 +117,7 @@ class MypyScriptChecks(test_utils.GenericTestBase):
         ) -> Ret:
             return Ret(cmd_tokens)
 
-        self.popen_swap_user_prefix_error = self.swap(
+        self.popen_swap_user_prefix_error = patch.object(
             subprocess, 'Popen', mock_popen_user_prefix_error_call)
 
         self.mypy_cmd_path = os.path.join(
@@ -186,7 +187,7 @@ class MypyScriptChecks(test_utils.GenericTestBase):
         self
     ) -> None:
         with self.popen_swap_user_prefix_error:
-            with self.swap(site, 'USER_BASE', None):
+            with patch.object(site, 'USER_BASE', None):
                 with self.assertRaisesRegex(
                     Exception,
                     'No USER_BASE found for the user.'
@@ -195,7 +196,7 @@ class MypyScriptChecks(test_utils.GenericTestBase):
 
     def test_install_mypy_prerequisites_with_wrong_script(self) -> None:
         with self.popen_swap_failure:
-            with self.swap(
+            with patch.object(
                 run_mypy_checks, 'MYPY_REQUIREMENTS_FILE_PATH', 'scripts.wrong'
             ):
                 code, _ = run_mypy_checks.install_mypy_prerequisites(False)

--- a/scripts/run_presubmit_checks_test.py
+++ b/scripts/run_presubmit_checks_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/run_presubmit_checks.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -36,7 +37,7 @@ class RunPresubmitChecksTests(test_utils.GenericTestBase):
         self.print_arr: list[str] = []
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
 
         current_dir = os.path.abspath(os.getcwd())
         self.changed_frontend_file = os.path.join(
@@ -87,7 +88,7 @@ class RunPresubmitChecksTests(test_utils.GenericTestBase):
             else:
                 raise Exception('Invalid cmd passed: %s' % cmd)
 
-        swap_check_output = self.swap(
+        swap_check_output = patch.object(
             subprocess, 'check_output', mock_check_output)
         with self.print_swap, swap_check_output, self.swap_pre_commit_linter:
             with self.swap_backend_tests, self.swap_frontend_tests:
@@ -117,7 +118,7 @@ class RunPresubmitChecksTests(test_utils.GenericTestBase):
             else:
                 raise Exception('Invalid cmd passed: %s' % cmd)
 
-        swap_check_output = self.swap(
+        swap_check_output = patch.object(
             subprocess, 'check_output', mock_check_output)
         with self.print_swap, swap_check_output, self.swap_pre_commit_linter:
             with self.swap_backend_tests, self.swap_frontend_tests:
@@ -147,7 +148,7 @@ class RunPresubmitChecksTests(test_utils.GenericTestBase):
             else:
                 raise Exception('Invalid cmd passed: %s' % cmd)
 
-        swap_check_output = self.swap(
+        swap_check_output = patch.object(
             subprocess, 'check_output', mock_check_output)
         with self.print_swap, swap_check_output, self.swap_pre_commit_linter:
             with self.swap_backend_tests:

--- a/scripts/run_tests_test.py
+++ b/scripts/run_tests_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/run_tests.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import subprocess
@@ -34,7 +35,7 @@ class RunTestsTests(test_utils.GenericTestBase):
         print_arr: list[str] = []
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        print_swap = patch.object(builtins, 'print', mock_print)
 
         scripts_called = {
             'setup': False,
@@ -58,13 +59,13 @@ class RunTestsTests(test_utils.GenericTestBase):
         def mock_install_third_party_libs() -> None:
             pass
 
-        swap_install_third_party_libs = self.swap(
+        swap_install_third_party_libs = patch.object(
             install_third_party_libs, 'main', mock_install_third_party_libs)
-        swap_setup = self.swap(setup, 'main', mock_setup)
-        swap_setup_gae = self.swap(setup_gae, 'main', mock_setup_gae)
-        swap_frontend_tests = self.swap(
+        swap_setup = patch.object(setup, 'main', mock_setup)
+        swap_setup_gae = patch.object(setup_gae, 'main', mock_setup_gae)
+        swap_frontend_tests = patch.object(
             run_frontend_tests, 'main', mock_frontend_tests)
-        swap_popen = self.swap(subprocess, 'Popen', mock_popen)
+        swap_popen = patch.object(subprocess, 'Popen', mock_popen)
 
         # We import run_backend_tests script under install_third_party_libs
         # mock since run_backend_tests script installs third party libs
@@ -74,7 +75,7 @@ class RunTestsTests(test_utils.GenericTestBase):
         with swap_install_third_party_libs:
             from scripts import run_backend_tests
             from scripts import run_tests
-            swap_backend_tests = self.swap(
+            swap_backend_tests = patch.object(
                 run_backend_tests, 'main', mock_backend_tests)
             with print_swap, swap_setup, swap_setup_gae, swap_popen:
                 with swap_frontend_tests, swap_backend_tests:

--- a/scripts/script_import_test.py
+++ b/scripts/script_import_test.py
@@ -23,6 +23,7 @@ in start, then adding the same import statement in a test function
 """
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import subprocess
 import sys
@@ -41,7 +42,7 @@ class InstallThirdPartyLibsImportTests(test_utils.GenericTestBase):
             cmd_tokens: List[str], *_args: str, **_kwargs: str
         ) -> None:
             commands.append(cmd_tokens)
-        run_swap = self.swap(subprocess, 'run', mock_run)
+        run_swap = patch.object(subprocess, 'run', mock_run)
 
         with run_swap:
             from scripts import install_third_party_libs  # isort:skip pylint: disable=unused-import,line-too-long

--- a/scripts/setup_gae_test.py
+++ b/scripts/setup_gae_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/setup_gae.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -68,11 +69,11 @@ class SetupGaeTests(test_utils.GenericTestBase):
             self.check_function_calls['url_retrieve_is_called'] = True
             if self.raise_error:
                 raise Exception
-        self.walk_swap = self.swap(os, 'walk', mock_walk)
-        self.remove_swap = self.swap(os, 'remove', mock_remove)
-        self.makedirs_swap = self.swap(os, 'makedirs', mock_makedirs)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
-        self.url_retrieve_swap = self.swap(
+        self.walk_swap = patch.object(os, 'walk', mock_walk)
+        self.remove_swap = patch.object(os, 'remove', mock_remove)
+        self.makedirs_swap = patch.object(os, 'makedirs', mock_makedirs)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
+        self.url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
 
     def test_main_with_no_installs_required(self) -> None:
@@ -93,9 +94,9 @@ class SetupGaeTests(test_utils.GenericTestBase):
         def mock_exists(unused_path: str) -> bool:
             return True
 
-        walk_swap = self.swap(os, 'walk', mock_walk)
-        remove_swap = self.swap(os, 'remove', mock_remove)
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        walk_swap = patch.object(os, 'walk', mock_walk)
+        remove_swap = patch.object(os, 'remove', mock_remove)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
         with walk_swap, remove_swap, exists_swap:
             setup_gae.main(args=[])
         self.assertEqual(check_file_removals, expected_check_file_removals)
@@ -119,11 +120,11 @@ class SetupGaeTests(test_utils.GenericTestBase):
             self.check_function_calls['extractall_is_called'] = True
         def mock_close(unused_self: str) -> None:
             self.check_function_calls['close_is_called'] = True
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        open_swap = self.swap(tarfile, 'open', mock_open)
-        extractall_swap = self.swap(
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
+        open_swap = patch.object(tarfile, 'open', mock_open)
+        extractall_swap = patch.object(
             tarfile.TarFile, 'extractall', mock_extractall)
-        close_swap = self.swap(tarfile.TarFile, 'close', mock_close)
+        close_swap = patch.object(tarfile.TarFile, 'close', mock_close)
 
         with self.walk_swap, self.remove_swap, self.makedirs_swap:
             with self.print_swap, self.url_retrieve_swap, exists_swap:
@@ -142,7 +143,7 @@ class SetupGaeTests(test_utils.GenericTestBase):
             if path == common.GOOGLE_CLOUD_SDK_HOME:
                 return False
             return True
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        exists_swap = patch.object(os.path, 'exists', mock_exists)
 
         with self.walk_swap, self.remove_swap, self.makedirs_swap:
             with self.print_swap, self.url_retrieve_swap, exists_swap:

--- a/scripts/setup_test.py
+++ b/scripts/setup_test.py
@@ -17,6 +17,7 @@
 """Unit tests for scripts/setup.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import collections
@@ -95,11 +96,11 @@ class SetupTests(test_utils.GenericTestBase):
         def mock_get(unused_var: str) -> None:
             return None
 
-        self.create_swap = self.swap(
+        self.create_swap = patch.object(
             setup, 'create_directory', mock_create_directory)
-        self.test_py_swap = self.swap(
+        self.test_py_swap = patch.object(
             setup, 'test_python_version', mock_test_python_version)
-        self.download_swap = self.swap(
+        self.download_swap = patch.object(
             setup, 'download_and_install_package',
             mock_download_and_install_package)
         self.exists_true_swap = self.swap_to_always_return(
@@ -110,19 +111,19 @@ class SetupTests(test_utils.GenericTestBase):
             common, 'is_x64_architecture', True)
         self.is_x64_architecture_false_swap = self.swap_to_always_return(
             common, 'is_x64_architecture', False)
-        self.chown_swap = self.swap(
+        self.chown_swap = patch.object(
             common, 'recursive_chown', mock_recursive_chown)
-        self.chmod_swap = self.swap(
+        self.chmod_swap = patch.object(
             common, 'recursive_chmod', mock_recursive_chmod)
-        self.uname_swap = self.swap(os, 'uname', mock_uname)
-        self.rename_swap = self.swap(os, 'rename', mock_rename)
-        self.isfile_swap = self.swap(os.path, 'isfile', mock_isfile)
-        self.delete_swap = self.swap(clean, 'delete_file', mock_delete_file)
-        self.get_swap = self.swap(os.environ, 'get', mock_get)
-        self.cd_swap = self.swap(common, 'CD', MockCD)
+        self.uname_swap = patch.object(os, 'uname', mock_uname)
+        self.rename_swap = patch.object(os, 'rename', mock_rename)
+        self.isfile_swap = patch.object(os.path, 'isfile', mock_isfile)
+        self.delete_swap = patch.object(clean, 'delete_file', mock_delete_file)
+        self.get_swap = patch.object(os.environ, 'get', mock_get)
+        self.cd_swap = patch.object(common, 'CD', MockCD)
         version_info = collections.namedtuple(
             'version_info', ['major', 'minor', 'micro'])
-        self.version_info_py38_swap = self.swap(
+        self.version_info_py38_swap = patch.object(
             sys, 'version_info', version_info(major=3, minor=8, micro=15)
         )
         self.python2_print_swap = self.swap_with_checks(
@@ -144,7 +145,7 @@ class SetupTests(test_utils.GenericTestBase):
         def mock_makedirs(unused_path: str) -> None:
             check_function_calls['makedirs_is_called'] = True
 
-        makedirs_swap = self.swap(os, 'makedirs', mock_makedirs)
+        makedirs_swap = patch.object(os, 'makedirs', mock_makedirs)
         with makedirs_swap, self.exists_false_swap:
             setup.create_directory('dir')
         self.assertTrue(check_function_calls['makedirs_is_called'])
@@ -155,7 +156,7 @@ class SetupTests(test_utils.GenericTestBase):
         }
         def mock_makedirs(unused_path: str) -> None:
             check_function_calls['makedirs_is_called'] = True
-        makedirs_swap = self.swap(os, 'makedirs', mock_makedirs)
+        makedirs_swap = patch.object(os, 'makedirs', mock_makedirs)
         with makedirs_swap, self.exists_true_swap:
             setup.create_directory('dir')
         self.assertFalse(check_function_calls['makedirs_is_called'])
@@ -175,12 +176,12 @@ class SetupTests(test_utils.GenericTestBase):
         def mock_uname() -> List[str]:
             return ['Linux']
 
-        print_swap = self.swap(
+        print_swap = patch.object(
             common, 'print_each_string_after_two_new_lines', mock_print)
-        uname_swap = self.swap(os, 'uname', mock_uname)
+        uname_swap = patch.object(os, 'uname', mock_uname)
         version_info = collections.namedtuple(
             'version_info', ['major', 'minor', 'micro'])
-        version_swap = self.swap(
+        version_swap = patch.object(
             sys, 'version_info', version_info(major=3, minor=4, micro=12))
         with print_swap, uname_swap, version_swap, self.assertRaisesRegex(
             Exception, 'No suitable python version found.'
@@ -196,12 +197,12 @@ class SetupTests(test_utils.GenericTestBase):
         def mock_print(msg_list: List[str]) -> None:
             print_arr.extend(msg_list)
 
-        print_swap = self.swap(
+        print_swap = patch.object(
             common, 'print_each_string_after_two_new_lines', mock_print)
-        os_name_swap = self.swap(common, 'OS_NAME', 'Windows')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Windows')
         version_info = collections.namedtuple(
             'version_info', ['major', 'minor', 'micro'])
-        version_swap = self.swap(
+        version_swap = patch.object(
             sys, 'version_info', version_info(major=3, minor=4, micro=12))
         with print_swap, os_name_swap, version_swap:
             with self.assertRaisesRegex(
@@ -256,12 +257,12 @@ class SetupTests(test_utils.GenericTestBase):
         def mock_remove(unused_path: str) -> None:
             check_function_calls['remove_is_called'] = True
 
-        url_retrieve_swap = self.swap(
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        open_swap = self.swap(tarfile, 'open', mock_open)
-        extract_swap = self.swap(tarfile.TarFile, 'extractall', mock_extractall)
-        close_swap = self.swap(tarfile.TarFile, 'close', mock_close)
-        remove_swap = self.swap(os, 'remove', mock_remove)
+        open_swap = patch.object(tarfile, 'open', mock_open)
+        extract_swap = patch.object(tarfile.TarFile, 'extractall', mock_extractall)
+        close_swap = patch.object(tarfile.TarFile, 'close', mock_close)
+        remove_swap = patch.object(os, 'remove', mock_remove)
 
         with url_retrieve_swap, open_swap, extract_swap, close_swap:
             with remove_swap:
@@ -285,8 +286,8 @@ class SetupTests(test_utils.GenericTestBase):
         def mock_print(msg: str) -> None:
             print_arr.append(msg)
 
-        getcwd_swap = self.swap(os, 'getcwd', mock_getcwd)
-        print_swap = self.swap(builtins, 'print', mock_print)
+        getcwd_swap = patch.object(os, 'getcwd', mock_getcwd)
+        print_swap = patch.object(builtins, 'print', mock_print)
         with self.test_py_swap, getcwd_swap, print_swap:
             with self.assertRaisesRegex(Exception, 'Invalid root directory.'):
                 setup.main(args=[])
@@ -298,7 +299,7 @@ class SetupTests(test_utils.GenericTestBase):
 
     def test_package_install_with_darwin_x64(self) -> None:
 
-        os_name_swap = self.swap(common, 'OS_NAME', 'Darwin')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Darwin')
 
         with self.test_py_swap, self.create_swap, os_name_swap:
             with self.download_swap, self.rename_swap, self.exists_false_swap:
@@ -318,11 +319,11 @@ class SetupTests(test_utils.GenericTestBase):
 
     def test_package_install_with_darwin_x86(self) -> None:
 
-        os_name_swap = self.swap(common, 'OS_NAME', 'Darwin')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Darwin')
         all_cmd_tokens: List[str] = []
         def mock_check_call(cmd_tokens: List[str]) -> None:
             all_cmd_tokens.extend(cmd_tokens)
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
+        check_call_swap = patch.object(subprocess, 'check_call', mock_check_call)
 
         with self.test_py_swap, self.create_swap, os_name_swap, self.chown_swap:
             with self.download_swap, self.rename_swap, self.exists_false_swap:
@@ -343,7 +344,7 @@ class SetupTests(test_utils.GenericTestBase):
 
     def test_package_install_with_linux_x64(self) -> None:
 
-        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Linux')
 
         with self.test_py_swap, self.create_swap, os_name_swap, self.chown_swap:
             with self.download_swap, self.rename_swap, self.exists_false_swap:
@@ -363,12 +364,12 @@ class SetupTests(test_utils.GenericTestBase):
                     common.YARN_VERSION, common.YARN_VERSION)])
 
     def test_package_install_with_linux_x86(self) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Linux')
 
         all_cmd_tokens: List[str] = []
         def mock_check_call(cmd_tokens: List[str]) -> None:
             all_cmd_tokens.extend(cmd_tokens)
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
+        check_call_swap = patch.object(subprocess, 'check_call', mock_check_call)
 
         with self.test_py_swap, self.create_swap, os_name_swap, check_call_swap:
             with self.download_swap, self.rename_swap, self.cd_swap:
@@ -398,10 +399,10 @@ class SetupTests(test_utils.GenericTestBase):
             nonlocal check_call_commands
             check_call_commands = commands
 
-        os_name_swap = self.swap(common, 'OS_NAME', 'Windows')
-        url_retrieve_swap = self.swap(
+        os_name_swap = patch.object(common, 'OS_NAME', 'Windows')
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
+        check_call_swap = patch.object(subprocess, 'check_call', mock_check_call)
 
         with self.test_py_swap, self.create_swap, os_name_swap, check_call_swap:
             with self.download_swap, self.rename_swap, self.delete_swap:
@@ -437,10 +438,10 @@ class SetupTests(test_utils.GenericTestBase):
             nonlocal check_call_commands
             check_call_commands = commands
 
-        os_name_swap = self.swap(common, 'OS_NAME', 'Windows')
-        url_retrieve_swap = self.swap(
+        os_name_swap = patch.object(common, 'OS_NAME', 'Windows')
+        url_retrieve_swap = patch.object(
             common, 'url_retrieve', mock_url_retrieve)
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
+        check_call_swap = patch.object(subprocess, 'check_call', mock_check_call)
 
         with self.test_py_swap, self.create_swap, os_name_swap, check_call_swap:
             with self.download_swap, self.rename_swap, self.delete_swap:
@@ -468,7 +469,7 @@ class SetupTests(test_utils.GenericTestBase):
     def test_package_install_with_incompatible_system_raises_error(
         self
     ) -> None:
-        os_name_swap = self.swap(common, 'OS_NAME', 'Solaris')
+        os_name_swap = patch.object(common, 'OS_NAME', 'Solaris')
 
         with self.test_py_swap, self.create_swap, os_name_swap, self.chown_swap:
             with self.rename_swap, self.exists_false_swap:
@@ -483,8 +484,8 @@ class SetupTests(test_utils.GenericTestBase):
         def mock_print(arg: str) -> None:
             print_list.append(arg)
 
-        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
-        print_swap = self.swap(builtins, 'print', mock_print)
+        os_name_swap = patch.object(common, 'OS_NAME', 'Linux')
+        print_swap = patch.object(builtins, 'print', mock_print)
 
         with self.test_py_swap, self.create_swap, self.chown_swap, print_swap:
             with self.rename_swap, self.exists_true_swap, os_name_swap:

--- a/scripts/start_test.py
+++ b/scripts/start_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/start.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 import os
 
 from core.constants import constants
@@ -56,7 +57,7 @@ class StartTests(test_utils.GenericTestBase):
             self.print_arr.append(msg)
         def mock_context_manager() -> MockCompilerContextManager:
             return MockCompilerContextManager()
-        self.swap_print = self.swap(
+        self.swap_print = patch.object(
             common, 'print_each_string_after_two_new_lines', mock_print)
         def mock_constants() -> None:
             print('mock_set_constants_to_default')
@@ -66,9 +67,9 @@ class StartTests(test_utils.GenericTestBase):
         # We need to create a swap for install_third_party_libs because
         # scripts/start.py installs third party libraries whenever it is
         # imported.
-        self.swap_install_third_party_libs = self.swap(
+        self.swap_install_third_party_libs = patch.object(
             install_third_party_libs, 'main', lambda: None)
-        self.swap_extend_index_yaml = self.swap(
+        self.swap_extend_index_yaml = patch.object(
             extend_index_yaml, 'main', lambda: None)
         self.swap_webpack_compiler = self.swap_with_checks(
             servers, 'managed_webpack_compiler',
@@ -84,9 +85,9 @@ class StartTests(test_utils.GenericTestBase):
             lambda **unused_kwargs: MockCompilerContextManager(),
             expected_kwargs=[{'watch_mode': True}]
         )
-        self.swap_redis_server = self.swap(
+        self.swap_redis_server = patch.object(
             servers, 'managed_redis_server', mock_context_manager)
-        self.swap_elasticsearch_dev_server = self.swap(
+        self.swap_elasticsearch_dev_server = patch.object(
             servers, 'managed_elasticsearch_dev_server', mock_context_manager)
         self.swap_firebase_auth_emulator = self.swap_with_checks(
             servers, 'managed_firebase_auth_emulator',
@@ -113,7 +114,7 @@ class StartTests(test_utils.GenericTestBase):
         self.swap_create_managed_web_browser = self.swap_to_always_raise(
             servers, 'create_managed_web_browser',
             Exception(MANAGED_WEB_BROWSER_ERROR))
-        self.swap_mock_set_constants_to_default = self.swap(
+        self.swap_mock_set_constants_to_default = patch.object(
             common, 'set_constants_to_default', mock_constants)
 
     def test_start_servers_successfully(self) -> None:
@@ -237,7 +238,7 @@ class StartTests(test_utils.GenericTestBase):
         swap_build = self.swap_with_checks(
             build, 'main', lambda **unused_kwargs: None,
             expected_kwargs=[{'args': ['--source_maps']}])
-        swap_emulator_mode = self.swap(constants, 'EMULATOR_MODE', False)
+        swap_emulator_mode = patch.object(constants, 'EMULATOR_MODE', False)
         self.swap_webpack_compiler = self.swap_with_checks(
             servers, 'managed_webpack_compiler',
             lambda **unused_kwargs: MockCompilerContextManager(),

--- a/scripts/third_party_size_check_test.py
+++ b/scripts/third_party_size_check_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/third_party_size_check.py"""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -34,7 +35,7 @@ class ThirdPartySizeCheckTests(test_utils.GenericTestBase):
         self.print_arr: list[str] = []
         def mock_print(msg: str) -> None:
             self.print_arr.append(msg)
-        self.print_swap = self.swap(builtins, 'print', mock_print)
+        self.print_swap = patch.object(builtins, 'print', mock_print)
         if os.path.isdir(os.path.join(os.getcwd(), 'dummy_dir')):
             shutil.rmtree('dummy_dir')
         skip_files_list = (
@@ -95,10 +96,10 @@ class ThirdPartySizeCheckTests(test_utils.GenericTestBase):
     def test_check_size_in_dir(self) -> None:
         def mock_get_skip_files_list() -> list[str]:
             return []
-        swap_get_skip_files_list = self.swap(
+        swap_get_skip_files_list = patch.object(
             third_party_size_check, 'get_skip_files_list',
             mock_get_skip_files_list)
-        swap_third_party_dir = self.swap(
+        swap_third_party_dir = patch.object(
             third_party_size_check, 'THIRD_PARTY_PATH',
             os.path.join(os.getcwd(), 'dummy_dir'))
         with swap_third_party_dir, swap_get_skip_files_list, self.print_swap:
@@ -112,10 +113,10 @@ class ThirdPartySizeCheckTests(test_utils.GenericTestBase):
                 os.path.join(os.getcwd(), 'dummy_dir', 'file1.py'),
                 os.path.join(os.getcwd(), 'dummy_dir', 'random*.py')
             ]
-        swap_get_skip_files_list = self.swap(
+        swap_get_skip_files_list = patch.object(
             third_party_size_check, 'get_skip_files_list',
             mock_get_skip_files_list)
-        swap_third_party_dir = self.swap(
+        swap_third_party_dir = patch.object(
             third_party_size_check, 'THIRD_PARTY_PATH',
             os.path.join(os.getcwd(), 'dummy_dir'))
         with swap_third_party_dir, swap_get_skip_files_list, self.print_swap:
@@ -124,7 +125,7 @@ class ThirdPartySizeCheckTests(test_utils.GenericTestBase):
             '    Number of files in third-party folder: 2', self.print_arr)
 
     def test_check_third_party_size_pass(self) -> None:
-        swap_check_size_in_dir = self.swap(
+        swap_check_size_in_dir = patch.object(
             third_party_size_check, '_check_size_in_dir',
             lambda *unused_args: 100)
         with self.print_swap, swap_check_size_in_dir:
@@ -135,11 +136,11 @@ class ThirdPartySizeCheckTests(test_utils.GenericTestBase):
             self.print_arr)
 
     def test_check_third_party_size_fail(self) -> None:
-        swap_check_size_in_dir = self.swap(
+        swap_check_size_in_dir = patch.object(
             third_party_size_check, '_check_size_in_dir',
             lambda *unused_args: (
                 third_party_size_check.THIRD_PARTY_SIZE_LIMIT + 1))
-        swap_sys_exit = self.swap(sys, 'exit', lambda _: None)
+        swap_sys_exit = patch.object(sys, 'exit', lambda _: None)
         with self.print_swap, swap_check_size_in_dir, swap_sys_exit:
             third_party_size_check.check_third_party_size()
 

--- a/scripts/typescript_checks_test.py
+++ b/scripts/typescript_checks_test.py
@@ -15,6 +15,7 @@
 """Unit tests for scripts/typescript_checks.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import json
 import os
@@ -41,7 +42,7 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
         ) -> subprocess.Popen[str]:  # pylint: disable=unsubscriptable-object
             return process
 
-        self.popen_swap = self.swap(subprocess, 'Popen', mock_popen)
+        self.popen_swap = patch.object(subprocess, 'Popen', mock_popen)
 
     def test_compiled_js_dir_validation(self) -> None:
         """Test that typescript_checks.COMPILED_JS_DIR is validated correctly
@@ -56,7 +57,7 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
                 config_data = json.load(f)
                 out_dir = os.path.join(
                     config_data['compilerOptions']['outDir'], '')
-            compiled_js_dir_swap = self.swap(
+            compiled_js_dir_swap = patch.object(
                 typescript_checks, 'COMPILED_JS_DIR', MOCK_COMPILED_JS_DIR)
             with compiled_js_dir_swap, self.assertRaisesRegex(
                 Exception,
@@ -72,9 +73,9 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
         def mock_validate_compiled_js_dir() -> None:
             pass
 
-        compiled_js_dir_swap = self.swap(
+        compiled_js_dir_swap = patch.object(
             typescript_checks, 'COMPILED_JS_DIR', MOCK_COMPILED_JS_DIR)
-        validate_swap = self.swap(
+        validate_swap = patch.object(
             typescript_checks, 'validate_compiled_js_dir',
             mock_validate_compiled_js_dir)
         with self.popen_swap, compiled_js_dir_swap, validate_swap:
@@ -107,7 +108,7 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
         ) -> subprocess.Popen[str]:  # pylint: disable=unsubscriptable-object
             return process
 
-        with self.swap(subprocess, 'Popen', mock_popen_for_errors):
+        with patch.object(subprocess, 'Popen', mock_popen_for_errors):
             with self.assertRaisesRegex(SystemExit, '1'):
                 typescript_checks.compile_and_check_typescript(
                     typescript_checks.TSCONFIG_FILEPATH)
@@ -115,7 +116,7 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
     def test_error_is_raised_for_invalid_compilation_of_strict_tsconfig(
             self) -> None:
         """Test that error is produced if stdout is not empty."""
-        with self.swap(typescript_checks, 'TS_STRICT_EXCLUDE_PATHS', []):
+        with patch.object(typescript_checks, 'TS_STRICT_EXCLUDE_PATHS', []):
             with self.assertRaisesRegex(SystemExit, '1'):
                 typescript_checks.compile_and_check_typescript(
                     typescript_checks.STRICT_TSCONFIG_FILEPATH)
@@ -151,8 +152,8 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
         ) -> MockProcess:  # pylint: disable=unsubscriptable-object
             return MockProcess()
 
-        swap_path_exists = self.swap(os.path, 'exists', lambda _: False)
-        with self.swap(subprocess, 'Popen', mock_popen_for_errors):
+        swap_path_exists = patch.object(os.path, 'exists', lambda _: False)
+        with patch.object(subprocess, 'Popen', mock_popen_for_errors):
             with self.assertRaisesRegex(SystemExit, '1'), swap_path_exists:
                 typescript_checks.compile_temp_strict_tsconfig(
                     typescript_checks.STRICT_TSCONFIG_FILEPATH,
@@ -163,7 +164,7 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
         """Test if the config path is correct when no arg is used."""
         def mock_compile_and_check_typescript(config_path: str) -> None:
             self.assertEqual(config_path, typescript_checks.TSCONFIG_FILEPATH)
-        compile_and_check_typescript_swap = self.swap(
+        compile_and_check_typescript_swap = patch.object(
             typescript_checks, 'compile_and_check_typescript',
             mock_compile_and_check_typescript)
 
@@ -175,7 +176,7 @@ class TypescriptChecksTests(test_utils.GenericTestBase):
         def mock_compile_and_check_typescript(config_path: str) -> None:
             self.assertEqual(
                 config_path, typescript_checks.STRICT_TSCONFIG_FILEPATH)
-        compile_and_check_typescript_swap = self.swap(
+        compile_and_check_typescript_swap = patch.object(
             typescript_checks, 'compile_and_check_typescript',
             mock_compile_and_check_typescript)
 

--- a/setup_test.py
+++ b/setup_test.py
@@ -15,6 +15,7 @@
 """Unit tests for setup.py."""
 
 from __future__ import annotations
+from unittest.mock import patch
 
 import builtins
 import os
@@ -67,7 +68,7 @@ class SetupTests(test_utils.GenericTestBase):
             if common.GOOGLE_CLOUD_SDK_HOME not in path
         ]
 
-        swap_path = self.swap(sys, 'path', dummy_path)
+        swap_path = patch.object(sys, 'path', dummy_path)
 
         with swap_setup, swap_path, swap_open:
             # Dirs defined in common.GOOGLE_CLOUD_SDK_HOME get added to


### PR DESCRIPTION

1. This PR fixes or fixes part of #18781.
2. This PR does the following: Replace all instances of swap.* functions with python mocks from the unittest library and then remove those helper functions 


