### PR TITLE
FIX #17668: Make Lesson Information Card Progreess Bar Responsive

### DIFF
--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
@@ -251,6 +251,20 @@
   z-index: 0;
 }
 
+.completed-checkpoint-node:hover {
+  background-color: #004d40;
+}
+
+.completed-checkpoint-node a {
+  align-items: center;
+  color: inherit;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  text-decoration: none;
+  width: 100%;
+}
+
 .in-progress-checkpoint-node {
   align-items: flex-start;
   background-color: #fff;

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
@@ -38,7 +38,8 @@
           </div>
           <div *ngFor="let checkpointNode of checkpointStatusArray; index as idx"
                [ngClass]="{'completed-checkpoint-node': checkpointStatusArray[idx] === 'completed', 'in-progress-checkpoint-node': checkpointStatusArray[idx] === 'in-progress', 'incomplete-checkpoint-node': checkpointStatusArray[idx] === 'incomplete'}">
-            {{ idx + 1 }}
+            <a *ngIf="checkpointStatusArray[idx] === 'completed'" (click)="validateIndexAndGoToCheckpoint(idx)">{{ idx + 1 }}</a>
+            <span *ngIf="checkpointStatusArray[idx] !== 'completed'">{{ idx + 1 }}</span>
           </div>
         </div>
         <p *ngIf="translatedCongratulatoryCheckpointMessage"

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.spec.ts
@@ -43,6 +43,9 @@ import {ExplorationPlayerStateService} from 'pages/exploration-player-page/servi
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {RatingComputationService} from 'components/ratings/rating-computation/rating-computation.service';
 import {CheckpointCelebrationUtilityService} from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
+import {StateObjectsBackendDict} from 'domain/exploration/StatesObjectFactory';
+import {ReadOnlyExplorationBackendApiService} from 'domain/exploration/read-only-exploration-backend-api.service';
+import {PlayerPositionService} from 'pages/exploration-player-page/services/player-position.service';
 
 @Pipe({name: 'truncateAndCapitalize'})
 class MockTruncteAndCapitalizePipe {
@@ -80,6 +83,13 @@ class MockCheckpointCelebrationUtilityService {
   getIsOnCheckpointedState(): boolean {
     return this.isOnCheckpointedState;
   }
+
+  getStateListForCheckpointMessages(
+    statesbackendDict: StateObjectsBackendDict,
+    initStateName: string
+  ): string[] {
+    return [];
+  }
 }
 
 class MockWindowRef {
@@ -110,6 +120,167 @@ class MockWindowRef {
   };
 }
 
+const dummyExplorationBackendDict = {
+  init_state_name: 'Introduction',
+  param_changes: [],
+  param_specs: {},
+  states: {
+    Introduction: {
+      classifier_model_id: null,
+      content: {
+        content_id: 'content',
+        html: '',
+      },
+      recorded_voiceovers: {
+        voiceovers_mapping: {
+          content: {},
+          default_outcome: {},
+        },
+      },
+      interaction: {
+        answer_groups: [],
+        confirmed_unclassified_answers: [],
+        customization_args: {
+          buttonText: {
+            value: 'Continue',
+          },
+        },
+        default_outcome: {
+          dest: 'Middle State',
+          dest_if_really_stuck: null,
+          feedback: {
+            content_id: 'default_outcome',
+            html: '',
+          },
+          param_changes: [],
+          labelled_as_correct: true,
+          refresher_exploration_id: null,
+          missing_prerequisite_skill_id: null,
+        },
+        hints: [],
+        solution: null,
+        id: 'Continue',
+      },
+      linked_skill_id: null,
+      param_changes: [],
+      solicit_answer_details: false,
+      card_is_checkpoint: true,
+    },
+    'Middle State': {
+      classifier_model_id: null,
+      content: {
+        content_id: 'content',
+        html: '',
+      },
+      recorded_voiceovers: {
+        voiceovers_mapping: {
+          content: {},
+          default_outcome: {},
+        },
+      },
+      interaction: {
+        answer_groups: [],
+        confirmed_unclassified_answers: [],
+        customization_args: {
+          buttonText: {
+            value: 'Continue',
+          },
+        },
+        default_outcome: {
+          dest: 'End State',
+          dest_if_really_stuck: null,
+          feedback: {
+            content_id: 'default_outcome',
+            html: '',
+          },
+          param_changes: [],
+          labelled_as_correct: true,
+          refresher_exploration_id: null,
+          missing_prerequisite_skill_id: null,
+        },
+        hints: [],
+        solution: null,
+        id: 'Continue',
+      },
+      linked_skill_id: null,
+      param_changes: [],
+      solicit_answer_details: false,
+      card_is_checkpoint: true,
+    },
+    'End State': {
+      classifier_model_id: null,
+      content: {
+        content_id: 'content',
+        html: '',
+      },
+      recorded_voiceovers: {
+        voiceovers_mapping: {
+          content: {},
+          default_outcome: {},
+        },
+      },
+      interaction: {
+        answer_groups: [],
+        confirmed_unclassified_answers: [],
+        customization_args: {
+          recommendedExplorationIds: {
+            value: [],
+          },
+        },
+        default_outcome: null,
+        hints: [],
+        solution: null,
+        id: 'EndExploration',
+      },
+      linked_skill_id: null,
+      param_changes: [],
+      solicit_answer_details: false,
+      card_is_checkpoint: false,
+    },
+  },
+  title: 'Dummy Title',
+  language_code: 'en',
+  objective: 'Dummy Objective',
+  next_content_id_index: 4,
+};
+
+const dummyExplorationMetadata = {
+  title: 'Dummy Title',
+  category: 'Dummy Category',
+  objective: 'Dummy Objective',
+  language_code: 'en',
+  tags: [],
+  blurb: 'Dummy Blurb',
+  author_notes: 'Dummy Author Notes',
+  states_schema_version: 50,
+  init_state_name: 'Introduction',
+  param_specs: {},
+  param_changes: [],
+  auto_tts_enabled: false,
+  edits_allowed: true,
+};
+
+const dummyExplorationBackendResponse = {
+  can_edit: true,
+  exploration: dummyExplorationBackendDict,
+  exploration_metadata: dummyExplorationMetadata,
+  exploration_id: 'expId',
+  is_logged_in: true,
+  session_id: 'dummy_session_id',
+  version: 1,
+  preferred_audio_language_code: 'en',
+  preferred_language_codes: ['en'],
+  auto_tts_enabled: false,
+  record_playthrough_probability: 1.0,
+  draft_change_list_id: 1,
+  has_viewed_lesson_info_modal_once: false,
+  furthest_reached_checkpoint_exp_version: 0,
+  furthest_reached_checkpoint_state_name: '',
+  most_recently_reached_checkpoint_state_name: 'Introduction',
+  most_recently_reached_checkpoint_exp_version: 0,
+  displayable_language_codes: [],
+};
+
 describe('Lesson Information card modal component', () => {
   let fixture: ComponentFixture<LessonInformationCardModalComponent>;
   let componentInstance: LessonInformationCardModalComponent;
@@ -121,8 +292,11 @@ describe('Lesson Information card modal component', () => {
   let urlService: UrlService;
   let userService: UserService;
   let explorationPlayerStateService: ExplorationPlayerStateService;
+  let playerTranscriptService: PlayerTranscriptService;
   let localStorageService: LocalStorageService;
   let checkpointCelebrationUtilityService: CheckpointCelebrationUtilityService;
+  let readOnlyExplorationBackendApiService: ReadOnlyExplorationBackendApiService;
+  let playerPositionService: PlayerPositionService;
 
   let expId = 'expId';
   let expTitle = 'Exploration Title';
@@ -148,6 +322,7 @@ describe('Lesson Information card modal component', () => {
         DateTimeFormatService,
         RatingComputationService,
         UrlInterpolationService,
+        ReadOnlyExplorationBackendApiService,
         {
           provide: CheckpointCelebrationUtilityService,
           useClass: MockCheckpointCelebrationUtilityService,
@@ -201,6 +376,7 @@ describe('Lesson Information card modal component', () => {
     urlInterpolationService = TestBed.inject(UrlInterpolationService);
     urlService = TestBed.inject(UrlService);
     userService = TestBed.inject(UserService);
+    playerTranscriptService = TestBed.inject(PlayerTranscriptService);
     localStorageService = TestBed.inject(LocalStorageService);
     explorationPlayerStateService = TestBed.inject(
       ExplorationPlayerStateService
@@ -208,6 +384,12 @@ describe('Lesson Information card modal component', () => {
     checkpointCelebrationUtilityService = TestBed.inject(
       CheckpointCelebrationUtilityService
     );
+
+    readOnlyExplorationBackendApiService = TestBed.inject(
+      ReadOnlyExplorationBackendApiService
+    );
+
+    playerPositionService = TestBed.inject(PlayerPositionService);
 
     spyOn(
       i18nLanguageCodeService,
@@ -324,6 +506,75 @@ describe('Lesson Information card modal component', () => {
 
     expect(componentInstance.getCompletedProgressBarWidth()).toEqual(75);
   });
+
+  it('should not go to invalid or incomplete checkpoint index', () => {
+    componentInstance.checkpointCount = 4;
+    componentInstance.completedCheckpointsCount = 2;
+
+    componentInstance.ngOnInit();
+
+    expect(() => {
+      componentInstance.validateIndexAndGoToCheckpoint(-1);
+    }).toThrowError('Checkpoint index out of bounds.');
+
+    expect(() => {
+      componentInstance.validateIndexAndGoToCheckpoint(4);
+    }).toThrowError('Checkpoint index out of bounds.');
+
+    expect(() => {
+      componentInstance.validateIndexAndGoToCheckpoint(3);
+    }).toThrowError('Checkpoint not reached yet.');
+
+    expect(() => {
+      componentInstance.validateIndexAndGoToCheckpoint(2);
+    }).toThrowError('Checkpoint not reached yet.');
+  });
+
+  it('should go to checkpoint index', fakeAsync(() => {
+    let mockStates = dummyExplorationBackendDict.states;
+    let mockInitStateName = dummyExplorationBackendDict.init_state_name;
+    const checkpointIndex = 1;
+    componentInstance.checkpointCount = 2;
+    componentInstance.completedCheckpointsCount = 2;
+
+    spyOn(
+      readOnlyExplorationBackendApiService,
+      'fetchExplorationAsync'
+    ).and.returnValue(Promise.resolve(dummyExplorationBackendResponse));
+
+    componentInstance.ngOnInit();
+    tick();
+    componentInstance.exploration.init_state_name = null;
+
+    expect(() => {
+      componentInstance.validateIndexAndGoToCheckpoint(checkpointIndex);
+    }).toThrowError('Exploration or its properties are undefined.');
+
+    componentInstance.exploration.init_state_name = mockInitStateName;
+
+    spyOn(
+      checkpointCelebrationUtilityService,
+      'getStateListForCheckpointMessages'
+    )
+      .withArgs(mockStates, mockInitStateName)
+      .and.returnValue(['Introduction', 'Middle State']);
+
+    spyOn(playerTranscriptService, 'findIndexOfLatestStateWithName')
+      .withArgs('Middle State')
+      .and.returnValues(null, 1);
+
+    expect(() => {
+      componentInstance.validateIndexAndGoToCheckpoint(checkpointIndex);
+    }).toThrowError('Checkpoint state card index is null.');
+
+    spyOn(playerPositionService, 'setDisplayedCardIndex');
+
+    componentInstance.validateIndexAndGoToCheckpoint(checkpointIndex);
+
+    expect(playerPositionService.setDisplayedCardIndex).toHaveBeenCalledWith(
+      checkpointIndex
+    );
+  }));
 
   it(
     'should correctly set logged-out progress learner URL ' +


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #17668 
2. This PR does the following: The progress bar in the lesson information card now allows the user to change the displayed card to a certain completed checkpoint when clicking the circle of a completed checkpoint. All changes were done in the lesson-information-card-modal.component files:
- In the .html file, the completed-checkpoint-node is now clickable so that it calls a function to go to a checkpoint.
- In the .css file, we made the changes so that the whole circle is clickable and changes colour slightly when hovered on.
- In the .ts file, we obtained the exploration information through the readOnlyExplorationBackendApiService in the ngOnInit() function. A function was created to receive the index of the checkpoint to transition to, it then validates that index, obtains the list of ordered checkpoints, extracts the name of the desired checkpoint, finds the index of that card in the player Transcript and calls the player position Service to change the displayed card to the desired index.
- In the specs.ts file, we added two tests: The first to test the created function with invalid inputs, such as indexes out of bounds or indexes of not yet reached checkpoints. The second to confirm the correct functioning of the function by using a mock exploration with states and correctly changing to a checkpoint.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Before:

https://github.com/oppia/oppia/assets/29431049/b0d25ecd-9b09-438a-85f1-159c3ea4bef1



<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
After:

https://github.com/oppia/oppia/assets/29431049/504fa0a7-28ae-4186-9a27-62252432a7ee


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

https://github.com/oppia/oppia/assets/29431049/70977093-1025-4ae3-b807-5697b9c4e116


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

https://github.com/oppia/oppia/assets/29431049/76230945-f2c1-4cb1-8861-1ca62ec6dda1


<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
