### PR TITLE
Fix #18581: [E2E Flake] Cannot read properties of undefined (reading 'waitForDisplayed')

### DIFF
--- a/core/templates/components/question-directives/question-player/question-player.component.html
+++ b/core/templates/components/question-directives/question-player/question-player.component.html
@@ -99,7 +99,6 @@
               (click)="performAction(actionButton)">
           <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
                role="button"
-               [attr.aria-label]="getActionButtonLabel(actionButton.type)"
                tabindex="0"
                *ngIf="!(actionButton.type === 'RETRY_SESSION') && !(actionButton.type === 'DASHBOARD' && !userIsLoggedIn) && !(actionButton.type === 'REVIEW_LOWEST_SCORED_SKILL' && getWorstSkillIds().length === 0)">
             <span [innerHTML]="getActionButtonIconHtml(actionButton.type)"></span>


### PR DESCRIPTION
1. This PR fixes or fixes part of #18581.
2. This PR does the following: Removes a line where it calls a function that doesn't exist in the actual component file.
3. (For bug-fixing PRs only) The original bug occurred because: An A11Y PR seemed to introduce this.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
