### PR TITLE
Fix #19816 Change where headerText and subheaderText value are set and fix their display on frontend

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -538,13 +538,13 @@
 }
 
 @media screen and (min-width: 300px) and (max-width: 768px) {
-  .oppia-top-navigation-bar .nav-mobile-header-text-container {
+  .oppia-top-navigation-bar.nav-mobile-header-text-container {
     display: inline-block;
     font-size: 1px;
     margin-top: 2px;
     max-height: 56px;
     text-overflow: ellipsis;
-    width: 50%;
+    width: calc(100% - 230px);
   }
   .oppia-top-navigation-bar .nav-mobile-header-editor {
     color: #fff;

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -29,7 +29,7 @@
     </picture>
   </a>
 </div>
-<div *ngIf="!windowIsNarrow" class="nav-mobile-header-text-container oppia-top-navigation-bar">
+<div *ngIf="headerText?.length && windowIsNarrow" class="nav-mobile-header-text-container oppia-top-navigation-bar">
   <span *ngIf="headerText?.length"
         class="nav-mobile-header-editor">
     {{ headerText }}

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
@@ -261,6 +261,76 @@ describe('TopNavigationBarComponent', () => {
     })
   );
 
+  it('should display headerText and subheaderText when windowIsNarrow is true', fakeAsync(() => {
+    spyOn(component, 'truncateNavbar').and.stub();
+    spyOn(wds, 'isWindowNarrow').and.returnValue(true);
+
+    component.headerText = 'Test Header';
+    component.subheaderText = 'Test Subheader';
+    fixture.detectChanges();
+
+    const headerTextElement = fixture.nativeElement.querySelector(
+      '.nav-mobile-header-editor'
+    );
+    const subheaderTextElement = fixture.nativeElement.querySelector(
+      '.nav-mobile-header-text'
+    );
+
+    expect(component.windowIsNarrow).toBe(true);
+    expect(headerTextElement.textContent).toContain('Test Header');
+    expect(subheaderTextElement.textContent).toContain('Test Subheader');
+
+    flush();
+  }));
+
+  it(
+    'should not display headerText and subheaderText when windowIsNarrow ' +
+      'is false',
+    fakeAsync(() => {
+      spyOn(component, 'truncateNavbar').and.stub();
+      spyOn(wds, 'isWindowNarrow').and.returnValue(false);
+
+      component.headerText = 'Test Header';
+      component.subheaderText = 'Test Subheader';
+      fixture.detectChanges();
+
+      const headerTextElement = fixture.nativeElement.querySelector(
+        '.nav-mobile-header-editor'
+      );
+      const subheaderTextElement = fixture.nativeElement.querySelector(
+        '.nav-mobile-header-text'
+      );
+
+      expect(component.windowIsNarrow).toBe(false);
+      expect(headerTextElement).toBeNull();
+      expect(subheaderTextElement).toBeNull();
+
+      flush();
+    })
+  );
+
+  it('should not display headerText and subheaderText when headerText is empty', fakeAsync(() => {
+    spyOn(component, 'truncateNavbar').and.stub();
+    spyOn(wds, 'isWindowNarrow').and.returnValue(true);
+
+    component.headerText = '';
+    component.subheaderText = 'Test Subheader';
+    fixture.detectChanges();
+
+    const headerTextElement = fixture.nativeElement.querySelector(
+      '.nav-mobile-header-editor'
+    );
+    const subheaderTextElement = fixture.nativeElement.querySelector(
+      '.nav-mobile-header-text'
+    );
+
+    expect(component.windowIsNarrow).toBe(true);
+    expect(headerTextElement).toBeNull();
+    expect(subheaderTextElement).toBeNull();
+
+    flush();
+  }));
+
   it("should show Oppia's logos", () => {
     expect(component.getStaticImageUrl('/logo/288x128_logo_white.webp')).toBe(
       '/assets/images/logo/288x128_logo_white.webp'

--- a/core/templates/pages/story-editor-page/editor-tab/story-editor.component.html
+++ b/core/templates/pages/story-editor-page/editor-tab/story-editor.component.html
@@ -210,7 +210,7 @@
                      cdkDrag>
                   <div class="story-editor-node"
                        [ngClass]="{'selected-node': (node.getId() === idOfNodeToEdit)}"
-                       (click)="navigateToChapterWithId(node.getId(), idx)">
+                       (click)="navigateToChapterWithId(node.getId(), idx, node.getTitle())">
                     <div class="story-editor-node-title">
                       <span> {{ idx+1 }}. </span>
                       <span class="e2e-test-chapter-title">{{ node.getTitle() }}</span>

--- a/core/templates/pages/story-editor-page/editor-tab/story-editor.component.spec.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-editor.component.spec.ts
@@ -617,7 +617,7 @@ describe('Story Editor Component having three story nodes', () => {
       'navigateToChapterEditorWithId'
     );
 
-    component.navigateToChapterWithId('chapter_1', 0);
+    component.navigateToChapterWithId('chapter_1', 0, 'Chapter 1');
 
     expect(navigationSpy).toHaveBeenCalled();
   });

--- a/core/templates/pages/story-editor-page/editor-tab/story-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-editor.component.ts
@@ -313,8 +313,12 @@ export class StoryEditorComponent implements OnInit, OnDestroy {
     }
   }
 
-  navigateToChapterWithId(id: string, index: number): void {
-    this.storyEditorNavigationService.navigateToChapterEditorWithId(id, index);
+  navigateToChapterWithId(id: string, index: number, title: string): void {
+    this.storyEditorNavigationService.navigateToChapterEditorWithId(
+      id,
+      index,
+      title
+    );
   }
 
   updateStoryDescriptionStatus(description: string): void {

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
@@ -153,7 +153,6 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
 
     this.isStoryPublished = this.storyEditorStateService.isStoryPublished;
     this.currentTitle = this.nodeIdToTitleMap[this.nodeId];
-    this.pageTitleService.setNavbarSubtitleForMobileView(this.currentTitle);
     this.editableTitle = this.currentTitle;
     this.currentDescription = this.description;
     this.editableDescription = this.currentDescription;
@@ -596,7 +595,6 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.pageTitleService.setNavbarTitleForMobileView('Chapter Editor');
     this.chapterOutlineIsShown = !this.windowDimensionsService.isWindowNarrow();
     this.chapterTodoCardIsShown =
       !this.windowDimensionsService.isWindowNarrow();

--- a/core/templates/pages/story-editor-page/services/story-editor-navigation.service.spec.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-navigation.service.spec.ts
@@ -111,9 +111,4 @@ describe('Story editor navigation service', () => {
     sens.navigateToStoryPreviewTab();
     expect(sens.getActiveTab()).toEqual('story_preview');
   });
-
-  it('should navigate to chapter editor', function () {
-    sens.navigateToChapterEditor();
-    expect(sens.getActiveTab()).toEqual('chapter_editor');
-  });
 });

--- a/core/templates/pages/story-editor-page/services/story-editor-navigation.service.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-navigation.service.ts
@@ -32,7 +32,8 @@ const STORY_PREVIEW = 'story_preview';
 export class StoryEditorNavigationService {
   activeTab: string = 'story_editor';
   chapterId!: string;
-  chapterIndex: number;
+  // Chapter index is null only before the story is loaded.
+  chapterIndex: number | null = null;
 
   private _activeTabIsSwitchedEventEmitter: EventEmitter<string> =
     new EventEmitter<string>();

--- a/core/templates/pages/story-editor-page/services/story-editor-navigation.service.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-navigation.service.ts
@@ -32,8 +32,7 @@ const STORY_PREVIEW = 'story_preview';
 export class StoryEditorNavigationService {
   activeTab: string = 'story_editor';
   chapterId!: string;
-  // 'chapterIndex' is null when we are navigating to a chapter with its ID.
-  chapterIndex: number | null = null;
+  chapterIndex: number;
 
   private _activeTabIsSwitchedEventEmitter: EventEmitter<string> =
     new EventEmitter<string>();
@@ -61,7 +60,7 @@ export class StoryEditorNavigationService {
 
   navigateToChapterEditorWithId(
     id: string,
-    index: number | null,
+    index: number,
     title: string
   ): void {
     this.activeTab = CHAPTER_EDITOR;
@@ -87,10 +86,6 @@ export class StoryEditorNavigationService {
       this.windowRef.nativeWindow.location.hash.split('/')[1] ===
       'story_preview'
     );
-  }
-
-  navigateToChapterEditor(): void {
-    this.navigateToChapterEditorWithId(this.chapterId, null, '');
   }
 
   navigateToStoryEditor(): void {

--- a/core/templates/pages/story-editor-page/services/story-editor-navigation.service.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-navigation.service.ts
@@ -18,6 +18,7 @@
 
 import {downgradeInjectable} from '@angular/upgrade/static';
 import {Injectable, EventEmitter} from '@angular/core';
+import {PageTitleService} from 'services/page-title.service';
 
 import {WindowRef} from 'services/contextual/window-ref.service';
 
@@ -37,7 +38,10 @@ export class StoryEditorNavigationService {
   private _activeTabIsSwitchedEventEmitter: EventEmitter<string> =
     new EventEmitter<string>();
 
-  constructor(private windowRef: WindowRef) {}
+  constructor(
+    private windowRef: WindowRef,
+    private pageTitleService: PageTitleService
+  ) {}
 
   getActiveTab(): string {
     return this.activeTab;
@@ -55,12 +59,18 @@ export class StoryEditorNavigationService {
     return this.chapterId;
   }
 
-  navigateToChapterEditorWithId(id: string, index: number | null): void {
+  navigateToChapterEditorWithId(
+    id: string,
+    index: number | null,
+    title: string
+  ): void {
     this.activeTab = CHAPTER_EDITOR;
     this.setChapterId(id);
     this._activeTabIsSwitchedEventEmitter.emit(CHAPTER_EDITOR);
     this.chapterIndex = index;
     this.windowRef.nativeWindow.location.hash = '/chapter_editor/' + id;
+    this.pageTitleService.setNavbarTitleForMobileView('Chapter Editor');
+    this.pageTitleService.setNavbarSubtitleForMobileView(title);
   }
 
   checkIfPresentInChapterEditor(): boolean {
@@ -80,7 +90,7 @@ export class StoryEditorNavigationService {
   }
 
   navigateToChapterEditor(): void {
-    this.navigateToChapterEditorWithId(this.chapterId, null);
+    this.navigateToChapterEditorWithId(this.chapterId, null, '');
   }
 
   navigateToStoryEditor(): void {

--- a/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
@@ -648,14 +648,15 @@ describe('Story Editor Page Component', () => {
       ).toHaveBeenCalled();
     }
   );
-  
+
   it('should navigate to chapter editor with chapter id after story is loaded', () => {
     spyOn(urlService, 'getStoryIdFromUrl').and.returnValue('story_1');
     spyOn(pageTitleService, 'setDocumentTitle');
     storyEditorNavigationService.checkIfPresentInChapterEditor = () => true;
 
     spyOn(component, 'navigateToChapterEditorWithChapterId');
-
+    spyOn(storyEditorStateService, 'isLoadingStory').and.returnValue(true);
+    
     component.ngOnInit();
 
     expect(component.navigateToChapterEditorWithChapterId).toHaveBeenCalled();

--- a/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
@@ -54,7 +54,7 @@ class MockStoryEditorNavigationService {
   checkIfPresentInChapterEditor = () => this.activeTab === 'chapter_editor';
   checkIfPresentInStoryPreviewTab = () => this.activeTab === 'story_preview';
   getActiveTab = () => this.activeTab;
-  navigateToChapterEditor = () => {
+  navigateToChapterEditorWithChapterId = () => {
     this.activeTab = 'chapter_editor';
   };
 
@@ -648,4 +648,16 @@ describe('Story Editor Page Component', () => {
       ).toHaveBeenCalled();
     }
   );
+  
+  it('should navigate to chapter editor with chapter id after story is loaded', () => {
+    spyOn(urlService, 'getStoryIdFromUrl').and.returnValue('story_1');
+    spyOn(pageTitleService, 'setDocumentTitle');
+    storyEditorNavigationService.checkIfPresentInChapterEditor = () => true;
+
+    spyOn(component, 'navigateToChapterEditorWithChapterId');
+
+    component.ngOnInit();
+
+    expect(component.navigateToChapterEditorWithChapterId).toHaveBeenCalled();
+  });
 });

--- a/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
@@ -54,7 +54,7 @@ class MockStoryEditorNavigationService {
   checkIfPresentInChapterEditor = () => this.activeTab === 'chapter_editor';
   checkIfPresentInStoryPreviewTab = () => this.activeTab === 'story_preview';
   getActiveTab = () => this.activeTab;
-  navigateToChapterEditorWithChapterId = () => {
+  navigateToChapterEditorWithId = () => {
     this.activeTab = 'chapter_editor';
   };
 
@@ -654,7 +654,7 @@ describe('Story Editor Page Component', () => {
     spyOn(pageTitleService, 'setDocumentTitle');
     storyEditorNavigationService.checkIfPresentInChapterEditor = () => true;
 
-    spyOn(component, 'navigateToChapterEditorWithChapterId');
+    spyOn(component, 'navigateToChapterEditorWithChapterId').and.callThrough();
     spyOn(storyEditorStateService, 'isLoadingStory').and.returnValue(true);
     
     component.ngOnInit();

--- a/core/templates/pages/story-editor-page/story-editor-page.component.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.ts
@@ -224,13 +224,14 @@ export class StoryEditorPageComponent implements OnInit, OnDestroy {
     this.storyEditorNavigationService.navigateToStoryEditor();
   }
 
-  async navigateToChapterEditorWithChapterId() {
+  async navigateToChapterEditorWithChapterId(): Promise<void> {
     if (this.storyEditorStateService.isLoadingStory()) {
       await new Promise<void>(resolve => {
         const subscription =
           this.storyEditorStateService.onStoryInitialized.subscribe(() => {
             resolve();
-            subscription.unsubscribe(); // Unsubscribe after the event is emitted to prevent memory leaks
+            // Unsubscribe after the event is emitted to prevent memory leaks.
+            subscription.unsubscribe();
           });
       });
     }

--- a/core/templates/pages/story-editor-page/story-editor-page.component.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.ts
@@ -224,6 +224,29 @@ export class StoryEditorPageComponent implements OnInit, OnDestroy {
     this.storyEditorNavigationService.navigateToStoryEditor();
   }
 
+  async navigateToChapterEditorWithChapterId() {
+    if (this.storyEditorStateService.isLoadingStory()) {
+      await new Promise<void>(resolve => {
+        const subscription =
+          this.storyEditorStateService.onStoryInitialized.subscribe(() => {
+            resolve();
+            subscription.unsubscribe(); // Unsubscribe after the event is emitted to prevent memory leaks
+          });
+      });
+    }
+    let linearNodesList = this.story.getStoryContents().getLinearNodesList();
+    let chapterId = this.storyEditorNavigationService.getChapterId();
+    let chapterIdx = linearNodesList.findIndex(
+      node => node.getId() === chapterId
+    );
+    let chapterTitle = linearNodesList[chapterIdx].getTitle();
+    this.storyEditorNavigationService.navigateToChapterEditorWithId(
+      chapterId,
+      chapterIdx,
+      chapterTitle
+    );
+  }
+
   onClosingStoryEditorBrowserTab(): void {
     const story = this.storyEditorStateService.getStory();
 
@@ -333,7 +356,7 @@ export class StoryEditorPageComponent implements OnInit, OnDestroy {
     this.pageTitleService.setNavbarTitleForMobileView('Story Editor');
 
     if (this.storyEditorNavigationService.checkIfPresentInChapterEditor()) {
-      this.storyEditorNavigationService.navigateToChapterEditor();
+      this.navigateToChapterEditorWithChapterId();
     } else if (
       this.storyEditorNavigationService.checkIfPresentInStoryPreviewTab()
     ) {

--- a/core/templates/services/UpgradedServices.ts
+++ b/core/templates/services/UpgradedServices.ts
@@ -826,7 +826,10 @@ export class UpgradedServices {
         upgradedServices['UtilsService']
       );
     upgradedServices['StoryEditorNavigationService'] =
-      new StoryEditorNavigationService(upgradedServices['WindowRef']);
+      new StoryEditorNavigationService(
+        upgradedServices['WindowRef'],
+        upgradedServices['PageTitleService']
+      );
     upgradedServices['TextInputRulesService'] = new TextInputRulesService(
       upgradedServices['NormalizeWhitespacePipe']
     );


### PR DESCRIPTION

## Overview

1. This PR fixes #19816.
2. This PR does the following: Relocated the updates for the `headerText` and `subheaderText` values from the Chapter Editor component (`story-node-editor.component.ts`) to the component responsible for the navigation of the Story Editor (in `story-editor-navigation.service.ts`), like it is done for the updates of SubTopic values in the component for routing of the Topic Editor (in `topic-editor-routing.service.ts`)
3. The original bug occurred because: The `headerText` (along with `subheaderText`) property undergoes updates after Angular's change detection cycle has concluded. This behavior stems from the component managing the new Chapter Editor Tab. The issue arises because it alters a bound value (as bound in the `top-navigation-bar.component.html`) within a new Tab (Chapter Editor), albeit within the same page (Story Editor). 
This error came from the code migration in #17968.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct


https://github.com/oppia/oppia/assets/12527288/2cba4632-b20e-485a-b7dd-5db2740edf4e

![After](https://github.com/oppia/oppia/assets/12527288/2c1cc890-856e-453b-a75e-9c4ce5fc1e41)