### PR TITLE
fix #19708 issue TypeError: Cannot read properties of undefined (reading 'author_username')

### DIFF
--- a/core/templates/domain/feedback_message/ThreadMessage.model.ts
+++ b/core/templates/domain/feedback_message/ThreadMessage.model.ts
@@ -75,15 +75,20 @@ export class ThreadMessage {
 
   static createFromBackendDict(
       threadMessageBackendDict: ThreadMessageBackendDict): ThreadMessage {
+
+        if (!threadMessageBackendDict) {
+          throw new Error("Invalid thread message backend dictionary.");
+        }
+
     return new ThreadMessage(
-      threadMessageBackendDict.author_username,
-      threadMessageBackendDict.created_on_msecs,
-      threadMessageBackendDict.entity_type, threadMessageBackendDict.entity_id,
-      threadMessageBackendDict.message_id, threadMessageBackendDict.text,
-      threadMessageBackendDict.updated_status,
-      threadMessageBackendDict.updated_subject,
+      threadMessageBackendDict.author_username || '',
+      threadMessageBackendDict.created_on_msecs || 0,
+      threadMessageBackendDict.entity_type || '', threadMessageBackendDict.entity_id || '',
+      threadMessageBackendDict.message_id || 0, threadMessageBackendDict.text || '',
+      threadMessageBackendDict.updated_status || '',
+      threadMessageBackendDict.updated_subject || '',
       new ThreadMessageSummary(
-        threadMessageBackendDict.author_username,
-        threadMessageBackendDict.text));
+        threadMessageBackendDict.author_username || '',
+        threadMessageBackendDict.text || ''));
   }
 }


### PR DESCRIPTION
1. This PR fixes or fixes part of #19708 .

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

##To address the issue, enhancements were made to the ThreadMessage.model.ts file. Here's a summary of the changes:
## Error Handling:
Added a conditional check to ensure that the threadMessageBackendDict is not null or undefined. This prevents accessing properties of an undefined object and avoids potential runtime errors.
## Default Values:
Provided default values for various properties in the ThreadMessage.createFromBackendDict method to handle cases where properties might be missing from the backend dictionary.


<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here


## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
