### PR TITLE
fix #19823 and fix#19868 fixed the  lighthouse accessibility : failure for minScore assertion and also arrow overflow

### DIFF
--- a/core/templates/pages/splash-page/splash-page.component.css
+++ b/core/templates/pages/splash-page/splash-page.component.css
@@ -138,7 +138,7 @@
   color: #6d6d6d;
   font-size: 3.0em;
   margin-right: 20px;
-  margin-top: 50px;
+  margin-top: 28px;
 }
 
 .splash-page .splash-arrows-container {

--- a/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.component.html
+++ b/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.component.html
@@ -1,7 +1,7 @@
 <ul class="oppia-navbar-desktop nav navbar-nav oppina-navbar-nav float-right"
     *ngIf="topic && topicRights.canEditTopic()">
   <li class="oppia-navbar-dropdown-menu">
-    <div ngbDropdown>
+    <div ngbDropdown role="button">
       <span [matTooltip]="getAllTopicWarnings()"
             matTooltipClass="oppia-mat-tooltip-list"
             [matTooltipDisabled]="isWarningTooltipDisabled()"
@@ -10,7 +10,9 @@
         <button class="btn btn-light oppia-save-changes-button e2e-test-save-topic-button float-left"
                 [ngClass]="{'btn-success': topicIsSaveable}"
                 (click)="saveChanges()"
-                [disabled]="!topicIsSaveable">
+                [disabled]="!topicIsSaveable"
+                aria-label="Save Changes"
+           >
           <span *ngIf="!isSaveInProgress()">
             <i class="fas fa-save md-18 md-dark oppia-save-publish-button-icon oppia-topic-editor-save-icon"
                alt="Save Topic">
@@ -32,7 +34,7 @@
       <button type="button"
               class="btn btn-light dropdown-toggle dropdown-toggle oppia-dropdown-toggle-button"
               [disabled]="!changeListLength"
-              aria-label="Dropdown toggle"
+              aria-label="Toggle Dropdown"
               ngbDropdownToggle>
       </button>
       <ul ngbDropdownMenu role="menu"
@@ -41,7 +43,9 @@
         <li title="Discard all pending changes">
           <a (click)="discardChanges()"
              [ngClass]="{'oppia-disabled-link': !changeListLength}"
-             class="dropdown-item">
+             class="dropdown-item"
+             role="menuitem"
+             >
             Discard Draft
           </a>
         </li>
@@ -54,7 +58,9 @@
             class="btn btn-light oppia-editor-publish-button e2e-test-publish-topic-button"
             (click)="publishTopic()"
             [ngClass]="{'btn-success': !isTopicSaveable() && getWarningsCount() === 0 && prepublishValidationIssues.length === 0}"
-            [disabled]="isTopicSaveable() || getWarningsCount() > 0 || prepublishValidationIssues.length > 0">
+            [disabled]="isTopicSaveable() || getWarningsCount() > 0 || prepublishValidationIssues.length > 0"
+            aria-label="Publish Topic"
+       >
       <i class="fas fa-cloud-upload-alt md-18 md-dark oppia-save-publish-button-icon"
          alt="Publish to Oppia Library">
       </i>
@@ -66,7 +72,9 @@
             (click)="unpublishTopic()"
             *ngIf="topicRights.isPublished() && topicRights.canPublishTopic()"
             class="btn btn-light"
-            [disabled]="isTopicSaveable()">
+            [disabled]="isTopicSaveable()"
+            aria-label="Unpublish Topic"
+       >
       Unpublish Topic
     </button>
   </li>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19823 and #19868
2. This PR does the following: I have fixed my code in the  topic-editor-navbar-page to fix the  lighthouse accessibility : failure for minScore assertion 
also fix the issue #19868
This PR does the following: I have fixed some styling issues in splash-container pages folder made changes here core/templates/pages/splash-page/splash-page.component.css which fixed the overflow of arrows from parent div. Basically margin-top is changed for class .spals-arrows.
4. (For bug-fixing PRs only) The original bug occurred because:  there were some labels missing     and The original bug occurred because: Bug was due to margin-top values was more than required
<img width="959" alt="fix-1" src="https://github.com/oppia/oppia/assets/118254863/df3c42ad-d4be-43e5-a1cf-b516e08376ad">
<img width="145" alt="mobile-fix" src="https://github.com/oppia/oppia/assets/118254863/9e103eaa-1e51-44d9-9271-18a6d209c45a">
I have added supported images for proof of change that fixed both of the issues

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [ ] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->
- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.


## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
