### PR TITLE
add flake lines to silence flakes

### DIFF
--- a/.github/workflows/e2e_lighthouse_performance_acceptance_tests.yml
+++ b/.github/workflows/e2e_lighthouse_performance_acceptance_tests.yml
@@ -110,6 +110,8 @@ jobs:
           - name: skillEditor
           - name: subscriptions
           - name: topicsAndSkillsDashboard
+            flaky_indicators: |
+              Classroom config tile selector is not visible
           - name: topicAndStoryEditor
           - name: topicAndStoryEditorFileUploadFeatures
           - name: topicAndStoryViewer


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

2. This PR does the following: I reviewed recent flakes and found a flake that repeats a lot ([1](https://github.com/oppia/oppia/actions/runs/8299907992/job/22718241070), [2](https://github.com/oppia/oppia/actions/runs/8245674166/job/22551234485), [3](https://github.com/oppia/oppia/actions/runs/8239110581/job/22531617070#step:9:11946) and more). I'm adding a line that will indicate that the test failure is flake, which will make the GitHub action to retry the test.
