### PR TITLE
Fix #20003: Adjust "My Dashboard" button's position when "Review Lowest Scored Skill" button appears

### DIFF
--- a/core/templates/components/question-directives/question-player/question-player.component.html
+++ b/core/templates/components/question-directives/question-player/question-player.component.html
@@ -95,12 +95,19 @@
 
     <div class="results-footer">
       <div class="question-player-results-footer" *ngIf="showActionButtonsFooter()">
-        <span *ngFor="let actionButton of questionPlayerConfig.resultActionButtons"
+        <span *ngFor="let actionButton of questionPlayerConfig.resultActionButtons | slice:0:2"
               (click)="performAction(actionButton)">
-          <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
+          <div *ngIf="!(actionButton.type === 'RETRY_SESSION') && actionButton.type === 'REVIEW_LOWEST_SCORED_SKILL' && !(getWorstSkillIds().length === 0)"
+               class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
                role="button"
-               tabindex="0"
-               *ngIf="!(actionButton.type === 'RETRY_SESSION') && !(actionButton.type === 'DASHBOARD' && !userIsLoggedIn) && !(actionButton.type === 'REVIEW_LOWEST_SCORED_SKILL' && getWorstSkillIds().length === 0)">
+               tabindex="0">
+            <span [innerHTML]="getActionButtonIconHtml(actionButton.type)"></span>
+            <span class="action-button-text" translate="{{actionButton.i18nId}}"></span>
+          </div>
+          <div *ngIf="!(actionButton.type === 'RETRY_SESSION') && actionButton.type === 'DASHBOARD' && userIsLoggedIn"
+               class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
+               role="button"
+               tabindex="0">
             <span [innerHTML]="getActionButtonIconHtml(actionButton.type)"></span>
             <span class="action-button-text" translate="{{actionButton.i18nId}}"></span>
           </div>


### PR DESCRIPTION
## Overview

1. This PR fixes  #20003 .
2. This PR does the following: The previous implementation of the file question-player.component.html was making two footers, in which there would be two buttons in the first footer and only one in the second footer. 

   But the list used to iterate through how many buttons would be placed in each footer was iterating a list of three element (contained all three buttons in it) which was making the css property justify-content leave space for a third button in the first footer (it isn't a problem to do this in the second footer as we want to have only one button on the right side, which will happen as long another button is considered prior to him). 

   This led to the "Review Lowest Scored Skill" button being correctly placed but, as space was left for a third button, the "My Dashboard" button wouldn't stick to the right. In order for this to happen, I made it so that we use the same list (so that we don't have to add new methods to the ts file or tests for it) and only iterate through the first two elements, which will always be the buttons in the first footer. 

   If the button "Review Lowest Scored Skill" doesn't appear it is still important to continue counting him, as we want to make the "My Dashboard" button stick to the right either way.

## Proof that changes are correct

![image](https://github.com/oppia/oppia/assets/133370932/bbc757e1-4cdd-4cce-963f-c1e25a3dd9f4)

![image](https://github.com/oppia/oppia/assets/133370932/84ce55d2-117e-485a-999a-cd509abdb8bd)


## Essential Checklist


- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

