### PR TITLE
Fix Issue #19990 : The lesson info dialog still appear after navigation to the profile page

### DIFF
--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
@@ -1,78 +1,126 @@
 <mat-card class="oppia-lesson-info-card">
   <div [ngStyle]="infoCardBackgroundCss" class="oppia-info-card-logo-thumbnail">
-    <img [src]="getStaticImageUrl(infoCardBackgroundImageUrl)"
-         class="oppia-info-card-bg-image"
-         alt="{{ expCategory }}">
-    <h2 class="oppia-info-card-title break-word" *ngIf="isHackyExpTitleTranslationDisplayed()" tabindex="0">
+    <img
+      [src]="getStaticImageUrl(infoCardBackgroundImageUrl)"
+      class="oppia-info-card-bg-image"
+      alt="{{ expCategory }}"
+    />
+    <h2
+      class="oppia-info-card-title break-word"
+      *ngIf="isHackyExpTitleTranslationDisplayed()"
+      tabindex="0"
+    >
       {{ expTitleTranslationKey | translate }}
     </h2>
-    <h2 class="oppia-info-card-title break-word"
-        tabindex="0"
-        *ngIf="!isHackyExpTitleTranslationDisplayed()">
+    <h2
+      class="oppia-info-card-title break-word"
+      tabindex="0"
+      *ngIf="!isHackyExpTitleTranslationDisplayed()"
+    >
       {{ expTitle }}
     </h2>
   </div>
   <div class="oppia-lesson-info-content">
     <div class="oppia-lesson-info-content-inner-container">
       <div class="oppia-lesson-exploration-progress-info">
-        <h4 class="oppia-exploration-description"
-            *ngIf="!isHackyExpDescTranslationDisplayed()">
+        <h4
+          class="oppia-exploration-description"
+          *ngIf="!isHackyExpDescTranslationDisplayed()"
+        >
           {{ expDesc | truncateAndCapitalize: 90 }}
         </h4>
-        <h4 class="oppia-exploration-description"
-            tabindex="0"
-            *ngIf="isHackyExpDescTranslationDisplayed()">
+        <h4
+          class="oppia-exploration-description"
+          tabindex="0"
+          *ngIf="isHackyExpDescTranslationDisplayed()"
+        >
           {{ expDescTranslationKey | translate | truncateAndCapitalize: 90 }}
         </h4>
-        <h4 tabindex="0" [ngClass]="(checkpointCount === 1) ? 'd-none' : 'progress-bar-label-text'">
+        <h4
+          tabindex="0"
+          [ngClass]="
+            checkpointCount === 1 ? 'd-none' : 'progress-bar-label-text'
+          "
+        >
           Learning Progress
         </h4>
-        <div class="progress-bar-container"
-             [ngClass]="{'d-none': checkpointCount === 1, 'multiple-checkpoints-bar': checkpointCount > 1, 'reverse-checkpoint-order': isLanguageRTL()}">
-          <div class="lesson-progress-bar"
-               [ngClass]="{'reverse-checkpoint-order': isLanguageRTL()}">
-            <div tabindex="0" class="completed-progress-bar"
-                 [style.width.%]="getCompletedProgressBarWidth()"
-                 [attr.aria-label]="getProgressPercentage() + ' percent completed'">
-            </div>
+        <div
+          class="progress-bar-container"
+          [ngClass]="{
+            'd-none': checkpointCount === 1,
+            'multiple-checkpoints-bar': checkpointCount > 1,
+            'reverse-checkpoint-order': isLanguageRTL()
+          }"
+        >
+          <div
+            class="lesson-progress-bar"
+            [ngClass]="{'reverse-checkpoint-order': isLanguageRTL()}"
+          >
+            <div
+              tabindex="0"
+              class="completed-progress-bar"
+              [style.width.%]="getCompletedProgressBarWidth()"
+              [attr.aria-label]="getProgressPercentage() + ' percent completed'"
+            ></div>
           </div>
-          <div *ngFor="let checkpointNode of checkpointStatusArray; index as idx"
-               [ngClass]="{'completed-checkpoint-node': checkpointStatusArray[idx] === 'completed', 'in-progress-checkpoint-node': checkpointStatusArray[idx] === 'in-progress', 'incomplete-checkpoint-node': checkpointStatusArray[idx] === 'incomplete'}">
+          <div
+            *ngFor="let checkpointNode of checkpointStatusArray; index as idx"
+            [ngClass]="{
+              'completed-checkpoint-node':
+                checkpointStatusArray[idx] === 'completed',
+              'in-progress-checkpoint-node':
+                checkpointStatusArray[idx] === 'in-progress',
+              'incomplete-checkpoint-node':
+                checkpointStatusArray[idx] === 'incomplete'
+            }"
+          >
             {{ idx + 1 }}
           </div>
         </div>
-        <p *ngIf="translatedCongratulatoryCheckpointMessage"
-           class="checkpoint-message-text e2e-test-lesson-info-modal-checkpoint-message">
+        <p
+          *ngIf="translatedCongratulatoryCheckpointMessage"
+          class="checkpoint-message-text e2e-test-lesson-info-modal-checkpoint-message"
+        >
           {{ translatedCongratulatoryCheckpointMessage }}
         </p>
         <div class="save-progress-btn-container">
           <div class="save-progress-btn-box">
-            <button type="button"
-                    class="btn btn-secondary save-progress-btn"
-                    *ngIf="(!userIsLoggedIn && checkpointCount>1)"
-                    [ngClass]="{'disabled oppia-disabled-link': checkpointStatusArray[0] === 'in-progress'}"
-                    tabindex="0"
-                    (keydown.enter)="saveLoggedOutProgress()"
-                    (click)="saveLoggedOutProgress()">
+            <button
+              type="button"
+              class="btn btn-secondary save-progress-btn"
+              *ngIf="!userIsLoggedIn && checkpointCount > 1"
+              [ngClass]="{
+                'disabled oppia-disabled-link':
+                  checkpointStatusArray[0] === 'in-progress'
+              }"
+              tabindex="0"
+              (keydown.enter)="saveLoggedOutProgress()"
+              (click)="saveLoggedOutProgress()"
+            >
               {{ 'I18N_SAVE_PROGRESS_TEXT' | translate }}
             </button>
           </div>
-          <div *ngIf="checkpointStatusArray[0] === 'in-progress'"
-               class="save-progress-btn-tooltip alert alert-danger">
+          <div
+            *ngIf="checkpointStatusArray[0] === 'in-progress'"
+            class="save-progress-btn-tooltip alert alert-danger"
+          >
             {{ 'I18N_SAVE_BUTTON_ALERT_TOOLTIP' | translate }}
           </div>
         </div>
-        <p *ngIf="explorationIsPrivate"
-           class="private-card-info">
-           {{ 'I18N_PLAYER_IS_PRIVATE' | translate }}
+        <p *ngIf="explorationIsPrivate" class="private-card-info">
+          {{ 'I18N_PLAYER_IS_PRIVATE' | translate }}
         </p>
 
-        <ul *ngIf="!explorationIsPrivate"
-            class="card-metrics row space-between center">
+        <ul
+          *ngIf="!explorationIsPrivate"
+          class="card-metrics row space-between center"
+        >
           <li tabindex="0" class="e2e-test-info-card-rating row-item">
-            <span class="fas fa-star fa-lg learn-info-card-star"
-                  [ngbTooltip]="'I18N_PLAYER_RATINGS_TOOLTIP' | translate"
-                  placement="top">
+            <span
+              class="fas fa-star fa-lg learn-info-card-star"
+              [ngbTooltip]="'I18N_PLAYER_RATINGS_TOOLTIP' | translate"
+              placement="top"
+            >
               <span class="oppia-icon-accessibility-label">
                 {{ 'I18N_PLAYER_RATINGS_TOOLTIP' | translate }}
               </span>
@@ -81,13 +129,15 @@
               {{ 'I18N_PLAYER_UNRATED' | translate }}
             </span>
             <span *ngIf="averageRating">
-              {{ averageRating | number:'1.1-1'}}
+              {{ averageRating | number: '1.1-1' }}
             </span>
           </li>
           <li tabindex="0" class="row-item">
-            <span class="far fa-eye"
-                  [ngbTooltip]="'I18N_PLAYER_VIEWS_TOOLTIP' | translate"
-                  placement="top">
+            <span
+              class="far fa-eye"
+              [ngbTooltip]="'I18N_PLAYER_VIEWS_TOOLTIP' | translate"
+              placement="top"
+            >
               <span class="oppia-icon-accessibility-label">
                 {{ 'I18N_PLAYER_VIEWS_TOOLTIP' | translate }}
               </span>
@@ -95,52 +145,71 @@
             {{ numViews | summarizeNonnegativeNumber }}
           </li>
           <li tabindex="0" class="row-item">
-            <span class="far fa-clock"
-                  [ngbTooltip]="'I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate"
-                  placement="top">
+            <span
+              class="far fa-clock"
+              [ngbTooltip]="'I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate"
+              placement="top"
+            >
               <span class="oppia-icon-accessibility-label">
                 {{ 'I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate }}
               </span>
             </span>
             {{ lastUpdatedString }}
           </li>
-          <ul tabindex="0" class="oppia-info-card-exploration-contributors-profile row center row-item"
-          (click)="closeModal()">
-            <i class="material-icons oppia-contributors-icon"
-               [ngbTooltip]="'I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate"
-               placement="top">
-               &#xE7EF;
+          <ul
+            tabindex="0"
+            class="oppia-info-card-exploration-contributors-profile row center row-item"
+            (click)="closeModal()"
+          >
+            <i
+              class="material-icons oppia-contributors-icon"
+              [ngbTooltip]="'I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate"
+              placement="top"
+            >
+              &#xE7EF;
             </i>
             <span class="oppia-icon-accessibility-label">
               {{ 'I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate }}
             </span>
             <div class="named-contributors-container">
-              <li *ngFor="let name of (contributorNames | limitTo: 2); index as idx"
-                  [ngbTooltip]="name"
-                  placement="top"
-                  class="contributor-{{idx}}">
+              <li
+                *ngFor="let name of contributorNames | limitTo: 2; index as idx"
+                [ngbTooltip]="name"
+                placement="top"
+                class="contributor-{{ idx }}"
+              >
                 <profile-link-image [username]="name"></profile-link-image>
               </li>
             </div>
-            <li *ngIf="contributorNames.length > 2"
-                class="oppia-contributors-more-circle"
-                [ngbTooltip]="contributorNames.slice(2).join(', ')"
-                placement="top">
-                +{{ contributorNames.length - 2 }}
+            <li
+              *ngIf="contributorNames.length > 2"
+              class="oppia-contributors-more-circle"
+              [ngbTooltip]="contributorNames.slice(2).join(', ')"
+              placement="top"
+            >
+              +{{ contributorNames.length - 2 }}
             </li>
-            <li *ngIf="contributorNames.length === 0"
-                [ngbTooltip]="'I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate"
-                placement="top">
-              <span class="far fa-globe fa-lg oppia-info-card-community-editable-icon"></span>
+            <li
+              *ngIf="contributorNames.length === 0"
+              [ngbTooltip]="
+                'I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate
+              "
+              placement="top"
+            >
+              <span
+                class="far fa-globe fa-lg oppia-info-card-community-editable-icon"
+              ></span>
             </li>
           </ul>
         </ul>
         <div *ngIf="!explorationIsPrivate" class="oppia-info-card-bottom-row">
           <div tabindex="0" class="fx-row">
             <div class="oppia-info-card-tag-icon">
-              <span class="fas fa-tags oppia-info-card-modal-tooltip"
-                    [ngbTooltip]="'I18N_PLAYER_TAGS_TOOLTIP' | translate"
-                    placement="top">
+              <span
+                class="fas fa-tags oppia-info-card-modal-tooltip"
+                [ngbTooltip]="'I18N_PLAYER_TAGS_TOOLTIP' | translate"
+                placement="top"
+              >
                 <span class="oppia-icon-accessibility-label">
                   {{ 'I18N_PLAYER_TAGS_TOOLTIP' | translate }}
                 </span>
@@ -148,25 +217,45 @@
             </div>
 
             <div class="exploration-tags">
-              <span *ngIf="explorationTags.tagsInTooltip.length > 0"
-                    class="oppia-info-card-tooltip-more"
-                    [ngbTooltip]="explorationTags.tagsInTooltip.join(', ')"
-                    placement="right">
-                    {{ 'I18N_PLAYER_PLUS_TAGS' | translate:{ additionalTagNumber: explorationTags.tagsInTooltip.length } }}
+              <span
+                *ngIf="explorationTags.tagsInTooltip.length > 0"
+                class="oppia-info-card-tooltip-more"
+                [ngbTooltip]="explorationTags.tagsInTooltip.join(', ')"
+                placement="right"
+              >
+                {{
+                  'I18N_PLAYER_PLUS_TAGS'
+                    | translate
+                      : {
+                          additionalTagNumber:
+                            explorationTags.tagsInTooltip.length
+                        }
+                }}
               </span>
               <span *ngIf="explorationTags.tagsToShow.length > 0">
-                {{ explorationTags.tagsToShow.join(", ") }}
+                {{ explorationTags.tagsToShow.join(', ') }}
               </span>
-              <span *ngIf="explorationTags.tagsToShow.length === 0 && explorationTags.tagsInTooltip.length === 0">
-                <span><em>{{ 'I18N_PLAYER_NO_TAGS' | translate }}</em></span>
+              <span
+                *ngIf="
+                  explorationTags.tagsToShow.length === 0 &&
+                  explorationTags.tagsInTooltip.length === 0
+                "
+              >
+                <span
+                  ><em>{{ 'I18N_PLAYER_NO_TAGS' | translate }}</em></span
+                >
               </span>
             </div>
           </div>
           <div flex="60" class="sharing-links-container">
-            <sharing-links flex="45" layoutType="row wrap" layoutAlignType="end center"
-                           twitterText="DEFAULT_TWITTER_SHARE_MESSAGE_PLAYER"
-                           shareType="exploration"
-                           [explorationId]="explorationId">
+            <sharing-links
+              flex="45"
+              layoutType="row wrap"
+              layoutAlignType="end center"
+              twitterText="DEFAULT_TWITTER_SHARE_MESSAGE_PLAYER"
+              shareType="exploration"
+              [explorationId]="explorationId"
+            >
             </sharing-links>
           </div>
         </div>
@@ -174,24 +263,38 @@
     </div>
   </div>
 </mat-card>
-<button type="button" class="oppia-close-popover-button e2e-test-close-lesson-info-modal-button" (click)="cancel()">
+<button
+  type="button"
+  class="oppia-close-popover-button e2e-test-close-lesson-info-modal-button"
+  (click)="cancel()"
+>
   <i class="material-icons md-18">&#xE5CD;</i>
   <span class="oppia-icon-accessibility-label">Close</span>
 </button>
-<div *ngIf="saveProgressMenuIsShown && !userIsLoggedIn"
-     class="save-progress-menu-backdrop">
-</div>
-<div class="save-progress-menu"
-     *ngIf="saveProgressMenuIsShown && !userIsLoggedIn">
+<div
+  *ngIf="saveProgressMenuIsShown && !userIsLoggedIn"
+  class="save-progress-menu-backdrop"
+></div>
+<div
+  class="save-progress-menu"
+  *ngIf="saveProgressMenuIsShown && !userIsLoggedIn"
+>
   <h3>{{ 'I18N_SAVE_PROGRESS_TEXT' | translate }}</h3>
   <div class="sign-in-box">
     <p>{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_1' | translate }}</p>
-    <button type="button"
-            class="btn btn-secondary create-account-btn"
-            (click)="onLoginButtonClicked()">
-          {{ 'I18N_CREATE_ACCOUNT' | translate }}
+    <button
+      type="button"
+      class="btn btn-secondary create-account-btn"
+      (click)="onLoginButtonClicked()"
+    >
+      {{ 'I18N_CREATE_ACCOUNT' | translate }}
     </button>
-    <p class="sign-in-text">{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_2' | translate }}<a class="sign-in-link" (click)="onLoginButtonClicked()">{{ 'I18N_TOPNAV_SIGN_IN' | translate }}</a></p>
+    <p class="sign-in-text">
+      {{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_2' | translate
+      }}<a class="sign-in-link" (click)="onLoginButtonClicked()">{{
+        'I18N_TOPNAV_SIGN_IN' | translate
+      }}</a>
+    </p>
   </div>
   <div class="separator">
     <div class="bars"></div>
@@ -199,14 +302,24 @@
     <div class="bars"></div>
   </div>
   <div class="uid-box">
-    <p class="guide-text">{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_3' | translate }}</p>
-    <p class="copy-text">{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_5' | translate }}</p>
-    <div [ngStyle]="{ 'flex-direction': isLanguageRTL() ? 'row-reverse' : 'row' }"
-         class="oppia-tooltip-container">
+    <p class="guide-text">
+      {{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_3' | translate }}
+    </p>
+    <p class="copy-text">
+      {{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_5' | translate }}
+    </p>
+    <div
+      [ngStyle]="{'flex-direction': isLanguageRTL() ? 'row-reverse' : 'row'}"
+      class="oppia-tooltip-container"
+    >
       <oppia-copy-url [urlToCopy]="loggedOutProgressUniqueUrl"></oppia-copy-url>
     </div>
   </div>
-  <button type="button" class="save-progress-close-button" (click)="closeSaveProgressMenu()">
+  <button
+    type="button"
+    class="save-progress-close-button"
+    (click)="closeSaveProgressMenu()"
+  >
     <i class="material-icons md-24">&#xE5CD;</i>
     <span class="oppia-icon-accessibility-label">Close</span>
   </button>

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
@@ -1,126 +1,78 @@
 <mat-card class="oppia-lesson-info-card">
   <div [ngStyle]="infoCardBackgroundCss" class="oppia-info-card-logo-thumbnail">
-    <img
-      [src]="getStaticImageUrl(infoCardBackgroundImageUrl)"
-      class="oppia-info-card-bg-image"
-      alt="{{ expCategory }}"
-    />
-    <h2
-      class="oppia-info-card-title break-word"
-      *ngIf="isHackyExpTitleTranslationDisplayed()"
-      tabindex="0"
-    >
+    <img [src]="getStaticImageUrl(infoCardBackgroundImageUrl)"
+         class="oppia-info-card-bg-image"
+         alt="{{ expCategory }}">
+    <h2 class="oppia-info-card-title break-word" *ngIf="isHackyExpTitleTranslationDisplayed()" tabindex="0">
       {{ expTitleTranslationKey | translate }}
     </h2>
-    <h2
-      class="oppia-info-card-title break-word"
-      tabindex="0"
-      *ngIf="!isHackyExpTitleTranslationDisplayed()"
-    >
+    <h2 class="oppia-info-card-title break-word"
+        tabindex="0"
+        *ngIf="!isHackyExpTitleTranslationDisplayed()">
       {{ expTitle }}
     </h2>
   </div>
   <div class="oppia-lesson-info-content">
     <div class="oppia-lesson-info-content-inner-container">
       <div class="oppia-lesson-exploration-progress-info">
-        <h4
-          class="oppia-exploration-description"
-          *ngIf="!isHackyExpDescTranslationDisplayed()"
-        >
+        <h4 class="oppia-exploration-description"
+            *ngIf="!isHackyExpDescTranslationDisplayed()">
           {{ expDesc | truncateAndCapitalize: 90 }}
         </h4>
-        <h4
-          class="oppia-exploration-description"
-          tabindex="0"
-          *ngIf="isHackyExpDescTranslationDisplayed()"
-        >
+        <h4 class="oppia-exploration-description"
+            tabindex="0"
+            *ngIf="isHackyExpDescTranslationDisplayed()">
           {{ expDescTranslationKey | translate | truncateAndCapitalize: 90 }}
         </h4>
-        <h4
-          tabindex="0"
-          [ngClass]="
-            checkpointCount === 1 ? 'd-none' : 'progress-bar-label-text'
-          "
-        >
+        <h4 tabindex="0" [ngClass]="(checkpointCount === 1) ? 'd-none' : 'progress-bar-label-text'">
           Learning Progress
         </h4>
-        <div
-          class="progress-bar-container"
-          [ngClass]="{
-            'd-none': checkpointCount === 1,
-            'multiple-checkpoints-bar': checkpointCount > 1,
-            'reverse-checkpoint-order': isLanguageRTL()
-          }"
-        >
-          <div
-            class="lesson-progress-bar"
-            [ngClass]="{'reverse-checkpoint-order': isLanguageRTL()}"
-          >
-            <div
-              tabindex="0"
-              class="completed-progress-bar"
-              [style.width.%]="getCompletedProgressBarWidth()"
-              [attr.aria-label]="getProgressPercentage() + ' percent completed'"
-            ></div>
+        <div class="progress-bar-container"
+             [ngClass]="{'d-none': checkpointCount === 1, 'multiple-checkpoints-bar': checkpointCount > 1, 'reverse-checkpoint-order': isLanguageRTL()}">
+          <div class="lesson-progress-bar"
+               [ngClass]="{'reverse-checkpoint-order': isLanguageRTL()}">
+            <div tabindex="0" class="completed-progress-bar"
+                 [style.width.%]="getCompletedProgressBarWidth()"
+                 [attr.aria-label]="getProgressPercentage() + ' percent completed'">
+            </div>
           </div>
-          <div
-            *ngFor="let checkpointNode of checkpointStatusArray; index as idx"
-            [ngClass]="{
-              'completed-checkpoint-node':
-                checkpointStatusArray[idx] === 'completed',
-              'in-progress-checkpoint-node':
-                checkpointStatusArray[idx] === 'in-progress',
-              'incomplete-checkpoint-node':
-                checkpointStatusArray[idx] === 'incomplete'
-            }"
-          >
+          <div *ngFor="let checkpointNode of checkpointStatusArray; index as idx"
+               [ngClass]="{'completed-checkpoint-node': checkpointStatusArray[idx] === 'completed', 'in-progress-checkpoint-node': checkpointStatusArray[idx] === 'in-progress', 'incomplete-checkpoint-node': checkpointStatusArray[idx] === 'incomplete'}">
             {{ idx + 1 }}
           </div>
         </div>
-        <p
-          *ngIf="translatedCongratulatoryCheckpointMessage"
-          class="checkpoint-message-text e2e-test-lesson-info-modal-checkpoint-message"
-        >
+        <p *ngIf="translatedCongratulatoryCheckpointMessage"
+           class="checkpoint-message-text e2e-test-lesson-info-modal-checkpoint-message">
           {{ translatedCongratulatoryCheckpointMessage }}
         </p>
         <div class="save-progress-btn-container">
           <div class="save-progress-btn-box">
-            <button
-              type="button"
-              class="btn btn-secondary save-progress-btn"
-              *ngIf="!userIsLoggedIn && checkpointCount > 1"
-              [ngClass]="{
-                'disabled oppia-disabled-link':
-                  checkpointStatusArray[0] === 'in-progress'
-              }"
-              tabindex="0"
-              (keydown.enter)="saveLoggedOutProgress()"
-              (click)="saveLoggedOutProgress()"
-            >
+            <button type="button"
+                    class="btn btn-secondary save-progress-btn"
+                    *ngIf="(!userIsLoggedIn && checkpointCount>1)"
+                    [ngClass]="{'disabled oppia-disabled-link': checkpointStatusArray[0] === 'in-progress'}"
+                    tabindex="0"
+                    (keydown.enter)="saveLoggedOutProgress()"
+                    (click)="saveLoggedOutProgress()">
               {{ 'I18N_SAVE_PROGRESS_TEXT' | translate }}
             </button>
           </div>
-          <div
-            *ngIf="checkpointStatusArray[0] === 'in-progress'"
-            class="save-progress-btn-tooltip alert alert-danger"
-          >
+          <div *ngIf="checkpointStatusArray[0] === 'in-progress'"
+               class="save-progress-btn-tooltip alert alert-danger">
             {{ 'I18N_SAVE_BUTTON_ALERT_TOOLTIP' | translate }}
           </div>
         </div>
-        <p *ngIf="explorationIsPrivate" class="private-card-info">
-          {{ 'I18N_PLAYER_IS_PRIVATE' | translate }}
+        <p *ngIf="explorationIsPrivate"
+           class="private-card-info">
+           {{ 'I18N_PLAYER_IS_PRIVATE' | translate }}
         </p>
 
-        <ul
-          *ngIf="!explorationIsPrivate"
-          class="card-metrics row space-between center"
-        >
+        <ul *ngIf="!explorationIsPrivate"
+            class="card-metrics row space-between center">
           <li tabindex="0" class="e2e-test-info-card-rating row-item">
-            <span
-              class="fas fa-star fa-lg learn-info-card-star"
-              [ngbTooltip]="'I18N_PLAYER_RATINGS_TOOLTIP' | translate"
-              placement="top"
-            >
+            <span class="fas fa-star fa-lg learn-info-card-star"
+                  [ngbTooltip]="'I18N_PLAYER_RATINGS_TOOLTIP' | translate"
+                  placement="top">
               <span class="oppia-icon-accessibility-label">
                 {{ 'I18N_PLAYER_RATINGS_TOOLTIP' | translate }}
               </span>
@@ -129,15 +81,13 @@
               {{ 'I18N_PLAYER_UNRATED' | translate }}
             </span>
             <span *ngIf="averageRating">
-              {{ averageRating | number: '1.1-1' }}
+              {{ averageRating | number:'1.1-1'}}
             </span>
           </li>
           <li tabindex="0" class="row-item">
-            <span
-              class="far fa-eye"
-              [ngbTooltip]="'I18N_PLAYER_VIEWS_TOOLTIP' | translate"
-              placement="top"
-            >
+            <span class="far fa-eye"
+                  [ngbTooltip]="'I18N_PLAYER_VIEWS_TOOLTIP' | translate"
+                  placement="top">
               <span class="oppia-icon-accessibility-label">
                 {{ 'I18N_PLAYER_VIEWS_TOOLTIP' | translate }}
               </span>
@@ -145,71 +95,51 @@
             {{ numViews | summarizeNonnegativeNumber }}
           </li>
           <li tabindex="0" class="row-item">
-            <span
-              class="far fa-clock"
-              [ngbTooltip]="'I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate"
-              placement="top"
-            >
+            <span class="far fa-clock"
+                  [ngbTooltip]="'I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate"
+                  placement="top">
               <span class="oppia-icon-accessibility-label">
                 {{ 'I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate }}
               </span>
             </span>
             {{ lastUpdatedString }}
           </li>
-          <ul
-            tabindex="0"
-            class="oppia-info-card-exploration-contributors-profile row center row-item"
-            (click)="closeModal()"
-          >
-            <i
-              class="material-icons oppia-contributors-icon"
-              [ngbTooltip]="'I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate"
-              placement="top"
-            >
-              &#xE7EF;
+          <ul tabindex="0" class="oppia-info-card-exploration-contributors-profile row center row-item" (click)="closeModal()">
+            <i class="material-icons oppia-contributors-icon"
+               [ngbTooltip]="'I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate"
+               placement="top">
+               &#xE7EF;
             </i>
             <span class="oppia-icon-accessibility-label">
               {{ 'I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate }}
             </span>
             <div class="named-contributors-container">
-              <li
-                *ngFor="let name of contributorNames | limitTo: 2; index as idx"
-                [ngbTooltip]="name"
-                placement="top"
-                class="contributor-{{ idx }}"
-              >
+              <li *ngFor="let name of (contributorNames | limitTo: 2); index as idx"
+                  [ngbTooltip]="name"
+                  placement="top"
+                  class="contributor-{{idx}}">
                 <profile-link-image [username]="name"></profile-link-image>
               </li>
             </div>
-            <li
-              *ngIf="contributorNames.length > 2"
-              class="oppia-contributors-more-circle"
-              [ngbTooltip]="contributorNames.slice(2).join(', ')"
-              placement="top"
-            >
-              +{{ contributorNames.length - 2 }}
+            <li *ngIf="contributorNames.length > 2"
+                class="oppia-contributors-more-circle"
+                [ngbTooltip]="contributorNames.slice(2).join(', ')"
+                placement="top">
+                +{{ contributorNames.length - 2 }}
             </li>
-            <li
-              *ngIf="contributorNames.length === 0"
-              [ngbTooltip]="
-                'I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate
-              "
-              placement="top"
-            >
-              <span
-                class="far fa-globe fa-lg oppia-info-card-community-editable-icon"
-              ></span>
+            <li *ngIf="contributorNames.length === 0"
+                [ngbTooltip]="'I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate"
+                placement="top">
+              <span class="far fa-globe fa-lg oppia-info-card-community-editable-icon"></span>
             </li>
           </ul>
         </ul>
         <div *ngIf="!explorationIsPrivate" class="oppia-info-card-bottom-row">
           <div tabindex="0" class="fx-row">
             <div class="oppia-info-card-tag-icon">
-              <span
-                class="fas fa-tags oppia-info-card-modal-tooltip"
-                [ngbTooltip]="'I18N_PLAYER_TAGS_TOOLTIP' | translate"
-                placement="top"
-              >
+              <span class="fas fa-tags oppia-info-card-modal-tooltip"
+                    [ngbTooltip]="'I18N_PLAYER_TAGS_TOOLTIP' | translate"
+                    placement="top">
                 <span class="oppia-icon-accessibility-label">
                   {{ 'I18N_PLAYER_TAGS_TOOLTIP' | translate }}
                 </span>
@@ -217,45 +147,25 @@
             </div>
 
             <div class="exploration-tags">
-              <span
-                *ngIf="explorationTags.tagsInTooltip.length > 0"
-                class="oppia-info-card-tooltip-more"
-                [ngbTooltip]="explorationTags.tagsInTooltip.join(', ')"
-                placement="right"
-              >
-                {{
-                  'I18N_PLAYER_PLUS_TAGS'
-                    | translate
-                      : {
-                          additionalTagNumber:
-                            explorationTags.tagsInTooltip.length
-                        }
-                }}
+              <span *ngIf="explorationTags.tagsInTooltip.length > 0"
+                    class="oppia-info-card-tooltip-more"
+                    [ngbTooltip]="explorationTags.tagsInTooltip.join(', ')"
+                    placement="right">
+                    {{ 'I18N_PLAYER_PLUS_TAGS' | translate:{ additionalTagNumber: explorationTags.tagsInTooltip.length } }}
               </span>
               <span *ngIf="explorationTags.tagsToShow.length > 0">
-                {{ explorationTags.tagsToShow.join(', ') }}
+                {{ explorationTags.tagsToShow.join(", ") }}
               </span>
-              <span
-                *ngIf="
-                  explorationTags.tagsToShow.length === 0 &&
-                  explorationTags.tagsInTooltip.length === 0
-                "
-              >
-                <span
-                  ><em>{{ 'I18N_PLAYER_NO_TAGS' | translate }}</em></span
-                >
+              <span *ngIf="explorationTags.tagsToShow.length === 0 && explorationTags.tagsInTooltip.length === 0">
+                <span><em>{{ 'I18N_PLAYER_NO_TAGS' | translate }}</em></span>
               </span>
             </div>
           </div>
           <div flex="60" class="sharing-links-container">
-            <sharing-links
-              flex="45"
-              layoutType="row wrap"
-              layoutAlignType="end center"
-              twitterText="DEFAULT_TWITTER_SHARE_MESSAGE_PLAYER"
-              shareType="exploration"
-              [explorationId]="explorationId"
-            >
+            <sharing-links flex="45" layoutType="row wrap" layoutAlignType="end center"
+                           twitterText="DEFAULT_TWITTER_SHARE_MESSAGE_PLAYER"
+                           shareType="exploration"
+                           [explorationId]="explorationId">
             </sharing-links>
           </div>
         </div>
@@ -263,38 +173,24 @@
     </div>
   </div>
 </mat-card>
-<button
-  type="button"
-  class="oppia-close-popover-button e2e-test-close-lesson-info-modal-button"
-  (click)="cancel()"
->
+<button type="button" class="oppia-close-popover-button e2e-test-close-lesson-info-modal-button" (click)="cancel()">
   <i class="material-icons md-18">&#xE5CD;</i>
   <span class="oppia-icon-accessibility-label">Close</span>
 </button>
-<div
-  *ngIf="saveProgressMenuIsShown && !userIsLoggedIn"
-  class="save-progress-menu-backdrop"
-></div>
-<div
-  class="save-progress-menu"
-  *ngIf="saveProgressMenuIsShown && !userIsLoggedIn"
->
+<div *ngIf="saveProgressMenuIsShown && !userIsLoggedIn"
+     class="save-progress-menu-backdrop">
+</div>
+<div class="save-progress-menu"
+     *ngIf="saveProgressMenuIsShown && !userIsLoggedIn">
   <h3>{{ 'I18N_SAVE_PROGRESS_TEXT' | translate }}</h3>
   <div class="sign-in-box">
     <p>{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_1' | translate }}</p>
-    <button
-      type="button"
-      class="btn btn-secondary create-account-btn"
-      (click)="onLoginButtonClicked()"
-    >
-      {{ 'I18N_CREATE_ACCOUNT' | translate }}
+    <button type="button"
+            class="btn btn-secondary create-account-btn"
+            (click)="onLoginButtonClicked()">
+          {{ 'I18N_CREATE_ACCOUNT' | translate }}
     </button>
-    <p class="sign-in-text">
-      {{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_2' | translate
-      }}<a class="sign-in-link" (click)="onLoginButtonClicked()">{{
-        'I18N_TOPNAV_SIGN_IN' | translate
-      }}</a>
-    </p>
+    <p class="sign-in-text">{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_2' | translate }}<a class="sign-in-link" (click)="onLoginButtonClicked()">{{ 'I18N_TOPNAV_SIGN_IN' | translate }}</a></p>
   </div>
   <div class="separator">
     <div class="bars"></div>
@@ -302,24 +198,14 @@
     <div class="bars"></div>
   </div>
   <div class="uid-box">
-    <p class="guide-text">
-      {{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_3' | translate }}
-    </p>
-    <p class="copy-text">
-      {{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_5' | translate }}
-    </p>
-    <div
-      [ngStyle]="{'flex-direction': isLanguageRTL() ? 'row-reverse' : 'row'}"
-      class="oppia-tooltip-container"
-    >
+    <p class="guide-text">{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_3' | translate }}</p>
+    <p class="copy-text">{{ 'I18N_SAVE_EXPLORATION_PROGRESS_TEXT_5' | translate }}</p>
+    <div [ngStyle]="{ 'flex-direction': isLanguageRTL() ? 'row-reverse' : 'row' }"
+         class="oppia-tooltip-container">
       <oppia-copy-url [urlToCopy]="loggedOutProgressUniqueUrl"></oppia-copy-url>
     </div>
   </div>
-  <button
-    type="button"
-    class="save-progress-close-button"
-    (click)="closeSaveProgressMenu()"
-  >
+  <button type="button" class="save-progress-close-button" (click)="closeSaveProgressMenu()">
     <i class="material-icons md-24">&#xE5CD;</i>
     <span class="oppia-icon-accessibility-label">Close</span>
   </button>

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
@@ -104,7 +104,8 @@
             </span>
             {{ lastUpdatedString }}
           </li>
-          <ul tabindex="0" class="oppia-info-card-exploration-contributors-profile row center row-item">
+          <ul tabindex="0" class="oppia-info-card-exploration-contributors-profile row center row-item"
+          (click)="closeModal()">
             <i class="material-icons oppia-contributors-icon"
                [ngbTooltip]="'I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate"
                placement="top">

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.spec.ts
@@ -123,6 +123,7 @@ describe('Lesson Information card modal component', () => {
   let explorationPlayerStateService: ExplorationPlayerStateService;
   let localStorageService: LocalStorageService;
   let checkpointCelebrationUtilityService: CheckpointCelebrationUtilityService;
+  let activeModal: NgbActiveModal;
 
   let expId = 'expId';
   let expTitle = 'Exploration Title';
@@ -208,6 +209,7 @@ describe('Lesson Information card modal component', () => {
     checkpointCelebrationUtilityService = TestBed.inject(
       CheckpointCelebrationUtilityService
     );
+    activeModal = TestBed.inject(NgbActiveModal);
 
     spyOn(
       i18nLanguageCodeService,
@@ -522,5 +524,12 @@ describe('Lesson Information card modal component', () => {
     componentInstance.checkpointCount = 7;
 
     expect(componentInstance.getProgressPercentage()).toEqual('28');
+  });
+
+  it('should close the modal', () => {
+    const closeSpy = spyOn(activeModal, 'close').and.callThrough();
+    componentInstance.closeModal();
+
+    expect(closeSpy).toHaveBeenCalled();
   });
 });

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
@@ -16,25 +16,25 @@
  * @fileoverview Component for lesson information card modal.
  */
 
-import { Clipboard } from '@angular/cdk/clipboard';
-import { Component } from '@angular/core';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { ConfirmOrCancelModal } from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
-import { StateCard } from 'domain/state_card/state-card.model';
-import { LearnerExplorationSummaryBackendDict } from 'domain/summary/learner-exploration-summary.model';
-import { UrlService } from 'services/contextual/url.service';
-import { UserService } from 'services/user.service';
-import { WindowRef } from 'services/contextual/window-ref.service';
-import { LocalStorageService } from 'services/local-storage.service';
+import {Clipboard} from '@angular/cdk/clipboard';
+import {Component} from '@angular/core';
+import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import {ConfirmOrCancelModal} from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
+import {StateCard} from 'domain/state_card/state-card.model';
+import {LearnerExplorationSummaryBackendDict} from 'domain/summary/learner-exploration-summary.model';
+import {UrlService} from 'services/contextual/url.service';
+import {UserService} from 'services/user.service';
+import {WindowRef} from 'services/contextual/window-ref.service';
+import {LocalStorageService} from 'services/local-storage.service';
 import {
   I18nLanguageCodeService,
   TranslationKeyType,
 } from 'services/i18n-language-code.service';
-import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
-import { RatingComputationService } from 'components/ratings/rating-computation/rating-computation.service';
-import { DateTimeFormatService } from 'services/date-time-format.service';
-import { ExplorationPlayerStateService } from 'pages/exploration-player-page/services/exploration-player-state.service';
-import { CheckpointCelebrationUtilityService } from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
+import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
+import {RatingComputationService} from 'components/ratings/rating-computation/rating-computation.service';
+import {DateTimeFormatService} from 'services/date-time-format.service';
+import {ExplorationPlayerStateService} from 'pages/exploration-player-page/services/exploration-player-state.service';
+import {CheckpointCelebrationUtilityService} from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
 
 interface ExplorationTagSummary {
   tagsToShow: string[];
@@ -69,7 +69,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
   expInfo!: LearnerExplorationSummaryBackendDict;
   completedCheckpointsCount!: number;
   checkpointStatusArray!: string[];
-  infoCardBackgroundCss!: { 'background-color': string };
+  infoCardBackgroundCss!: {'background-color': string};
   infoCardBackgroundImageUrl!: string;
   averageRating!: number | null;
   numViews!: number;
@@ -268,7 +268,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
       if (urlId === null) {
         throw new Error(
           'User should not be able to login if ' +
-          'loggedOutProgressUniqueUrlId is not null.'
+            'loggedOutProgressUniqueUrlId is not null.'
         );
       }
       this.localStorageService.updateUniqueProgressIdOfLoggedOutLearner(urlId);

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
@@ -279,4 +279,8 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
   closeSaveProgressMenu(): void {
     this.saveProgressMenuIsShown = false;
   }
+
+  closeModal(): void{
+    this.ngbActiveModal.close();
+  }
 }

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.ts
@@ -16,25 +16,25 @@
  * @fileoverview Component for lesson information card modal.
  */
 
-import {Clipboard} from '@angular/cdk/clipboard';
-import {Component} from '@angular/core';
-import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
-import {ConfirmOrCancelModal} from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
-import {StateCard} from 'domain/state_card/state-card.model';
-import {LearnerExplorationSummaryBackendDict} from 'domain/summary/learner-exploration-summary.model';
-import {UrlService} from 'services/contextual/url.service';
-import {UserService} from 'services/user.service';
-import {WindowRef} from 'services/contextual/window-ref.service';
-import {LocalStorageService} from 'services/local-storage.service';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Component } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { ConfirmOrCancelModal } from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
+import { StateCard } from 'domain/state_card/state-card.model';
+import { LearnerExplorationSummaryBackendDict } from 'domain/summary/learner-exploration-summary.model';
+import { UrlService } from 'services/contextual/url.service';
+import { UserService } from 'services/user.service';
+import { WindowRef } from 'services/contextual/window-ref.service';
+import { LocalStorageService } from 'services/local-storage.service';
 import {
   I18nLanguageCodeService,
   TranslationKeyType,
 } from 'services/i18n-language-code.service';
-import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
-import {RatingComputationService} from 'components/ratings/rating-computation/rating-computation.service';
-import {DateTimeFormatService} from 'services/date-time-format.service';
-import {ExplorationPlayerStateService} from 'pages/exploration-player-page/services/exploration-player-state.service';
-import {CheckpointCelebrationUtilityService} from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
+import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
+import { RatingComputationService } from 'components/ratings/rating-computation/rating-computation.service';
+import { DateTimeFormatService } from 'services/date-time-format.service';
+import { ExplorationPlayerStateService } from 'pages/exploration-player-page/services/exploration-player-state.service';
+import { CheckpointCelebrationUtilityService } from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
 
 interface ExplorationTagSummary {
   tagsToShow: string[];
@@ -69,7 +69,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
   expInfo!: LearnerExplorationSummaryBackendDict;
   completedCheckpointsCount!: number;
   checkpointStatusArray!: string[];
-  infoCardBackgroundCss!: {'background-color': string};
+  infoCardBackgroundCss!: { 'background-color': string };
   infoCardBackgroundImageUrl!: string;
   averageRating!: number | null;
   numViews!: number;
@@ -268,7 +268,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
       if (urlId === null) {
         throw new Error(
           'User should not be able to login if ' +
-            'loggedOutProgressUniqueUrlId is not null.'
+          'loggedOutProgressUniqueUrlId is not null.'
         );
       }
       this.localStorageService.updateUniqueProgressIdOfLoggedOutLearner(urlId);
@@ -280,7 +280,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
     this.saveProgressMenuIsShown = false;
   }
 
-  closeModal(): void{
+  closeModal(): void {
     this.ngbActiveModal.close();
   }
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19990 .
2. This PR does the following: Adds a closeModal method to lesson-information-card-modal component
3. The original bug occurred because: *There was no onclick handler for closing the modal when user navigates to one of the contributor's profile*

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct

https://github.com/oppia/oppia/assets/98162702/0eda8012-c22a-43c9-a87f-c652b69e2bce


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. (For changes involving responsiveness or adjustment
of UI elements, this should be a video that gradually resizes the viewport from wide
to narrow and back again.) If this PR is for a developer-facing feature, provide
the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be sure
that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
