### PR TITLE
Fix #19847 : Remove overflow bars when hieght is less than max-hieght.

### DIFF
--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.html
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.html
@@ -8,7 +8,7 @@
 <style>
   .oppia-rte {
     max-height: 500px;
-    overflow: scroll;
+    overflow-y: auto;
   }
   .oppia-cke-offline-warning {
     background: #eee;


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #19847 .
2. This PR does the following: Previously, I applied "max-height: 500px" and "overflow: scroll" which worked on Mac. However, there was an issue on Windows where the overflow bars were visible all the time, even when they weren't needed.so now i solve that bug.
## Essential Checklist

- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [X] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct
<img width="634" alt="Screenshot 2024-03-01 at 11 15 47 PM" src="https://github.com/oppia/oppia/assets/136263179/f8073934-671c-48f1-a5cb-d1a44aea71b0">

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
