### PR TITLE
Minor updates to issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request_form.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug in the Oppia project.
+        Thanks for taking the time to request a new feature in the Oppia project.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/4_server_error_template.md
+++ b/.github/ISSUE_TEMPLATE/4_server_error_template.md
@@ -1,7 +1,7 @@
 ---
 name: Server error
 about: Report a production bug from the server logs
-labels: triage needed, server errors
+labels: triage needed, server errors, bug
 ---
 <!--
   - Before filing a new issue, please do a quick search to check that it hasn't

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,10 +35,12 @@ Otherwise, please delete this section.
 
 <!--
 Add videos/screenshots of the user-facing interface to demonstrate that the changes
-made in this PR work correctly. If this PR is for a developer-facing feature,
-provide the videos/screenshots of developer-facing interface. Please also include
-videos/screenshots of the developer tools browser console, so that we can be
-sure that there are no console errors.
+made in this PR work correctly. (For changes involving responsiveness or adjustment
+of UI elements, this should be a video that gradually resizes the viewport from wide
+to narrow and back again.) If this PR is for a developer-facing feature, provide
+the videos/screenshots of developer-facing interface. Please also include
+videos/screenshots of the developer tools browser console, so that we can be sure
+that there are no console errors.
 
 When you make updates to the PR, please update these videos/screenshots as well.
 You can drop videos/screenshots from previous versions of the PR.


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #N/A
2. This PR does the following: Small fixes to the issue and PR templates:
    - Changed the feature request form to not refer to "bug"
    - Updated the server errors form to include a "bug" label on issues filed, since otherwise this just gets done manually during issue triage
    - In PR instructions, clarify the requirements for PRs that affect responsive UI

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

No proof of changes needed because this just fixes issue/PR templates.