### PR TITLE
FIX #16976: Open all contributors in lesson info dialog box

### DIFF
--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
@@ -74,7 +74,37 @@
   color: #fff;
   font-size: 12px;
   height: 18px;
+  list-style-type: none;
+  position: relative;
   width: 18px;
+}
+
+.oppia-contributors-more-circle-expand {
+  background-color: rgba(26, 26, 26, 0.99);
+  border-radius: 5px;
+  left: 50%;
+  padding: 7px;
+  position: absolute;
+  top: -8px;
+  transform: translate(-50%, -100%);
+}
+
+.oppia-contributors-more-circle-expand::after {
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 9px solid rgba(26, 26, 26, 0.95);
+  bottom: -8px;
+  content: "";
+  height: 0;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+  width: 0;
+}
+
+.oppia-contributors-more-circle-expand a {
+  color: #fff;
+  font-size: 10px;
 }
 
 .oppia-info-card-title {

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
@@ -121,12 +121,17 @@
                 <profile-link-image [username]="name"></profile-link-image>
               </li>
             </div>
-            <li *ngIf="contributorNames.length > 2"
-                class="oppia-contributors-more-circle"
-                [ngbTooltip]="contributorNames.slice(2).join(', ')"
-                placement="top">
+            <div (mouseover)="contributorsListIsShown = true" (mouseleave)="contributorsListIsShown = false">
+              <li *ngIf="contributorNames.length > 2" class="oppia-contributors-more-circle">
                 +{{ contributorNames.length - 2 }}
-            </li>
+                <div *ngIf="contributorsListIsShown" class="oppia-contributors-more-circle-expand">
+                  <ng-container *ngFor="let name of contributorNames | slice:2; let isLast=last">
+                    <profile-link-text [username]="name"></profile-link-text>
+                    <span *ngIf="!isLast">, </span>
+                  </ng-container>
+                </div>
+              </li>
+            </div>
             <li *ngIf="contributorNames.length === 0"
                 [ngbTooltip]="'I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate"
                 placement="top">

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
@@ -86,6 +86,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
   userIsLoggedIn: boolean = false;
   lessonAuthorsSubmenuIsShown: boolean = false;
   saveProgressMenuIsShown: boolean = false;
+  contributorsListIsShown: boolean = false;
 
   constructor(
     private ngbActiveModal: NgbActiveModal,


### PR DESCRIPTION
## Overview

1. This PR fixes #16976
2. This PR does the following:
Creates a menu with the contributor names with hyperlinks using the <profile-link-text [username]="name"> component that already exists. It looks similar to the ngb tooltip on the other names and is shown when the mouse passes over the contributors circle.
To do this I changed the lesson-information-card-modal.component files: changed the HTM of that part, created new CSS classes and added a boolean variable to the TS file to show or hide the menu.
4. The original bug occurred because:
The first two contributors could be opened by clicking the image (<profile-link-image [username]="name"> component) with the name beeing shown by the ngb-tooltip. The other usernames were being displayed in the same way but were not clickable as the ngb tooltip doesn't allow hyperlinks.


## Essential Checklist

- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [X] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

https://github.com/oppia/oppia/assets/29431049/ab7ddc15-3f70-4191-b7d3-7ed1eb741c17



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
