### PR TITLE
Fix #19793: All languages functionality not working

### DIFF
--- a/core/templates/pages/library-page/search-bar/search-bar.component.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.ts
@@ -195,9 +195,6 @@ export class SearchBarComponent implements OnInit, OnDestroy {
       this.searchQuery, this.selectionDetails.categories.selections,
       this.selectionDetails.languageCodes.selections
     );
-    if (!searchUrlQueryString) {
-      return;
-    }
     this.searchService.executeSearchQuery(
       this.searchQuery, this.selectionDetails.categories.selections,
       this.selectionDetails.languageCodes.selections, () => {


### PR DESCRIPTION
## Overview

1. This PR fixes #19793  .
2. This PR does the following: This PR removes 3 lines in the file
oppia/core/templates/pages/library-page/search-bar/search-bar.components.ts. This way it will not stop from searching without tokens in the URL
3. (For bug-fixing PRs only) The original bug occurred because: I checked the commit (PR #18882  ) where this was implemented and the code still works without errors removing those lines.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

[Screencast_from_05-03-2024_202640.webm](https://github.com/oppia/oppia/assets/61390659/377acfd3-3bd0-40a6-8d8b-be36b649dfd4)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
