### PR TITLE
Fix #20059: Console errors are not thrown inside acceptance tests.

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/spec/helpers/reporter.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/helpers/reporter.ts
@@ -168,24 +168,6 @@ const Reporter: jasmine.CustomReporter = {
     specCount++;
     const seconds = result?.duration ? result.duration / 1000 : 0;
 
-    try {
-      ConsoleReporter.reportConsoleErrors();
-    } catch (error) {
-      // Here we catch the error and add it to the failed expectations.
-      // We do not set any of the stack or actual/expected values as they
-      // are not relevant since the error message is just showing the console
-      // errors that were found during the test.
-      result.failedExpectations.push({
-        message: error,
-        stack: '',
-        actual: '',
-        expected: '',
-        matcherName: '',
-        passed: false,
-      });
-      result.status = 'failed';
-    }
-
     switch (result.status) {
       case 'pending':
         pendingSpecs.push(result);
@@ -283,3 +265,7 @@ const Reporter: jasmine.CustomReporter = {
 
 jasmine.getEnv().clearReporters();
 jasmine.getEnv().addReporter(Reporter);
+// Here we report console errors after each test suite.
+afterEach(() => {
+  ConsoleReporter.reportConsoleErrors();
+});


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20059.
2. This PR does the following: This PR fixes console errors not being considered as a exit code 1 inside acceptance tests by moving the report console errors check to a global after each.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof of Changes
![image](https://github.com/oppia/oppia/assets/70992422/3664ed64-9c66-4c5a-9a40-6b0d2d4d948d)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
