### PR TITLE
Fixes bug in the voiceover admin page

### DIFF
--- a/core/domain/voiceover_services.py
+++ b/core/domain/voiceover_services.py
@@ -362,7 +362,7 @@ def get_voiceover_filenames(
     # method instead.
     # https://github.com/python/mypy/issues/9590
     k = lambda voiceover: voiceover['duration_secs']
-    contributed_voiceovers.sort(key=k)
+    contributed_voiceovers.sort(key=k, reverse=True)
 
     if (
         len(contributed_voiceovers) >

--- a/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.html
+++ b/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.html
@@ -1,5 +1,5 @@
 <mat-card class="oppia-editor-card-with-avatar oppia-page-card oppia-long-text-card">
-  <h3>Update language/accent pairs available for learners and voice artists</h3>
+  <h3>Update language/accent pairs that learners and voice artists can select</h3>
   <div class="card-content">
     <div *ngIf="!pageIsInitialized">
       <p>Loading ...</p>
@@ -38,10 +38,10 @@
         <mat-form-field class="oppia-language-accent-dropdown-selector">
           <mat-label>Language Accent pair</mat-label>
           <mat-select (selectionChange)="addLanguageAccentCodeSupport($event.value)">
-            <mat-option *ngFor="let languageAccentCodeToDescription of availableLanguageAccentCodesToDescriptions | keyvalue"
-                        [value]="languageAccentCodeToDescription.key">
+            <mat-option *ngFor="let languageAccentDescriptionToCode of availableLanguageAccentDescriptionsToCodes | keyvalue"
+                        [value]="languageAccentDescriptionToCode.value">
               <span>
-                {{languageAccentCodeToDescription.value}}
+                {{languageAccentDescriptionToCode.key}}
               </span>
             </mat-option>
           </mat-select>

--- a/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.spec.ts
+++ b/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.spec.ts
@@ -89,7 +89,7 @@ describe('Voiceover Admin Page component ', () => {
         'en-US': true,
       },
     };
-    component.availableLanguageAccentCodesToDescriptions = {};
+    component.availableLanguageAccentDescriptionsToCodes = {};
     let voiceoverAdminDataResponse = {
       languageAccentMasterList: languageAccentMasterList,
       languageCodesMapping: languageCodesMapping,
@@ -131,16 +131,16 @@ describe('Voiceover Admin Page component ', () => {
     expect(
       voiceoverBackendApiService.fetchVoiceArtistMetadataAsync
     ).toHaveBeenCalled();
-    expect(component.availableLanguageAccentCodesToDescriptions).toEqual({
-      'hi-IN': 'Hindi (India)',
+    expect(component.availableLanguageAccentDescriptionsToCodes).toEqual({
+      'Hindi (India)': 'hi-IN',
     });
     expect(component.pageIsInitialized).toBeTrue();
   }));
 
   it('should be able to add language accent pair', fakeAsync(() => {
-    component.availableLanguageAccentCodesToDescriptions = {
-      'en-US': 'English (United States)',
-      'hi-IN': 'Hindi (India)',
+    component.availableLanguageAccentDescriptionsToCodes = {
+      'English (United States)': 'en-US',
+      'Hindi (India)': 'hi-IN',
     };
     component.languageAccentCodesToDescriptionsMasterList = {
       'en-US': 'English (United States)',
@@ -162,14 +162,14 @@ describe('Voiceover Admin Page component ', () => {
     expect(component.supportedLanguageAccentCodesToDescriptions).toEqual({
       'en-US': 'English (United States)',
     });
-    expect(component.availableLanguageAccentCodesToDescriptions).toEqual({
-      'hi-IN': 'Hindi (India)',
+    expect(component.availableLanguageAccentDescriptionsToCodes).toEqual({
+      'Hindi (India)': 'hi-IN',
     });
   }));
 
   it('should be able to remove language accent pair', fakeAsync(() => {
-    component.availableLanguageAccentCodesToDescriptions = {
-      'hi-IN': 'Hindi (India)',
+    component.availableLanguageAccentDescriptionsToCodes = {
+      'Hindi (India)': 'hi-IN',
     };
     component.languageAccentCodesToDescriptionsMasterList = {
       'en-US': 'English (United States)',
@@ -201,15 +201,15 @@ describe('Voiceover Admin Page component ', () => {
 
     expect(ngbModal.open).toHaveBeenCalled();
     expect(component.supportedLanguageAccentCodesToDescriptions).toEqual({});
-    expect(component.availableLanguageAccentCodesToDescriptions).toEqual({
-      'hi-IN': 'Hindi (India)',
-      'en-US': 'English (United States)',
+    expect(component.availableLanguageAccentDescriptionsToCodes).toEqual({
+      'Hindi (India)': 'hi-IN',
+      'English (United States)': 'en-US',
     });
   }));
 
   it('should not remove language accent pair when confirm modal is cancelled', fakeAsync(() => {
-    component.availableLanguageAccentCodesToDescriptions = {
-      'hi-IN': 'Hindi (India)',
+    component.availableLanguageAccentDescriptionsToCodes = {
+      'Hindi (India)': 'hi-IN',
     };
     component.languageAccentCodesToDescriptionsMasterList = {
       'en-US': 'English (United States)',
@@ -239,8 +239,8 @@ describe('Voiceover Admin Page component ', () => {
     expect(component.supportedLanguageAccentCodesToDescriptions).toEqual({
       'en-US': 'English (United States)',
     });
-    expect(component.availableLanguageAccentCodesToDescriptions).toEqual({
-      'hi-IN': 'Hindi (India)',
+    expect(component.availableLanguageAccentDescriptionsToCodes).toEqual({
+      'Hindi (India)': 'hi-IN',
     });
   }));
 

--- a/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.ts
+++ b/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.ts
@@ -34,6 +34,10 @@ interface LanguageAccentCodeToLanguageCode {
   [languageAccentCode: string]: string;
 }
 
+export interface LanguageAccentDescriptionToCode {
+  [languageAccentDescription: string]: string;
+}
+
 @Component({
   selector: 'oppia-voiceover-admin-page',
   templateUrl: './voiceover-admin-page.component.html',
@@ -49,7 +53,7 @@ export class VoiceoverAdminPageComponent implements OnInit {
 
   languageAccentCodeToLanguageCode!: LanguageAccentCodeToLanguageCode;
   supportedLanguageAccentCodesToDescriptions!: LanguageAccentToDescription;
-  availableLanguageAccentCodesToDescriptions!: LanguageAccentToDescription;
+  availableLanguageAccentDescriptionsToCodes!: LanguageAccentDescriptionToCode;
   languageAccentCodesToDescriptionsMasterList!: LanguageAccentToDescription;
   languageCodesMapping!: LanguageCodesMapping;
   pageIsInitialized: boolean = false;
@@ -75,8 +79,8 @@ export class VoiceoverAdminPageComponent implements OnInit {
         this.languageCodesMapping = response.languageCodesMapping;
         this.languageAccentCodeToLanguageCode = {};
         this.supportedLanguageAccentCodesToDescriptions = {};
-        this.availableLanguageAccentCodesToDescriptions = {};
         this.languageAccentCodesToDescriptionsMasterList = {};
+        this.availableLanguageAccentDescriptionsToCodes = {};
         this.initializeLanguageAccentCodesFields(
           response.languageAccentMasterList
         );
@@ -182,8 +186,9 @@ export class VoiceoverAdminPageComponent implements OnInit {
       if (
         !(languageAccentCode in this.supportedLanguageAccentCodesToDescriptions)
       ) {
-        this.availableLanguageAccentCodesToDescriptions[languageAccentCode] =
-          languageAccentDescription;
+        this.availableLanguageAccentDescriptionsToCodes[
+          languageAccentDescription
+        ] = languageAccentCode;
       }
     }
 
@@ -199,8 +204,8 @@ export class VoiceoverAdminPageComponent implements OnInit {
 
     this.supportedLanguageAccentCodesToDescriptions[languageAccentCodeToAdd] =
       languageAccentDescription;
-    delete this.availableLanguageAccentCodesToDescriptions[
-      languageAccentCodeToAdd
+    delete this.availableLanguageAccentDescriptionsToCodes[
+      languageAccentDescription
     ];
 
     if (!(languageCode in this.languageCodesMapping)) {
@@ -237,9 +242,9 @@ export class VoiceoverAdminPageComponent implements OnInit {
         delete this.supportedLanguageAccentCodesToDescriptions[
           languageAccentCodeToRemove
         ];
-        this.availableLanguageAccentCodesToDescriptions[
-          languageAccentCodeToRemove
-        ] = languageAccentDescription;
+        this.availableLanguageAccentDescriptionsToCodes[
+          languageAccentDescription
+        ] = languageAccentCodeToRemove;
 
         delete this.languageCodesMapping[languageCode][
           languageAccentCodeToRemove

--- a/data/voiceovers/language_accent_master_list.json
+++ b/data/voiceovers/language_accent_master_list.json
@@ -236,7 +236,7 @@
     "pa": {
         "pa-IN": "Punjabi (India)"
     },
-    "pcm-NG": {
+    "pcm": {
         "pcm-NG": "Nigerian Pidgin (Nigeria)"
     },
     "pl": {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

The PR fixes the following issues in the voiceover admin page:
1. The language accent options in the available language accent dropdown should be sorted.
2. The heading the language card should be updated to "Update language/accent pairs that learners and voice artists can select"
3. Should be able to select accent for language code "pcm".
4. Should be able to surface longest voiceovers while selecting accent for a voice artist. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

Before changes: The dropdown of supported language accent for voiceover does not contains options in sorted order.

https://github.com/oppia/oppia/assets/57531197/7c5aa0dd-7210-402c-ad8d-d6e1d213b591

----------------------------------------------------

After changes: The dropdown of the supported language-accent dropdown for voiceovers do contains the options in sorted order.

https://github.com/oppia/oppia/assets/57531197/585b4c40-3f8c-4f7f-b18d-df3a71b47f2f

----------------------------------------------------

The sample voiceover for a voice artist are reverse sorted e.g in the below video the first audio says "Longest voiceover for 7 to 8 seconds" and the last audio says "Voiceover for 2 seconds". _(Here I have not added the video proof of before changes since it is just a reverse sorting of voiceovers that is performed with [this change](https://github.com/oppia/oppia/pull/20141/files#diff-1a14d81780010f7711679d50da0ac989462fda75075e182b2f04df1673f230f4R365))_

https://github.com/oppia/oppia/assets/57531197/922a348b-7044-46d3-8fc1-ac288770d95e

----------------------------------------------------




<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
