### PR TITLE
Fix #18107: error on editing question interaction

### DIFF
--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -833,9 +833,12 @@ class InteractionInstance(translation_domain.BaseTranslatableObject):
             InteractionInstance
             .convert_customization_args_dict_to_customization_args(
                 interaction_dict['id'],
-                interaction_dict['customization_args']
+                interaction_dict['customization_args'])
+            if (
+                interaction_dict['customization_args'] is not None and
+                interaction_dict['id'] is not None
             )
-        )
+            else None)
 
         return cls(
             interaction_dict['id'],
@@ -2250,7 +2253,8 @@ class InteractionInstance(translation_domain.BaseTranslatableObject):
         return (
             InteractionCustomizationArg
             .convert_cust_args_dict_to_cust_args_based_on_specs(
-                customization_args_dict, ca_specs_dict))
+                customization_args_dict, ca_specs_dict)
+            if customization_args_dict else None)
 
 
 class InteractionCustomizationArg(translation_domain.BaseTranslatableObject):


### PR DESCRIPTION
## Overview

1. This PR fixes #18107
2. This PR does the following: Includes a check on `customization_args_dict` so that an empty object will be skipped.
3. (For bug-fixing PRs only) The original bug occurred because: Some objects in the change list had null customization arguments, leading to errors when attempting to access them.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

https://github.com/oppia/oppia/assets/100014271/ccca484b-e231-4567-9d81-3d08fd4cda5c



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
