### PR TITLE
Fix issue 19649

### DIFF
--- a/extensions/interactions/NumberWithUnits/directives/number-with-units-rules.service.ts
+++ b/extensions/interactions/NumberWithUnits/directives/number-with-units-rules.service.ts
@@ -44,6 +44,12 @@ export class NumberWithUnitsRulesService {
     answer: NumberWithUnitsAnswer,
     inputs: NumberWithUnitsRuleInputs
   ): boolean {
+    // Implement validation to prevent duplicate units.
+    var inputsObject = this.unitsObjectFactory.fromDict(inputs.f);
+    if (this.hasDuplicateUnits(inputsObject)) {
+      console.error('Duplicate units detected. Please provide unique units.');
+      return false;
+    }
     // Returns true only if input is exactly equal to answer.
     var answerObject = this.unitsObjectFactory.fromDict(answer);
     var inputsObject = this.unitsObjectFactory.fromDict(inputs.f);
@@ -77,6 +83,11 @@ export class NumberWithUnitsRulesService {
     var answerString = answerObject.toMathjsCompatibleString();
     var inputsString = inputsObject.toMathjsCompatibleString();
     return unit(answerString).equals(unit(inputsString));
+  }
+
+  private hasDuplicateUnits(inputsObject: any): boolean {
+    var uniqueUnits = new Set(inputsObject.units);
+    return uniqueUnits.size !== inputsObject.units.length;
   }
 }
 

--- a/extensions/interactions/NumericInput/directives/numeric-input-rules.service.ts
+++ b/extensions/interactions/NumericInput/directives/numeric-input-rules.service.ts
@@ -78,6 +78,9 @@ export class NumericInputRulesService {
     answer: NumericInputAnswer,
     inputs: NumericInputIsWithinToleranceRuleInputs
   ): boolean {
+    if (inputs.tol <= 0) {
+      throw new Error('Tolerance value must be greater than zero.');
+    }
     return answer >= inputs.x - inputs.tol && answer <= inputs.x + inputs.tol;
   }
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19649.
2. This PR does the following: This PR addresses an error in the NumericInput interaction within Oppia where the 'tol' value in the IsWithinTolerance rule is set to zero or less. It ensures that the 'tol' value is greater than zero by implementing a validation check and error handling mechanism in the IsWithinTolerance method of the NumericInputRulesService.
3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred due to the lack of validation for the 'tol' value in the IsWithinTolerance rule. When the 'tol' value was set to zero or less, it caused disruption in the functionality of the NumericInput interaction. This issue was introduced in a previous PR where tolerance-based validation was implemented without considering the case of zero or negative tolerance values.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
