### PR TITLE
Fix #19655: Validates empty or non-printable text for Links in RTE

### DIFF
--- a/core/templates/services/rte-helper-modal.controller.ts
+++ b/core/templates/services/rte-helper-modal.controller.ts
@@ -393,9 +393,11 @@ export class RteHelperModalComponent {
             customizationArgsDict as {
               [Prop in CustomizationArgsNameAndValueArray[number]['name']]: CustomizationArgsNameAndValueArray[number]['value'];
             }
-          )[caName] =
-            this.tmpCustomizationArgs[i].value ||
-            this.tmpCustomizationArgs[i - 1].value;
+          )[caName] = this.hasPrintableCharacters(
+            this.tmpCustomizationArgs[i].value.toString()
+          )
+            ? this.tmpCustomizationArgs[i].value
+            : this.tmpCustomizationArgs[i - 1].value;
         } else {
           (
             customizationArgsDict as {
@@ -413,5 +415,22 @@ export class RteHelperModalComponent {
     return videoUrl[2] !== undefined
       ? videoUrl[2].split(/[^0-9a-z_\-]/i)[0]
       : videoUrl[0];
+  }
+
+  hasPrintableCharacters(input: string): boolean {
+    // Returns false if empty.
+    if (!input) {
+      return false;
+    }
+
+    // Returns true if any printable character between the specified ASCII range is found.
+    for (let i = 0; i < input.length; i++) {
+      const charCode = input.charCodeAt(i);
+      if (charCode > 32 && charCode <= 126) {
+        return true;
+      }
+    }
+    // Returns false otherwise.
+    return false;
   }
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19655.
2. This PR does the following: Adds validation logic for empty or non printable link text
3. (For bug-fixing PRs only) The original bug occurred because: The case when the link has text value containing only non printable characters was not handled properly.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct

https://github.com/oppia/oppia/assets/66303548/a37e29e1-a432-4728-b000-d382aec34a17


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. (For changes involving responsiveness or adjustment
of UI elements, this should be a video that gradually resizes the viewport from wide
to narrow and back again.) If this PR is for a developer-facing feature, provide
the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be sure
that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
