### PR TITLE
Fix part of 19858: Catch and Log Mailchimp Signup Errors

### DIFF
--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -963,6 +963,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             expected_status_int=400
         )
         error_msg = (
+            'At \'http://localhost/adminhandler\' these errors are happening:\n'
             'Schema validation for \'platform_param_name\' failed: Expected '
             'string, received 123')
         self.assertEqual(response['error'], error_msg)
@@ -986,6 +987,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             expected_status_int=400
         )
         error_msg = (
+            'At \'http://localhost/adminhandler\' these errors are happening:\n'
             'Schema validation for \'commit_message\' failed: Expected '
             'string, received 123')
         self.assertEqual(response['error'], error_msg)
@@ -1009,6 +1011,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             expected_status_int=400
         )
         error_msg = (
+            'At \'http://localhost/adminhandler\' these errors are happening:\n'
             'Schema validation for \'new_rules\' failed: Expected list, '
             'received {}')
         self.assertEqual(response['error'], error_msg)
@@ -1022,6 +1025,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
         csrf_token = self.get_new_csrf_token()
 
         error_msg = (
+            'At \'http://localhost/adminhandler\' these errors are happening:\n'
             'Schema validation for \'new_rules\' failed: \'int\' '
             'object is not subscriptable')
         response = self.post_json(
@@ -1125,7 +1129,11 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             '/adminsuperadminhandler', {}, csrf_token=self.get_new_csrf_token(),
             expected_status_int=400)
 
-        error_msg = 'Missing key in handler args: username.'
+        error_msg = (
+            'At \'http://localhost/adminsuperadminhandler\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: username.'
+        )
         self.assertEqual(response['error'], error_msg)
 
     def test_grant_super_admin_privileges_fails_with_invalid_username(
@@ -1177,7 +1185,11 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
         response = self.delete_json(
             '/adminsuperadminhandler', params={}, expected_status_int=400)
 
-        error_msg = 'Missing key in handler args: username.'
+        error_msg = (
+            'At \'http://localhost/adminsuperadminhandler\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: username.'
+        )
         self.assertEqual(response['error'], error_msg)
 
     def test_revoke_super_admin_privileges_fails_with_invalid_username(
@@ -1268,6 +1280,7 @@ class GenerateDummyExplorationsTest(test_utils.GenericTestBase):
             }, csrf_token=csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/adminhandler\' these errors are happening:\n'
             'Schema validation for \'num_dummy_exps_to_generate\' failed: '
             'Could not convert str to int: invalid_type')
         self.assertEqual(response['error'], error_msg)
@@ -1292,6 +1305,7 @@ class GenerateDummyExplorationsTest(test_utils.GenericTestBase):
             }, csrf_token=csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/adminhandler\' these errors are happening:\n'
             'Schema validation for \'num_dummy_exps_to_publish\' failed: '
             'Could not convert str to int: invalid_type')
         self.assertEqual(response['error'], error_msg)
@@ -1441,6 +1455,9 @@ class AdminRoleHandlerTest(test_utils.GenericTestBase):
             params={'filter_criterion': 'invalid', 'username': 'user1'},
             expected_status_int=400)
         error_msg = (
+            'At \'http://localhost/adminrolehandler?'
+            'filter_criterion=invalid&username=user1\' '
+            'these errors are happening:\n'
             'Schema validation for \'filter_criterion\' failed: Received '
             'invalid which is not in the allowed range of choices: '
             '[\'role\', \'username\']')
@@ -2286,6 +2303,9 @@ class DataExtractionQueryHandlerTests(test_utils.GenericTestBase):
         }
 
         error_msg = (
+            'At \'http://localhost/explorationdataextractionhandler?'
+            'exp_id=exp&exp_version=a&state_name=Introduction&num_answers=0\' '
+            'these errors are happening:\n'
             'Schema validation for \'exp_version\' failed: '
             'Could not convert str to int: a')
         response = self.get_json(
@@ -2433,7 +2453,11 @@ class UpdateUsernameHandlerTest(test_utils.GenericTestBase):
                 'new_username': None},
             csrf_token=csrf_token,
             expected_status_int=400)
-        error_msg = 'Missing key in handler args: new_username.'
+        error_msg = (
+            'At \'http://localhost/updateusernamehandler\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: new_username.'
+        )
         self.assertEqual(response['error'], error_msg)
 
     def test_update_username_with_none_old_username(self) -> None:
@@ -2446,7 +2470,11 @@ class UpdateUsernameHandlerTest(test_utils.GenericTestBase):
                 'new_username': self.NEW_USERNAME},
             csrf_token=csrf_token,
             expected_status_int=400)
-        error_msg = 'Missing key in handler args: old_username.'
+        error_msg = (
+            'At \'http://localhost/updateusernamehandler\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: old_username.'
+        )
         self.assertEqual(response['error'], error_msg)
 
     def test_update_username_with_non_string_new_username(self) -> None:
@@ -2460,7 +2488,10 @@ class UpdateUsernameHandlerTest(test_utils.GenericTestBase):
             csrf_token=csrf_token,
             expected_status_int=400)
         self.assertEqual(
-            response['error'], 'Schema validation for \'new_username\' failed:'
+            response['error'],
+            'At \'http://localhost/updateusernamehandler\' '
+            'these errors are happening:\n'
+            'Schema validation for \'new_username\' failed:'
             ' Expected string, received 123')
 
     def test_update_username_with_non_string_old_username(self) -> None:
@@ -2474,6 +2505,8 @@ class UpdateUsernameHandlerTest(test_utils.GenericTestBase):
             csrf_token=csrf_token,
             expected_status_int=400)
         error_msg = (
+            'At \'http://localhost/updateusernamehandler\' '
+            'these errors are happening:\n'
             'Schema validation for \'old_username\' failed: Expected'
             ' string, received 123')
         self.assertEqual(response['error'], error_msg)
@@ -2490,6 +2523,8 @@ class UpdateUsernameHandlerTest(test_utils.GenericTestBase):
             csrf_token=csrf_token,
             expected_status_int=400)
         error_msg = (
+            'At \'http://localhost/updateusernamehandler\' '
+            'these errors are happening:\n'
             'Schema validation for \'new_username\' failed: Validation failed'
             ': has_length_at_most ({\'max_value\': %s}) for object %s'
             % (constants.MAX_USERNAME_LENGTH, long_username))
@@ -2940,6 +2975,7 @@ class GenerateDummyBlogPostTest(test_utils.GenericTestBase):
             }, csrf_token=csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/adminhandler\' these errors are happening:\n'
             'Schema validation for \'blog_post_title\' failed: Received %s '
             'which is not in the allowed range of choices: [\'Leading The '
             'Arabic Translations Team\', \'Education\', \'Blog with different'
@@ -2996,4 +3032,7 @@ class IntereactionByExplorationIdHandlerTests(test_utils.GenericTestBase):
             '/interactions', params={},
             expected_status_int=400)
         self.assertEqual(
-            response['error'], 'Missing key in handler args: exp_id.')
+            response['error'],
+            'At \'http://localhost/interactions\' these errors are happening:\n'
+            'Missing key in handler args: exp_id.'
+        )

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -523,7 +523,11 @@ class BaseHandler(
             'Use self.normalized_payload instead of self.payload.')
 
         if errors:
-            raise self.InvalidInputException('\n'.join(errors))
+            raise self.InvalidInputException(
+                'At \'%s\' these errors are happening:\n%s' % (
+                    self.request.uri, '\n'.join(errors)
+                )
+            )
 
     @property
     def current_user_is_site_maintainer(self) -> bool:

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -2065,6 +2065,8 @@ class SchemaValidationRequestArgsTests(test_utils.GenericTestBase):
                 '/mock_play_exploration?exploration_id=%s' % self.exp_id,
                     expected_status_int=400)
             error_msg = (
+                'At \'http://localhost/mock_play_exploration?'
+                'exploration_id=exp_id\' these errors are happening:\n'
                 'Schema validation for \'exploration_id\' failed: Could not '
                 'convert str to int: %s' % self.exp_id)
             self.assertEqual(response['error'], error_msg)

--- a/core/controllers/beam_jobs_test.py
+++ b/core/controllers/beam_jobs_test.py
@@ -130,4 +130,7 @@ class BeamJobRunResultHandlerTests(BeamHandlerTestBase):
             self.get_json('/beam_job_run_result', expected_status_int=400))
 
         self.assertEqual(
-            response['error'], 'Missing key in handler args: job_id.')
+            response['error'],
+            'At \'http://localhost/beam_job_run_result\' these errors are '
+            'happening:\n'
+            'Missing key in handler args: job_id.')

--- a/core/controllers/blog_admin_test.py
+++ b/core/controllers/blog_admin_test.py
@@ -179,7 +179,10 @@ class BlogAdminHandlerTest(test_utils.GenericTestBase):
             '/blogadminhandler', payload, csrf_token=csrf_token,
             expected_status_int=400)
         self.assertEqual(
-            response_dict['error'], 'Schema validation for \'new_platform_'
+            response_dict['error'],
+            'At \'http://localhost/blogadminhandler\' '
+            'these errors are happening:\n'
+            'Schema validation for \'new_platform_'
             'parameter_values\' failed: The value of max_number_of_tags_'
             'assigned_to_blog_post platform parameter is not of valid type, '
             'it should be one of typing.Union[str, int, bool, float].')
@@ -233,7 +236,10 @@ class BlogAdminHandlerTest(test_utils.GenericTestBase):
             '/blogadminhandler', payload, csrf_token=csrf_token,
             expected_status_int=400)
         self.assertEqual(
-            response_dict['error'], 'Schema validation for \'new_platform_'
+            response_dict['error'],
+            'At \'http://localhost/blogadminhandler\' '
+            'these errors are happening:\n'
+            'Schema validation for \'new_platform_'
             'parameter_values\' failed: The value of max_number_of_tags_'
             'assigned_to_blog_post should be greater than 0, it is -2.')
 
@@ -264,7 +270,10 @@ class BlogAdminHandlerTest(test_utils.GenericTestBase):
             '/blogadminhandler', payload, csrf_token=csrf_token,
             expected_status_int=400)
         self.assertEqual(
-            response_dict['error'], 'Schema validation for \'new_platform_'
+            response_dict['error'],
+            'At \'http://localhost/blogadminhandler\' '
+            'these errors are happening:\n'
+            'Schema validation for \'new_platform_'
             'parameter_values\' failed: The value of platform parameter '
             'max_number_of_tags_assigned_to_blog_post is of type \'string\', '
             'expected it to be of type \'number\'')

--- a/core/controllers/blog_dashboard_test.py
+++ b/core/controllers/blog_dashboard_test.py
@@ -410,9 +410,11 @@ class BlogPostHandlerTests(test_utils.GenericTestBase):
         response = self.put_json(
             '%s/%s' % (feconf.BLOG_EDITOR_DATA_URL_PREFIX, self.blog_post.id),
             payload, csrf_token=csrf_token, expected_status_int=400)
-        self.assertEqual(
-            response['error'], 'Schema validation for \'change_dict\''
-            ' failed: Title should be a string.')
+        self.assertIn(
+            'Schema validation for \'change_dict\''
+            ' failed: Title should be a string.',
+            response['error'],
+        )
 
     def test_publishing_unpublishing_blog_post(self) -> None:
         self.login(self.BLOG_EDITOR_EMAIL)

--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -253,6 +253,8 @@ class CollectionEditorTests(BaseCollectionEditorControllerTests):
             long_message_dict, csrf_token=csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/collection_editor_handler/data/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'commit_message\' failed: Validation '
             'failed: has_length_at_most ({\'max_value\': 375}) for object %s'
             % long_message)

--- a/core/controllers/contributor_dashboard_admin_test.py
+++ b/core/controllers/contributor_dashboard_admin_test.py
@@ -548,6 +548,8 @@ class TranslationContributionStatsHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             response['error'],
+            'At \'http://localhost/translationcontributionstatshandler\' these '
+            'errors are happening:\n'
             'Missing key in handler args: username.')
 
     def test_get_stats_with_invalid_username_raises_error(self) -> None:

--- a/core/controllers/contributor_dashboard_test.py
+++ b/core/controllers/contributor_dashboard_test.py
@@ -1363,8 +1363,8 @@ class MachineTranslationStateTextsHandlerTests(test_utils.GenericTestBase):
             'Schema validation for \'target_language_code\' failed: '
             'Validation failed: is_supported_audio_language_code ({}) for '
             'object invalid_language_code')
-        self.assertEqual(
-            output['error'], error_msg)
+        self.assertIn(
+            error_msg, output['error'])
 
     def test_handler_with_no_target_language_code_raises_exception(
         self
@@ -1376,9 +1376,10 @@ class MachineTranslationStateTextsHandlerTests(test_utils.GenericTestBase):
                 'content_ids': '["content"]',
             }, expected_status_int=400)
 
-        error_msg = 'Missing key in handler args: target_language_code.'
-        self.assertEqual(
-            output['error'], error_msg)
+        self.assertIn(
+            'Missing key in handler args: target_language_code.'
+            output['error'],
+        )
 
     def test_handler_with_invalid_exploration_id_returns_not_found(
         self
@@ -1400,8 +1401,8 @@ class MachineTranslationStateTextsHandlerTests(test_utils.GenericTestBase):
             }, expected_status_int=400)
 
         error_msg = 'Missing key in handler args: exp_id.'
-        self.assertEqual(
-            output['error'], error_msg)
+        self.assertIn(
+            error_msg, output['error'])
 
     def test_handler_with_invalid_state_name_returns_not_found(self) -> None:
         self.get_json(
@@ -1421,8 +1422,8 @@ class MachineTranslationStateTextsHandlerTests(test_utils.GenericTestBase):
             }, expected_status_int=400)
 
         error_msg = 'Missing key in handler args: state_name.'
-        self.assertEqual(
-            output['error'], error_msg)
+        self.assertIn(
+            error_msg, output['error'])
 
     def test_handler_with_invalid_content_ids_returns_none(self) -> None:
         exp_services.update_exploration(
@@ -1495,8 +1496,8 @@ class MachineTranslationStateTextsHandlerTests(test_utils.GenericTestBase):
         )
 
         error_msg = 'Missing key in handler args: content_ids.'
-        self.assertEqual(
-            output['error'], error_msg)
+        self.assertIn(
+            error_msg, output['error'])
 
     def test_handler_with_valid_input_returns_translation(self) -> None:
         exp_services.update_exploration(

--- a/core/controllers/contributor_dashboard_test.py
+++ b/core/controllers/contributor_dashboard_test.py
@@ -1377,7 +1377,7 @@ class MachineTranslationStateTextsHandlerTests(test_utils.GenericTestBase):
             }, expected_status_int=400)
 
         self.assertIn(
-            'Missing key in handler args: target_language_code.'
+            'Missing key in handler args: target_language_code.',
             output['error'],
         )
 

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -896,6 +896,8 @@ solicit_answer_details: false
             % (exp_id), expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/createhandler/download/exp_id1?output_'
+            'format=invalid_output_format\' these errors are happening:\n'
             'Schema validation for \'output_format\' failed: Received '
             'invalid_output_format which is not in the allowed range of '
             'choices: [\'zip\', \'json\']'
@@ -1447,6 +1449,8 @@ class VersioningIntegrationTest(BaseEditorControllerTests):
             }, csrf_token=csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/createhandler/revert/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'current_version\' failed: Could not '
             'convert str to int: invalid_version'
         )
@@ -2257,6 +2261,8 @@ class ExplorationRightsIntegrationTest(BaseEditorControllerTests):
         )
 
         error_msg = (
+            'At \'http://localhost/createhandler/data/eid\' these errors are '
+            'happening:\n'
             'Schema validation for \'commit_message\' failed: Validation '
             'failed: has_length_at_most ({\'max_value\': 375}) for object %s'
             % long_commit_message
@@ -2388,6 +2394,8 @@ class ExplorationRightsIntegrationTest(BaseEditorControllerTests):
 
         self.assertEqual(
             response_dict['error'],
+            'At \'http://localhost/createhandler/rights/eid\' '
+            'these errors are happening:\n'
             'Missing key in handler args: version.')
 
         # Raises error as version from payload does not match the exploration
@@ -2472,6 +2480,8 @@ class UserExplorationEmailsIntegrationTest(BaseEditorControllerTests):
             csrf_token=csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/createhandler/notificationpreferences/eid\' '
+            'these errors are happening:\n'
             'Schema validation for \'message_type\' failed: Received '
             'invalid_message_type which is not in the allowed range '
             'of choices: [\'feedback\', \'suggestion\']'
@@ -3119,6 +3129,8 @@ class EditorAutosaveTest(BaseEditorControllerTests):
             csrf_token=self.csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/createhandler/data/3\' these errors '
+            'are happening:\n'
             'Schema validation for \'change_list\' failed: Command '
             'edit_exploration_propert is not allowed'
         )
@@ -3152,6 +3164,8 @@ class EditorAutosaveTest(BaseEditorControllerTests):
             csrf_token=self.csrf_token, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/createhandler/autosave_draft/1\' these '
+            'errors are happening:\n'
             'Schema validation for \'change_list\' failed: Command '
             'edit_exploration_propert is not allowed'
         )

--- a/core/controllers/email_dashboard_test.py
+++ b/core/controllers/email_dashboard_test.py
@@ -533,6 +533,8 @@ class EmailDashboardResultTests(test_utils.EmailTestBase):
             expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/emaildashboarddatahandler?'
+            'invalid_param_key=2\' these errors are happening:\n'
             'Missing key in handler args: num_queries_to_fetch.\n'
             'Found extra args: [\'invalid_param_key\'].')
         self.assertEqual(

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -537,11 +537,9 @@ class FeedbackThreadTests(test_utils.GenericTestBase):
                 'updated_status': None
             }, csrf_token=csrf_token, expected_status_int=400)
 
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: text.',
             response['error'],
-            'At \'http://localhost/threadhandler/exploration.exp_id.'
-            'WzE3MTI2MTY5NjUzOTBdWzY1NjFd\' these errors are happening:\n'
-            'Missing key in handler args: text.'
         )
 
         self.logout()

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -195,7 +195,7 @@ class FeedbackThreadIntegrationTests(test_utils.GenericTestBase):
             }, csrf_token=csrf_token, expected_status_int=400)
         self.assertEqual(
             response_dict['error'],
-            'At \'http://localhost/threadlisthandler/0\ '
+            'At \'http://localhost/threadlisthandler/0\' '
             'these errors are happening:\n'
             'Missing key in handler args: text.'
         )

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -179,7 +179,10 @@ class FeedbackThreadIntegrationTests(test_utils.GenericTestBase):
             }, csrf_token=csrf_token, expected_status_int=400)
         self.assertEqual(
             response_dict['error'],
-            'Missing key in handler args: subject.')
+            'At \'http://localhost/threadlisthandler/0\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: subject.'
+        )
         self.logout()
 
     def test_missing_thread_text_raises_400_error(self) -> None:
@@ -191,7 +194,11 @@ class FeedbackThreadIntegrationTests(test_utils.GenericTestBase):
                 'subject': u'New Thread ¡unicode!',
             }, csrf_token=csrf_token, expected_status_int=400)
         self.assertEqual(
-            response_dict['error'], 'Missing key in handler args: text.')
+            response_dict['error'],
+            'At \'http://localhost/threadlisthandler/0\ '
+            'these errors are happening:\n'
+            'Missing key in handler args: text.'
+        )
         self.logout()
 
     def test_post_message_to_existing_thread(self) -> None:
@@ -531,7 +538,11 @@ class FeedbackThreadTests(test_utils.GenericTestBase):
             }, csrf_token=csrf_token, expected_status_int=400)
 
         self.assertEqual(
-            response['error'], 'Missing key in handler args: text.')
+            response['error'],
+            'At \'http://localhost/threadhandler/exploration.exp_id.'
+            'WzE3MTI2MTY5NjUzOTBdWzY1NjFd\' these errors are happening:\n'
+            'Missing key in handler args: text.'
+        )
 
         self.logout()
 

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -344,6 +344,9 @@ class LibraryPageTests(test_utils.GenericTestBase):
         }, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/searchhandler/data?category=missing-'
+            'outer-parens&language_code=%28%22en%22%29\' '
+            'these errors are happening:\n'
             'Schema validation for \'category\' failed: Validation '
             'failed: is_search_query_string ({}) for '
             'object missing-outer-parens'
@@ -356,6 +359,9 @@ class LibraryPageTests(test_utils.GenericTestBase):
         }, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/searchhandler/data?category=%28missing-'
+            'inner-quotes%29&language_code=%28%22en%22%29\' '
+            'these errors are happening:\n'
             'Schema validation for \'category\' failed: Validation '
             'failed: is_search_query_string ({}) for '
             'object (missing-inner-quotes)'
@@ -369,6 +375,9 @@ class LibraryPageTests(test_utils.GenericTestBase):
         }, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/searchhandler/data?category=%28%22A+'
+            'category%22%29&language_code=missing-outer-parens\' '
+            'these errors are happening:\n'
             'Schema validation for \'language_code\' failed: Validation '
             'failed: is_search_query_string ({}) for '
             'object missing-outer-parens'
@@ -381,6 +390,9 @@ class LibraryPageTests(test_utils.GenericTestBase):
         }, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/searchhandler/data?category=%28%22A+'
+            'category%22%29&language_code=%28missing-inner-quotes%29\' '
+            'these errors are happening:\n'
             'Schema validation for \'language_code\' failed: Validation '
             'failed: is_search_query_string ({}) for '
             'object (missing-inner-quotes)'

--- a/core/controllers/practice_sessions_test.py
+++ b/core/controllers/practice_sessions_test.py
@@ -157,6 +157,8 @@ class PracticeSessionsPageDataHandlerTests(BasePracticeSessionsControllerTests):
                 'invalid'),
             expected_status_int=400)
         error_msg = (
+            'At \'http://localhost/practice_session/data/staging/invalid?'
+            'selected_subtopic_ids=1,2\' these errors are happening:\n'
             'Schema validation for \'selected_subtopic_ids\' failed: '
             'Extra data: line 1 column 2 (char 1)'
         )

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -539,14 +539,16 @@ class SignupHandler(
             'can_receive_email_updates']
         bulk_email_signup_message_should_be_shown = False
 
-        bulk_email_signup_message_should_be_shown = (
-            user_services.update_email_preferences(
-                self.user_id, can_receive_email_updates,
-                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE,
-                feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE,
-                feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE
-            )
+        config_bulk_email_failed = user_services.update_email_preferences(
+            self.user_id, can_receive_email_updates,
+            feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE,
+            feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE,
+            feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE,
         )
+        # Only block registration if bulk email configuration failed and the
+        # user requested bulk emails.
+        bulk_email_signup_message_should_be_shown = (
+            can_receive_email_updates and config_bulk_email_failed)
         if bulk_email_signup_message_should_be_shown:
             self.render_json({
                 'bulk_email_signup_message_should_be_shown': (

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -135,13 +135,13 @@ class ProfileDataHandlerTests(test_utils.GenericTestBase):
             original_preferences['preferred_translation_language_code'])
         self.put_json(feconf.PREFERENCES_DATA_URL, {
             'updates': [{
-                'update_type': 'preferred_site_language_code', 
+                'update_type': 'preferred_site_language_code',
                 'data': 'en'
             }]
         }, csrf_token=csrf_token)
         self.put_json(feconf.PREFERENCES_DATA_URL, {
             'updates': [{
-                'update_type': 'preferred_audio_language_code', 
+                'update_type': 'preferred_audio_language_code',
                 'data': 'hi-en'
             }]
         }, csrf_token=csrf_token)
@@ -609,6 +609,8 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         )
         self.assertEqual(
             response['error'],
+            'At \'http://localhost/signuphandler/data\' '
+            'these errors are happening:\n'
             'Missing key in handler args: can_receive_email_updates.'
         )
 
@@ -1225,6 +1227,8 @@ class BulkEmailWebhookEndpointTests(test_utils.GenericTestBase):
             )
         self.assertEqual(
             response['error'],
+            'At \'http://localhost/bulk_email_webhook_endpoint/secret\' '
+            'these errors are happening:\n'
             'Missing key in handler args: data[email].'
         )
 
@@ -1627,7 +1631,11 @@ class UrlHandlerTests(test_utils.GenericTestBase):
         response = self.get_json(
             '/url_handler', expected_status_int=400)
         error = {
-            'error': 'Missing key in handler args: current_url.',
+            'error': (
+                'At \'http://localhost/url_handler\' '
+                'these errors are happening:\n'
+                'Missing key in handler args: current_url.'
+            ),
             'status_code': 400
         }
         self.assertEqual(response, error)

--- a/core/controllers/question_editor_test.py
+++ b/core/controllers/question_editor_test.py
@@ -759,11 +759,11 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTests):
             payload,
             csrf_token=csrf_token, expected_status_int=400)
         max_len_object = 'a' * 376
-        self.assertEqual(
-            response_json['error'],
+        self.assertIn(
             'Schema validation for \'commit_message\' failed: Validation '
             'failed: has_length_at_most ({\'max_value\': 375}) for object %s'
-            % max_len_object
+            % max_len_object,
+            response_json['error'],
         )
 
     def test_put_with_admin_email_allows_question_editing(self) -> None:

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -529,6 +529,9 @@ class QuestionsUnitTest(test_utils.GenericTestBase):
         json_response = self.get_json(url, expected_status_int=400)
         self.assertEqual(
             json_response['error'],
+            'At \'http://localhost/question_player_handler?question_count=1'
+            '&skill_ids=invalid_skill_id&fetch_by_difficulty=true\' '
+            'these errors are happening:\n'
             'Schema validation for \'skill_ids\' failed: Invalid skill id'
         )
 
@@ -1503,7 +1506,11 @@ class LearnerProgressTest(test_utils.GenericTestBase):
             '/explorehandler/exploration_complete_event/%s' % self.EXP_ID_1_0,
             payload, csrf_token=csrf_token, expected_status_int=400)
         self.assertEqual(
-            response['error'], 'Missing key in handler args: version.')
+            response['error'],
+            'At \'http://localhost/explorehandler/exploration_complete_event/'
+            'exp_2\' these errors are happening:\n'
+            'Missing key in handler args: version.'
+        )
 
     def test_exp_incomplete_event_handler(self) -> None:
         """Test handler for leaving an exploration incomplete."""
@@ -1606,7 +1613,12 @@ class LearnerProgressTest(test_utils.GenericTestBase):
         response = self.post_json(
             '/explorehandler/exploration_maybe_leave_event/%s' % self.EXP_ID_0,
             payload, csrf_token=csrf_token, expected_status_int=400)
-        error_msg = 'Missing key in handler args: version.'
+        error_msg = (
+            'At \'http://localhost/explorehandler/'
+            'exploration_maybe_leave_event/exp_0\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: version.'
+        )
         self.assertEqual(response['error'], error_msg)
 
     def test_remove_exp_from_incomplete_list_handler(self) -> None:
@@ -2086,10 +2098,12 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
         }, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/explorehandler/stats_events/15\' '
+            'these errors are happening:\n'
             'Schema validation for \'aggregated_stats\' '
             'failed: num_starts not in aggregated stats dict.'
         )
-        self.assertEqual(response['error'], error_msg)
+        self.assertIn(error_msg, response['error'])
 
         self.logout()
 
@@ -2108,10 +2122,12 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
         }, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/explorehandler/stats_events/15\' '
+            'these errors are happening:\n'
             'Schema validation for \'aggregated_stats\' '
             'failed: Expected num_starts to be an int, received invalid'
         )
-        self.assertEqual(response['error'], error_msg)
+        self.assertIn(error_msg, response['error'])
 
         self.logout()
 
@@ -2127,11 +2143,13 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
                     'exp_version': self.exp_version}, expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/explorehandler/stats_events/15\' '
+            'these errors are happening:\n'
             'Schema validation for \'aggregated_stats\' '
             'failed: total_hit_count not in '
             'state stats mapping of Home in aggregated stats dict.'
         )
-        self.assertEqual(response['error'], error_msg)
+        self.assertIn(error_msg, response['error'])
 
         self.logout()
 
@@ -2154,10 +2172,12 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
         )
 
         error_msg = (
+            'At \'http://localhost/explorehandler/stats_events/15\' '
+            'these errors are happening:\n'
             'Schema validation for \'aggregated_stats\' '
             'failed: Expected total_hit_count to be an int, received invalid'
         )
-        self.assertEqual(response['error'], error_msg)
+        self.assertIn(error_msg, response['error'])
 
         self.logout()
 
@@ -2233,7 +2253,10 @@ class AnswerSubmittedEventHandlerTest(test_utils.GenericTestBase):
             }, expected_status_int=400
         )
         self.assertEqual(
-            response['error'], 'Missing key in handler args: version.'
+            response['error'],
+            'At \'http://localhost/explorehandler/answer_submitted_event/6\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: version.'
         )
 
     def test_submit_answer_for_exp_raises_error_with_no_answer_matching_type(
@@ -2268,6 +2291,8 @@ class AnswerSubmittedEventHandlerTest(test_utils.GenericTestBase):
         )
         self.assertEqual(
             response['error'],
+            'At \'http://localhost/explorehandler/answer_submitted_event/6\' '
+            'these errors are happening:\n'
             'Schema validation for \'answer\' failed: ' +
             'Type of 1.1 is not present in options'
         )
@@ -2342,6 +2367,8 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(
             response['error'],
+            'At \'http://localhost/explorehandler/state_hit_event/6\' '
+            'these errors are happening:\n'
             'Missing key in handler args: exploration_version.'
         )
 
@@ -2374,7 +2401,9 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
 
         self.assertEqual(
             response['error'],
-            'Missing key in handler args: new_state_name.'
+            'At \'http://localhost/explorehandler/state_hit_event/6\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: new_state_name.',
         )
 
         self.logout()
@@ -2444,7 +2473,11 @@ class StateCompleteEventHandlerTests(test_utils.GenericTestBase):
             }, expected_status_int=400
         )
 
-        error_msg = 'Missing key in handler args: exp_version.'
+        error_msg = (
+            'At \'http://localhost/explorehandler/state_complete_event/6\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: exp_version.'
+        )
         self.assertEqual(response['error'], error_msg)
 
         self.logout()
@@ -2660,7 +2693,11 @@ class ExplorationStartEventHandlerTests(test_utils.GenericTestBase):
             }, expected_status_int=400
         )
 
-        error_msg = 'Missing key in handler args: version.'
+        error_msg = (
+            'At \'http://localhost/explorehandler/exploration_start_event/6\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: version.'
+        )
         self.assertEqual(response['error'], error_msg)
 
         self.logout()
@@ -2729,7 +2766,11 @@ class ExplorationActualStartEventHandlerTests(test_utils.GenericTestBase):
             }, expected_status_int=400
         )
 
-        error_msg = 'Missing key in handler args: exploration_version.'
+        error_msg = (
+            'At \'http://localhost/explorehandler/'
+            'exploration_actual_start_event/6\' these errors are happening:\n'
+            'Missing key in handler args: exploration_version.'
+        )
         self.assertEqual(response['error'], error_msg)
 
         self.logout()
@@ -2798,7 +2839,11 @@ class SolutionHitEventHandlerTests(test_utils.GenericTestBase):
                 'time_spent_in_state_secs': 2.0
             }, expected_status_int=400
         )
-        error_msg = 'Missing key in handler args: exploration_version.'
+        error_msg = (
+            'At \'http://localhost/explorehandler/solution_hit_event/6\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: exploration_version.'
+        )
         self.assertEqual(response['error'], error_msg)
 
         self.logout()

--- a/core/controllers/recent_commits_test.py
+++ b/core/controllers/recent_commits_test.py
@@ -150,10 +150,10 @@ class RecentCommitsHandlerUnitTests(test_utils.GenericTestBase):
             feconf.RECENT_COMMITS_DATA_URL,
             params={'query_type': 'invalid_query_type'},
             expected_status_int=400)
-        self.assertEqual(
-            response['error'],
+        self.assertIn(
             'Schema validation for \'query_type\' failed: Received '
             'invalid_query_type which is not in the allowed range of '
-            'choices: [\'all_non_private_commits\']'
+            'choices: [\'all_non_private_commits\']',
+            response['error'],
         )
         self.logout()

--- a/core/controllers/release_coordinator_test.py
+++ b/core/controllers/release_coordinator_test.py
@@ -262,6 +262,8 @@ class FeatureFlagsHandlerTest(test_utils.GenericTestBase):
                 )
         self.assertEqual(
             response['error'],
+            'At \'http://localhost/feature_flags\' '
+            'these errors are happening:\n'
             'Schema validation for \'rollout_percentage\' failed: '
             'Validation failed: is_at_most ({\'max_value\': 100}) '
             'for object 200')

--- a/core/controllers/resources_test.py
+++ b/core/controllers/resources_test.py
@@ -73,7 +73,10 @@ class AssetDevHandlerImageTests(test_utils.GenericTestBase):
             expected_status_int=400)
 
         self.assertEqual(
-            response_dict['error'], 'Missing key in handler args: filename.')
+            response_dict['error'],
+            'At \'http://localhost/createhandler/imageupload/exploration/0\' '
+            'these errors are happening:\n'
+            'Missing key in handler args: filename.')
 
         self.logout()
 
@@ -105,6 +108,8 @@ class AssetDevHandlerImageTests(test_utils.GenericTestBase):
             expected_status_int=400)
 
         error_msg = (
+            'At \'http://localhost/createhandler/imageupload/exploration/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'filename\' failed: Validation'
             ' failed: is_regex_matched ({\'regex_pattern\': '
             '\'\\\\w+[.]\\\\w+\'}) for object .png'
@@ -461,10 +466,12 @@ class AssetDevHandlerImageTests(test_utils.GenericTestBase):
         self.assertEqual(response_dict['status_code'], 400)
 
         error_msg = (
+            'At \'http://localhost/createhandler/imageupload/exploration/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'filename\' failed: Validation failed: '
             'is_regex_matched ({\'regex_pattern\': \'\\\\w+[.]\\\\w+\'}) '
             'for object test')
-        self.assertIn(error_msg, response_dict['error'])
+        self.assertEqual(error_msg, response_dict['error'])
 
         self.logout()
 
@@ -609,6 +616,8 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
                 ('raw_audio_file', self.TEST_AUDIO_FILE_FLAC, raw_audio)]
         )
         error_msg = (
+            'At \'http://localhost/createhandler/audioupload/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'raw_audio_file\' failed: '
             'Audio not recognized as a mp3 file\n'
             'Schema validation for \'filename\' failed: Validation failed: '
@@ -641,6 +650,8 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
         )
         self.logout()
         error_msg = (
+            'At \'http://localhost/createhandler/audioupload/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'raw_audio_file\' failed: '
             'Audio not recognized as a mp3 file')
         self.assertEqual(response_dict['error'], error_msg)
@@ -669,6 +680,8 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
         self.logout()
 
         error_msg = (
+            'At \'http://localhost/createhandler/audioupload/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'raw_audio_file\' failed: '
             'Audio not recognized as a mp3 file\n'
             'Schema validation for \'filename\' failed: Validation failed: '
@@ -721,6 +734,8 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
         self.logout()
         self.assertEqual(response_dict['status_code'], 400)
         error_msg = (
+            'At \'http://localhost/createhandler/audioupload/0\' '
+            'these errors are happening:\n'
             'Schema validation for \'filename\' failed: Validation failed: '
             'is_regex_matched ({\'regex_pattern\': '
             '\'[^\\\\s]+(\\\\.(?i)(mp3))$\'}) for object test.wav')
@@ -742,7 +757,10 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
         self.logout()
         self.assertEqual(response_dict['status_code'], 400)
         self.assertEqual(
-            response_dict['error'], 'Schema validation for '
+            response_dict['error'],
+            'At \'http://localhost/createhandler/audioupload/0\' '
+            'these errors are happening:\n'
+            'Schema validation for '
             '\'raw_audio_file\' failed: No audio supplied')
 
     def test_upload_bad_audio(self) -> None:
@@ -761,7 +779,10 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
         self.logout()
         self.assertEqual(response_dict['status_code'], 400)
         self.assertEqual(
-            response_dict['error'], 'Schema validation for \'raw_audio_file\''
+            response_dict['error'],
+            'At \'http://localhost/createhandler/audioupload/0\' '
+            'these errors are happening:\n'
+            'Schema validation for \'raw_audio_file\''
             ' failed: Audio not recognized as a mp3 file')
 
     def test_missing_extensions_are_detected(self) -> None:
@@ -786,6 +807,8 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
         self.logout()
         self.assertEqual(response_dict['status_code'], 400)
         error_msg = (
+            'At \'http://localhost/createhandler/audioupload/0\' these '
+            'errors are happening:\n'
             'Schema validation for \'filename\' failed: Validation failed: '
             'is_regex_matched ({\'regex_pattern\': '
             '\'[^\\\\s]+(\\\\.(?i)(mp3))$\'}) for object test')
@@ -843,7 +866,10 @@ class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
         self.logout()
         self.assertEqual(response_dict['status_code'], 400)
         self.assertEqual(
-            response_dict['error'], 'Schema validation for \'raw_audio_file\' '
+            response_dict['error'],
+            'At \'http://localhost/createhandler/audioupload/0\' these '
+            'errors are happening:\n'
+            'Schema validation for \'raw_audio_file\' '
             'failed: Audio not recognized as a mp3 file')
 
     def test_upload_check_for_duration_sec_as_response(self) -> None:

--- a/core/controllers/skill_mastery_test.py
+++ b/core/controllers/skill_mastery_test.py
@@ -99,6 +99,8 @@ class SkillMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             json_response['error'],
+            'At \'http://localhost/skill_mastery_handler/data\' '
+            'these errors are happening:\n'
             'Missing key in handler args: selected_skill_ids.')
 
         self.logout()
@@ -267,6 +269,8 @@ class SkillMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             json_response['error'],
+            'At \'http://localhost/skill_mastery_handler/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'mastery_change_per_skill\' failed: ' +
             'Expected dict, received %s' % (mastery_change_per_skill)
         )
@@ -284,6 +288,8 @@ class SkillMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             json_response['error'],
+            'At \'http://localhost/skill_mastery_handler/data\' '
+            'these errors are happening:\n'
             'Missing key in handler args: mastery_change_per_skill.'
         )
 
@@ -343,6 +349,8 @@ class SkillMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             json_response['error'],
+            'At \'http://localhost/skill_mastery_handler/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'mastery_change_per_skill\' failed: ' +
             'Could not convert dict to float: {}')
 
@@ -358,8 +366,10 @@ class SkillMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             json_response['error'],
-           'Schema validation for \'mastery_change_per_skill\' failed: ' +
-           'Expected float, received True')
+            'At \'http://localhost/skill_mastery_handler/data\' '
+            'these errors are happening:\n'
+            'Schema validation for \'mastery_change_per_skill\' failed: '
+            'Expected float, received True')
 
         self.logout()
 
@@ -611,6 +621,9 @@ class SubtopicMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             response_json['error'],
+            'At \'http://localhost/subtopic_mastery_handler/data?'
+            'selected_topic_ids=invalid_topic_id\' '
+            'these errors are happening:\n'
             'Schema validation for \'selected_topic_ids\' failed: '
             'Expecting value: line 1 column 1 (char 0)')
 
@@ -624,6 +637,8 @@ class SubtopicMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             json_response['error'],
+            'At \'http://localhost/subtopic_mastery_handler/data\' '
+            'these errors are happening:\n'
             'Missing key in handler args: selected_topic_ids.')
 
         self.logout()

--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -337,9 +337,10 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
                 feconf.STORY_EDITOR_DATA_URL_PREFIX, self.story_id),
             change_cmd, csrf_token=csrf_token, expected_status_int=400)
 
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: commit_message.',
             json_response['error'],
-            'Missing key in handler args: commit_message.')
+        )
 
         self.logout()
 
@@ -541,9 +542,10 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
                 feconf.STORY_EDITOR_DATA_URL_PREFIX, self.story_id),
             change_cmd, csrf_token=csrf_token, expected_status_int=400)
 
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: version.',
             json_response['error'],
-            'Missing key in handler args: version.')
+        )
 
         self.logout()
 

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -1166,9 +1166,10 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
                 suggestion.suggestion_id), {},
             csrf_token=csrf_token,
             expected_status_int=400)
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: translation_html.',
             response['error'],
-            'Missing key in handler args: translation_html.')
+        )
         self.logout()
 
     def test_cannot_update_translation_with_invalid_translation_html(
@@ -1417,9 +1418,9 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             expected_status_int=400
         )
 
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: question_state_data.',
             response['error'],
-            'Missing key in handler args: question_state_data.'
         )
         self.logout()
 
@@ -1483,9 +1484,9 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             expected_status_int=400
         )
 
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: skill_difficulty.',
             response['error'],
-            'Missing key in handler args: skill_difficulty.'
         )
 
         self.logout()
@@ -1549,9 +1550,9 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             expected_status_int=400
         )
 
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: next_content_id_index.',
             response['error'],
-            'Missing key in handler args: next_content_id_index.'
         )
         self.logout()
 
@@ -2158,10 +2159,10 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
                 feconf.SUGGESTION_LIST_URL_PREFIX,
                 self.author_id))['suggestions']
 
-        self.assertEqual(
-            response['error'],
+        self.assertIn(
             'Schema validation for \'target_version_at_submission\' failed: '
-            'Could not convert str to int: invalid_target_version'
+            'Could not convert str to int: invalid_target_version',
+            response['error'],
         )
         self.assertEqual(len(suggestions), 1)
         self.logout()

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -350,12 +350,13 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
             expected_status_int=400)
 
         invalid_description = 'Story Description' * 60
-        self.assertEqual(
-            json_response['error'],
+        self.assertIn(
             'Schema validation for \'description\' failed: '
             'Validation failed: has_length_at_most '
             f'({{\'max_value\': {constants.MAX_CHARS_IN_STORY_DESCRIPTION}}}) '
-            f'for object {invalid_description}')
+            f'for object {invalid_description}',
+            json_response['error'],
+        )
 
         self.logout()
 
@@ -647,12 +648,13 @@ class TopicEditorTests(
             '%s/%s' % (
                 feconf.TOPIC_EDITOR_DATA_URL_PREFIX, self.topic_id),
             change_cmd, csrf_token=csrf_token, expected_status_int=400)
-        self.assertEqual(
-            json_response['error'],
+        self.assertIn(
             'Schema validation for \'commit_message\' failed: '
             'Validation failed: has_length_at_most '
             f'({{\'max_value\': {constants.MAX_COMMIT_MESSAGE_LENGTH}}}) '
-            f'for object {commit_msg}')
+            f'for object {commit_msg}',
+            json_response['error'],
+        )
 
     def test_editable_topic_handler_put_raises_error_with_invalid_name(
         self
@@ -861,9 +863,10 @@ class TopicEditorTests(
             }, csrf_token=csrf_token,
             expected_status_int=400)
 
-        self.assertEqual(
+        self.assertIn(
+            'Missing key in handler args: version.',
             json_response['error'],
-            'Missing key in handler args: version.')
+        )
 
         self.logout()
 
@@ -1108,10 +1111,11 @@ class TopicPublishHandlerTests(BaseTopicEditorControllerTests):
                 feconf.TOPIC_STATUS_URL_PREFIX, self.topic_id),
             {'publish_status': invalid}, csrf_token=csrf_token,
             expected_status_int=400)
-        self.assertEqual(
-            response['error'],
+        self.assertIn(
             'Schema validation for \'publish_status\' failed: '
-            f'Expected bool, received {invalid}')
+            f'Expected bool, received {invalid}',
+            response['error'],
+        )
 
         self.logout()
 

--- a/core/controllers/topics_and_skills_dashboard_test.py
+++ b/core/controllers/topics_and_skills_dashboard_test.py
@@ -474,6 +474,8 @@ class SkillsDashboardPageDataHandlerTests(BaseTopicsAndSkillsDashboardTests):
             expected_status_int=400)
 
         expected_error = (
+            'At \'http://localhost/skills_dashboard/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'num_skills_to_fetch\' '
             'failed: Could not convert str to int: string'
         )
@@ -501,6 +503,8 @@ class SkillsDashboardPageDataHandlerTests(BaseTopicsAndSkillsDashboardTests):
             expected_status_int=400)
 
         expected_error = (
+            'At \'http://localhost/skills_dashboard/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'next_cursor\' failed: '
             'Expected string, received 40'
         )
@@ -541,6 +545,8 @@ class SkillsDashboardPageDataHandlerTests(BaseTopicsAndSkillsDashboardTests):
             expected_status_int=400)
 
         expected_error = (
+            'At \'http://localhost/skills_dashboard/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'classroom_name\' failed: '
             'Expected string, received 20'
         )
@@ -563,6 +569,8 @@ class SkillsDashboardPageDataHandlerTests(BaseTopicsAndSkillsDashboardTests):
             expected_status_int=400)
 
         expected_error = (
+            'At \'http://localhost/skills_dashboard/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'keywords\' failed: '
             'Expected list, received 20'
         )
@@ -581,6 +589,8 @@ class SkillsDashboardPageDataHandlerTests(BaseTopicsAndSkillsDashboardTests):
             expected_status_int=400)
 
         expected_error = (
+            'At \'http://localhost/skills_dashboard/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'keywords\' failed: '
             'Expected string, received 20'
         )
@@ -603,6 +613,8 @@ class SkillsDashboardPageDataHandlerTests(BaseTopicsAndSkillsDashboardTests):
             expected_status_int=400)
 
         expected_error = (
+            'At \'http://localhost/skills_dashboard/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'status\' failed: '
             'Expected string, received 20'
         )
@@ -625,6 +637,8 @@ class SkillsDashboardPageDataHandlerTests(BaseTopicsAndSkillsDashboardTests):
             expected_status_int=400)
 
         expected_error = (
+            'At \'http://localhost/skills_dashboard/data\' '
+            'these errors are happening:\n'
             'Schema validation for \'sort\' failed: '
             'Expected string, received 20'
         )

--- a/core/controllers/voiceover_test.py
+++ b/core/controllers/voiceover_test.py
@@ -108,6 +108,8 @@ class VoiceoverLanguageCodesMappingHandlerTests(test_utils.GenericTestBase):
             payload, csrf_token=csrf_token, expected_status_int=400)
         self.assertEqual(
             response_dict['error'],
+            'At \'http://localhost/voiceover_language_codes_mapping\' '
+            'these errors are happening:\n'
             'Schema validation for \'language_codes_mapping\' failed: '
             'Expected dict, received en-US')
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1642,8 +1642,7 @@ def update_email_preferences(
             to the bulk email provider's database initiated the update here.
 
     Returns:
-        bool. Whether to send a mail to the user to complete bulk email service
-        signup.
+        bool. Whether updating the user's bulk email preferences failed.
     """
     email_preferences_model = user_models.UserEmailPreferencesModel.get(
         user_id, strict=False)

--- a/core/platform/bulk_email/mailchimp_bulk_email_services.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services.py
@@ -280,7 +280,7 @@ def add_or_update_user_status(
                 feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash,
                 unsubscribed_mailchimp_data)
 
-    except mailchimpclient.MailChimpError as error:
+    except Exception as error:
         # This has to be done since the message can only be accessed from
         # MailChimpError by error.message in Python2, but this is deprecated in
         # Python3.

--- a/core/platform/bulk_email/mailchimp_bulk_email_services.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services.py
@@ -195,13 +195,9 @@ def add_or_update_user_status(
         tag: str. Tag to add to user in mailchimp.
 
     Returns:
-        bool. Whether the user was successfully added to the db. (This will be
-        False if the user was permanently deleted earlier and therefore cannot
-        be added back.)
-
-    Raises:
-        Exception. Any error (other than the case where the user was permanently
-            deleted earlier) raised by the mailchimp API.
+        bool. Whether the user was successfully added to the db. This will be
+        False if and only if MailChimp throws an error or getting the MailChimp
+        client fails.
     """
     client = _get_mailchimp_class()
     if not client:
@@ -301,5 +297,8 @@ def add_or_update_user_status(
                 if not user_creation_successful:
                     return False
         else:
-            raise Exception(error_message['detail']) from error
+            logging.error(
+                'Mailchimp error prevented email signup: %s',
+                error_message['detail'])
+            return False
     return True

--- a/core/platform/bulk_email/mailchimp_bulk_email_services.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services.py
@@ -198,6 +198,9 @@ def add_or_update_user_status(
         bool. Whether the user was successfully added to the db. This will be
         False if and only if MailChimp throws an error or getting the MailChimp
         client fails.
+
+    Raises:
+        Exception. Raised if the tag or merge fields are invalid.
     """
     client = _get_mailchimp_class()
     if not client:

--- a/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
@@ -348,11 +348,14 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
             # which causes mypy to throw an error. Thus to avoid the error, we
             # used ignore here.
             mailchimp.lists.members.users_data = None # type: ignore[assignment]
-            with self.assertRaisesRegex(
-                Exception, 'Server Error'):
+            with self.capture_logging(min_level=logging.ERROR) as logs:
                 mailchimp_bulk_email_services.add_or_update_user_status(
                     self.user_email_1, {}, 'Web',
                     can_receive_email_updates=True)
+                self.assertItemsEqual(
+                    ['Mailchimp error prevented email signup: Server Error'],
+                    logs
+                )
 
     def test_android_merge_fields(self) -> None:
         mailchimp = self.MockMailchimpClass()


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #19858.
2. This PR does the following: This PR changes the error-handling code to catch and log errors from MailChimp. If an error occurs, users are directed to sign up for the mailing list manually and then allowed to register. It also adds improved logging. Specifically, it logs the URL at which schema validation failures occur. This improved logging would have helped interpret the second server error in https://github.com/oppia/oppia/issues/19858#issuecomment-1976801124.
3. (For bug-fixing PRs only) The original bug occurred because: Oppia's MailChimp configuration was changed, causing email signups to fail. These failures prevented users from registering if they wanted to subscribe to Oppia's mailing list. This PR changes the error-handling code to catch and log errors from MailChimp. If an error occurs, users are directed to sign up for the mailing list manually and then allowed to register.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

https://github.com/oppia/oppia/assets/19878639/166a1473-330b-459e-ab43-b80d2bdf50fd

To simulate mailchimp failing and get debugging information, I applied this diff:

```diff
diff --git a/assets/constants.ts b/assets/constants.ts
index 8e3d5e8684..12824d08ff 100644
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -6162,7 +6162,7 @@ export default {
 
   "MIN_QUESTION_COUNT_FOR_A_DIAGNOSTIC_TEST_SKILL": 3,
 
-  "BULK_EMAIL_SERVICE_SIGNUP_URL": "",
+  "BULK_EMAIL_SERVICE_SIGNUP_URL": "emailSignup.example.com",
 
   // The default number of opportunities to show on the contributor dashboard
   // page.
diff --git a/core/controllers/profile.py b/core/controllers/profile.py
index 7800cbc0bb..9ec8a673d6 100644
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -530,6 +530,7 @@ class SignupHandler(
     @acl_decorators.require_user_id_else_redirect_to_homepage
     def post(self) -> None:
         """Handles POST requests."""
+        logging.error('[DEBUGGING] CAN_SEND_EMAILS=%s', feconf.CAN_SEND_EMAILS)
         assert self.user_id is not None
         assert self.normalized_payload is not None
         username = self.normalized_payload['username']
@@ -545,10 +546,16 @@ class SignupHandler(
             feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE,
             feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE,
         )
+        logging.error(
+            '[DEBUGGING] bulk_signup_failed=%s',
+            bulk_email_signup_message_should_be_shown)
         # Only block registration if bulk email configuration failed and the
         # user requested bulk emails.
         bulk_email_signup_message_should_be_shown = (
             can_receive_email_updates and config_bulk_email_failed)
+        logging.error(
+            '[DEBUGGING] bulk_email_signup_message_should_be_shown=%s',
+            bulk_email_signup_message_should_be_shown)
         if bulk_email_signup_message_should_be_shown:
             self.render_json({
                 'bulk_email_signup_message_should_be_shown': (
diff --git a/core/domain/user_services.py b/core/domain/user_services.py
index e1c01b39d5..d50c2b2cbd 100644
--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1644,6 +1644,7 @@ def update_email_preferences(
     Returns:
         bool. Whether updating the user's bulk email preferences failed.
     """
+    logging.error('[DEBUGGING] update_email_preferences() called')
     email_preferences_model = user_models.UserEmailPreferencesModel.get(
         user_id, strict=False)
     if email_preferences_model is None:
@@ -1664,6 +1665,9 @@ def update_email_preferences(
             bulk_email_services.add_or_update_user_status(
                 email, {}, 'Account',
                 can_receive_email_updates=can_receive_email_updates))
+        logging.error(
+            '[DEBUGGING] user_creation_successful=%s',
+            user_creation_successful)
         if not user_creation_successful:
             email_preferences_model.site_updates = False
             email_preferences_model.update_timestamps()
diff --git a/core/feconf.py b/core/feconf.py
index 87faad4ce1..65a214d198 100644
--- a/core/feconf.py
+++ b/core/feconf.py
@@ -587,7 +587,7 @@ NOREPLY_EMAIL_ADDRESS = 'noreply@example.com'
 # correspond to owners of the app before setting this to True. If
 # SYSTEM_EMAIL_ADDRESS is not that of an app owner, email messages from this
 # address cannot be sent. If True then emails can be sent to any user.
-CAN_SEND_EMAILS = False
+CAN_SEND_EMAILS = True
 # If you want to turn on this facility please check the email templates in the
 # send_role_notification_email() function in email_manager.py and modify them
 # accordingly.
diff --git a/core/platform/bulk_email/dev_mode_bulk_email_services.py b/core/platform/bulk_email/dev_mode_bulk_email_services.py
index 552e3f1e8b..3654a6605b 100644
--- a/core/platform/bulk_email/dev_mode_bulk_email_services.py
+++ b/core/platform/bulk_email/dev_mode_bulk_email_services.py
@@ -61,4 +61,5 @@ def add_or_update_user_status(
         'Updated status of email ID %s\'s bulk email preference in the service '
         'provider\'s db to %s. Cannot access API, since this is a dev '
         'environment.' % (user_email, can_receive_email_updates))
-    return True
+    logging.error('[DEBUGGING] Simulating mailchimp failure.')
+    return False
```

The devserver logs confirm that the simulated failure was correctly interpreted by the backend code:

```text
2024-03-31 17:15:14 ERROR:root:[DEBUGGING] CAN_SEND_EMAILS=True
2024-03-31 17:15:14 ERROR:root:[DEBUGGING] update_email_preferences() called
2024-03-31 17:15:14 ERROR:root:[DEBUGGING] Simulating mailchimp failure.
2024-03-31 17:15:14 ERROR:root:[DEBUGGING] user_creation_successful=False
2024-03-31 17:15:14 ERROR:root:[DEBUGGING] bulk_signup_failed=False
2024-03-31 17:15:14 ERROR:root:[DEBUGGING] bulk_email_signup_message_should_be_shown=True
2024-03-31 17:15:14 INFO     2024-03-31 21:15:14,914 module.py:883] default: "POST /signuphandler/data HTTP/1.1" 200 56
2024-03-31 17:15:15 INFO     2024-03-31 21:15:15,310 module.py:883] default: "GET / HTTP/1.1" 200 2310
2024-03-31 17:15:20 ERROR:root:[DEBUGGING] CAN_SEND_EMAILS=True
2024-03-31 17:15:20 ERROR:root:[DEBUGGING] update_email_preferences() called
2024-03-31 17:15:20 ERROR:root:[DEBUGGING] Simulating mailchimp failure.
2024-03-31 17:15:20 ERROR:root:[DEBUGGING] user_creation_successful=False
2024-03-31 17:15:20 ERROR:root:[DEBUGGING] bulk_signup_failed=False
2024-03-31 17:15:20 ERROR:root:[DEBUGGING] bulk_email_signup_message_should_be_shown=False
2024-03-31 17:15:20 ERROR:root:Please ensure that the value for the admin platform property SIGNUP_EMAIL_SUBJECT_CONTENT is set, before allowing post-signup emails to be sent.
```

Note that there's a mistake in the debugging code. The value logged for `bulk_signup_failed` is actually `bulk_email_signup_message_should_be_shown`, which you can see from the diff above.

I also tried with the browser console open:

https://github.com/oppia/oppia/assets/19878639/b34c4b68-1139-462f-ae63-b5da880ab98c

The console errors also happen in develop:

https://github.com/oppia/oppia/assets/19878639/49fced53-2350-4b77-8a0b-1ce6d9283139

Note that since MailChimp does not integrate with our backup server, this change cannot be effectively tested on the backup server.

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
