### PR TITLE
Fix hover effect

### DIFF
--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -253,8 +253,8 @@
   color: #fff;
   padding: 15px 20px;
   position: relative;
-  z-index: 100;
   cursor: pointer;
+  z-index: 100;
 }
 
 .oppia-android-carousel-item-container {

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -254,6 +254,7 @@
   padding: 15px 20px;
   position: relative;
   z-index: 100;
+  cursor: pointer;
 }
 
 .oppia-android-carousel-item-container {

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -251,8 +251,8 @@
   background-color: #00645c;
   border-radius: 50%;
   color: #fff;
-  padding: 15px 20px;
   cursor: pointer;
+  padding: 15px 20px;
   position: relative;
   z-index: 100;
 }

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -248,12 +248,12 @@
 }
 
 .oppia-android-carousel-chevron {
+  cursor: pointer;
   background-color: #00645c;
   border-radius: 50%;
   color: #fff;
   padding: 15px 20px;
   position: relative;
-  cursor: pointer;
   z-index: 100;
 }
 

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -248,11 +248,11 @@
 }
 
 .oppia-android-carousel-chevron {
-  cursor: pointer;
   background-color: #00645c;
   border-radius: 50%;
   color: #fff;
   padding: 15px 20px;
+  cursor: pointer;
   position: relative;
   z-index: 100;
 }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes  #19527 .
2. This PR does the following: The Pr adds pointer hover effect to the chevron buttons so that users know that the buttons is meant to click because before the pr the buttons does not have pointer hover effect making it confusing for the user to predict to click the button or not
3. (For bug-fixing PRs only) The original bug occurred because: It is not specifically a bug but the feature is not added

## Essential Checklist

- [✔️] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [✔️] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [✔️] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [✔️] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [✔️] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

https://github.com/oppia/oppia/assets/77529419/3078e115-4fda-48da-a1da-6850b9ecf140

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
