### PR TITLE
Fixes part of #19266: Disable iframe scrolling for the donation box

### DIFF
--- a/core/templates/pages/donate-page/donate-page.component.ts
+++ b/core/templates/pages/donate-page/donate-page.component.ts
@@ -23,7 +23,6 @@ import { WindowRef } from 'services/contextual/window-ref.service';
 import 'popper.js';
 import 'bootstrap';
 import { ThanksForDonatingModalComponent } from './thanks-for-donating-modal.component';
-import { InsertScriptService } from 'services/insert-script.service';
 import { DonationBoxModalComponent } from './donation-box/donation-box-modal.component';
 
 interface ImpactStat {
@@ -176,8 +175,7 @@ export class DonatePageComponent implements OnInit {
   constructor(
     private urlInterpolationService: UrlInterpolationService,
     private windowRef: WindowRef,
-    private ngbModal: NgbModal,
-    private insertScriptService: InsertScriptService,
+    private ngbModal: NgbModal
   ) {}
 
   ngOnInit(): void {

--- a/core/templates/pages/donate-page/donation-box/donation-box.component.ts
+++ b/core/templates/pages/donate-page/donation-box/donation-box.component.ts
@@ -30,7 +30,7 @@ import { InsertScriptService, KNOWN_SCRIPTS } from 'services/insert-script.servi
       allow="payment"
       seamless="seamless"
       frameborder="0"
-      scrolling="yes"
+      scrolling="no"
       width="100%"
       title="donorbox">
     </iframe>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #19266.
2. This PR does the following: Disable scrolling for the donation box iframe and removes an unused injection in the DonatePageComponent. This makes the donation box load faster.
3. (For bug-fixing PRs only) The original bug occurred because: iframe scrolling was enabled in the new page to handle mobile pages in case the height of the device wasn't enough but in such cases, the modal overflow itself is scrollable so users can still scroll through the donation box.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->
- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.


## Proof that changes are correct

|                   |                 | ngOnInit      | Last ngAfterViewChecked | Time taken in millisecs |
| ----------------- | --------------- | ------------- | ----------------------- | ----------------------- |
| Current           | First page load | 1705548475562 | 1705548477814           | 2252                    |
| Current           | Next page load  | 1705548499102 | 1705548501142           | 2040                    |
| Disable scrolling | First page load | 1705555483597 | 1705555485501           | 1904                    |
| Disable scrolling | Next page load  | 1705555604400 | 1705555605680           | 1280                    |

### Scrollbar enabled
https://github.com/oppia/oppia/assets/31477127/3e8d664e-ec1f-4283-95bf-b2c7d2bab3c8

### Scrollbar disabled
https://github.com/oppia/oppia/assets/31477127/7cbe9d97-c104-41ad-ba55-a33bfaf9ffd1


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
