### PR TITLE
Fix #19511: make name optional for subscribing

### DIFF
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -230,6 +230,9 @@ class MailingListSubscriptionHandler(
             'name': {
                 'schema': {
                     'type': 'basestring',
+                    'validators': [{
+                        'id': 'is_nonempty'
+                    }]
                 },
                 'default_value': None
             },

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -230,10 +230,8 @@ class MailingListSubscriptionHandler(
             'name': {
                 'schema': {
                     'type': 'basestring',
-                    'validators': [{
-                        'id': 'is_nonempty'
-                    }]
-                }
+                },
+                'default_value': None
             },
             'tag': {
                 'schema': {

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -1095,7 +1095,7 @@ class MailingListSubscriptionHandlerTests(test_utils.GenericTestBase):
                 }, csrf_token=csrf_token)
             self.assertEqual(json_response, {'status': True})
 
-            # name should be optional
+            # Name parameter should be optional.
             json_response = self.put_json(
                 '/mailinglistsubscriptionhandler', {
                     'email': 'email2@example.com',

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -1144,6 +1144,13 @@ class MailingListSubscriptionHandlerTests(test_utils.GenericTestBase):
             self.put_json(
                 '/mailinglistsubscriptionhandler', {
                     'email': 'email@example.com',
+                    'tag': 'Web',
+                    'name': ''
+                }, csrf_token=csrf_token, expected_status_int=400)
+
+            self.put_json(
+                '/mailinglistsubscriptionhandler', {
+                    'email': 'email@example.com',
                     'tag': '',
                     'name': 'Name'
                 }, csrf_token=csrf_token, expected_status_int=400)

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -1095,6 +1095,14 @@ class MailingListSubscriptionHandlerTests(test_utils.GenericTestBase):
                 }, csrf_token=csrf_token)
             self.assertEqual(json_response, {'status': True})
 
+            # name should be optional
+            json_response = self.put_json(
+                '/mailinglistsubscriptionhandler', {
+                    'email': 'email2@example.com',
+                    'tag': 'Web',
+                }, csrf_token=csrf_token)
+            self.assertEqual(json_response, {'status': True})
+
         self.logout()
 
     def test_email_provider_error(self) -> None:
@@ -1131,13 +1139,6 @@ class MailingListSubscriptionHandlerTests(test_utils.GenericTestBase):
                     'email': 'invalidemail.com',
                     'tag': 'Web',
                     'name': 'Name'
-                }, csrf_token=csrf_token, expected_status_int=400)
-
-            self.put_json(
-                '/mailinglistsubscriptionhandler', {
-                    'email': 'email@example.com',
-                    'tag': 'Web',
-                    'name': ''
                 }, csrf_token=csrf_token, expected_status_int=400)
 
             self.put_json(

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -41,7 +41,7 @@ import requests
 
 from typing import (
     Dict, Final, List, Literal, Optional, Sequence, TypedDict,
-    Union, overload)
+    overload)
 
 MYPY = False
 if MYPY: # pragma: no cover

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1594,7 +1594,7 @@ def record_user_created_an_exploration(user_id: str) -> None:
 def add_user_to_mailing_list(
     email: str,
     tag: str,
-    name: Union[str, None]=None
+    name: Optional[str]=None
 ) -> bool:
     """Adds user to the bulk email provider with the relevant tag and required
     merge fields.


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #19511.
2. This PR does the following: it allows subscribe requests without the name parameter. Currently frontend doesn't set this field at all.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

[Screen recording 2024-01-18 18.55.40.webm](https://github.com/oppia/oppia/assets/6707908/20234e9d-b4f8-413f-bd1e-c41dba6e155b)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
