### PR TITLE
Fix Validation Issues in UserSettings Model 

### DIFF
--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -326,52 +326,6 @@ class UserSettings:
                 '%s is not a valid value for the dashboard display '
                 'preferences.' % (self.creator_dashboard_display_pref))
 
-        if not isinstance(self.subject_interests, list):
-            raise utils.ValidationError(
-                'Expected subject_interests to be a list.')
-
-        for interest in self.subject_interests:
-            if not isinstance(interest, str):
-                raise utils.ValidationError(
-                    'Expected each subject interest to be a string.')
-            if not interest:
-                raise utils.ValidationError(
-                    'Expected each subject interest to be non-empty.')
-            if not re.match(constants.TAG_REGEX, interest):
-                raise utils.ValidationError(
-                    'Expected each subject interest to consist only of '
-                    'lowercase alphabetic characters and spaces.')
-
-        if len(set(self.subject_interests)) != len(self.subject_interests):
-            raise utils.ValidationError(
-                'Expected each subject interest to be distinct.')
-
-        if not isinstance(self.user_bio, str):
-            raise utils.ValidationError(
-                'Expected user_bio to be a string.')
-
-        if len(self.user_bio) > feconf.MAX_BIO_LENGTH_IN_CHARS:
-            raise utils.ValidationError(
-                'User bio exceeds maximum character limit: %s'
-                % feconf.MAX_BIO_LENGTH_IN_CHARS)
-
-        if not isinstance(self.preferred_language_codes, list):
-            raise utils.ValidationError(
-                'Expected preferred_language_codes to be a list.')
-
-        for language_code in self.preferred_language_codes:
-            if not isinstance(language_code, str):
-                raise utils.ValidationError(
-                    'Expected each language code to be a string.')
-            if not language_code:
-                raise utils.ValidationError(
-                    'Expected each language code to be non-empty.')
-
-        if len(set(self.preferred_language_codes)) != (
-            len(self.preferred_language_codes)):
-            raise utils.ValidationError(
-                'Expected each language code to be distinct.')
-
     def record_user_edited_an_exploration(self) -> None:
         """Updates last_edited_an_exploration to the current datetime for the
         user.

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -363,13 +363,6 @@ class UserSettingsTests(test_utils.GenericTestBase):
             ' received %s' % self.user_settings.email):
             self.user_settings.validate()
 
-    def test_validation_empty_email_raises_error(self) -> None:
-        self.user_settings.email = ''
-        with self.assertRaisesRegex(
-            utils.ValidationError, 'No user email specified.'
-        ):
-            self.user_settings.validate()
-
     def test_validation_wrong_email_raises_error(self) -> None:
         invalid_emails_list = [
             'testemail.com', '@testemail.com', 'testemail.com@']
@@ -409,99 +402,6 @@ class UserSettingsTests(test_utils.GenericTestBase):
             user_services.create_new_profiles(
                 auth_id, self.OWNER_EMAIL, [self.modifiable_new_user_data]
             )
-
-    def test_validate_invalid_subject_interests_are_not_accepted(self) -> None:
-        # TODO(#13059): Here we use MyPy ignore because after we fully type the
-        # codebase we plan to get rid of the tests that intentionally test wrong
-        # inputs that we can normally catch by typing.
-        self.user_settings.subject_interests = 'not a list'  # type: ignore[assignment]
-        with self.assertRaisesRegex(utils.ValidationError, 'to be a list'):
-            self.user_settings.validate()
-
-        # TODO(#13059): Here we use MyPy ignore because after we fully type the
-        # codebase we plan to get rid of the tests that intentionally test wrong
-        # inputs that we can normally catch by typing.
-        self.user_settings.subject_interests = ['ab', 'de', 1]  # type: ignore[list-item]
-        with self.assertRaisesRegex(utils.ValidationError, 'to be a string'):
-            self.user_settings.validate()
-
-        self.user_settings.subject_interests = ['ab', '']
-        with self.assertRaisesRegex(utils.ValidationError, 'to be non-empty'):
-            self.user_settings.validate()
-
-        self.user_settings.subject_interests = ['!']
-        with self.assertRaisesRegex(
-            utils.ValidationError,
-            'to consist only of lowercase alphabetic characters and spaces'
-            ):
-            self.user_settings.validate()
-
-        self.user_settings.subject_interests = ['has-hyphens']
-        with self.assertRaisesRegex(
-            utils.ValidationError,
-            'to consist only of lowercase alphabetic characters and spaces'
-            ):
-            self.user_settings.validate()
-
-        self.user_settings.subject_interests = ['HasCapitalLetters']
-        with self.assertRaisesRegex(
-            utils.ValidationError,
-            'to consist only of lowercase alphabetic characters and spaces'
-            ):
-            self.user_settings.validate()
-
-        self.user_settings.subject_interests = ['a', 'a']
-        with self.assertRaisesRegex(utils.ValidationError, 'to be distinct'):
-            self.user_settings.validate()
-
-        # The following cases are all valid.
-        self.user_settings.subject_interests = []
-        self.user_settings.validate()
-        self.user_settings.subject_interests = ['singleword', 'has spaces']
-        self.user_settings.validate()
-
-    def test_validate_invalid_user_bio_is_not_accepted(self) -> None:
-        # TODO(#13059): Here we use MyPy ignore because after we fully type the
-        # codebase we plan to get rid of the tests that intentionally test wrong
-        # inputs that we can normally catch by typing.
-        self.user_settings.user_bio = 123 # type: ignore[assignment]
-        with self.assertRaisesRegex(
-            utils.ValidationError,
-            'Expected user_bio to be a string.'):
-            self.user_settings.validate()
-
-        self.user_settings.user_bio = (
-                'a' * (feconf.MAX_BIO_LENGTH_IN_CHARS + 1))
-        with self.assertRaisesRegex(
-            utils.ValidationError,
-            'User bio exceeds maximum character limit: %s'
-                    % feconf.MAX_BIO_LENGTH_IN_CHARS
-            ):
-            self.user_settings.validate()
-
-    def test_validate_invalid_preferred_language_codes_are_not_accepted(
-        self) -> None:
-        # TODO(#13059): Here we use MyPy ignore because after we fully type the
-        # codebase we plan to get rid of the tests that intentionally test wrong
-        # inputs that we can normally catch by typing.
-        self.user_settings.preferred_language_codes = 'not a list' # type: ignore[assignment]
-        with self.assertRaisesRegex(utils.ValidationError, 'to be a list'):
-            self.user_settings.validate()
-
-        # TODO(#13059): Here we use MyPy ignore because after we fully type the
-        # codebase we plan to get rid of the tests that intentionally test wrong
-        # inputs that we can normally catch by typing.
-        self.user_settings.preferred_language_codes = ['en', 'hi', 1] # type: ignore[list-item]
-        with self.assertRaisesRegex(utils.ValidationError, 'to be a string'):
-            self.user_settings.validate()
-
-        self.user_settings.preferred_language_codes = ['en', '']
-        with self.assertRaisesRegex(utils.ValidationError, 'to be non-empty'):
-            self.user_settings.validate()
-
-        self.user_settings.preferred_language_codes = ['en', 'en']
-        with self.assertRaisesRegex(utils.ValidationError, 'to be distinct'):
-            self.user_settings.validate()
 
     def test_has_not_fully_registered_for_guest_user_is_false(
         self


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR does the following:This PR removes the validation in 'validate' method of UserSettings Model and tests for it.
2. (For bug-fixing PRs only) The original bug occurred because: Some 'user_bio' fields on the server are null. This results in the entire server throwing a 500 for some users when [this PR](https://github.com/oppia/oppia/pull/19399) is deployed.
## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
##Proof that changes are correct
<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
No proof of changes needed because the code being deleted are some validations and thier test only.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
