### PR TITLE
Fix #18512: Graph Interaction Mobile Grey Out Bug

### DIFF
--- a/extensions/interactions/GraphInput/directives/graph-input-interaction.component.html
+++ b/extensions/interactions/GraphInput/directives/graph-input-interaction.component.html
@@ -1,7 +1,7 @@
 <style>
   .graph-input-container {
     background: #fff;
-    overflow: hidden;
+    display: flow-root;
     padding: 8px;
   }
   .oppia-error-message-text {

--- a/extensions/interactions/GraphInput/directives/graph-input-interaction.component.html
+++ b/extensions/interactions/GraphInput/directives/graph-input-interaction.component.html
@@ -1,6 +1,7 @@
 <style>
   .graph-input-container {
     background: #fff;
+    overflow: hidden;
     padding: 8px;
   }
   .oppia-error-message-text {
@@ -19,8 +20,7 @@
              [canEditEdgeWeight]="canEditEdgeWeight"
              [interactionIsActive]="interactionIsActive">
   </graph-viz>
-  <!-- The '9999px' is just to push the button as right as possible. Due to the limits of the parent container, it does not overflow out of the div.-->
-  <button [ngStyle]="isLanguageRTL() ? {'margin' : '0 30px 0 9999px'} : {'margin' : '0 9999px 0 30px'}" mat-raised-button (click)="resetGraph()" [disabled]="!interactionIsActive" [innerHTML]="'I18N_INTERACTIONS_GRAPH_RESET_BUTTON' | translate"></button>
+  <button [ngStyle]="isLanguageRTL() ? {'margin' : '0 30px 0 0', 'float': 'right'} : {'margin' : '0 0 0 30px', 'float': 'left'}" mat-raised-button (click)="resetGraph()" [disabled]="!interactionIsActive" [innerHTML]="'I18N_INTERACTIONS_GRAPH_RESET_BUTTON' | translate"></button>
   <span [hidden]="errorMessage" class="text-danger oppia-error-message-text" aria-live="assertive">
     {{errorMessage | translate}}
   </span>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #18512.
2. This PR does the following: Fixs the reset button styling.
3. (For bug-fixing PRs only) The original bug occurred because: Old RTL fix caused the graph interaction to cause modals to go into "desktop mode"  because of the reset button styling.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct
[Untitled_ Jan 18,2024 10_55 AM.webm](https://github.com/oppia/oppia/assets/70992422/89f020b4-3757-491a-b894-2d96bc5bbb8e)

#### Proof of changes on mobile phone
Shown in Original Video

#### Proof of changes in Arabic language
Shown in Original Video

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
