### PR TITLE
Fix #20205 : The dismiss button does not show the Donate page!

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
@@ -725,6 +725,7 @@ export class LoggedInUser extends BaseUser {
         'The dismiss button does not close the Thanks for Donating popup!'
       );
     }
+    await this.page.waitForSelector(donatePage);
     const donatePageShowed = await this.page.$(donatePage);
     if (donatePageShowed === null) {
       throw new Error('The dismiss button does not show the Donate page!');

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
@@ -97,7 +97,7 @@ const readOurBlogButton =
   'a.e2e-test-thanks-for-donating-page-read-our-blog-button';
 const dismissButton = 'i.e2e-test-thanks-for-donating-page-dismiss-button';
 const thanksForDonatingClass = '.modal-open';
-const donatePage = '.modal-backdrop.fade';
+const donatePage = '.donate-content-container';
 
 const mobileNavbarOpenSidebarButton = 'a.e2e-mobile-test-navbar-button';
 const mobileSidebarAboutButton = 'a.e2e-mobile-test-sidebar-about-button';
@@ -719,6 +719,7 @@ export class LoggedInUser extends BaseUser {
    */
   async clickDismissButtonInThanksForDonatingPage(): Promise<void> {
     await this.clickOn(dismissButton);
+    await this.page.waitForSelector(thanksForDonatingClass, {hidden: true});
     const thanksForDonatingHeader = await this.page.$(thanksForDonatingClass);
     if (thanksForDonatingHeader !== null) {
       throw new Error(


### PR DESCRIPTION
## Overview

1. This PR fixes #20205 .
2. This PR does the following: This PR addresses a flaky test issue in the `clickDismissButtonInThanksForDonatingPage` function. The test was failing intermittently because the `donatePage` element was being fetched before it had enough time to load after the dismiss button was clicked.

To resolve this, I've added a `waitForSelector` function call after clicking the dismiss button. This ensures that Puppeteer waits for the `donatePage` element to appear in the DOM before proceeding with the test.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
NA

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
