### PR TITLE
Make updates to clarify PR and issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report_form.yml
@@ -30,8 +30,8 @@ body:
         Steps to reproduce the behavior. **Example:** "1. Go to the library page. 2. Click on the 'Sign in' button. 3. See error."
 
         **Notes:**
-        - Please list the full step-by-step instructions. Do not require the reader to infer the steps from watching a video.
-        - (For devs) If any feature flags need to be turned on to reproduce the issue, specify them here as well.
+          - Please list the full step-by-step instructions. Do not require the reader to infer the steps from watching a video.
+          - (For devs) If any feature flags need to be turned on to reproduce the issue, specify them here as well.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/1_bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report_form.yml
@@ -26,7 +26,12 @@ body:
   - type: textarea
     attributes:
       label: Steps To Reproduce
-      description: Steps to reproduce the behavior. **Example:** "1. Go to the library page. 2. Click on the 'Sign in' button. 3. See error."
+      description: |
+        Steps to reproduce the behavior. **Example:** "1. Go to the library page. 2. Click on the 'Sign in' button. 3. See error."
+
+        **Notes:**
+        - Please list the full step-by-step instructions. Do not require the reader to infer the steps from watching a video.
+        - (For devs) If any feature flags need to be turned on to reproduce the issue, specify them here as well.
     validations:
       required: true
   - type: textarea
@@ -105,6 +110,8 @@ body:
       value: |
         Before addressing the bug, please identify which PR caused the issue (you can follow the steps [here](https://github.com/oppia/oppia/wiki/How-to-find-the-commit-which-introduced-a-bug)). If you identify the PR, comment on the issue with a link to it. If not, mention the commit hash of the oldest commit you saw the bug on (and the month and year it was made in).
 
-        Also, if this is your first issue, please make sure to follow https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#choosing-a-good-first-issue and https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#setting-things-up before claiming it. Thanks!
+        Then, please leave a comment with details of the approach that you plan to take to fix the issue (see [example](https://github.com/oppia/oppia/issues/19157#issuecomment-1858788463)).
+
+        **Note:** If this is your first Oppia issue, please make sure to follow our guidelines for [choosing an issue](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#choosing-a-good-first-issue) and [setting things up](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#setting-things-up). You will also need to show a demo of the fix working correctly on your local machine. Thanks!
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3_ci_error_template.yml
+++ b/.github/ISSUE_TEMPLATE/3_ci_error_template.yml
@@ -1,7 +1,7 @@
 name: CI Flake report
 description: Create a report to help us improve
 title: "[Flake]: "
-labels: [triage needed, bug]
+labels: [triage needed, bug, CI breakage]
 body:
   - type: dropdown
     id: ci-test-type
@@ -31,7 +31,10 @@ body:
     id: additional-information
     attributes:
       label: Additional Information
-      description: Add any other context about the flake here.
+      description: |
+        Add any other context about the flake here, e.g. the link to the GitHub Actions logs page.
+
+        For e2e flakes, include screenshots/videos of the failure here, since these may get wiped from GitHub Actions after a few days/weeks. (Click on "Summary" at the top-left of the test log page, scroll to the bottom, downlaod the appropriate webdriverio-screenshots/webdriverio-video artifacts, and upload them here.)
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/4_server_error_template.md
+++ b/.github/ISSUE_TEMPLATE/4_server_error_template.md
@@ -17,6 +17,8 @@ Add error logs here.
 
 **Where did the error occur?** Add the page the error occurred on.
 
+**Which release did the error occur in?** Add the Oppia release version associated with the error.
+
 **Frequency of occurrence** Add details about how many times the error occurred within a given time period (e.g. the last week, the last 30 days, etc.). This helps issue triagers establish severity.
 
 **Additional context** Add any other context that would be useful. Make sure to anonymize user data like user IDs, exploration IDs, state names, user names, etc. Replace any personal data with appropriate placeholders.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,13 @@ If there is no corresponding issue number, fill in N/A where it says [fill_in_nu
 
 ## Essential Checklist
 
+Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
+
+- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
+- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
+- [ ] I have written tests for my code.
 - [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
-- [ ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
-- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
-- [ ] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
-- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
+- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
 
 ## Testing doc (for PRs with Beam jobs that modify production server data)
 
@@ -35,13 +37,13 @@ Otherwise, please delete this section.
 ## Proof that changes are correct
 
 <!--
-Add videos/screenshots of the user-facing interface to demonstrate that the changes
-made in this PR work correctly. (For changes involving responsiveness or adjustment
-of UI elements, this should be a video that gradually resizes the viewport from wide
-to narrow and back again.) If this PR is for a developer-facing feature, provide
-the videos/screenshots of developer-facing interface. Please also include
-videos/screenshots of the developer tools browser console, so that we can be sure
-that there are no console errors.
+Add before-and-after videos/screenshots of the user-facing interface (including
+the browser devtools console) to demonstrate that the changes made in this PR
+work correctly. Make sure the actions taken in the before and after videos are
+the same. (For changes involving responsiveness or adjustment of UI elements,
+this should be a video that gradually resizes the viewport from wide to narrow
+and back again.) If this PR is for a developer-facing feature, provide
+videos/screenshots of the developer-facing interface instead.
 
 When you make updates to the PR, please update these videos/screenshots as well.
 You can drop videos/screenshots from previous versions of the PR.


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Updates issue/PR templates based on issues seen in the dev workflow:
  - Sometimes issues are reported using a video instead of a set of steps; we discourage this
  - Devs should specify feature flags to turn on when reporting an issue
  - Starter instructions should be clarified; leaving a description of the approach is mandatory for all devs
  - "CI breakage" label should be auto-applied to CI errors
  - Added instructions to retrieve screenshots/videos and upload them to flake-report issues
  - Added release version to server errors template
  - Updated PR checklist to have more relevant items
  - Clarify "PR proof" instructions to require before/after videos/screenshots

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

No proof of changes needed because this only modifies issue/PR templates.