### PR TITLE
Fix #20177: Corrected a tooltip in Topics and Skills Dashboard page.

### DIFF
--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-list/topics-list.component.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-list/topics-list.component.html
@@ -36,7 +36,7 @@
             <div>
               <span class="topic-classroom e2e-test-topic-classroom">
                 <span *ngIf="topic.classroom">{{topic.classroom}}</span>
-                <span ngbTooltip="Assign this topic to a classroom from the admin page" placement="bottom" *ngIf="!topic.classroom">No classroom assigned.</span>
+                <span ngbTooltip="Assign this topic to a classroom from the classroom admin page" placement="bottom" *ngIf="!topic.classroom">No classroom assigned.</span>
               </span>
             </div>
             <div><span class="topic-description e2e-test-topic-description">{{topic.description}}</span></div>

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-list/topics-list.component.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-list/topics-list.component.html
@@ -36,7 +36,7 @@
             <div>
               <span class="topic-classroom e2e-test-topic-classroom">
                 <span *ngIf="topic.classroom">{{topic.classroom}}</span>
-                <span ngbTooltip="Assign this topic to a classroom from the classroom admin page" placement="bottom" *ngIf="!topic.classroom">No classroom assigned.</span>
+                <span ngbTooltip="Assign this topic to a classroom from the classroom admin page." placement="bottom" *ngIf="!topic.classroom">No classroom assigned.</span>
               </span>
             </div>
             <div><span class="topic-description e2e-test-topic-description">{{topic.description}}</span></div>


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #20177 .
2. This PR does the following: On the Topics and Skills Dashboard, when curriculum admins hover over a published topic that is not assigned to a classroom, they expect a tooltip that instructs them the page where topics are added to classrooms. While they should be instructed to go to the more recent Classroom Admin page, they are instead instructed to go to the outdated Admin page Config tab.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
![image](https://github.com/oppia/oppia/assets/136263179/604e8db7-11c4-46a3-926e-8236b92213ca)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
