### PR TITLE
Fix Hover Effect of the buttons

### DIFF
--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -291,6 +291,11 @@
   padding: 15px 20px;
   position: relative;
   z-index: 100;
+  cursor: pointer; 
+  transition: background-color 0.3s ease;
+}
+.oppia-android-carousel-chevron:hover {
+  background-color: #3d9991;
 }
 
 .oppia-android-carousel-item-container {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes  #19527 .
2. This PR does the following: The PR introduces a cursor pointer and hover effect to the chevron buttons, enhancing user experience by providing a visual cue that the buttons are clickable. Prior to this update, the absence of a hover effect made it less clear for users to identify the clickable nature of the buttons.
3. (For bug-fixing PRs only) The original bug occurred because: It is not specifically a bug but the feature is not added

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network
https://github.com/oppia/oppia/assets/94298791/3a0f3798-5394-4f75-8834-3e7824f9f5eb

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
