### PR TITLE
Fix #19536: Adds hover effect to subscribe button on android page

### DIFF
--- a/core/templates/components/button-directives/primary-button.component.html
+++ b/core/templates/components/button-directives/primary-button.component.html
@@ -1,6 +1,7 @@
 <button type="submit"
         class="oppia-primary-button"
         [ngClass]="customClasses"
+        [disabled]="disabled"
         (click)="handleButtonClick()">
   {{ buttonText }}
 </button>

--- a/core/templates/components/button-directives/primary-button.component.ts
+++ b/core/templates/components/button-directives/primary-button.component.ts
@@ -31,6 +31,7 @@ import './primary-button.component.css';
 export class PrimaryButtonComponent {
   @Input() buttonText: string = '';
   @Input() customClasses?: string[];
+  @Input() disabled?: boolean = false;
   @Input() buttonHref: string | null = null;
   @Output() onClickPrimaryButton: EventEmitter<void> = new EventEmitter<void>();
 

--- a/core/templates/pages/android-page/android-page.component.html
+++ b/core/templates/pages/android-page/android-page.component.html
@@ -205,11 +205,10 @@
               Please confirm before subscribing.
             </div>
             <div class="oppia-android-updates-input-padding text-center">
-              <oppia-primary-button
-                      [disabled]="!userCanSubscribe || !validateEmailAddress()"
-                      (onClickPrimaryButton)="subscribeToAndroidList()"
-                      [customClasses]="'btn oppia-android-updates-button w-100'"
-                      [buttonText]="'I18N_ANDROID_PAGE_UPDATES_SUBMIT_BUTTON_TEXT' | translate">
+              <oppia-primary-button [disabled]="!userCanSubscribe || !validateEmailAddress()"
+                                    (onClickPrimaryButton)="subscribeToAndroidList()"
+                                    [customClasses]="'btn oppia-android-updates-button w-100'"
+                                    [buttonText]="'I18N_ANDROID_PAGE_UPDATES_SUBMIT_BUTTON_TEXT' | translate">
               </oppia-primary-button>
             </div>
           </div>

--- a/core/templates/pages/android-page/android-page.component.html
+++ b/core/templates/pages/android-page/android-page.component.html
@@ -205,11 +205,12 @@
               Please confirm before subscribing.
             </div>
             <div class="oppia-android-updates-input-padding text-center">
-              <button [disabled]="!userCanSubscribe || !validateEmailAddress()"
-                      (click)="subscribeToAndroidList()"
-                      class="btn oppia-android-updates-button w-100">
-                {{ 'I18N_ANDROID_PAGE_UPDATES_SUBMIT_BUTTON_TEXT' | translate }}
-              </button>
+              <oppia-primary-button
+                      [disabled]="!userCanSubscribe || !validateEmailAddress()"
+                      (onClickPrimaryButton)="subscribeToAndroidList()"
+                      [customClasses]="'btn oppia-android-updates-button w-100'"
+                      [buttonText]="'I18N_ANDROID_PAGE_UPDATES_SUBMIT_BUTTON_TEXT' | translate">
+              </oppia-primary-button>
             </div>
           </div>
           <div *ngIf="userHasSubscribed"


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19536 .
2. This PR does the following: Introduces `oppia-primary-button` component in place of a plain `button` component to automatically add color hover effect to the subscribe button.


## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

https://github.com/oppia/oppia/assets/66303548/65e219c9-31cf-4838-b0d0-47cfacec91fd




## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
