### PR TITLE
Fixes part of #20137: Adds Greek to the list of supported languages

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -5245,7 +5245,7 @@ export default {
     "ariaLabelInEnglish": "German"
   }, {
     "code": "el",
-    "description": "ελληνικά (Greek)",
+    "description": "Ελληνικά (Greek)",
     "direction": "ltr",
     "decimal_separator": ",",
     "ariaLabelInEnglish": "Greek"
@@ -5568,6 +5568,12 @@ export default {
     "direction": "ltr",
     "decimal_separator": ".",
     "ariaLabelInEnglish": "Traditional Chinese"
+  }, {
+    "id": "el",
+    "text": "Ελληνικά",
+    "direction": "ltr",
+    "decimal_separator": ",",
+    "ariaLabelInEnglish": "Greek"
   }],
 
   // List of supported audio languages in which we have audio and translations


### PR DESCRIPTION
## Overview

1. This PR fixes part of #20137.
2. This PR does the following: Adds Greek to the list of supported languages

@seanlip  PTAL

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly). 

## Proof that changes are correct

### Before
![Capture](https://github.com/oppia/oppia/assets/9382526/68a4ade1-4ae2-42ef-93ed-bac50e02ee3a)

### After
![image](https://github.com/oppia/oppia/assets/9382526/aad645b8-b40a-4f75-865b-5aee1b8a80d9)
