### PR TITLE
Fix #19542 : Increasing the gap between radion button and label

### DIFF
--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -253,8 +253,8 @@
   color: #fff;
   padding: 15px 20px;
   position: relative;
-  z-index: 100;
   cursor: pointer;
+  z-index: 100;
 }
 
 .oppia-android-carousel-item-container {

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -52,13 +52,13 @@
   background: #0003;
 }
 
-.oppia-android-updates-button:hover:disabled {
-  background: #0003;
+.oppia-android-updates-button:hover {
+  background-color: #3d9991;
+  color: #fff;
 }
 
-.oppia-android-updates-button:hover {
-  color: #fff;
-  background-color: #3d9991;
+.oppia-android-updates-button:hover:disabled {
+  background: #0003;
 }
 
 .oppia-android-updates-checkbox-label {

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -53,6 +53,7 @@
 }
 
 .oppia-android-updates-button:hover {
+  /* changing color for aesthetics */
   background-color: #3d9991;
   color: #fff;
 }

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -254,6 +254,7 @@
   padding: 15px 20px;
   position: relative;
   z-index: 100;
+  cursor: pointer;
 }
 
 .oppia-android-carousel-item-container {

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -251,8 +251,8 @@
   background-color: #00645c;
   border-radius: 50%;
   color: #fff;
-  padding: 15px 20px;
   cursor: pointer;
+  padding: 15px 20px;
   position: relative;
   z-index: 100;
 }

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -52,16 +52,13 @@
   background: #0003;
 }
 
-.oppia-android-updates-button:hover {
-  background-color: #3d9991;
-}
-
 .oppia-android-updates-button:hover:disabled {
   background: #0003;
 }
 
 .oppia-android-updates-button:hover {
   color: #fff;
+  background-color: #3d9991;
 }
 
 .oppia-android-updates-checkbox-label {

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -53,13 +53,7 @@
 }
 
 .oppia-android-updates-button:hover {
-  /* changing color for aesthetics */
-  background-color: #3d9991;
   color: #fff;
-}
-
-.oppia-android-updates-button:hover:disabled {
-  background: #0003;
 }
 
 .oppia-android-updates-checkbox-label {
@@ -257,7 +251,6 @@
   background-color: #00645c;
   border-radius: 50%;
   color: #fff;
-  cursor: pointer;
   padding: 15px 20px;
   position: relative;
   z-index: 100;

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -53,6 +53,14 @@
 }
 
 .oppia-android-updates-button:hover {
+  background-color: #3d9991;
+}
+
+.oppia-android-updates-button:hover:disabled {
+  background: #0003;
+}
+
+.oppia-android-updates-button:hover {
   color: #fff;
 }
 

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -248,12 +248,12 @@
 }
 
 .oppia-android-carousel-chevron {
+  cursor: pointer;
   background-color: #00645c;
   border-radius: 50%;
   color: #fff;
   padding: 15px 20px;
   position: relative;
-  cursor: pointer;
   z-index: 100;
 }
 

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -248,11 +248,11 @@
 }
 
 .oppia-android-carousel-chevron {
-  cursor: pointer;
   background-color: #00645c;
   border-radius: 50%;
   color: #fff;
   padding: 15px 20px;
+  cursor: pointer;
   position: relative;
   z-index: 100;
 }

--- a/core/templates/pages/signup-page/signup-page.component.html
+++ b/core/templates/pages/signup-page/signup-page.component.html
@@ -169,7 +169,7 @@ link before completing the signup process, they will be logged out.
 
   .radio label {
     display: flex;
-    gap: 2px;
+    gap: 4px;
   }
 
 </style>

--- a/core/templates/pages/signup-page/signup-page.component.html
+++ b/core/templates/pages/signup-page/signup-page.component.html
@@ -166,4 +166,10 @@ link before completing the signup process, they will be logged out.
   .oppia-checkbox-margin {
     margin-right: 6px;
   }
+
+  .radio label {
+    display: flex;
+    gap: 2px;
+  }
+
 </style>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19542 
2. This PR does the following: Adds space between radio button label

## Essential Checklist

- [✔️] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [✔️] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [✔️] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [✔️] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [✔️] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct


#### Proof of changes on desktop with slow/throttled network

https://github.com/oppia/oppia/assets/77529419/e28e52cc-afb7-43cd-8a9c-de403b4db2e1

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
