### PR TITLE
Fix Part of #19527 : Fix Hover Effect of the Buttons on the android page

### DIFF
--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -305,7 +305,7 @@
 
 .oppia-android-carousel-button:active,
 .oppia-android-carousel-button:focus {
-  outline: none; 
+  outline: none;
 }
 
 .oppia-android-carousel-item-container {

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -290,7 +290,22 @@
   color: #fff;
   padding: 15px 20px;
   position: relative;
+  transition: background-color 0.3s ease;
   z-index: 100;
+}
+
+.oppia-android-carousel-chevron:hover {
+  background-color: #3d9991;
+}
+
+.oppia-android-carousel-button {
+  background: none;
+  border: none;
+}
+
+.oppia-android-carousel-button:active,
+.oppia-android-carousel-button:focus {
+  outline: none; 
 }
 
 .oppia-android-carousel-item-container {

--- a/core/templates/pages/android-page/android-page.component.html
+++ b/core/templates/pages/android-page/android-page.component.html
@@ -137,7 +137,7 @@
         <div class="oppia-android-key-feature-image-container oppia-web-only col-md-7">
           <div class="row oppia-android-carousel-direction">
             <button class="col-md-2 align-self-center oppia-android-carousel-button" (click)="changeFeaturesShown((3 + featuresShown) % 4)">
-              <i class="fas fa-chevron-left oppia-android-carousel-chevron float-right"></i>
+              <i class="fas fa-chevron-left oppia-android-carousel-chevron float-right "></i>
             </button>
             <div class="oppia-android-key-feature-image-container col-md-8">
               <img *ngIf="featuresShown === 0" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-1.svg" alt="Image showing the story page">

--- a/core/templates/pages/android-page/android-page.component.html
+++ b/core/templates/pages/android-page/android-page.component.html
@@ -136,9 +136,9 @@
         </div>
         <div class="oppia-android-key-feature-image-container oppia-web-only col-md-7">
           <div class="row oppia-android-carousel-direction">
-            <div class="col-md-2 align-self-center" (click)="changeFeaturesShown((3 + featuresShown) % 4)">
+            <button class="col-md-2 align-self-center oppia-android-carousel-button" (click)="changeFeaturesShown((3 + featuresShown) % 4)">
               <i class="fas fa-chevron-left oppia-android-carousel-chevron float-right"></i>
-            </div>
+            </button>
             <div class="oppia-android-key-feature-image-container col-md-8">
               <img *ngIf="featuresShown === 0" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-1.svg" alt="Image showing the story page">
               <img *ngIf="featuresShown === 1" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-2.svg" alt="Image showing a lesson being played">


### PR DESCRIPTION
## Overview
1. This PR fixes # #19527.
2. This PR does the following: The PR introduces a cursor pointer and hover effect to the chevron buttons, enhancing user experience by providing a visual cue that the buttons are clickable. Prior to this update, the absence of a hover effect made it less clear for users to identify the clickable nature of the buttons.
3. (For bug-fixing PRs only) The original bug occurred because: It is not specifically a bug but the feature is not added

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network
https://github.com/oppia/oppia/assets/94298791/3a0f3798-5394-4f75-8834-3e7824f9f5eb


#### Proof of changes on desktop with slow/throttled network
Shown in the above video
#### Proof of changes on mobile phone
Shown in the above video
#### Proof of changes in Arabic language
Shown in the above video

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
