### PR TITLE
Fix #19858: Make MailChimp Error Handling Comprehensive

### DIFF
--- a/core/platform/bulk_email/mailchimp_bulk_email_services.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services.py
@@ -266,42 +266,49 @@ def add_or_update_user_status(
                 merge_fields['NAME'])
 
     try:
-        client.lists.members.get(
-            feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash)
+        try:
+            client.lists.members.get(
+                feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash)
 
-        # If member is already added to mailchimp list, we cannot permanently
-        # delete a list member, since they cannot be programmatically added
-        # back, so we change their status based on preference.
-        if can_receive_email_updates:
-            client.lists.members.tags.update(
-                feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash, tag_data)
-            client.lists.members.update(
-                feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash,
-                subscribed_mailchimp_data)
-        else:
-            client.lists.members.update(
-                feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash,
-                unsubscribed_mailchimp_data)
-
-    except Exception as error:
-        # This has to be done since the message can only be accessed from
-        # MailChimpError by error.message in Python2, but this is deprecated in
-        # Python3.
-        # In Python3, the message can be accessed directly by KeyError
-        # (https://github.com/VingtCinq/python-mailchimp/pull/65), so as a
-        # workaround for Python2, the 'message' attribute is obtained by
-        # str() and then it is converted to dict. This works in Python3 as well.
-        error_message = ast.literal_eval(str(error))
-        # Error 404 corresponds to 'User does not exist'.
-        if error_message['status'] == 404:
+            # If member is already added to mailchimp list, we cannot
+            # permanently delete a list member, since they cannot be
+            # programmatically added back, so we change their status based on
+            # preference.
             if can_receive_email_updates:
-                user_creation_successful = _create_user_in_mailchimp_db(
-                    client, new_user_mailchimp_data)
-                if not user_creation_successful:
-                    return False
-        else:
-            logging.error(
-                'Mailchimp error prevented email signup: %s',
-                error_message['detail'])
-            return False
+                client.lists.members.tags.update(
+                    feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash, tag_data)
+                client.lists.members.update(
+                    feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash,
+                    subscribed_mailchimp_data)
+            else:
+                client.lists.members.update(
+                    feconf.MAILCHIMP_AUDIENCE_ID, subscriber_hash,
+                    unsubscribed_mailchimp_data)
+        except mailchimpclient.MailChimpError as mailchimp_err:
+            # This has to be done since the message can only be accessed from
+            # MailChimpError by error.message in Python2, but this is deprecated
+            # in Python3.  In Python3, the message can be accessed directly by
+            # KeyError (https://github.com/VingtCinq/python-mailchimp/pull/65),
+            # so as a workaround for Python2, the 'message' attribute is
+            # obtained by str() and then it is converted to dict. This works in
+            # Python3 as well.
+            error_message = ast.literal_eval(str(mailchimp_err))
+            # Error 404 corresponds to 'User does not exist'.
+            if error_message['status'] == 404:
+                if can_receive_email_updates:
+                    user_creation_successful = _create_user_in_mailchimp_db(
+                        client, new_user_mailchimp_data)
+                    if not user_creation_successful:
+                        return False
+            else:
+                raise mailchimp_err
+    except Exception as error:
+        # If our MailChimp operations fail for any reason, we want to still let
+        # the user complete their operation (e.g. signing-up for Oppia), so we
+        # log the error message and return False so that the caller can surface
+        # an error message to the user. Note that this is also where we handle
+        # the non-404 errors caught in the preceding try-except block, since
+        # those errors are re-raised in the preceding except block.
+        logging.error('Mailchimp error prevented email signup: %s', error)
+        return False
     return True

--- a/core/platform/bulk_email/mailchimp_bulk_email_services.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services.py
@@ -201,6 +201,9 @@ def add_or_update_user_status(
 
     Raises:
         Exception. Raised if the tag or merge fields are invalid.
+        MailChimpError. Raised if MailChimp throws an error besides a 404 error
+            for a missing user. Should be caught by outer try-except block so
+            long as the error thrown by MailChimp inherits from Exception.
     """
     client = _get_mailchimp_class()
     if not client:

--- a/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
@@ -353,7 +353,10 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
                     self.user_email_1, {}, 'Web',
                     can_receive_email_updates=True)
                 self.assertItemsEqual(
-                    ['Mailchimp error prevented email signup: Server Error'],
+                    [
+                        'Mailchimp error prevented email signup: '
+                        '{\'status\': 401, \'detail\': \'Server Error\'}'
+                    ],
                     logs
                 )
 
@@ -399,11 +402,14 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
             self.assertEqual(len(mailchimp.lists.members.users_data), 3)
 
             # Create user raises exception for other errors.
-            with self.assertRaisesRegex(
-                Exception, 'Server Issue'):
+            with self.capture_logging(min_level=logging.ERROR) as logs:
                 mailchimp_bulk_email_services.add_or_update_user_status(
                     'test5@example.com', {}, 'Web',
                     can_receive_email_updates=True)
+                self.assertItemsEqual(
+                    ['Mailchimp error prevented email signup: Server Issue'],
+                    logs
+                )
 
     def test_permanently_delete_user(self) -> None:
         mailchimp = self.MockMailchimpClass()


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19858.
2. This PR does the following: Ensures that all errors from MailChimp while signing a user up for the mailing list are caught, even those errors that arise when trying to handle missing users. Note that this fully resolves the #19858 issue because it ensures that future configuration errors don't block user signups. We have already resolved the immediate problem by making the name fields not required in the MailChimp database.
3. (For bug-fixing PRs only) The original bug occurred because: The MailChimp server configuration was changed to require names, but the web app was not updated to provide those names. This caused user signups to the mailing list to fail, and poor error-handling led those failures to block user registration.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This PR only changes how errors from MailChimp (which shouldn't ever happen and no longer happen on production) are handled. Correctness is confirmed by backend tests which use mocks to artificially induce MailChimp errors, but since these changes only activate under conditions that shouldn't ever happen, we can't test this end-to-end.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
