### PR TITLE
Fix #18447: Make question submission modal mobile-responsive

### DIFF
--- a/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.html
+++ b/core/templates/components/forms/schema-based-editors/schema-based-list-editor.component.html
@@ -16,6 +16,11 @@
     height: 30px;
     margin-top: 4px;
   }
+  @media screen and (max-width: 700px) {
+    .schema-based-list-editor {
+      margin-top: 1rem;
+    }
+  }
 </style>
 <div class="schema-based-list-editor">
   <form #listEditorForm="ngForm">

--- a/core/templates/components/state-directives/rule-editor/rule-editor.component.html
+++ b/core/templates/components/state-directives/rule-editor/rule-editor.component.html
@@ -111,7 +111,7 @@
 
     .form-group.oppia-rule-editor-span {
       margin-bottom: 0;
-      margin-top: 0;
+      margin-top: 1rem;
       position: relative;
       top: -30px;
     }

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.html
@@ -136,10 +136,15 @@
   }
   @media screen and (max-width: 500px) {
     strong {
-      font-size: 18px;
+      font-size: 1.5rem;
     }
     .oppia-correctness-label-editor {
       margin-top: 0;
+    }
+  }
+  @media screen and (max-width: 700px) {
+    .oppia-edit-feedback {
+      margin-top: 3rem;
     }
   }
 </style>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18447.
2. This PR does the following: Make question submission modal mobile-responsive
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

For before screenshots, see the original issue #18447.

![Screenshot 2024-04-28 at 22 07 31](https://github.com/oppia/oppia/assets/19878639/e376a2e5-8507-4ef3-9c20-0fb06c6dcc86)
![Screenshot 2024-04-28 at 22 07 04](https://github.com/oppia/oppia/assets/19878639/d49932f8-3523-458e-8794-ad99542ea10a)
![Screenshot 2024-04-28 at 22 06 45](https://github.com/oppia/oppia/assets/19878639/f670bdf6-7585-4b4a-91cc-1bd8ecf2adfc)

#### Proof of changes on desktop with slow/throttled network

These changes only affect the CSS code that runs on the user's local machine. Therefore, network speed cannot affect how these changes work.

#### Proof of changes on mobile phone

![Screenshot 2024-04-28 at 22 06 24](https://github.com/oppia/oppia/assets/19878639/5a312cf5-6f5f-45b3-ba16-fb1c57e4795a)
![Screenshot 2024-04-28 at 22 05 53](https://github.com/oppia/oppia/assets/19878639/ec579ea7-03d4-4f51-aa8f-3ff99252bf38)
![Screenshot 2024-04-28 at 22 05 25](https://github.com/oppia/oppia/assets/19878639/91af4fc3-7e2e-4ccf-8791-cee6da0b99aa)

#### Proof of changes in Arabic language

Not relevant because the question submission text has not been translated, as shown in the screenshot below (note the translated menu bar in the background):

![Screenshot 2024-04-28 at 22 19 59](https://github.com/oppia/oppia/assets/19878639/ffc0d62c-7f8d-4d01-9aec-e8c305d5f357)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
