### PR TITLE
Fix #19668: Add/Edit Response Modal's Element Text Input Loses Focus for each Letter Typed in

### DIFF
--- a/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.html
+++ b/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.html
@@ -20,7 +20,7 @@
 <div class="schema-based-list-editor">
   <form #listEditorForm="ngForm">
     <table class="w-100">
-      <tr *ngFor="let item of localValue; let idx = index" id="e2e-test-schema-based-list-editor-table-row">
+      <tr *ngFor="let item of localValue; let idx = index; trackBy: trackByIndex" id="e2e-test-schema-based-list-editor-table-row">
         <td class="e2e-test-schema-based-list-editor-table-data">
           <schema-based-editor [schema]="itemSchema"
                                [disabled]="disabled"

--- a/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.spec.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.spec.ts
@@ -357,7 +357,7 @@ describe('Schema Based List Editor Component', () => {
     expect(component.localValue).toEqual(expectedValue);
   });
 
-  it('should return the correct index when tracking', () => {
+  it('should return the correct index when tracking by index', () => {
     const index = 5;
     const result = component.trackByIndex(index);
     expect(result).toBe(index);

--- a/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.spec.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.spec.ts
@@ -356,4 +356,10 @@ describe('Schema Based List Editor Component', () => {
     const expectedValue = ['item1', 'item2', 'item3'];
     expect(component.localValue).toEqual(expectedValue);
   });
+
+  it('should return the correct index when tracking', () => {
+    const index = 5;
+    const result = component.trackByIndex(index);
+    expect(result).toBe(index);
+  });
 });

--- a/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.ts
@@ -236,6 +236,10 @@ export class SchemaBasedListEditorComponent
     this.onChange(this.localValue);
   }
 
+  trackByIndex(index: number): number {
+    return index;
+  }
+
   ngOnInit(): void {
     this.baseFocusLabel =
       this.labelForFocusTarget ||


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19668.
2. This PR does the following: Tracks the schema based list editor items by index so it doesn't rerender everytime an item's value changes.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Skill Editor
https://github.com/oppia/oppia/assets/70992422/0a636cb9-2bd0-4b47-93aa-01d69dabbc97

Exploration Editor
https://github.com/oppia/oppia/assets/70992422/686b2fe7-3a1f-4746-9c4d-c189284317e7

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
