### PR TITLE
Fix #19507: Corrected responsive design for exploration editor nav tools 

### DIFF
--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
@@ -336,7 +336,7 @@
   .navbar-text {
     align-items: center;
     display: flex;
-    margin-left: 3%;
+    margin-left: 1em;
   }
 
   .navbar-text h1 {
@@ -348,7 +348,7 @@
   .navbar-icons {
     display: flex;
     margin-bottom: 0;
-    margin-right: 5%;
+    margin-right: 1em;
   }
 
   .nav-list-item {


### PR DESCRIPTION
## Overview
This PR fixes #19507. I simply replaced the % with em for the margin values in the classes in navbar-text and navbar-icon classes in exploration-editor-page.component.html.
## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct


https://github.com/oppia/oppia/assets/28910543/43287fb4-0dc2-4214-a725-672db9064b8a




