### PR TITLE
Revert "Fix #12238: Making the question and header sticky in the question editor modal"

### DIFF
--- a/core/templates/components/question-directives/question-editor/question-editor.component.html
+++ b/core/templates/components/question-directives/question-editor/question-editor.component.html
@@ -9,8 +9,7 @@
                       (onSaveInapplicableSkillMisconceptionIds)="saveInapplicableSkillMisconceptionIds($event)"
                       [interactionIsShown]="interactionIsShown"
                       [stateContentPlaceholder]="getStateContentPlaceholder()"
-                      [stateContentSaveButtonPlaceholder]="getStateContentSaveButtonPlaceholder()"
-                      [stateContentShouldStayVisibleOnScroll]="stateContentShouldStayVisibleOnScroll">
+                      [stateContentSaveButtonPlaceholder]="getStateContentSaveButtonPlaceholder()">
   </oppia-state-editor>
 </div>
 

--- a/core/templates/components/question-directives/question-editor/question-editor.component.ts
+++ b/core/templates/components/question-directives/question-editor/question-editor.component.ts
@@ -60,7 +60,6 @@ export class QuestionEditorComponent implements OnInit, OnDestroy {
   @Input() question!: Question;
   @Input() questionId!: string;
   @Input() questionStateData!: State;
-  @Input() stateContentShouldStayVisibleOnScroll!: boolean;
   interactionIsShown!: boolean;
   oppiaBlackImgUrl!: string;
   stateEditorIsInitialized!: boolean;

--- a/core/templates/components/question-directives/questions-list/questions-list.component.html
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.html
@@ -43,8 +43,7 @@
                            [misconceptionsBySkill]="misconceptionsBySkill"
                            [questionStateData]="questionStateData"
                            [question]="question"
-                           [userCanEditQuestion]="canEditQuestion"
-                           [stateContentShouldStayVisibleOnScroll]="false">
+                           [userCanEditQuestion]="canEditQuestion">
     </oppia-question-editor>
     <div class="alert alert-danger" *ngIf="question.getStateData().interaction.id && questionValidationService.getValidationErrorMessage(question)">
       {{questionValidationService.getValidationErrorMessage(question)}}

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -23,7 +23,7 @@
   </p>
 </ng-template>
 
-<mat-card class="oppia-editor-card-with-avatar" [ngClass]="{'oppia-editor-card-with-avatar-sticky': stateContentShouldStayVisibleOnScroll}">
+<mat-card class="oppia-editor-card-with-avatar">
   <div class="state-content-header-container" (click)="toggleConceptCard()">
     <div class="state-content-header oppia-mobile-collapsible-card-header">
       <h3 class="oppia-exp-content-card-header">Content</h3>
@@ -92,12 +92,6 @@
 </div>
 
 <style>
-  .oppia-editor-card-with-avatar-sticky {
-    position: sticky;
-    top: 82px;
-    z-index: 1;
-  }
-
   .state-content-header-container {
     display: none;
     padding: 0 30px;

--- a/core/templates/components/state-editor/state-editor.component.ts
+++ b/core/templates/components/state-editor/state-editor.component.ts
@@ -81,7 +81,6 @@ export class StateEditorComponent implements OnInit, OnDestroy {
   @Input() interactionIsShown!: boolean;
   @Input() stateContentSaveButtonPlaceholder!: string;
   @Input() stateContentPlaceholder!: string;
-  @Input() stateContentShouldStayVisibleOnScroll!: boolean;
 
   oppiaBlackImgUrl!: string;
   // State name is null if their is no state selected or have no active state.

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-editor-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-editor-modal.component.html
@@ -33,8 +33,7 @@
                              [misconceptionsBySkill]="misconceptionsBySkill"
                              [questionStateData]="questionStateData"
                              [question]="question"
-                             [userCanEditQuestion]="canEditQuestion"
-                             [stateContentShouldStayVisibleOnScroll]="false">
+                             [userCanEditQuestion]="canEditQuestion">
       </oppia-question-editor>
     </div>
     <div class="alert alert-danger" *ngIf="question.getStateData().interaction.id && getQuestionValidationErrorMessage()">

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -20,37 +20,32 @@
 </div>
 
 <div class="modal-body">
-  <section class="oppia-suggestion-review-container">
-    <div class="oppia-question-details" tabindex="0">
-      <div class="oppia-question-suggestion">
-        <strong class="oppia-difficulty-title">
-          Selected Difficulty: {{skillDifficultyLabel}}
-        </strong>
-        <div *ngIf="skillRubricExplanations.length > 0">
-          <strong class="oppia-skill-rubrics"
-                  title="Use these notes to make sure your question is at the right difficulty.">
-            Notes from Skill Rubric
-          </strong>
-          <ul>
-            <li *ngFor="let explanation of skillRubricExplanations">
-              <span class="oppia-skill-explanation" [innerHtml]="explanation"></span>
-            </li>
-          </ul>
-        </div>
-      </div>
+  <div class="oppia-question-details" tabindex="0">
+    <strong class="oppia-difficulty-title">
+      Selected Difficulty: {{skillDifficultyLabel}}
+    </strong>
+    <div *ngIf="skillRubricExplanations.length > 0">
+      <strong class="oppia-skill-rubrics"
+              title="Use these notes to make sure your question is at the right difficulty.">
+        Notes from Skill Rubric
+      </strong>
+      <ul>
+        <li *ngFor="let explanation of skillRubricExplanations">
+          <span class="oppia-skill-explanation" [innerHtml]="explanation"></span>
+        </li>
+      </ul>
     </div>
-    <div *ngIf="showQuestion">
-      <oppia-question-editor [questionId]="questionId"
-                             [misconceptionsBySkill]="misconceptionsBySkill"
-                             [questionStateData]="questionStateData"
-                             [question]="question"
-                             [userCanEditQuestion]="canEditQuestion"
-                             [stateContentShouldStayVisibleOnScroll]="true"
-                             (questionChange)="questionChanged()"
-                             tabindex="0">
-      </oppia-question-editor>
-    </div>
-  </section>
+  </div>
+  <div *ngIf="showQuestion">
+    <oppia-question-editor [questionId]="questionId"
+                           [misconceptionsBySkill]="misconceptionsBySkill"
+                           [questionStateData]="questionStateData"
+                           [question]="question"
+                           [userCanEditQuestion]="canEditQuestion"
+                           (questionChange)="questionChanged()"
+                           tabindex="0">
+    </oppia-question-editor>
+  </div>
   <section [hidden]="!reviewable"
            class="oppia-reviewer-actions">
     <div class="oppia-suggestion-review-message">
@@ -115,17 +110,6 @@
 </div>
 
 <style>
-  .modal-header {
-    background-color: #fff;
-    position: sticky;
-    top: 0;
-    z-index: 1000;
-  }
-  .oppia-suggestion-review-container {
-    height: 1300px;
-    padding-bottom: 0;
-    padding-top: 0;
-  }
   .oppia-close-button-position {
     font-size: 2.5rem;
     position: absolute;
@@ -197,7 +181,7 @@
   }
   .oppia-question-suggestion {
     height: 100%;
-    overflow: auto;
+    overflow: scroll;
   }
   .oppia-reviewer-actions {
     border-top: 1px solid #e5e5e5;

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
@@ -47,7 +47,6 @@
                           [addState]="addState.bind(this)"
                           [interactionIsShown]="interactionIsShown"
                           [explorationIsLinkedToStory]="explorationIsLinkedToStory"
-                          [stateContentShouldStayVisibleOnScroll]="false"
                           (onSaveStateContent)="saveStateContent($event)"
                           (onSaveNextContentIdIndex)="saveNextContentIdIndex()"
                           (onSaveInteractionData)="saveInteractionData($event)"


### PR DESCRIPTION
## Overview
1. This PR Reverts oppia/oppia#20127
2. This PR does the following: 

oppia/oppia#20127 causes some major regression in the current release branch https://github.com/oppia/oppia/issues/20290

Until the issue is fixed properly, we have to revert oppia/oppia#20127

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] ~~I have written tests for my code.~~ -> Manually tested since it are css changes, proof provided below.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct


#### Proof of changes in Arabic language



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
