### PR TITLE
Add acceptance testing team as code-owner for relevant files 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -739,6 +739,11 @@
 /core/templates/pages/release-coordinator-page/features-tab/ @oppia/core-reviewers
 /core/templates/services/platform-feature*.ts @oppia/core-reviewers
 
+# Acceptance Tests.
+/core/tests/puppeteer-acceptance-tests/ @oppia/acceptance-test-reviewers
+/core/tests/puppeteer/ @oppia/acceptance-test-reviewers
+/scripts/run_acceptance_tests_test.py @oppia/acceptance-test-reviewers
+/scripts/run_acceptance_tests.py @oppia/acceptance-test-reviewers
 
 # Critical files.
 #


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR adds acceptance testing team as code-owner for relevant files.
2. This PR does the following: establishes code owners for the acceptance testing team. for the following files and directories:
```
    /core/tests/puppeteer-acceptance-tests/
    /core/tests/puppeteer/
    /scripts/run_acceptance_tests_test.py
    /scripts/run_acceptance_tests.py
```

3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [X] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct

No proof of changes is needed because it doesn't affect the application.

#### Proof of changes on desktop with slow/throttled network

No proof of changes is needed because it doesn't affect the application.

#### Proof of changes on mobile phone

No proof of changes is needed because it doesn't affect the application.

#### Proof of changes in Arabic language

No proof of changes is needed because it doesn't affect the application.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
