### PR TITLE
Fix#20125: Correct Flake (Error Using Google Docs Viewer with Puppeteer) in Logged-In User Acceptance Tests.

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/spec/blog-editor-tests/try-to-publish-a-duplicate-blog-post-and-get-blocked.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/blog-editor-tests/try-to-publish-a-duplicate-blog-post-and-get-blocked.spec.ts
@@ -27,6 +27,8 @@ const duplicateBlogPostWarning =
   ' Blog Post with the' +
   ' given title exists already. Please use a different title. ';
 
+// This is the error that appears in the console when we try to post a blog with a title
+// that already exists. Since we are testing this functionality, this error occurred.
 ConsoleReporter.setConsoleErrorsToIgnore([
   'Blog Post with the given title exists already. Please use a different title.',
 ]);

--- a/core/tests/puppeteer-acceptance-tests/spec/exploration-editor-tests/create-exploration-and-change-basic-settings.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/exploration-editor-tests/create-exploration-and-change-basic-settings.spec.ts
@@ -30,11 +30,9 @@ enum INTERACTION_TYPES {
   END_EXPLORATION = 'End Exploration',
 }
 
-/**
- * After deleting the exploration if we want to access the exploration with the
- * URL, then these errors can arise. So, we ignore these errors.
- * Using regex because each time the exploration ID will be different.
- */
+// After deleting the exploration if we want to access the exploration with the
+// URL, then these errors can arise. So, we ignore these errors.
+// Using regex because each time the exploration ID will be different.
 ConsoleReporter.setConsoleErrorsToIgnore([
   /HttpErrorResponse:.*404 Not Found/,
   /Error: Could not find the resource http:\/\/localhost:8181\/explorehandler\/features\/[a-zA-Z0-9]+\.?/,

--- a/core/tests/puppeteer-acceptance-tests/spec/exploration-editor-tests/create-exploration-and-change-basic-settings.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/exploration-editor-tests/create-exploration-and-change-basic-settings.spec.ts
@@ -30,7 +30,7 @@ enum INTERACTION_TYPES {
   END_EXPLORATION = 'End Exploration',
 }
 
-// After deleting the exploration if we want to access the exploration with the
+// After deleting the exploration, if we want to access the exploration with the
 // URL, then these errors can arise. So, we ignore these errors.
 // Using regex because each time the exploration ID will be different.
 ConsoleReporter.setConsoleErrorsToIgnore([

--- a/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-on-navbar.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-on-navbar.spec.ts
@@ -20,8 +20,16 @@
 import {UserFactory} from '../../puppeteer-testing-utilities/user-factory';
 import {LoggedInUser} from '../../user-utilities/logged-in-users-utils';
 import testConstants from '../../puppeteer-testing-utilities/test-constants';
+import {ConsoleReporter} from '../../puppeteer-testing-utilities/console-reporter';
 
 const DEFAULT_SPEC_TIMEOUT_MSECS = testConstants.DEFAULT_SPEC_TIMEOUT_MSECS;
+
+// Exclude the error related to Google Docs Viewer since it's from an external service
+// and cannot be controlled.
+// https://stackoverflow.com/questions/50909239/how-to-use-google-docs-viewer-with-puppeteer
+ConsoleReporter.setConsoleErrorsToIgnore([
+  'https://content.googleapis.com/drive/v2internal/viewerimpressions?key=AIzaSyC1eQ1xj69IdTMeii5r7brs3R90eck-m7k&alt=json Failed to load resource: the server responded with a status of 403 ()',
+]);
 
 describe('Logged-in User', function () {
   let testUser: LoggedInUser;

--- a/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-on-navbar.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/logged-in-user-tests/click-all-buttons-on-navbar.spec.ts
@@ -25,8 +25,7 @@ import {ConsoleReporter} from '../../puppeteer-testing-utilities/console-reporte
 const DEFAULT_SPEC_TIMEOUT_MSECS = testConstants.DEFAULT_SPEC_TIMEOUT_MSECS;
 
 // Exclude the error related to Google Docs Viewer since it's from an external service
-// and cannot be controlled.
-// https://stackoverflow.com/questions/50909239/how-to-use-google-docs-viewer-with-puppeteer
+// and cannot be controlled by us. (https://stackoverflow.com/q/50909239)
 ConsoleReporter.setConsoleErrorsToIgnore([
   'https://content.googleapis.com/drive/v2internal/viewerimpressions?key=AIzaSyC1eQ1xj69IdTMeii5r7brs3R90eck-m7k&alt=json Failed to load resource: the server responded with a status of 403 ()',
 ]);

--- a/core/tests/puppeteer-acceptance-tests/spec/voiceover-admin-tests/add-voiceover-artist-to-an-exploration.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/spec/voiceover-admin-tests/add-voiceover-artist-to-an-exploration.spec.ts
@@ -34,7 +34,6 @@ enum INTERACTION_TYPES {
 // The backend 400 error is a known consequence of adding an invalid user ID.
 // By ignoring it, we prevent noise in the test output and focus on other unexpected errors.
 // The frontend toast message is directly asserted by test case, ensuring it is displayed correctly.
-
 ConsoleReporter.setConsoleErrorsToIgnore([
   new RegExp(
     'http://localhost:8181/voice_artist_management_handler/exploration/.*Failed to load resource: the server responded with a status of 400'


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #20125 
2. This PR does the following: There was an error in console occuring. 
When using Puppeteer to preview documents via Google Docs Viewer in Node.js, the browser throws an error. Despite the URL working well in a browser environment, attempting to access it through Puppeteer results in an error.
Set that error to ignore because it was from external factors and breaking the tests.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
<img width="924" alt="Screenshot 2024-04-24 at 11 06 57 PM" src="https://github.com/oppia/oppia/assets/136263179/ab20d1f6-9a1f-4e39-89e8-f5170d1d41a5">

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
