### PR TITLE
Remove types for puppeteer acceptance tests in TSConfig

### DIFF
--- a/tsconfig.puppeteer-acceptance-tests.json
+++ b/tsconfig.puppeteer-acceptance-tests.json
@@ -16,8 +16,7 @@
     "types": [
       "node",
       "jasmine",
-      "puppeteer",
-      "puppeteer-acceptance-tests"
+      "puppeteer"
     ],
     "lib": [
       "ES2017",


### PR DESCRIPTION
This PR removes the types in the TSConfig for puppeteer-acceptance-tests removed in this PR: #19939.