### PR TITLE
Fix issue #19807: add check that interaction informations are valid to make the change

### DIFF
--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -2235,8 +2235,9 @@ class InteractionInstance(translation_domain.BaseTranslatableObject):
         all_interaction_ids = (
             interaction_registry.Registry.get_all_interaction_ids()
         )
-        interaction_id_is_valid = interaction_id not in all_interaction_ids
-        if interaction_id_is_valid or interaction_id is None:
+        interaction_id_is_not_valid = interaction_id not in all_interaction_ids
+        no_customization_args = len(customization_args_dict) == 0
+        if interaction_id_is_not_valid or interaction_id is None or no_customization_args:
             return {}
 
         ca_specs_dict = (


### PR DESCRIPTION
Fixes [#19807](https://github.com/oppia/oppia/issues/19807)
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19807.

2. This PR does the following: 
When modifying a question, the client creates a list of all the steps of the change and sends it as JSON to the server. The server then looks at each of these micro changes one by one to make the necessary modifications in the database. However, when we change the interaction, on the frontend side, we first create a change with only the new type of interaction information (found in the JSON at [content][interaction][hints][id]), and then we create another change where we add the necessary information for creating the interaction (found in the JSON at [content][interaction][customization_args]). However, on the backend side, we expect, before this PR, when receiving the new type of interaction, to also receive the interaction arguments. Therefore, this PR expanded the condition for processing a change to ensure that we have both pieces of information to make the change, and to no longer do it when we only have the type of interaction.

4. (For bug-fixing PRs only) The original bug occurred because: 
The bug occurs when modifying the interaction of an existing question.

## Essential Checklist

- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [X] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

https://github.com/oppia/oppia/assets/129402601/b5965803-343f-42ff-b3e2-5996983999e4

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
