### PR TITLE
Fix #12770: Resolve console errors by refining error detection and handling in tests

### DIFF
--- a/core/tests/webdriverio_utils/general.js
+++ b/core/tests/webdriverio_utils/general.js
@@ -92,18 +92,20 @@ var checkForConsoleErrors = async function(
     );
     const ERROR_IS_EXPECTED = EXPECTED_CONSOLE_ERRORS.some(
       (expectedError, index) => {
-      if (logEntry.message.includes(expectedError)) {
-        expectedErrorsNotFound.splice(index, 1);
-        return true;
+        if (logEntry.message.includes(expectedError)) {
+          expectedErrorsNotFound.splice(index, 1);
+          return true;
+        }
+        return false;
       }
-      return false;
-    });
-    if (logEntry.level.value > CONSOLE_LOG_THRESHOLD &&
-      !ERROR_IS_IGNORED && !ERROR_IS_EXPECTED) {
+    );
+    if (
+      logEntry.level.value > CONSOLE_LOG_THRESHOLD &&
+      !ERROR_IS_IGNORED && !ERROR_IS_EXPECTED
+    ) {
       unexpectedErrors.push(logEntry.message);
     }
-  };
-
+  }
   if (expectedErrorsNotFound.length > 0) {
     throw new Error(`Expected errors not found: ${expectedErrorsNotFound.join(', ')}`);
   }

--- a/core/tests/webdriverio_utils/general.js
+++ b/core/tests/webdriverio_utils/general.js
@@ -86,9 +86,9 @@ var checkForConsoleErrors = async function(
   var unexpectedErrors = [];
   var expectedErrorsNotFound = [...EXPECTED_CONSOLE_ERRORS];
   for (let i = 0; i < browserLogs.length; i++) {
-    const logEntry = browserLogs[i];
-    const ERROR_IS_IGNORED = errorsToIgnore.some(e =>
-      logEntry.message.match(e)
+    let logEntry = browserLogs[i];
+    const ERROR_IS_IGNORED = errorsToIgnore.some(
+      e => logEntry.message.match(e)
     );
     const ERROR_IS_EXPECTED = EXPECTED_CONSOLE_ERRORS.some(
       (expectedError, index) => {
@@ -107,7 +107,8 @@ var checkForConsoleErrors = async function(
     }
   }
   if (expectedErrorsNotFound.length > 0) {
-    throw new Error(`Expected errors not found: ${expectedErrorsNotFound.join(', ')}`);
+    throw new Error(`Expected errors not found:
+    ${expectedErrorsNotFound.join(', ')}`);
   }
   if (unexpectedErrors.length > 0) {
     throw new Error(`Unexpected errors found: ${unexpectedErrors.join(', ')}`);

--- a/core/tests/webdriverio_utils/general.js
+++ b/core/tests/webdriverio_utils/general.js
@@ -72,6 +72,10 @@ var CONSOLE_ERRORS_TO_IGNORE = [
   )
 ];
 
+var EXPECTED_CONSOLE_ERRORS = [
+  _.escapeRegExp('Error occurred while processing test scenario'),
+];
+
 var checkForConsoleErrors = async function(
     errorsToIgnore = [], skipDebugging = true) {
   errorsToIgnore = errorsToIgnore.concat(CONSOLE_ERRORS_TO_IGNORE);

--- a/core/tests/webdriverio_utils/general.js
+++ b/core/tests/webdriverio_utils/general.js
@@ -107,7 +107,8 @@ var checkForConsoleErrors = async function(
     }
   }
   if (expectedErrorsNotFound.length > 0) {
-    throw new Error(`Expected errors not found:
+    throw new Error(
+      `Expected errors not found:
     ${expectedErrorsNotFound.join(', ')}`);
   }
   if (unexpectedErrors.length > 0) {

--- a/core/tests/webdriverio_utils/general.js
+++ b/core/tests/webdriverio_utils/general.js
@@ -85,19 +85,25 @@ var checkForConsoleErrors = async function(
   var browserLogs = await browser.getLogs('browser');
   var unexpectedErrors = [];
   var expectedErrorsNotFound = [...EXPECTED_CONSOLE_ERRORS];
-  browserLogs.forEach(logEntry => {
-    const errorIsIgnored = errorsToIgnore.some(e => logEntry.message.match(e));
-    const errorIsExpected = EXPECTED_CONSOLE_ERRORS.some((expectedError, index) => {
+  for (let i = 0; i < browserLogs.length; i++) {
+    const logEntry = browserLogs[i];
+    const ERROR_IS_IGNORED = errorsToIgnore.some(e =>
+      logEntry.message.match(e)
+    );
+    const ERROR_IS_EXPECTED = EXPECTED_CONSOLE_ERRORS.some(
+      (expectedError, index) => {
       if (logEntry.message.includes(expectedError)) {
         expectedErrorsNotFound.splice(index, 1);
         return true;
       }
       return false;
     });
-    if (logEntry.level.value > CONSOLE_LOG_THRESHOLD && !errorIsIgnored && !errorIsExpected) {
+    if (logEntry.level.value > CONSOLE_LOG_THRESHOLD &&
+      !ERROR_IS_IGNORED && !ERROR_IS_EXPECTED) {
       unexpectedErrors.push(logEntry.message);
     }
-  });
+  };
+
   if (expectedErrorsNotFound.length > 0) {
     throw new Error(`Expected errors not found: ${expectedErrorsNotFound.join(', ')}`);
   }


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #12770.
2. This PR does the following: It addresses the issue with end-to-end (E2E) test by modifying the `checkForConsoleErrors` function.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct

![image](https://github.com/oppia/oppia/assets/109406757/7161997f-65fe-4aa8-978d-742baafad3b0)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
