### PR TITLE
FIX #20253 : Acceptance Flake (Docker): The Watch A Video button does not open the right page! (Docker Setup)

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
@@ -420,12 +420,13 @@ export class BaseUser {
    */
   async waitForText(text: string, timeout: number = 30000): Promise<void> {
     try {
+      await this.page.waitForSelector('body');
       await this.page.waitForFunction(
         (textToFind: string) => {
           const bodyText = document.querySelector('body')?.innerText || '';
           return bodyText.includes(textToFind);
         },
-        {timeout},
+        { timeout },
         text
       );
     } catch (error) {

--- a/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
@@ -410,6 +410,29 @@ export class BaseUser {
   getCurrentUrlWithoutParameters(): string {
     return this.page.url().split('?')[0];
   }
+
+  /**
+   * This function Waits for a specific text to appear in the body of the page.
+   * This function only waits for rendered text. It does not wait for text in iframes or text that is hidden or not rendered for some reason.
+   * The text matching is case-sensitive and space-sensitive, so it might not find the text if there are differences in case or white space.
+   * @param {string} text - The text to wait for.
+   * @param {number} [timeout=30000] - The maximum time to wait in milliseconds. Defaults to 30000 (30 seconds).
+   */
+  async waitForText(text: string, timeout: number = 30000): Promise<void> {
+    try {
+      await this.page.waitForFunction(
+        textToFind => {
+          const bodyText = document.querySelector('body')?.innerText || '';
+          return bodyText.includes(textToFind);
+        },
+        {timeout},
+        text
+      );
+    } catch (error) {
+      error.message = `Failed to find text "${text}" within ${timeout} ms.`;
+      throw error;
+    }
+  }
 }
 
 export const BaseUserFactory = (): BaseUser => new BaseUser();

--- a/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/puppeteer-testing-utilities/puppeteer-utils.ts
@@ -421,7 +421,7 @@ export class BaseUser {
   async waitForText(text: string, timeout: number = 30000): Promise<void> {
     try {
       await this.page.waitForFunction(
-        textToFind => {
+        (textToFind: string) => {
           const bodyText = document.querySelector('body')?.innerText || '';
           return bodyText.includes(textToFind);
         },

--- a/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/user-utilities/logged-in-users-utils.ts
@@ -674,10 +674,11 @@ export class LoggedInUser extends BaseUser {
       throw new Error('The Watch A Video button does not exist!');
     }
     await Promise.all([
-      this.page.waitForNavigation(),
+      this.page.waitForNavigation({waitUntil: ['load', 'networkidle2']}),
       this.clickOn(watchAVideoButton),
     ]);
 
+    await this.waitForText('Create New Account');
     const url = this.getCurrentUrlWithoutParameters();
     const expectedWatchAVideoUrl = this.isViewportAtMobileWidth()
       ? mobileWatchAVideoUrl


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #20253 .
2. This PR does the following: This PR addresses an flake that was occurring due to the destination site’s URL being fetched before it had completely loaded.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
- 
## Proof that changes are correct

<img width="1436" alt="Screenshot 2024-05-07 at 5 50 21 PM" src="https://github.com/oppia/oppia/assets/124369508/cbc193f8-b300-4046-872c-995d198370bd">

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
