### PR TITLE
Fix part of #18268: Migrate acceptance tests to Typescript

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
@@ -29,29 +29,7 @@ const acceptedBrowserAlerts = [
   'This action is irreversible. Are you sure?'
 ];
 
-interface IUserProperties {
-  page: Page;
-  browserObject: Browser;
-  userHasAcceptedCookies: boolean;
-  username: string;
-  email: string;
-}
-
-export interface IBaseUser extends IUserProperties {
-  openBrowser: () => Promise<Page>;
-  signInWithEmail: (email: string) => Promise<void>;
-  signUpNewUser: (userName: string, signInEmail: string) => Promise<void>;
-  reloadPage: () => Promise<void>;
-  clickOn: (selector: string) => Promise<void>;
-  type: (selector: string, text: string) => Promise<void>;
-  select: (selector: string, option: string) => Promise<void>;
-  goto: (url: string) => Promise<void>;
-  uploadFile: (filePath: string) => Promise<void>;
-  logout: () => Promise<void>;
-  closeBrowser: () => Promise<void>;
-}
-
-export class BaseUser implements IBaseUser {
+export class BaseUser {
   page!: Page;
   browserObject!: Browser;
   userHasAcceptedCookies: boolean = false;
@@ -209,4 +187,4 @@ export class BaseUser implements IBaseUser {
   }
 }
 
-export const BaseUserFactory = (): IBaseUser => new BaseUser();
+export const BaseUserFactory = (): BaseUser => new BaseUser();

--- a/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/user-factory.ts
+++ b/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/user-factory.ts
@@ -64,7 +64,7 @@ export class UserFactory {
    * This function creates a composition of the user and the role
    * through object prototypes and returns the instance of that user.
    */
-  private static composeUserWithRole = function<
+  private static composeUserWithRoles = function<
     TUser extends BaseUser,
     TRoles extends BaseUser[]
   >(
@@ -116,7 +116,7 @@ export class UserFactory {
 
       await superAdminInstance.expectUserToHaveRole(user.username, role);
 
-      UserFactory.composeUserWithRole(user, [USER_ROLE_MAPPING[role]()]);
+      UserFactory.composeUserWithRoles(user, [USER_ROLE_MAPPING[role]()]);
     }
 
     return user as TUser & MultipleRoleIntersection<typeof roles>;
@@ -131,7 +131,7 @@ export class UserFactory {
       username: string, email: string,
       roles: OptionalRoles<TRoles> = [] as OptionalRoles<TRoles>
   ): Promise<LoggedInUser & MultipleRoleIntersection<TRoles>> {
-    let user = UserFactory.composeUserWithRole(
+    let user = UserFactory.composeUserWithRoles(
       BaseUserFactory(), [LoggedInUserFactory()]);
     await user.openBrowser();
     await user.signUpNewUser(username, email);
@@ -153,11 +153,11 @@ export class UserFactory {
 
     const user = await UserFactory.createNewUser(
       username, 'testadmin@example.com');
-    const superAdmin = UserFactory.composeUserWithRole(
+    const superAdmin = UserFactory.composeUserWithRoles(
       user, [SuperAdminFactory()]);
     await superAdmin.assignRoleToUser(username, ROLES.BLOG_ADMIN);
     await superAdmin.expectUserToHaveRole(username, ROLES.BLOG_ADMIN);
-    superAdminInstance = UserFactory.composeUserWithRole(
+    superAdminInstance = UserFactory.composeUserWithRoles(
       superAdmin, [BlogAdminFactory()]);
 
     return superAdminInstance;

--- a/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/user-factory.ts
+++ b/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/user-factory.ts
@@ -16,11 +16,11 @@
  * @fileoverview Utility File for declaring and initializing users.
  */
 
-import { SuperAdminFactory, ISuperAdmin } from '../user-utilities/super-admin-utils';
-import { BaseUserFactory, IBaseUser } from './puppeteer-utils';
+import { SuperAdminFactory, SuperAdmin } from '../user-utilities/super-admin-utils';
+import { BaseUserFactory, BaseUser } from './puppeteer-utils';
 import { TranslationAdminFactory } from '../user-utilities/translation-admin-utils';
-import { LoggedInUserFactory, ILoggedInUser } from '../user-utilities/logged-in-users-utils';
-import { BlogAdminFactory, IBlogAdmin } from '../user-utilities/blog-admin-utils';
+import { LoggedInUserFactory, LoggedInUser } from '../user-utilities/logged-in-users-utils';
+import { BlogAdminFactory, BlogAdmin } from '../user-utilities/blog-admin-utils';
 import { QuestionAdminFactory } from '../user-utilities/question-admin-utils';
 import { BlogPostEditorFactory } from '../user-utilities/blog-post-editor-utils';
 import testConstants from './test-constants';
@@ -44,7 +44,7 @@ const USER_ROLE_MAPPING = {
  * composition of the user and the role for type inference.
  */
 type UnionToIntersection<U> =
-  (U extends IBaseUser ? (k: U) => void : never) extends
+  (U extends BaseUser ? (k: U) => void : never) extends
     ((k: infer I) => void) ? I : never;
 
 type MultipleRoleIntersection<T extends (keyof typeof USER_ROLE_MAPPING)[]> =
@@ -56,8 +56,8 @@ type OptionalRoles<TRoles extends (keyof typeof USER_ROLE_MAPPING)[]> =
 /**
  * Global user instances that are created and can be reused again.
  */
-let superAdminInstance: ISuperAdmin & IBlogAdmin | null = null;
-let activeUsers: IBaseUser[] = [];
+let superAdminInstance: SuperAdmin & BlogAdmin | null = null;
+let activeUsers: BaseUser[] = [];
 
 export class UserFactory {
   /**
@@ -65,25 +65,27 @@ export class UserFactory {
    * through object prototypes and returns the instance of that user.
    */
   private static composeUserWithRole = function<
-    TUser extends IBaseUser,
-    TRole extends IBaseUser
+    TUser extends BaseUser,
+    TRoles extends BaseUser[]
   >(
       user: TUser,
-      role: TRole
-  ): TUser & TRole {
-    const userPrototype = Object.getPrototypeOf(user);
-    const rolePrototype = Object.getPrototypeOf(role);
+      roles: TRoles
+  ): TUser & UnionToIntersection<TRoles[number]> {
+    for (const role of roles) {
+      const userPrototype = Object.getPrototypeOf(user);
+      const rolePrototype = Object.getPrototypeOf(role);
 
-    Object.getOwnPropertyNames(rolePrototype).forEach((name: string) => {
-      Object.defineProperty(
-        userPrototype,
-        name,
-        Object.getOwnPropertyDescriptor(rolePrototype, name) ||
-          Object.create(null)
-      );
-    });
+      Object.getOwnPropertyNames(rolePrototype).forEach((name: string) => {
+        Object.defineProperty(
+          userPrototype,
+          name,
+          Object.getOwnPropertyDescriptor(rolePrototype, name) ||
+            Object.create(null)
+        );
+      });
+    }
 
-    return user as TUser & TRole;
+    return user as TUser & UnionToIntersection<TRoles[number]>;
   };
 
   /**
@@ -91,7 +93,7 @@ export class UserFactory {
    * that user.
    */
   static assignRolesToUser = async function<
-    TUser extends IBaseUser,
+    TUser extends BaseUser,
     TRoles extends (keyof typeof USER_ROLE_MAPPING)[]
   >(
       user: TUser,
@@ -114,7 +116,7 @@ export class UserFactory {
 
       await superAdminInstance.expectUserToHaveRole(user.username, role);
 
-      UserFactory.composeUserWithRole(user, USER_ROLE_MAPPING[role]());
+      UserFactory.composeUserWithRole(user, [USER_ROLE_MAPPING[role]()]);
     }
 
     return user as TUser & MultipleRoleIntersection<typeof roles>;
@@ -128,9 +130,9 @@ export class UserFactory {
   >(
       username: string, email: string,
       roles: OptionalRoles<TRoles> = [] as OptionalRoles<TRoles>
-  ): Promise<ILoggedInUser & MultipleRoleIntersection<TRoles>> {
+  ): Promise<LoggedInUser & MultipleRoleIntersection<TRoles>> {
     let user = UserFactory.composeUserWithRole(
-      BaseUserFactory(), LoggedInUserFactory());
+      BaseUserFactory(), [LoggedInUserFactory()]);
     await user.openBrowser();
     await user.signUpNewUser(username, email);
     activeUsers.push(user);
@@ -144,7 +146,7 @@ export class UserFactory {
    */
   static createNewSuperAdmin = async function(
       username: string
-  ): Promise<ISuperAdmin & IBlogAdmin> {
+  ): Promise<SuperAdmin & BlogAdmin> {
     if (superAdminInstance !== null) {
       return superAdminInstance;
     }
@@ -152,11 +154,11 @@ export class UserFactory {
     const user = await UserFactory.createNewUser(
       username, 'testadmin@example.com');
     const superAdmin = UserFactory.composeUserWithRole(
-      user, SuperAdminFactory());
+      user, [SuperAdminFactory()]);
     await superAdmin.assignRoleToUser(username, ROLES.BLOG_ADMIN);
     await superAdmin.expectUserToHaveRole(username, ROLES.BLOG_ADMIN);
     superAdminInstance = UserFactory.composeUserWithRole(
-      superAdmin, BlogAdminFactory());
+      superAdmin, [BlogAdminFactory()]);
 
     return superAdminInstance;
   };
@@ -174,7 +176,7 @@ export class UserFactory {
    * This function closes the browser for the provided user.
    */
   static closeBrowserForUser = async function(
-      user: IBaseUser
+      user: BaseUser
   ): Promise<void> {
     const index = activeUsers.indexOf(user);
     activeUsers.splice(index, 1);

--- a/core/tests/puppeteer-acceptance-tests/spec/blog-admin-tests/assign-roles-to-users-and-change-tag-properties.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/blog-admin-tests/assign-roles-to-users-and-change-tag-properties.spec.ts
@@ -20,16 +20,16 @@ import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
-import { IBlogAdmin } from '../../user-utilities/blog-admin-utils';
-import { ISuperAdmin } from '../../user-utilities/super-admin-utils';
+import { BlogAdmin } from '../../user-utilities/blog-admin-utils';
+import { SuperAdmin } from '../../user-utilities/super-admin-utils';
 
 const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 const ROLES = testConstants.Roles;
 const BLOG_RIGHTS = testConstants.BlogRights;
 
 describe('Blog Admin', function() {
-  let superAdmin: ISuperAdmin;
-  let blogAdmin: IBlogAdmin;
+  let superAdmin: SuperAdmin;
+  let blogAdmin: BlogAdmin;
 
   beforeAll(async function() {
     superAdmin = await UserFactory.createNewSuperAdmin('superAdm');

--- a/core/tests/puppeteer-acceptance-tests/spec/blog-editor-tests/try-to-publish-a-duplicate-blog-post-and-get-blocked.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/blog-editor-tests/try-to-publish-a-duplicate-blog-post-and-get-blocked.spec.ts
@@ -20,7 +20,7 @@ import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
-import { IBlogPostEditor } from '../../user-utilities/blog-post-editor-utils';
+import { BlogPostEditor } from '../../user-utilities/blog-post-editor-utils';
 
 const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 const ROLES = testConstants.Roles;
@@ -28,7 +28,7 @@ const duplicateBlogPostWarning = ' Blog Post with the' +
   ' given title exists already. Please use a different title. ';
 
 describe('Blog Editor', function() {
-  let blogPostEditor: IBlogPostEditor;
+  let blogPostEditor: BlogPostEditor;
 
   beforeAll(async function() {
     blogPostEditor = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-in-about-foundation-page.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-in-about-foundation-page.spec.ts
@@ -19,14 +19,14 @@
 
 import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
-import { ILoggedInUser } from '../../user-utilities/logged-in-users-utils';
+import { LoggedInUser } from '../../user-utilities/logged-in-users-utils';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
 
 const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 
 describe('Logged-in User in About Foundation page', function() {
-  let testUser: ILoggedInUser;
+  let testUser: LoggedInUser;
 
   beforeAll(async function() {
     testUser = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-in-about-page.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-in-about-page.spec.ts
@@ -19,14 +19,14 @@
 
 import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
-import { ILoggedInUser } from '../../user-utilities/logged-in-users-utils';
+import { LoggedInUser } from '../../user-utilities/logged-in-users-utils';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
 
 const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 
 describe('Logged-in User in About page', function() {
-  let testUser: ILoggedInUser;
+  let testUser: LoggedInUser;
 
   beforeAll(async function() {
     testUser = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-in-thanks-for-donating-page.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-in-thanks-for-donating-page.spec.ts
@@ -19,14 +19,14 @@
 
 import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
-import { ILoggedInUser } from '../../user-utilities/logged-in-users-utils';
+import { LoggedInUser } from '../../user-utilities/logged-in-users-utils';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
 
 const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 
 describe('Logged-in User in Thanks for Donating page', function() {
-  let testUser: ILoggedInUser;
+  let testUser: LoggedInUser;
 
   beforeAll(async function() {
     testUser = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-on-navbar.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-on-navbar.spec.ts
@@ -19,14 +19,14 @@
 
 import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
-import { ILoggedInUser } from '../../user-utilities/logged-in-users-utils';
+import { LoggedInUser } from '../../user-utilities/logged-in-users-utils';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
 
 const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 
 describe('Logged-in User', function() {
-  let testUser: ILoggedInUser;
+  let testUser: LoggedInUser;
 
   beforeAll(async function() {
     testUser = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/spec/practice-question-admin-tests/add-and-remove-contribution-rights.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/practice-question-admin-tests/add-and-remove-contribution-rights.spec.ts
@@ -19,7 +19,7 @@
 
 import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
-import { IQuestionAdmin } from '../../user-utilities/question-admin-utils';
+import { QuestionAdmin } from '../../user-utilities/question-admin-utils';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
 
@@ -27,7 +27,7 @@ const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 const ROLES = testConstants.Roles;
 
 describe('Question Admin', function() {
-  let questionAdmin: IQuestionAdmin;
+  let questionAdmin: QuestionAdmin;
 
   beforeAll(async function() {
     questionAdmin = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/spec/translation-admin-tests/add-translation-rights.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/translation-admin-tests/add-translation-rights.spec.ts
@@ -19,14 +19,14 @@
 
 import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
-import { ITranslationAdmin } from '../../user-utilities/translation-admin-utils';
+import { TranslationAdmin } from '../../user-utilities/translation-admin-utils';
 import testConstants from '../../puppeteer-testing-utilities/test-constants';
 
 const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 const ROLES = testConstants.Roles;
 
 describe('Translation Admin', function() {
-  let translationAdmin: ITranslationAdmin;
+  let translationAdmin: TranslationAdmin;
 
   beforeAll(async function() {
     translationAdmin = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/spec/translation-admin-tests/remove-translation-rights.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/translation-admin-tests/remove-translation-rights.spec.ts
@@ -19,7 +19,7 @@
 
 import { UserFactory } from
   '../../puppeteer-testing-utilities/user-factory';
-import { ITranslationAdmin } from '../../user-utilities/translation-admin-utils';
+import { TranslationAdmin } from '../../user-utilities/translation-admin-utils';
 import testConstants from
   '../../puppeteer-testing-utilities/test-constants';
 
@@ -27,7 +27,7 @@ const DEFAULT_SPEC_TIMEOUT = testConstants.DEFAULT_SPEC_TIMEOUT;
 const ROLES = testConstants.Roles;
 
 describe('Translation Admin', function() {
-  let translationAdmin: ITranslationAdmin;
+  let translationAdmin: TranslationAdmin;
 
   beforeAll(async function() {
     translationAdmin = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/blog-admin-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/blog-admin-utils.ts
@@ -16,7 +16,7 @@
  * @fileoverview Blog Admin users utility file.
  */
 
-import { IBaseUser, BaseUser } from
+import { BaseUser } from
   '../puppeteer-testing-utilities/puppeteer-utils';
 import testConstants from
   '../puppeteer-testing-utilities/test-constants';
@@ -32,17 +32,7 @@ const blogAdminUrl = testConstants.URLs.BlogAdmin;
 
 const LABEL_FOR_SAVE_BUTTON = 'Save';
 
-export interface IBlogAdmin extends IBaseUser {
-  assignUserToRoleFromBlogAdminPage: (
-    username: string, role: keyof typeof BLOG_RIGHTS) => Promise<void>;
-  removeBlogEditorRoleFromUsername: (
-    username: string) => Promise<void>;
-  setMaximumTagLimitTo: (limit: number) => Promise<void>;
-  expectMaximumTagLimitNotToBe: (limit: number) => Promise<void>;
-  expectMaximumTagLimitToBe: (limit: number) => Promise<void>;
-}
-
-class BlogAdmin extends BaseUser implements IBlogAdmin {
+export class BlogAdmin extends BaseUser {
   /**
    * This function assigns a user with a role from the blog admin page.
    */
@@ -107,4 +97,4 @@ class BlogAdmin extends BaseUser implements IBlogAdmin {
   }
 }
 
-export let BlogAdminFactory = (): IBlogAdmin => new BlogAdmin();
+export let BlogAdminFactory = (): BlogAdmin => new BlogAdmin();

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/blog-post-editor-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/blog-post-editor-utils.ts
@@ -16,7 +16,7 @@
  * @fileoverview Blog Admin users utility file.
  */
 
-import { IBaseUser, BaseUser } from
+import { BaseUser } from
   '../puppeteer-testing-utilities/puppeteer-utils';
 import testConstants from
   '../puppeteer-testing-utilities/test-constants';
@@ -41,32 +41,7 @@ const LABEL_FOR_SAVE_DRAFT_BUTTON = 'SAVE AS DRAFT';
 const LABEL_FOR_DELETE_BUTTON = 'Delete';
 const LABEL_FOR_CONFIRM_BUTTON = 'Confirm';
 
-export interface IBlogPostEditor extends IBaseUser {
-  addUserBioInBlogDashboard: () => Promise<void>;
-  navigateToBlogDashboardPage: () => Promise<void>;
-  createDraftBlogPostWithTitle:
-    (draftBlogPostTitle: string) => Promise<void>;
-  deleteDraftBlogPostWithTitle:
-    (draftBlogPostTitle: string) => Promise<void>;
-  expectPublishButtonToBeDisabled: () => Promise<void>;
-  publishNewBlogPostWithTitle:
-    (newBlogPostTitle: string) => Promise<void>;
-  createNewBlogPostWithTitle:
-    (newBlogPostTitle: string) => Promise<void>;
-  deletePublishedBlogPostWithTitle: (blogPostTitle: string) => Promise<void>;
-  expectUserUnableToPublishBlogPost:
-    (expectedWarningMessage: string) => Promise<void>;
-  expectNumberOfBlogPostsToBe: (number: number) => Promise<void>;
-  navigateToPublishTab: () => Promise<void>;
-  expectDraftBlogPostWithTitleToBePresent: (
-    checkDraftBlogPostByTitle: string) => Promise<void>;
-  expectPublishedBlogPostWithTitleToBePresent: (
-    blogPostTitle: string) => Promise<void>;
-  expectBlogDashboardAccessToBeUnauthorized: () => Promise<void>;
-  expectBlogDashboardAccessToBeAuthorized: () => Promise<void>;
-}
-
-class BlogPostEditor extends BaseUser implements IBlogPostEditor {
+export class BlogPostEditor extends BaseUser {
   /**
    * Function for adding blog post author bio in blog dashboard.
    */
@@ -390,4 +365,4 @@ class BlogPostEditor extends BaseUser implements IBlogPostEditor {
   }
 }
 
-export let BlogPostEditorFactory = (): IBlogPostEditor => new BlogPostEditor();
+export let BlogPostEditorFactory = (): BlogPostEditor => new BlogPostEditor();

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
@@ -16,7 +16,7 @@
  * @fileoverview Logged-in users utility file.
  */
 
-import { IBaseUser, BaseUser } from
+import { BaseUser } from
   '../puppeteer-testing-utilities/puppeteer-utils';
 import testConstants from
   '../puppeteer-testing-utilities/test-constants';
@@ -89,40 +89,7 @@ const dismissButton = 'i.e2e-test-thanks-for-donating-page-dismiss-button';
 const thanksForDonatingClass = '.modal-open';
 const donatePage = '.modal-backdrop.fade';
 
-export interface ILoggedInUser extends IBaseUser {
-  navigateToHome: () => Promise<void>;
-  navigateToAboutPage: () => Promise<void>;
-  navigateToAboutFoundationPage: () => Promise<void>;
-  navigateToThanksForDonatingPage: () => Promise<void>;
-  clickAboutButtonInAboutMenuOnNavbar: () => Promise<void>;
-  clickBrowseOurLessonsButtonInAboutPage: () => Promise<void>;
-  clickAccessAndroidAppButtonInAboutPage: () => Promise<void>;
-  clickVisitClassroomButtonInAboutPage: () => Promise<void>;
-  clickBrowseLibraryButtonInAboutPage: () => Promise<void>;
-  clickCreateLessonsButtonInAboutPage: () => Promise<void>;
-  clickExploreLessonsButtonInAboutPage: () => Promise<void>;
-  clickAboutFoundationButtonInAboutMenuOnNavbar: () => Promise<void>;
-  click61MillionChildrenLinkInAboutFoundation: () => Promise<void>;
-  clickEvenThoseWhoAreInSchoolLinkInAboutFoundation: () => Promise<void>;
-  clickSourceUnescoLinkInAboutFoundation: () => Promise<void>;
-  click420MillionLinkInAboutFoundation: () => Promise<void>;
-  clickLearnMoreAboutOppiaButtonInAboutFoundation: () => Promise<void>;
-  clickBecomeAVolunteerButtonInAboutFoundation: () => Promise<void>;
-  clickConsiderBecomingAPartnerTodayLinkInAboutFoundation: () => Promise<void>;
-  clickJoinOurLargeVolunteerCommunityLinkInAboutFoundation: () => Promise<void>;
-  clickDonationsLinkInAboutFoundation: () => Promise<void>;
-  clickBlogButtonInAboutMenuOnNavbar: () => Promise<void>;
-  clickPartnershipsButtonInGetInvolvedMenuOnNavbar: () => Promise<void>;
-  clickVolunteerButtonInGetInvolvedMenuOnNavbar: () => Promise<void>;
-  clickDonateButtonInGetInvolvedMenuOnNavbar: () => Promise<void>;
-  clickContactUsButtonInGetInvolvedMenuOnNavbar: () => Promise<void>;
-  clickDonateButtonOnNavbar: () => Promise<void>;
-  clickWatchAVideoButtonInThanksForDonatingPage: () => Promise<void>;
-  clickReadOurBlogButtonInThanksForDonatingPage: () => Promise<void>;
-  clickDismissButtonInThanksForDonatingPage: () => Promise<void>;
-}
-
-class LoggedInUser extends BaseUser implements ILoggedInUser {
+export class LoggedInUser extends BaseUser {
   /**
    * Function to navigate to the home page.
    */
@@ -652,4 +619,4 @@ class LoggedInUser extends BaseUser implements ILoggedInUser {
   }
 }
 
-export let LoggedInUserFactory = (): ILoggedInUser => new LoggedInUser();
+export let LoggedInUserFactory = (): LoggedInUser => new LoggedInUser();

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/question-admin-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/question-admin-utils.ts
@@ -16,7 +16,7 @@
  * @fileoverview Question admin users utility file.
  */
 
-import { IBaseUser, BaseUser } from
+import { BaseUser } from
   '../puppeteer-testing-utilities/puppeteer-utils';
 import testConstants from
   '../puppeteer-testing-utilities/test-constants';
@@ -63,27 +63,7 @@ const removeContributonRightsCategorySelector =
 const removeContributionRightsSubmitButton =
   'button#remove-contribution-rights-submit-button';
 
-export interface IQuestionAdmin extends IBaseUser {
-  navigateToContributorDashboardAdminPage: () => Promise<void>;
-  addReviewQuestionRights: (username: string) => Promise<void>;
-  addSubmitQuestionRights: (username: string) => Promise<void>;
-  removeReviewQuestionRights: (username: string) => Promise<void>;
-  removeSubmitQuestionRights: (username: string) => Promise<void>;
-  getDisplayedListOfQuestionReviewers: () => Promise<string[]>;
-  getDisplayedListOfQuestionSubmitters: () => Promise<string[]>;
-  getContributionStatusForUser: (
-    username: string, contribution: string) => Promise<string>;
-  verifyUserCanReviewQuestions: (username: string) => Promise<void>;
-  verifyUserCanSubmitQuestions: (username: string) => Promise<void>;
-  verifyUserCannotReviewQuestions: (username: string) => Promise<void>;
-  verifyUserCannotSubmitQuestions: (username: string) => Promise<void>;
-  verifyQuestionReviewersIncludeUser: (username: string) => Promise<void>;
-  verifyQuestionSubmittersIncludeUser: (username: string) => Promise<void>;
-  verifyQuestionReviewersExcludeUser: (username: string) => Promise<void>;
-  verifyQuestionSubmittersExcludeUser: (username: string) => Promise<void>;
-}
-
-class QuestionAdmin extends BaseUser implements IQuestionAdmin {
+export class QuestionAdmin extends BaseUser {
   /**
    * Function for navigating to the contributor dashboard admin page.
    */
@@ -317,4 +297,4 @@ class QuestionAdmin extends BaseUser implements IQuestionAdmin {
   }
 }
 
-export let QuestionAdminFactory = (): IQuestionAdmin => new QuestionAdmin();
+export let QuestionAdminFactory = (): QuestionAdmin => new QuestionAdmin();

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/super-admin-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/super-admin-utils.ts
@@ -16,7 +16,7 @@
  * @fileoverview Super Admin users utility file.
  */
 
-import { IBaseUser, BaseUser } from
+import { BaseUser } from
   '../puppeteer-testing-utilities/puppeteer-utils';
 import testConstants from
   '../puppeteer-testing-utilities/test-constants';
@@ -29,13 +29,7 @@ const roleEditorButtonSelector = 'button.e2e-test-role-edit-button';
 const rolesSelectDropdown = 'div.mat-select-trigger';
 const addRoleButton = 'button.oppia-add-role-button';
 
-export interface ISuperAdmin extends IBaseUser {
-  assignRoleToUser: (username: string, role: string) => Promise<void>;
-  expectUserToHaveRole: (username: string, role: string) => Promise<void>;
-  expectUserNotToHaveRole: (username: string, role: string) => Promise<void>;
-}
-
-class SuperAdmin extends BaseUser implements ISuperAdmin {
+export class SuperAdmin extends BaseUser {
   /**
    * The function to assign a role to a user.
    */
@@ -102,4 +96,4 @@ class SuperAdmin extends BaseUser implements ISuperAdmin {
   }
 }
 
-export let SuperAdminFactory = (): ISuperAdmin => new SuperAdmin();
+export let SuperAdminFactory = (): SuperAdmin => new SuperAdmin();

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/translation-admin-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/translation-admin-utils.ts
@@ -16,7 +16,7 @@
  * @fileoverview Translation admin role utility file.
  */
 
-import { IBaseUser, BaseUser } from
+import { BaseUser } from
   '../puppeteer-testing-utilities/puppeteer-utils';
 import testConstants from
   '../puppeteer-testing-utilities/test-constants';
@@ -65,21 +65,7 @@ const removeContributonRightsLanguageSelect =
 const removeContributionRightsSubmitButton =
   'button#remove-contribution-rights-submit-button';
 
-export interface ITranslationAdmin extends IBaseUser {
-  navigateToContributorDashboardAdminPage: () => Promise<void>;
-  addTranslationLanguageReviewRights: (
-    username: string, languageCode: string) => Promise<void>;
-  removeTranslationLanguageReviewRights: (
-    username: string, languageCode: string) => Promise<void>;
-  viewContributionRightsForUser: (username: string) => Promise<void>;
-  viewContributorTranslationRightsByLanguageCode: (
-    languageCode: string) => Promise<void>;
-  expectDisplayedLanguagesToContain: (language: string) => Promise<void>;
-  expectUserToBeDisplayed: (username: string) => Promise<void>;
-  expectUserToNotBeDisplayed: (username: string) => Promise<void>;
-}
-
-class TranslationAdmin extends BaseUser implements ITranslationAdmin {
+export class TranslationAdmin extends BaseUser {
   /**
    * Function for navigating to the contributor dashboard admin page.
    */
@@ -196,4 +182,4 @@ class TranslationAdmin extends BaseUser implements ITranslationAdmin {
 }
 
 export let TranslationAdminFactory =
-  (): ITranslationAdmin => new TranslationAdmin();
+  (): TranslationAdmin => new TranslationAdmin();


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #18268.
2. This PR does the following: Removes interfaces and adds multiple role compose. Removing interfaces since there is no multiple implementations of classes and adds unnecessary complication.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
