### PR TITLE
Fix #19957:  The skills are unassigned from a topic, even when deletion fails

### DIFF
--- a/core/controllers/skill_editor.py
+++ b/core/controllers/skill_editor.py
@@ -315,13 +315,13 @@ class EditableSkillDataHandler(
             InvalidInputException. The skill still has associated questions.
         """
         assert self.user_id is not None
-        skill_services.remove_skill_from_all_topics(self.user_id, skill_id)
 
         if skill_services.skill_has_associated_questions(skill_id):
             raise self.InvalidInputException(
                 'Please delete all questions associated with this skill '
                 'first.')
 
+        skill_services.remove_skill_from_all_topics(self.user_id, skill_id)
         skill_services.delete_skill(self.user_id, skill_id)
 
         self.render_json(self.values)


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of [[BUG]: The skills are unassigned from a topic, even when deletion fails #19957](https://github.com/oppia/oppia/issues/19957).
2. This PR does the following: the line that removes the skill from the topics has been moved after the check for associated questions and the raising of the exception if deletion fails, in the file
oppia/core/controllers/skill_editor.py so the skill is only unassigned from the topics if it will actually be deleted.
3. (For bug-fixing PRs only) The original bug occurred because: this [PR Fix #9756, #9755 Fixing error in deleting skill #9769](https://github.com/oppia/oppia/pull/9769) removed verification of skill assigned to topics.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

https://github.com/luanaaferraaz/oppia/assets/109438076/b389ba81-3fbd-47c9-94c2-e8fb42ea0e4c

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
