### PR TITLE
FIX #10274: Create global initial version constant and use it for initializing all the versioned entities 

### DIFF
--- a/core/domain/collection_domain.py
+++ b/core/domain/collection_domain.py
@@ -539,7 +539,7 @@ class Collection:
         """
         return cls(
             collection_id, title, category, objective, language_code, [],
-            feconf.CURRENT_COLLECTION_SCHEMA_VERSION, [], 0)
+            feconf.CURRENT_COLLECTION_SCHEMA_VERSION, [], feconf.INITIAL_ENTITY_VERSION)
 
     @classmethod
     def from_dict(

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1455,7 +1455,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
         return cls(
             exploration_id, title, category, objective, language_code, [], '',
             '', feconf.CURRENT_STATE_SCHEMA_VERSION,
-            init_state_name, states_dict, {}, [], 0,
+            init_state_name, states_dict, {}, [], feconf.INITIAL_ENTITY_VERSION,
             feconf.DEFAULT_AUTO_TTS_ENABLED,
             content_id_generator.next_content_id_index, True)
 

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -2062,7 +2062,7 @@ class Question(translation_domain.BaseTranslatableObject):
         return cls(
             question_id, default_question_state_data,
             feconf.CURRENT_STATE_SCHEMA_VERSION,
-            constants.DEFAULT_LANGUAGE_CODE, 0, skill_ids, [],
+            constants.DEFAULT_LANGUAGE_CODE, feconf.INITIAL_ENTITY_VERSION, skill_ids, [],
             content_id_generator.next_content_id_index)
 
     def update_language_code(self, language_code: str) -> None:

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -1668,7 +1668,7 @@ class Story:
             story_id, title, None, None, None, description,
             feconf.DEFAULT_STORY_NOTES, story_contents,
             feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION,
-            constants.DEFAULT_LANGUAGE_CODE, corresponding_topic_id, 0,
+            constants.DEFAULT_LANGUAGE_CODE, corresponding_topic_id, feconf.INITIAL_ENTITY_VERSION,
             url_fragment, '')
 
     @classmethod

--- a/core/domain/subtopic_page_domain.py
+++ b/core/domain/subtopic_page_domain.py
@@ -345,7 +345,7 @@ class SubtopicPage:
             subtopic_page_id, topic_id,
             SubtopicPageContents.create_default_subtopic_page_contents(),
             feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION,
-            constants.DEFAULT_LANGUAGE_CODE, 0)
+            constants.DEFAULT_LANGUAGE_CODE, feconf.INITIAL_ENTITY_VERSION)
 
     @classmethod
     def convert_html_fields_in_subtopic_page_contents(

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -1641,7 +1641,7 @@ class Topic:
             topic_id, name, name, url_fragment, None, None, None,
             description, [], [], [], [],
             feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION, 1,
-            constants.DEFAULT_LANGUAGE_CODE, 0,
+            constants.DEFAULT_LANGUAGE_CODE, feconf.INITIAL_ENTITY_VERSION,
             feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION, '',
             False, page_title_frag, [])
 

--- a/core/feconf.py
+++ b/core/feconf.py
@@ -27,6 +27,9 @@ from core.constants import constants
 
 from typing import Callable, Dict, Final, List, TypedDict, Union
 
+# Constant to dictate initial value for the version
+INITIAL_ENTITY_VERSION = 0
+
 # The datastore model ID for the list of featured activity references. This
 # value should not be changed.
 ACTIVITY_REFERENCE_LIST_FEATURED = 'featured'


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #10274.
2. This PR does the following: This PR does the following: According to the Issue "Currently, the initial value for the version number is hardcoded in the domain layer for all the entities which make it open for any entity to add incorrect initial version number", following by suggesting the creation of a Global Variable to act as a consultable constant that all files that require the initial version number can access. It was also pointed that there may be more files that needed refactoring, so after doing what was suggested and created a constant called INITIAL_ENTITY_VERSION in feconf.py, I tried to find more files that needed to be modified. The files controllers and domain have been fully searched:

Modified files:

- exp_domain.py
- topic_domain.py
- collection_domain.py
- exp_fetchers_test.py
- question_domain.py
- story_domain.py
- subtopic_page_domain.py

Found that needed refactoring but needs to be looked into/Uncertain of how to properly modify:

- skill_domain.py
- stats_domain.py

This Issue fix is pure refactoring and no logic has been modified or added

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

This is a simple refactoring work. The logic has not been altered and avoided parts of the code that I did not understand or was reluctant to refactor(such files are listed in the PR description). Ran the according test file for each refactored file and the local server is working. 

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
