### PR TITLE
FIX #17763: Add chapter number to exploration learner view page

### DIFF
--- a/core/templates/pages/exploration-player-page/layout-directives/learner-view-info.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/learner-view-info.component.html
@@ -3,6 +3,13 @@
     <span class="oppia-navbar-breadcrumb-separator"></span>
     <div class="lesson-info-section">
       <h1 class="oppia-exploration-h1">
+        <span *ngIf="explorationStoryChapter">
+          <span class="chapter-identifier" [innerHTML]="'I18N_TOPIC_VIEWER_CHAPTER' | translate">
+          </span>
+          <span class="chapter-identifier">
+            {{ explorationStoryChapter }}-
+          </span>
+        </span>
         <span class="e2e-test-exploration-header oppia-exploration-header"
               itemprop="description">
           <span *ngIf="!isHackyExpTitleTranslationDisplayed()">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #17763.
2. This PR does the following:
Adds a feature that displays the current chapter number as the user navigates through the contents of an exploration in the context of a story. To achieve this we followed a similar structure as what was used to obtain the topic of which the exploration is part of, by extracting the storyURLfragment that was already available on the page and fetching the story Playthrough data using the StoryViewerBackendApiService. We then searched for the index of the exploration in the story nodes list, as that is what determines the chapter number of an exploration in a story. This was added within an already existent if statement that checks whether the exploration is part of a story. We modified the HTML file to make it show the chapter indication on the header of the page and also translated it using an already-defined variable (I18N_TOPIC_VIEWER_CHAPTER). We also created two tests, to check if no chapter is displayed when the exploration is not part of a story and a test to check if the correct chapter is displayed using a mock story playthrough object.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
This first video shows the exploration pages before the changes we implemented, where they don't display the chapter number.

https://github.com/oppia/oppia/assets/29431049/255c796c-05f3-4d7a-ad47-73c8f446b5ae



The following video shows the changes working on a throttled network and on a mobile device screen with the emulator.
The Arabic pages are also shown.
We first show how the chapter is shown in an exploration that is part of a story and how it is not shown in a community exploration that is not part of a story.

https://github.com/oppia/oppia/assets/29431049/48ae8eef-2786-4d0b-9982-2b4a010bd8cc




<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



<!--
#### Proof of changes on desktop with slow/throttled network
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->



<!--
#### Proof of changes on mobile phone

In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->


<!--
#### Proof of changes in Arabic language

If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
