### PR TITLE
Fix parrt of #17712 CODEOWNERS file changes for acceptance testing team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -739,6 +739,11 @@
 /core/templates/pages/release-coordinator-page/features-tab/ @oppia/core-reviewers
 /core/templates/services/platform-feature*.ts @oppia/core-reviewers
 
+# Acceptance Tests.
+/core/tests/puppeteer-acceptance-tests/ @oppia/acceptance-test-reviewers
+/core/tests/puppeteer/ @oppia/acceptance-test-reviewers
+/scripts/run_acceptance_tests_test.py @oppia/acceptance-test-reviewers
+/scripts/run_acceptance_tests.py @oppia/acceptance-test-reviewers
 
 # Critical files.
 #


### PR DESCRIPTION
This PR fixes or fixes part of [#17712](https://github.com/oppia/oppia/issues/17712)

This PR establishes code owners for the acceptance testing team. for the following files and directories:

/core/tests/puppeteer-acceptance-tests/
/core/tests/puppeteer/
/scripts/run_acceptance_tests_test.py
/scripts/run_acceptance_tests.py
