### PR TITLE
Add feature flag for undo translation status feature

### DIFF
--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -49,6 +49,7 @@ class FeatureNames(enum.Enum):
     IS_IMPROVEMENTS_TAB_ENABLED = 'is_improvements_tab_enabled'
     LEARNER_GROUPS_ARE_ENABLED = 'learner_groups_are_enabled'
     NEW_LESSON_PLAYER = 'new_lesson_player'
+    UNDO_TRANSLATION_STATUS = 'undo_translation_status'
 
 
 # Names of feature objects defined in FeatureNames should be added
@@ -73,7 +74,8 @@ DEV_FEATURES_LIST = [
     FeatureNames.SHOW_FEEDBACK_UPDATES_IN_PROFILE_PIC_DROPDOWN,
     FeatureNames.SHOW_REDESIGNED_LEARNER_DASHBOARD,
     FeatureNames.SHOW_TRANSLATION_SIZE,
-    FeatureNames.NEW_LESSON_PLAYER
+    FeatureNames.NEW_LESSON_PLAYER,
+    FeatureNames.UNDO_TRANSLATION_STATUS
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -192,6 +194,13 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
     FeatureNames.NEW_LESSON_PLAYER.value: (
         (
             'This flag is to enable the exploration player redesign.',
+            feature_flag_domain.ServerMode.DEV
+        )
+    ),
+    FeatureNames.UNDO_TRANSLATION_STATUS.value: (
+        (
+            'This flag to let translation reviewers undo the status '
+            'of translation reviews.',
             feature_flag_domain.ServerMode.DEV
         )
     )

--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -49,7 +49,7 @@ class FeatureNames(enum.Enum):
     IS_IMPROVEMENTS_TAB_ENABLED = 'is_improvements_tab_enabled'
     LEARNER_GROUPS_ARE_ENABLED = 'learner_groups_are_enabled'
     NEW_LESSON_PLAYER = 'new_lesson_player'
-    UNDO_TRANSLATION_STATUS = 'undo_translation_status'
+    CD_ALLOW_UNDOING_TRANSLATION_REVIEW = 'cd_allow_undoing_translation_review'
 
 
 # Names of feature objects defined in FeatureNames should be added
@@ -75,7 +75,7 @@ DEV_FEATURES_LIST = [
     FeatureNames.SHOW_REDESIGNED_LEARNER_DASHBOARD,
     FeatureNames.SHOW_TRANSLATION_SIZE,
     FeatureNames.NEW_LESSON_PLAYER,
-    FeatureNames.UNDO_TRANSLATION_STATUS
+    FeatureNames.CD_ALLOW_UNDOING_TRANSLATION_REVIEW
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -197,10 +197,10 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
             feature_flag_domain.ServerMode.DEV
         )
     ),
-    FeatureNames.UNDO_TRANSLATION_STATUS.value: (
+    FeatureNames.CD_ALLOW_UNDOING_TRANSLATION_REVIEW.value: (
         (
-            'This flag to let translation reviewers undo the status '
-            'of translation reviews.',
+            'This flag allows translation reviewers to undo translation '
+            'suggestion review on the contributor dashboard.',
             feature_flag_domain.ServerMode.DEV
         )
     )

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -37,6 +37,7 @@ export enum FeatureNames {
   LearnerGroupsAreEnabled = 'learner_groups_are_enabled',
   CdAdminDashboardNewUi = 'cd_admin_dashboard_new_ui',
   NewLessonPlayer = 'new_lesson_player',
+  UndoTranslationStatus = 'undo_translation_status',
 }
 
 export interface FeatureStatusSummaryBackendDict {

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -37,7 +37,7 @@ export enum FeatureNames {
   LearnerGroupsAreEnabled = 'learner_groups_are_enabled',
   CdAdminDashboardNewUi = 'cd_admin_dashboard_new_ui',
   NewLessonPlayer = 'new_lesson_player',
-  UndoTranslationStatus = 'undo_translation_status',
+  CdAllowUndoingTranslationReview = 'cd_allow_undoing_translation_review',
 }
 
 export interface FeatureStatusSummaryBackendDict {


### PR DESCRIPTION
## Overview

1. This PR does the following: Introducing a feature flag which will allow translation reviewers to undo translation review status. #https://github.com/oppia/oppia/issues/19167.

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
