### PR TITLE
Fix #20018: (Flake) Classroom config tile selector is not visible.

### DIFF
--- a/.github/workflows/e2e_lighthouse_performance_acceptance_tests.yml
+++ b/.github/workflows/e2e_lighthouse_performance_acceptance_tests.yml
@@ -110,8 +110,6 @@ jobs:
           - name: skillEditor
           - name: subscriptions
           - name: topicsAndSkillsDashboard
-            flaky_indicators: |
-              Classroom config tile selector is not visible
           - name: topicAndStoryEditor
           - name: topicAndStoryEditorFileUploadFeatures
           - name: topicAndStoryViewer

--- a/core/tests/webdriverio_utils/DiagnosticTestPage.js
+++ b/core/tests/webdriverio_utils/DiagnosticTestPage.js
@@ -23,7 +23,7 @@ var waitFor = require('./waitFor.js');
 var DiagnosticTestPage = function () {
   var startDiagnosticTestButton = $('.e2e-test-start-diagnostic-test');
   var addNewClassroomButton = $('.e2e-test-add-new-classroom-config');
-  var newClassrooomNameInput = $('.e2e-test-new-classroom-name');
+  var newClassroomNameInput = $('.e2e-test-new-classroom-name');
   var newClassroomUrlFragmentInput = $('.e2e-test-new-classroom-url-fragment');
   var createNewClassroomButton = $('.e2e-test-create-new-classroom');
   var recommendedTopicSummaryTile = $(
@@ -63,7 +63,7 @@ var DiagnosticTestPage = function () {
 
     await action.setValue(
       'New classroom name input',
-      newClassrooomNameInput,
+      newClassroomNameInput,
       classroomName
     );
 
@@ -76,6 +76,11 @@ var DiagnosticTestPage = function () {
     await action.click(
       'Create new classroom config button',
       createNewClassroomButton
+    );
+
+    await waitFor.invisibilityOf(
+      newClassroomNameInput,
+      'Create classroom config modal taking too long to disappear.'
     );
   };
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #20018.
2. This PR does the following: This PR makes sure that the create classroom config modal is closed before trying to select the newly created classroom config tile.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
