### PR TITLE
Fix #20166 : Updates character ‘s’ Next to Edit Icon in ‘Insert Image’ of RTE with 'SVG'

### DIFF
--- a/extensions/objects/templates/svg-editor.component.html
+++ b/extensions/objects/templates/svg-editor.component.html
@@ -283,7 +283,7 @@
   <div *ngIf="isDiagramSaved()">
     <div class="diagram-editor-saved-image-container e2e-test-saved-diagram-container">
       <i class="fas fa-pen diagram-editor-edit edit-icon" (click)="continueDiagramEditing()"
-         title="Continue editing the diagram">s
+         title="Continue editing the diagram">SVG
       </i>
       <img [src]="data.savedSvgUrl" [ngStyle]="svgContainerStyle">
     </div>

--- a/extensions/objects/templates/svg-editor.component.html
+++ b/extensions/objects/templates/svg-editor.component.html
@@ -283,7 +283,8 @@
   <div *ngIf="isDiagramSaved()">
     <div class="diagram-editor-saved-image-container e2e-test-saved-diagram-container">
       <i class="fas fa-pen diagram-editor-edit edit-icon" (click)="continueDiagramEditing()"
-         title="Continue editing the diagram">SVG
+         title="Continue editing the diagram">
+         <span class="edit-text">SVG</span>
       </i>
       <img [src]="data.savedSvgUrl" [ngStyle]="svgContainerStyle">
     </div>
@@ -327,6 +328,14 @@
     right: 6px;
     text-shadow: 0 0 1px #fff;
     top: 6px;
+  }
+
+  .edit-icon {
+    font-size: 16px;
+  }
+
+  .edit-text {
+    font-size: 10px;
   }
 
   .svg-editor .svg-editor {

--- a/extensions/objects/templates/svg-editor.component.html
+++ b/extensions/objects/templates/svg-editor.component.html
@@ -284,7 +284,7 @@
     <div class="diagram-editor-saved-image-container e2e-test-saved-diagram-container">
       <i class="fas fa-pen diagram-editor-edit edit-icon" (click)="continueDiagramEditing()"
          title="Continue editing the diagram">
-         <span class="edit-text">SVG</span>
+        <span class="edit-text">SVG</span>
       </i>
       <img [src]="data.savedSvgUrl" [ngStyle]="svgContainerStyle">
     </div>
@@ -335,6 +335,7 @@
   }
 
   .edit-text {
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 10px;
   }
 


### PR DESCRIPTION
## Overview
1. This PR fixes #20166.
2. This PR does the following: it updates character ‘s’ Next to Edit Icon in ‘Insert Image’ of RTE with 'SVG' as the edit icon opens the SVG editor. 


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Before :
<img width="744" alt="Screenshot 2024-04-24 at 11 01 26 PM" src="https://github.com/oppia/oppia/assets/124369508/1ded71ea-47f1-4e02-b7fc-2ad90c7766a6">

After :
<img width="668" alt="Screenshot 2024-04-25 at 12 47 10 PM" src="https://github.com/oppia/oppia/assets/124369508/122fbc50-b0e3-4d63-a94c-1930df07c4a0">


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
