### PR TITLE
[BUG]: Invisible Input Field for Promo Bar Message in Misc Tab of Release Coordinator #20294

### DIFF
--- a/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
+++ b/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
@@ -62,6 +62,7 @@
                  type="text"
                  formControlName="message">
         </div>
+        
         <mat-divider></mat-divider>
         <div class="oppia-action-buttons-container">
           <button mat-raised-button


### PR DESCRIPTION
please check that i fix the input box right now it will visible all the time 