### PR TITLE
Fix part of #19570: pagination ui in contribution admin dashboard table

### DIFF
--- a/core/controllers/contributor_dashboard_admin.py
+++ b/core/controllers/contributor_dashboard_admin.py
@@ -644,7 +644,10 @@ class ContributorDashboardAdminStatsHandler(
                 assert page_size is not None
                 assert offset is not None
                 assert language_code is not None
-                translation_submitter_stats, next_offset, more = (
+                (
+                    translation_submitter_stats, next_offset, more,
+                    total_records
+                ) = (
                     contribution_stats_services
                     .get_translation_submitter_total_stats(
                         page_size,
@@ -659,7 +662,8 @@ class ContributorDashboardAdminStatsHandler(
                 response = {
                     'stats': translation_submitter_frontend_dicts,
                     'next_offset': next_offset,
-                    'more': more
+                    'more': more,
+                    'total_records': total_records,
                 }
 
             elif contribution_subtype == feconf.CONTRIBUTION_SUBTYPE_REVIEW:
@@ -668,7 +672,7 @@ class ContributorDashboardAdminStatsHandler(
                 assert page_size is not None
                 assert offset is not None
                 assert language_code is not None
-                translation_reviewer_stats, next_offset, more = (
+                translation_reviewer_stats, next_offset, more, total_records = (
                     contribution_stats_services
                     .get_translation_reviewer_total_stats(
                         page_size,
@@ -682,7 +686,8 @@ class ContributorDashboardAdminStatsHandler(
                 response = {
                     'stats': translation_reviewer_frontend_dicts,
                     'next_offset': next_offset,
-                    'more': more
+                    'more': more,
+                    'total_records': total_records,
                 }
 
             else:
@@ -703,7 +708,7 @@ class ContributorDashboardAdminStatsHandler(
                 # schema mypy is assuming is can be None.
                 assert page_size is not None
                 assert offset is not None
-                question_submitter_stats, next_offset, more = (
+                question_submitter_stats, next_offset, more, total_records = (
                     contribution_stats_services
                     .get_question_submitter_total_stats(
                         page_size,
@@ -717,7 +722,8 @@ class ContributorDashboardAdminStatsHandler(
                 response = {
                     'stats': question_submitter_frontend_dicts,
                     'next_offset': next_offset,
-                    'more': more
+                    'more': more,
+                    'total_records': total_records,
                 }
 
             elif contribution_subtype == feconf.CONTRIBUTION_SUBTYPE_REVIEW:
@@ -725,7 +731,7 @@ class ContributorDashboardAdminStatsHandler(
                 # schema mypy is assuming is can be None.
                 assert page_size is not None
                 assert offset is not None
-                question_reviewer_stats, next_offset, more = (
+                question_reviewer_stats, next_offset, more, total_records = (
                     contribution_stats_services
                     .get_question_reviewer_total_stats(
                         page_size,
@@ -738,7 +744,8 @@ class ContributorDashboardAdminStatsHandler(
                 response = {
                     'stats': question_reviewer_frontend_dicts,
                     'next_offset': next_offset,
-                    'more': more
+                    'more': more,
+                    'total_records': total_records,
                 }
 
             else:

--- a/core/domain/contribution_stats_services.py
+++ b/core/domain/contribution_stats_services.py
@@ -240,7 +240,8 @@ def get_translation_submitter_total_stats(
 ) -> Tuple[
         List[suggestion_registry.TranslationSubmitterTotalContributionStats],
         int,
-        bool]:
+        bool,
+        int]:
     """Returns the list of domain objects according to values specified.
 
     Args:
@@ -267,7 +268,7 @@ def get_translation_submitter_total_stats(
                     this batch. If False, there are no further results
                     after this batch.
     """
-    translation_submitter_models, next_offset, more = (
+    translation_submitter_models, next_offset, more, total_records = (
         suggestion_models.TranslationSubmitterTotalContributionStatsModel
         .fetch_page(
             page_size=page_size,
@@ -286,7 +287,8 @@ def get_translation_submitter_total_stats(
     return (
         translation_submitter_stats,
         next_offset,
-        more
+        more,
+        total_records,
     )
 
 
@@ -299,7 +301,8 @@ def get_translation_reviewer_total_stats(
 ) -> Tuple[
         List[suggestion_registry.TranslationReviewerTotalContributionStats],
         int,
-        bool
+        bool,
+        int,
     ]:
     """Returns the list of domain objects according to values specified.
 
@@ -325,7 +328,7 @@ def get_translation_reviewer_total_stats(
                 this batch. If False, there are no further results
                 after this batch.
     """
-    translation_reviewer_models, next_offset, more = (
+    translation_reviewer_models, next_offset, more, total_records = (
         suggestion_models.TranslationReviewerTotalContributionStatsModel
         .fetch_page(
             page_size=page_size,
@@ -344,7 +347,8 @@ def get_translation_reviewer_total_stats(
     return (
         translation_reviewer_stats,
         next_offset,
-        more
+        more,
+        total_records,
     )
 
 
@@ -357,7 +361,8 @@ def get_question_submitter_total_stats(
 ) -> Tuple[
         List[suggestion_registry.QuestionSubmitterTotalContributionStats],
         int,
-        bool
+        bool,
+        int,
     ]:
     """Returns the list of domain objects according to values specified.
 
@@ -384,7 +389,7 @@ def get_question_submitter_total_stats(
                 this batch. If False, there are no further results
                 after this batch.
     """
-    question_submitter_models, next_offset, more = (
+    question_submitter_models, next_offset, more, total_records = (
         suggestion_models.QuestionSubmitterTotalContributionStatsModel
         .fetch_page(
             page_size=page_size,
@@ -403,7 +408,8 @@ def get_question_submitter_total_stats(
     return (
         question_submitter_stats,
         next_offset,
-        more
+        more,
+        total_records
     )
 
 
@@ -415,7 +421,8 @@ def get_question_reviewer_total_stats(
 ) -> Tuple[
         List[suggestion_registry.QuestionReviewerTotalContributionStats],
         int,
-        bool
+        bool,
+        int,
     ]:
     """Returns the list of domain objects according to values specified.
 
@@ -440,7 +447,7 @@ def get_question_reviewer_total_stats(
                 this batch. If False, there are no further results
                 after this batch.
     """
-    question_reviewer_models, next_offset, more = (
+    question_reviewer_models, next_offset, more, total_records = (
         suggestion_models.QuestionReviewerTotalContributionStatsModel
         .fetch_page(
             page_size=page_size,
@@ -458,7 +465,8 @@ def get_question_reviewer_total_stats(
     return (
         question_reviewer_stats,
         next_offset,
-        more
+        more,
+        total_records,
     )
 
 

--- a/core/domain/contribution_stats_services.py
+++ b/core/domain/contribution_stats_services.py
@@ -257,7 +257,7 @@ def get_translation_submitter_total_stats(
             who are active in max_days_since_last_activity.
 
     Returns:
-        3-tuple(sorted_results, next_offset, more). where:
+        3-tuple(sorted_results, next_offset, more, total_records). where:
                 sorted_results:
                     list(TranslationSubmitterTotalContributionStats).
                     The list of domain objects which match the supplied
@@ -267,6 +267,7 @@ def get_translation_submitter_total_stats(
                 more: bool. If True, there are (probably) more results after
                     this batch. If False, there are no further results
                     after this batch.
+                total_records: int. Total number of results present.
     """
     translation_submitter_models, next_offset, more, total_records = (
         suggestion_models.TranslationSubmitterTotalContributionStatsModel
@@ -317,7 +318,7 @@ def get_translation_reviewer_total_stats(
             who are active in max_days_since_last_activity.
 
     Returns:
-        3-tuple(sorted_results, next_offset, more). where:
+        3-tuple(sorted_results, next_offset, more, total_records). where:
             sorted_results:
                 list(TranslationReviewerTotalContributionStats).
                 The list of domain objects which match the supplied
@@ -327,6 +328,7 @@ def get_translation_reviewer_total_stats(
             more: bool. If True, there are (probably) more results after
                 this batch. If False, there are no further results
                 after this batch.
+            total_records: int. Total number of results present.
     """
     translation_reviewer_models, next_offset, more, total_records = (
         suggestion_models.TranslationReviewerTotalContributionStatsModel
@@ -378,7 +380,7 @@ def get_question_submitter_total_stats(
             who are active in max_days_since_last_activity.
 
     Returns:
-        3-tuple(sorted_results, next_offset, more). where:
+        3-tuple(sorted_results, next_offset, more, total_records). where:
             sorted_results:
                 list(QuestionSubmitterTotalContributionStats).
                 The list of domain objects which match the supplied topic_ids
@@ -388,6 +390,7 @@ def get_question_submitter_total_stats(
             more: bool. If True, there are (probably) more results after
                 this batch. If False, there are no further results
                 after this batch.
+            total_records: int. Total number of results present.
     """
     question_submitter_models, next_offset, more, total_records = (
         suggestion_models.QuestionSubmitterTotalContributionStatsModel
@@ -436,7 +439,7 @@ def get_question_reviewer_total_stats(
             who are active in max_days_since_last_activity.
 
     Returns:
-        3-tuple(sorted_results, next_offset, more). where:
+        3-tuple(sorted_results, next_offset, more, total_records). where:
             sorted_results:
                 list(QuestionReviewerTotalContributionStats).
                 The list of domain objects which match the supplied
@@ -446,6 +449,7 @@ def get_question_reviewer_total_stats(
             more: bool. If True, there are (probably) more results after
                 this batch. If False, there are no further results
                 after this batch.
+            total_records: int. Total number of results present.
     """
     question_reviewer_models, next_offset, more, total_records = (
         suggestion_models.QuestionReviewerTotalContributionStatsModel

--- a/core/domain/contribution_stats_services_test.py
+++ b/core/domain/contribution_stats_services_test.py
@@ -371,7 +371,7 @@ class ContributorAdminDashboardServicesUnitTest(test_utils.GenericTestBase):
         ).put()
 
     def test_get_translation_submitter_admin_stats(self) -> None:
-        stats, next_offset, more = (
+        stats, next_offset, more, total_records = (
             contribution_stats_services.get_translation_submitter_total_stats( # pylint: disable=line-too-long
             page_size=2,
             offset=1,
@@ -384,12 +384,13 @@ class ContributorAdminDashboardServicesUnitTest(test_utils.GenericTestBase):
 
         self.assertEqual(2, len(stats))
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(3, next_offset)
         self.assertEqual('user3', stats[0].contributor_id)
         self.assertEqual('user2', stats[1].contributor_id)
 
     def test_get_translation_reviewer_admin_stats(self) -> None:
-        stats, next_offset, more = (
+        stats, next_offset, more, total_records = (
             contribution_stats_services.get_translation_reviewer_total_stats( # pylint: disable=line-too-long
             page_size=2,
             offset=1,
@@ -401,12 +402,13 @@ class ContributorAdminDashboardServicesUnitTest(test_utils.GenericTestBase):
 
         self.assertEqual(2, len(stats))
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(3, next_offset)
         self.assertEqual('user3', stats[0].contributor_id)
         self.assertEqual('user2', stats[1].contributor_id)
 
     def test_get_question_submitter_admin_stats(self) -> None:
-        stats, next_offset, more = (
+        stats, next_offset, more, total_records = (
             contribution_stats_services.get_question_submitter_total_stats( # pylint: disable=line-too-long
             page_size=2,
             offset=1,
@@ -418,12 +420,13 @@ class ContributorAdminDashboardServicesUnitTest(test_utils.GenericTestBase):
 
         self.assertEqual(2, len(stats))
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(3, next_offset)
         self.assertEqual('user3', stats[0].contributor_id)
         self.assertEqual('user2', stats[1].contributor_id)
 
     def test_get_question_reviewer_admin_stats(self) -> None:
-        stats, next_offset, more = (
+        stats, next_offset, more, total_records = (
             contribution_stats_services.get_question_reviewer_total_stats( # pylint: disable=line-too-long
             page_size=2,
             offset=1,
@@ -434,6 +437,7 @@ class ContributorAdminDashboardServicesUnitTest(test_utils.GenericTestBase):
 
         self.assertEqual(2, len(stats))
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(3, next_offset)
         self.assertEqual('user2', stats[0].contributor_id)
         self.assertEqual('user1', stats[1].contributor_id)

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -2292,7 +2292,8 @@ class TranslationSubmitterTotalContributionStatsModel(base_models.BaseModel):
         max_days_since_last_activity: Optional[int]
     ) -> Tuple[Sequence[TranslationSubmitterTotalContributionStatsModel],
                 int,
-                bool]:
+                bool,
+                int]:
         """Returns the models according to values specified.
 
         Args:
@@ -2360,6 +2361,8 @@ class TranslationSubmitterTotalContributionStatsModel(base_models.BaseModel):
                     cls.language_code == language_code
                 )).order(sort)
 
+        total_count = sort_query.count()
+
         sorted_results: List[
             TranslationSubmitterTotalContributionStatsModel] = []
         today = datetime.date.today()
@@ -2394,7 +2397,8 @@ class TranslationSubmitterTotalContributionStatsModel(base_models.BaseModel):
         return (
             sorted_results,
             next_offset,
-            more
+            more,
+            total_count
         )
 
     @classmethod
@@ -2713,7 +2717,8 @@ class TranslationReviewerTotalContributionStatsModel(base_models.BaseModel):
         max_days_since_last_activity: Optional[int]
     ) -> Tuple[Sequence[TranslationReviewerTotalContributionStatsModel],
                 int,
-                bool]:
+                bool,
+                int]:
         """Returns the models according to values specified.
 
         Args:
@@ -2764,6 +2769,8 @@ class TranslationReviewerTotalContributionStatsModel(base_models.BaseModel):
                 cls.language_code == language_code
             )).order(sort)
 
+        total_records = sort_query.count()
+
         sorted_results: List[
             TranslationReviewerTotalContributionStatsModel] = []
         today = datetime.date.today()
@@ -2798,7 +2805,8 @@ class TranslationReviewerTotalContributionStatsModel(base_models.BaseModel):
         return (
             sorted_results,
             next_offset,
-            more
+            more,
+            total_records,
         )
 
     @classmethod
@@ -3038,7 +3046,8 @@ class QuestionSubmitterTotalContributionStatsModel(base_models.BaseModel):
         max_days_since_last_activity: Optional[int]
     ) -> Tuple[Sequence[QuestionSubmitterTotalContributionStatsModel],
                 int,
-                bool]:
+                bool,
+                int]:
         """Returns the models according to values specified.
 
         Args:
@@ -3101,6 +3110,8 @@ class QuestionSubmitterTotalContributionStatsModel(base_models.BaseModel):
         else:
             sort_query = cls.get_all().order(sort)
 
+        total_records = sort_query.count()
+
         sorted_results: List[
             QuestionSubmitterTotalContributionStatsModel] = []
         today = datetime.date.today()
@@ -3135,7 +3146,8 @@ class QuestionSubmitterTotalContributionStatsModel(base_models.BaseModel):
         return (
             sorted_results,
             next_offset,
-            more
+            more,
+            total_records,
         )
 
     @classmethod
@@ -3336,7 +3348,8 @@ class QuestionReviewerTotalContributionStatsModel(base_models.BaseModel):
         max_days_since_last_activity: Optional[int]
     ) -> Tuple[Sequence[QuestionReviewerTotalContributionStatsModel],
                 int,
-                bool]:
+                bool,
+                int]:
         """Returns the models according to values specified.
 
         Args:
@@ -3382,7 +3395,7 @@ class QuestionReviewerTotalContributionStatsModel(base_models.BaseModel):
         # separately below. Learn more about this here:
         # https://cloud.google.com/appengine/docs/legacy/standard/go111/datastore/query-restrictions#properties_used_in_inequality_filters_must_be_sorted_first.
         sort_query = cls.get_all().order(sort)
-
+        total_records = sort_query.count()
         sorted_results: List[
             QuestionReviewerTotalContributionStatsModel] = []
         today = datetime.date.today()
@@ -3417,7 +3430,8 @@ class QuestionReviewerTotalContributionStatsModel(base_models.BaseModel):
         return (
             sorted_results,
             next_offset,
-            more
+            more,
+            total_records,
         )
 
     @classmethod

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -2309,7 +2309,7 @@ class TranslationSubmitterTotalContributionStatsModel(base_models.BaseModel):
                 who are active in max_days_since_last_activity.
 
         Returns:
-            3-tuple(sorted_results, next_offset, more). where:
+            3-tuple(sorted_results, next_offset, more, total_records). where:
                 sorted_results:
                     list(TranslationSubmitterTotalContributionStatsModel).
                     The list of models which match the supplied language_code,
@@ -2319,6 +2319,7 @@ class TranslationSubmitterTotalContributionStatsModel(base_models.BaseModel):
                 more: bool. If True, there are (probably) more results after
                     this batch. If False, there are no further results
                     after this batch.
+                total_records: int. The total number of results present.
         """
 
         sort_options_dict = {
@@ -2361,7 +2362,7 @@ class TranslationSubmitterTotalContributionStatsModel(base_models.BaseModel):
                     cls.language_code == language_code
                 )).order(sort)
 
-        total_count = sort_query.count()
+        total_records = sort_query.count()
 
         sorted_results: List[
             TranslationSubmitterTotalContributionStatsModel] = []
@@ -2398,7 +2399,7 @@ class TranslationSubmitterTotalContributionStatsModel(base_models.BaseModel):
             sorted_results,
             next_offset,
             more,
-            total_count
+            total_records
         )
 
     @classmethod
@@ -2732,7 +2733,7 @@ class TranslationReviewerTotalContributionStatsModel(base_models.BaseModel):
                 who are active in max_days_since_last_activity.
 
         Returns:
-            3-tuple(sorted_results, next_offset, more). where:
+            3-tuple(sorted_results, next_offset, more, total_records). where:
                 sorted_results:
                     list(TranslationSubmitterTotalContributionStatsModel).
                     The list of models which match the supplied language_code,
@@ -2742,6 +2743,7 @@ class TranslationReviewerTotalContributionStatsModel(base_models.BaseModel):
                 more: bool. If True, there are (probably) more results after
                     this batch. If False, there are no further results
                     after this batch.
+                total_records: int. The total number of results present.
         """
 
         sort_options_dict = {
@@ -3062,7 +3064,7 @@ class QuestionSubmitterTotalContributionStatsModel(base_models.BaseModel):
                 who are active in max_days_since_last_activity.
 
         Returns:
-            3-tuple(sorted_results, next_offset, more). where:
+            3-tuple(sorted_results, next_offset, more, total_records). where:
                 sorted_results:
                     list(QuestionSubmitterTotalContributionStatsModel).
                     The list of models which match the supplied topic_ids
@@ -3072,6 +3074,7 @@ class QuestionSubmitterTotalContributionStatsModel(base_models.BaseModel):
                 more: bool. If True, there are (probably) more results after
                     this batch. If False, there are no further results
                     after this batch.
+                total_records: int. The total number of results present.
         """
 
         sort_options_dict = {
@@ -3362,7 +3365,7 @@ class QuestionReviewerTotalContributionStatsModel(base_models.BaseModel):
                 who are active in max_days_since_last_activity.
 
         Returns:
-            3-tuple(sorted_results, next_offset, more). where:
+            3-tuple(sorted_results, next_offset, more, total_records). where:
                 sorted_results:
                     list(QuestionReviewerTotalContributionStatsModel).
                     The list of models which match the supplied
@@ -3372,6 +3375,7 @@ class QuestionReviewerTotalContributionStatsModel(base_models.BaseModel):
                 more: bool. If True, there are (probably) more results after
                     this batch. If False, there are no further results
                     after this batch.
+                total_records: int. The total number of results present.
         """
 
         sort_options_dict = {

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -3229,7 +3229,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for decreasing performance(default) sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -3243,10 +3243,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 3)
 
         # Check for non-performance sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -3261,10 +3262,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 4)
 
         # Check for decreasing Accuracy sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -3279,10 +3281,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 4)
 
         # Check for increasing Accuracy sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3297,10 +3300,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for decreasing Translated cards sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3315,10 +3319,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for increasing Translated cards sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3332,10 +3337,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for decreasing last activity sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3350,10 +3356,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for increasing last activity sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3368,6 +3375,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
     def test_fetch_page_with_filtering(self) -> None:
@@ -3472,7 +3480,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for 'es' language filter.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -3486,10 +3494,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 3)
         self.assertEqual(next_offset, 3)
 
         # Check for 'hi' language filter.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=1,
@@ -3502,10 +3511,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(len(sorted_results), 1)
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 1)
 
         # Check for topic filter ['topic1', 'topic2'].
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -3519,10 +3529,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 2)
 
         # Check for last activity under 7 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3538,7 +3549,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(next_offset, 3)
 
         # Check for last activity under 90 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3552,10 +3563,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 3)
 
         # Check for no sorted_results in given time.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=1,
@@ -3567,6 +3579,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 1)
 
     def test_fetch_page_with_sorting_and_filtering(self) -> None:
@@ -3669,7 +3682,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for topic filter and non-performance sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3683,11 +3696,12 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(len(sorted_results), 2)
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 2)
 
         # Check for decreasing last activity sort order and
         # topic filter.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3702,6 +3716,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 2)
 
     def test_fetch_page_with_pagination(self) -> None:
@@ -3806,7 +3821,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for pagination with offset 2.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3820,10 +3835,11 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 4)
 
         # Check for pagination with no results.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -3836,6 +3852,7 @@ class TranslationSubmitterTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 4)
 
     def test_has_reference_to_user_id(self) -> None:
@@ -4214,7 +4231,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for decreasing order of reviewed cards(default)
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -4227,10 +4244,11 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertFalse(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 4)
 
         # Check for increasing order of reviewed cards.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -4244,10 +4262,11 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 4)
 
         # Check for decreasing order of last activity.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -4261,10 +4280,11 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for increasing order of last activity.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -4278,6 +4298,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 3)
 
     def test_fetch_page_with_filtering(self) -> None:
@@ -4354,7 +4375,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for 'es' language filter.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -4367,10 +4388,11 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 3)
         self.assertEqual(next_offset, 3)
 
         # Check for 'hi' language filter.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -4383,9 +4405,10 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertFalse(more)
         self.assertEqual(next_offset, 1)
+        self.assertEqual(total_records, 1)
 
         # Check for max_days_since_last_activity filter within 7 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -4398,9 +4421,10 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertFalse(more)
         self.assertEqual(next_offset, 3)
+        self.assertEqual(total_records, 1)
 
         # Check for max_days_since_last_activity filter within 90 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -4413,10 +4437,11 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 3)
 
         # Check for no sorted_results within 7 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=1,
@@ -4427,6 +4452,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 1)
 
     def test_fetch_page_with_sorting_and_filtering(self) -> None:
@@ -4503,7 +4529,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for language filter and IncreasingLastActivity sort.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=1,
@@ -4516,11 +4542,12 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(len(sorted_results), 1)
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 1)
 
         # Check for max_days_since_last_activity filter within 7 days
         # and IncreasingReviewedTranslations sort.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -4533,6 +4560,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(len(sorted_results), 1)
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 3)
 
     def test_fetch_page_with_pagination(self) -> None:
@@ -4608,7 +4636,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for Pagination with offset 2.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -4621,6 +4649,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 4)
 
     def test_fetch_page_covering_all_branches(self) -> None:
@@ -4696,7 +4725,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for last_acitvity filter within 7 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
             page_size=2,
@@ -4708,10 +4737,11 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 3)
 
         # Check for last_acitvity filter within 90 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
             page_size=1,
@@ -4723,10 +4753,11 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 1)
 
         # Check for no sorted_results within 7 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.TranslationReviewerTotalContributionStatsModel
             .fetch_page(
             page_size=1,
@@ -4737,6 +4768,7 @@ class TranslationReviewerTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 1)
 
     def test_apply_deletion_policy(self) -> None:
@@ -4993,7 +5025,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for decreasing performance(default) sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -5006,10 +5038,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertFalse(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 4)
 
         # Check for increasing performance sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -5023,10 +5056,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 4)
 
         # Check for decreasing Accuracy sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -5040,10 +5074,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 3)
 
         # Check for increasing Accuracy sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -5057,10 +5092,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertFalse(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 4)
 
         # Check for decreasing Submitted cards sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -5074,10 +5110,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 3)
 
         # Check for increasing Submitted cards sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -5091,10 +5128,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 3)
 
         # Check for decreasing last activity sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5108,10 +5146,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for increasing last activity sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5125,6 +5164,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
     def test_fetch_page_with_filtering(self) -> None:
@@ -5202,7 +5242,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for topic filter.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=4,
@@ -5215,10 +5255,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 2)
 
         # Check for max_days_since_last_activity under 7 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5230,10 +5271,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(len(sorted_results), 1)
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 4)
 
         # Check for max_days_since_last_activity under 90 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5246,10 +5288,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_4')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for no sorted_results in given time.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=1,
@@ -5262,6 +5305,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 0)
 
     def test_fetch_page_with_sorting_and_filtering(self) -> None:
@@ -5339,7 +5383,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for topic filter and non-performance sort order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=1,
@@ -5351,11 +5395,12 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 2)
 
         # Check for max_days_since_last_activity in 90 days
         # and DecreasingLastActivity order.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5369,6 +5414,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_4')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 4)
 
     def test_fetch_page_with_pagination(self) -> None:
@@ -5446,7 +5492,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for pagination with offset=2.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5459,10 +5505,11 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 4)
 
         # Check for pagination with no results.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionSubmitterTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5473,6 +5520,7 @@ class QuestionSubmitterTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 4)
 
     def test_get_deletion_policy(self) -> None:
@@ -5664,7 +5712,7 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for decreasing order of reviewed questions(default)
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -5676,10 +5724,11 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 3)
         self.assertEqual(next_offset, 3)
 
         # Check for increasing order of reviewed questions.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=3,
@@ -5692,10 +5741,11 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertFalse(more)
+        self.assertEqual(total_records, 3)
         self.assertEqual(next_offset, 3)
 
         # Check for decreasing order of last activity.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5708,10 +5758,11 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_1')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for increasing order of last activity.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5774,7 +5825,7 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for max_days_since_last_activity filter within 7 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5785,10 +5836,11 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(len(sorted_results), 1)
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 3)
 
         # Check for max_days_since_last_activity filter within 90 days.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5800,10 +5852,11 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
         # Check for no sorted_results within 1 day.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=1,
@@ -5813,6 +5866,7 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 3)
 
     def test_fetch_page_with_sorting_and_filtering(self) -> None:
@@ -5864,7 +5918,7 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
 
         # Check for max_days_since_last_activity filter within 90 days
         # and IncreasingReviewedQuestions sort.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5877,11 +5931,12 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertEqual(sorted_results[1].id, 'model_3')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 3)
 
         # Check for max_days_since_last_activity filter within 7 days
         # and IncreasingReviewedQuestions sort.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5893,11 +5948,12 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(len(sorted_results), 1)
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertFalse(more)
+        self.assertEqual(total_records, 1)
         self.assertEqual(next_offset, 3)
 
         # Check for max_days_since_last_activity filter within 90 days
         # and IncreasingLastActivity sort.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5910,6 +5966,7 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_3')
         self.assertEqual(sorted_results[1].id, 'model_2')
         self.assertTrue(more)
+        self.assertEqual(total_records, 4)
         self.assertEqual(next_offset, 2)
 
     def test_fetch_page_with_pagination(self) -> None:
@@ -5960,7 +6017,7 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         ).put()
 
         # Check for pagination with offset=1.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5972,10 +6029,11 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
         self.assertEqual(sorted_results[0].id, 'model_2')
         self.assertEqual(sorted_results[1].id, 'model_1')
         self.assertFalse(more)
+        self.assertEqual(total_records, 2)
         self.assertEqual(next_offset, 3)
 
         # Check for pagination with no results.
-        sorted_results, next_offset, more = (
+        sorted_results, next_offset, more, total_records = (
             suggestion_models.QuestionReviewerTotalContributionStatsModel
             .fetch_page(
                 page_size=2,
@@ -5985,6 +6043,7 @@ class QuestionReviewerTotalContributionStatsModelUnitTests(
             ))
         self.assertEqual(len(sorted_results), 0)
         self.assertFalse(more)
+        self.assertEqual(total_records, 0)
         self.assertEqual(next_offset, 3)
 
     def test_get_deletion_policy(self) -> None:

--- a/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.html
+++ b/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.html
@@ -17,7 +17,7 @@
   </div>
   <div class="dashboard-list-header" *ngIf="!loadingMessage && !noDataMessage && checkMobileView()">
     <div class="dashboard-list-header-count">
-      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of {{ more ? 'many' : getUpperLimitValueForPagination() }} </span>
+      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of {{ totalRecords }} </span>
     </div>
     <div class="results-per-page-div">
       <span>Results per page: </span>
@@ -386,7 +386,7 @@
   </table>
   <div class="dashboard-list-footer" *ngIf="!loadingMessage && !noDataMessage && !checkMobileView()">
     <div class="dashboard-list-footer-count">
-      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of {{ more ? 'many' : getUpperLimitValueForPagination() }} </span>
+      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of {{ totalRecords }} </span>
     </div>
     <div class="dashboard-list-pagination">
       <div>

--- a/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.html
+++ b/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.html
@@ -386,7 +386,7 @@
   </table>
   <div class="dashboard-list-footer" *ngIf="!loadingMessage && !noDataMessage && !checkMobileView()">
     <div class="dashboard-list-footer-count">
-      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of many</span>
+      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of {{ more ? 'many' : getUpperLimitValueForPagination() }} </span>
     </div>
     <div class="dashboard-list-pagination">
       <div>

--- a/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.html
+++ b/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.html
@@ -17,7 +17,7 @@
   </div>
   <div class="dashboard-list-header" *ngIf="!loadingMessage && !noDataMessage && checkMobileView()">
     <div class="dashboard-list-header-count">
-      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of many</span>
+      <span>Displaying {{ statsPageNumber * itemsPerPage + 1 }} - {{ getUpperLimitValueForPagination() }} of {{ more ? 'many' : getUpperLimitValueForPagination() }} </span>
     </div>
     <div class="results-per-page-div">
       <span>Results per page: </span>

--- a/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.spec.ts
@@ -108,6 +108,7 @@ describe('Contributor stats component', () => {
           stats: [],
           nextOffset: 1,
           more: false,
+          totalRecords: 0,
         } as TranslationSubmitterStatsData));
 
       const changes: SimpleChanges = {
@@ -140,7 +141,8 @@ describe('Contributor stats component', () => {
         .and.returnValue(Promise.resolve({
           stats: [],
           nextOffset: 1,
-          more: false
+          more: false,
+          totalRecords: 0,
         } as TranslationReviewerStatsData));
 
       const changes: SimpleChanges = {
@@ -171,7 +173,8 @@ describe('Contributor stats component', () => {
         .and.returnValue(Promise.resolve({
           stats: [],
           nextOffset: 1,
-          more: false
+          more: false,
+          totalRecords: 0,
         } as QuestionSubmitterStatsData));
 
       const changes: SimpleChanges = {
@@ -204,7 +207,8 @@ describe('Contributor stats component', () => {
         .and.returnValue(Promise.resolve({
           stats: [],
           nextOffset: 1,
-          more: false
+          more: false,
+          totalRecords: 0,
         } as QuestionReviewerStatsData));
 
       const changes: SimpleChanges = {
@@ -358,7 +362,8 @@ describe('Contributor stats component', () => {
         .and.returnValue(Promise.resolve({
           stats: [],
           nextOffset: 1,
-          more: false
+          more: false,
+          totalRecords: 0,
         } as QuestionReviewerStatsData));
     }));
   });

--- a/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.ts
+++ b/core/templates/pages/contributor-dashboard-admin-page/contributor-dashboard-tables/contributor-admin-stats-table.component.ts
@@ -80,6 +80,7 @@ export class ContributorAdminStatsTable implements OnInit {
 
   nextOffset: number = 0;
   more: boolean = true;
+  totalRecords = 0;
 
   expandedElement: TranslationSubmitterStats[] |
     TranslationReviewerStats[] |
@@ -94,7 +95,7 @@ export class ContributorAdminStatsTable implements OnInit {
   TAB_NAME_QUESTION_COORDINATOR: string = 'Question Coordinator';
   loadingMessage!: string;
   noDataMessage!: string;
-  itemsPerPageChoice: number[] = [20, 50, 100];
+  itemsPerPageChoice: number[] = [1, 20, 50, 100];
   itemsPerPage: number = 20;
   statsPageNumber: number = 0;
   MOVE_TO_NEXT_PAGE: string = 'next_page';
@@ -250,6 +251,7 @@ export class ContributorAdminStatsTable implements OnInit {
             this.dataSource = response.stats;
             this.nextOffset = response.nextOffset;
             this.more = response.more;
+            this.totalRecords = response.totalRecords;
             this.loadingMessage = '';
             this.noDataMessage = '';
             if (this.dataSource.length === 0) {
@@ -284,6 +286,7 @@ export class ContributorAdminStatsTable implements OnInit {
             this.dataSource = response.stats;
             this.nextOffset = response.nextOffset;
             this.more = response.more;
+            this.totalRecords = response.totalRecords;
             this.loadingMessage = '';
             this.noDataMessage = '';
             if (this.dataSource.length === 0) {
@@ -322,6 +325,7 @@ export class ContributorAdminStatsTable implements OnInit {
             this.dataSource = response.stats;
             this.nextOffset = response.nextOffset;
             this.more = response.more;
+            this.totalRecords = response.totalRecords;
             this.loadingMessage = '';
             this.noDataMessage = '';
             if (this.dataSource.length === 0) {
@@ -356,6 +360,7 @@ export class ContributorAdminStatsTable implements OnInit {
             this.dataSource = response.stats;
             this.nextOffset = response.nextOffset;
             this.more = response.more;
+            this.totalRecords = response.totalRecords;
             this.loadingMessage = '';
             this.noDataMessage = '';
             if (this.dataSource.length === 0) {
@@ -370,6 +375,7 @@ export class ContributorAdminStatsTable implements OnInit {
     this.nextOffset = 0;
     this.dataSource = [];
     this.more = true;
+    this.totalRecords = 0;
     this.firstTimeFetchingData = true;
     this.goToPageNumber(0);
   }

--- a/core/templates/pages/contributor-dashboard-admin-page/services/contributor-dashboard-admin-stats-backend-api.service.spec.ts
+++ b/core/templates/pages/contributor-dashboard-admin-page/services/contributor-dashboard-admin-stats-backend-api.service.spec.ts
@@ -437,7 +437,8 @@ describe('Contribution Admin dasboard stats service', () => {
         expect(result).toEqual({
           stats: [],
           nextOffset: 0,
-          more: false
+          more: false,
+          totalRecords: 0,
         });
       });
     }));

--- a/core/templates/pages/contributor-dashboard-admin-page/services/contributor-dashboard-admin-stats-backend-api.service.ts
+++ b/core/templates/pages/contributor-dashboard-admin-page/services/contributor-dashboard-admin-stats-backend-api.service.ts
@@ -103,48 +103,56 @@ export interface TranslationSubmitterStatsData {
   stats: TranslationSubmitterStats[];
   nextOffset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 export interface TranslationSubmitterStatsBackendDict {
   stats: TranslationSubmitterBackendDict[];
   next_offset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 export interface TranslationReviewerStatsData {
   stats: TranslationReviewerStats[];
   nextOffset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 export interface TranslationReviewerStatsBackendDict {
   stats: TranslationReviewerBackendDict[];
   next_offset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 export interface QuestionSubmitterStatsData {
   stats: QuestionSubmitterStats[];
   nextOffset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 export interface QuestionSubmitterStatsBackendDict {
   stats: QuestionSubmitterBackendDict[];
   next_offset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 export interface QuestionReviewerStatsData {
   stats: QuestionReviewerStats[];
   nextOffset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 export interface QuestionReviewerStatsBackendDict {
   stats: QuestionReviewerBackendDict[];
   next_offset: number;
   more: boolean;
+  totalRecords: number;
 }
 
 @Injectable({
@@ -236,7 +244,8 @@ export class ContributorDashboardAdminStatsBackendApiService {
                 backendDict => TranslationSubmitterStats
                   .createFromBackendDict(backendDict)),
               nextOffset: response.next_offset,
-              more: response.more
+              more: response.more,
+              totalRecords: response.totalRecords,
             });
           }, errorResponse => {
             reject(errorResponse.error.error);
@@ -257,7 +266,8 @@ export class ContributorDashboardAdminStatsBackendApiService {
                 backendDict => TranslationReviewerStats
                   .createFromBackendDict(backendDict)),
               nextOffset: response.next_offset,
-              more: response.more
+              more: response.more,
+              totalRecords: response.totalRecords,
             });
           }, errorResponse => {
             reject(errorResponse.error.error);
@@ -280,7 +290,8 @@ export class ContributorDashboardAdminStatsBackendApiService {
                 backendDict => QuestionSubmitterStats
                   .createFromBackendDict(backendDict)),
               nextOffset: response.next_offset,
-              more: response.more
+              more: response.more,
+              totalRecords: response.totalRecords,
             });
           }, errorResponse => {
             reject(errorResponse.error.error);
@@ -301,7 +312,8 @@ export class ContributorDashboardAdminStatsBackendApiService {
                 backendDict => QuestionReviewerStats
                   .createFromBackendDict(backendDict)),
               nextOffset: response.next_offset,
-              more: response.more
+              more: response.more,
+              totalRecords: response.totalRecords
             });
           }, errorResponse => {
             reject(errorResponse.error.error);
@@ -312,7 +324,8 @@ export class ContributorDashboardAdminStatsBackendApiService {
     return Promise.resolve({
       stats: [],
       nextOffset: 0,
-      more: false
+      more: false,
+      totalRecords: 0,
     });
   }
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19570 .
2. This PR does the following:
Fixes paging ui. For example, 
Earlier for 25 items and page size of 20, the table footer would show `1-20 of many` for first page and `21-25 of many` for second page, which was wrong. 
Now it would show `1-20 of many` for first page, `21-25 of 25` for second page.
Note that for first page, frontend doesn't know the total number of items so it is showing many. The paging api returns boolean value `next` denoting whether there are next pages or not.
3. (For bug-fixing PRs only) The original bug occurred because many was hardcoded in #19018 
## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)



## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
<img width="1439" alt="Screenshot 2024-01-24 at 14 36 22" src="https://github.com/oppia/oppia/assets/58803066/a6c37d04-7b75-42c3-ba8f-7e6a4c1f1290">

<img width="1366" alt="Screenshot 2024-01-24 at 14 36 36" src="https://github.com/oppia/oppia/assets/58803066/26708a96-8845-4fe0-9b8d-75234a22d627">



#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
NA

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->
NA

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->
NA

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
