### PR TITLE
Fix #19890: Unable to save after canceling save the first time

### DIFF
--- a/core/templates/components/question-directives/questions-list/questions-list.component.spec.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.spec.ts
@@ -763,6 +763,18 @@ describe('Questions List Component', () => {
     })
   );
 
+  it('should not disable save button when user cancels the save modal', fakeAsync(() => {
+    component.questionIsBeingUpdated = true;
+    spyOn(ngbModal, 'open').and.returnValue({
+      result: Promise.reject(),
+    } as NgbModalRef);
+
+    component.saveQuestion();
+    tick();
+
+    expect(component.questionIsBeingSaved).toBe(false);
+  }));
+
   it(
     "should close 'confirm question modal exit' modal when user clicks" +
       ' cancel',

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -690,6 +690,7 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
             // Note to developers:
             // This callback is triggered when the Cancel button is
             // clicked. No further action is needed.
+            this.questionIsBeingSaved = false;
           }
         );
     } else {

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -687,9 +687,6 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
             }
           },
           () => {
-            // Note to developers:
-            // This callback is triggered when the Cancel button is
-            // clicked. No further action is needed.
             this.questionIsBeingSaved = false;
           }
         );


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19890.
2. This PR does the following: This PR reenables the save button in the skill editor after canceling the modal by setting the questionIsBeingSaved variable in the callback of the ngbModal cancel.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
https://github.com/oppia/oppia/assets/70992422/4b61d9b7-c258-46bb-b750-6c8a467d9b1a

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
