### PR TITLE
FIX #17668: Make Lesson Information Card Progreess Bar Responsive

### DIFF
--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
@@ -251,6 +251,20 @@
   z-index: 0;
 }
 
+.completed-checkpoint-node:hover {
+  background-color: #004d40;
+}
+
+.completed-checkpoint-node a {
+  align-items: center;
+  color: inherit;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  text-decoration: none;
+  width: 100%;
+}
+
 .in-progress-checkpoint-node {
   align-items: flex-start;
   background-color: #fff;

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
@@ -38,7 +38,8 @@
           </div>
           <div *ngFor="let checkpointNode of checkpointStatusArray; index as idx"
                [ngClass]="{'completed-checkpoint-node': checkpointStatusArray[idx] === 'completed', 'in-progress-checkpoint-node': checkpointStatusArray[idx] === 'in-progress', 'incomplete-checkpoint-node': checkpointStatusArray[idx] === 'incomplete'}">
-            {{ idx + 1 }}
+            <a *ngIf="checkpointStatusArray[idx] === 'completed'" (click)="validateIndexAndGoToCheckpoint(idx)">{{ idx + 1 }}</a>
+            <span *ngIf="checkpointStatusArray[idx] !== 'completed'">{{ idx + 1 }}</span>
           </div>
         </div>
         <p *ngIf="translatedCongratulatoryCheckpointMessage"


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #17668.
2. This PR does the following:
The progress bar in the lesson information card now allows the user to change the displayed card to a certain completed checkpoint when clicking the circle of a completed checkpoint.
All changes were done in the lesson-information-card-modal.component files:
- In the .html file, the completed-checkpoint-node is now clickable so that it calls a function to go to a checkpoint.
- In the .css file, we made the changes so that the whole circle is clickable and changes colour slightly when hovered on.
- In the .ts file, we obtained the exploration information through the readOnlyExplorationBackendApiService in the ngOnInit() function.  A function was created to receive the index of the checkpoint to transition to, it then validates that index, obtains the list of ordered checkpoints, extracts the name of the desired checkpoint, finds the index of that card in the player Transcript and calls the player position Service to change the displayed card to the desired index.
- In the specs.ts file, we added two tests:
The first to test the created function with invalid inputs, such as indexes out of bounds or indexes of not yet reached checkpoints. The second to confirm the correct functioning of the function by using a mock exploration with states and correctly changing to a checkpoint.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
Before Video:

https://github.com/oppia/oppia/assets/29431049/645619c5-d433-4686-a983-8619fad19017


#### Proof of changes on desktop with slow/throttled network
After Video:

https://github.com/oppia/oppia/assets/29431049/fdfe2d35-f8ec-45ea-96c9-e2b2a71674fa


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

https://github.com/oppia/oppia/assets/29431049/88085d7d-284b-48e4-9ea4-b9d362594ba9


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

https://github.com/oppia/oppia/assets/29431049/3df84dec-2b14-435a-9468-fbc05219a91f


<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
