### PR TITLE
Fix part of #20303: Add oppia-image-uploader-modal component

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1621,5 +1621,10 @@
     "I18N_WARNING_MODAL_DESCRIPTION": "This will show the full solution. Are you sure?",
     "I18N_WARNING_MODAL_TITLE": "Warning!",
     "I18N_WORKED_EXAMPLE": "Worked Example",
-    "I18N_YES": "Yes"
+    "I18N_YES": "Yes",
+    "I18N_IMAGE_UPLOAD_ERROR": "Error: Could not read image file.",
+    "I18N_IMAGE_UPLOADER_MODAL_DRAG": "Drag to crop and resize:",
+    "I18N_IMAGE_UPLOADER_MODAL_ADD_BUTTON": "Add <[imageName]>",
+    "I18N_IMAGE_UPLOADER_MODAL_CANCEL_BUTTON": "Cancel",
+    "I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING": "Upload <[imageName]>"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -660,6 +660,11 @@
     "I18N_HEADING_VOLUNTEER": "Volunteer",
     "I18N_HINT_NEED_HELP": "Need help? View a hint for this problem!",
     "I18N_HINT_TITLE": "Hint",
+    "I18N_IMAGE_UPLOADER_MODAL_ADD_BUTTON": "Add <[imageName]>",
+    "I18N_IMAGE_UPLOADER_MODAL_CANCEL_BUTTON": "Cancel",
+    "I18N_IMAGE_UPLOADER_MODAL_DRAG": "Drag to crop and resize:",
+    "I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING": "Upload <[imageName]>",
+    "I18N_IMAGE_UPLOAD_ERROR": "Error: Could not read image file.",    
     "I18N_INTERACTIONS_ALGEBRAIC_EXPR_INSTRUCTION": "Type an expression here.",
     "I18N_INTERACTIONS_CODE_REPL_INSTRUCTION": "Type code in the editor",
     "I18N_INTERACTIONS_CODE_REPL_NARROW_INSTRUCTION": "Go to code editor",
@@ -1621,10 +1626,5 @@
     "I18N_WARNING_MODAL_DESCRIPTION": "This will show the full solution. Are you sure?",
     "I18N_WARNING_MODAL_TITLE": "Warning!",
     "I18N_WORKED_EXAMPLE": "Worked Example",
-    "I18N_YES": "Yes",
-    "I18N_IMAGE_UPLOAD_ERROR": "Error: Could not read image file.",
-    "I18N_IMAGE_UPLOADER_MODAL_DRAG": "Drag to crop and resize:",
-    "I18N_IMAGE_UPLOADER_MODAL_ADD_BUTTON": "Add <[imageName]>",
-    "I18N_IMAGE_UPLOADER_MODAL_CANCEL_BUTTON": "Cancel",
-    "I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING": "Upload <[imageName]>"
+    "I18N_YES": "Yes"
 }

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -1621,5 +1621,10 @@
 	"I18N_WARNING_MODAL_DESCRIPTION": "Text shown in the warning modal before the solution is displayed",
 	"I18N_WARNING_MODAL_TITLE": "Title of the modal shown before the modal that displays the solution, to warn the user\n\n{{Identical|Warning}}",
 	"I18N_WORKED_EXAMPLE": "The text that is displayed on the button to view another worked example when a skill concept card is displayed in the exploration player.",
-	"I18N_YES": "Text on button to accept the content of a modal.\n\n{{Identical|Yes}}"
+	"I18N_YES": "Text on button to accept the content of a modal.\n\n{{Identical|Yes}}",
+	"I18N_IMAGE_UPLOAD_ERROR": "Text displayed in the image uploader modal. - Error text of the dialog shown to upload a image. This error is shown when the file uploaded by the user is not an image.",
+	"I18N_IMAGE_UPLOADER_MODAL_DRAG": "Text displayed in the image uploader modal instructing the user to drag and drop the image to crop it.",
+	"I18N_IMAGE_UPLOADER_MODAL_ADD_BUTTON": "Text displayed in the image uploader modal. - Text of the add button of the dialog shown to upload an image.\n{{Identical|Add}}",
+	"I18N_IMAGE_UPLOADER_MODAL_CANCEL_BUTTON": "Text displayed in the image uploader modal. - Text of the cancel button of the dialog shown to upload an image.\n{{Identical|Cancel}}",
+	"I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING": "Heading displayed at the top of the image uploader modal."
 }

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -660,6 +660,11 @@
 	"I18N_HEADING_VOLUNTEER": "Text shown in the footer and navbar. - Link to a page that contains Oppia's Volunteer's page",
 	"I18N_HINT_NEED_HELP": "Text shown in the modal to prompt the learner to view a hint.",
 	"I18N_HINT_TITLE": "Title of the modal that shows a hint to the learner.",
+	"I18N_IMAGE_UPLOADER_MODAL_ADD_BUTTON": "Text displayed in the image uploader modal. - Text of the add button of the dialog shown to upload an image.\n{{Identical|Add}}",
+	"I18N_IMAGE_UPLOADER_MODAL_CANCEL_BUTTON": "Text displayed in the image uploader modal. - Text of the cancel button of the dialog shown to upload an image.\n{{Identical|Cancel}}",
+	"I18N_IMAGE_UPLOADER_MODAL_DRAG": "Text displayed in the image uploader modal instructing the user to drag and drop the image to crop it.",
+	"I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING": "Heading displayed at the top of the image uploader modal.",
+	"I18N_IMAGE_UPLOAD_ERROR": "Text displayed in the image uploader modal. - Error text of the dialog shown to upload a image. This error is shown when the file uploaded by the user is not an image.",
 	"I18N_INTERACTIONS_ALGEBRAIC_EXPR_INSTRUCTION": "Instructions to the learner to interact with the AlgebraicExpression interaction.",
 	"I18N_INTERACTIONS_CODE_REPL_INSTRUCTION": "Instructions to the learner to interact with the CodeRepl interaction.",
 	"I18N_INTERACTIONS_CODE_REPL_NARROW_INSTRUCTION": "Shorter instructions to the learner to interact with the CodeRepl interaction.",
@@ -1621,10 +1626,5 @@
 	"I18N_WARNING_MODAL_DESCRIPTION": "Text shown in the warning modal before the solution is displayed",
 	"I18N_WARNING_MODAL_TITLE": "Title of the modal shown before the modal that displays the solution, to warn the user\n\n{{Identical|Warning}}",
 	"I18N_WORKED_EXAMPLE": "The text that is displayed on the button to view another worked example when a skill concept card is displayed in the exploration player.",
-	"I18N_YES": "Text on button to accept the content of a modal.\n\n{{Identical|Yes}}",
-	"I18N_IMAGE_UPLOAD_ERROR": "Text displayed in the image uploader modal. - Error text of the dialog shown to upload a image. This error is shown when the file uploaded by the user is not an image.",
-	"I18N_IMAGE_UPLOADER_MODAL_DRAG": "Text displayed in the image uploader modal instructing the user to drag and drop the image to crop it.",
-	"I18N_IMAGE_UPLOADER_MODAL_ADD_BUTTON": "Text displayed in the image uploader modal. - Text of the add button of the dialog shown to upload an image.\n{{Identical|Add}}",
-	"I18N_IMAGE_UPLOADER_MODAL_CANCEL_BUTTON": "Text displayed in the image uploader modal. - Text of the cancel button of the dialog shown to upload an image.\n{{Identical|Cancel}}",
-	"I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING": "Heading displayed at the top of the image uploader modal."
+	"I18N_YES": "Text on button to accept the content of a modal.\n\n{{Identical|Yes}}"
 }

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
@@ -23,7 +23,7 @@
         {{ 'I18N_IMAGE_UPLOAD_ERROR' | translate }}
       </div>
       <div *ngIf="(isThumbnail() && uploadedImage)">
-        <div *ngIf="allowedBgColors.length >= 1">
+        <div>
           <div *ngIf="hasMoreThanOneBgColor()">
             <div>Choose background color:</div>
             <div class="oppia-thumbnail-colour-select">

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
@@ -50,10 +50,10 @@
             <oppia-thumbnail-display *ngIf="uploadedImage" [classes]="['oppia-thumbnail-image']"
               [imgSrc]="uploadedImage" [aspectRatio]="'16:9'" [background]="bgColor">
             </oppia-thumbnail-display>
-            <div class="oppia-thumbnail-preview-title">
+            <div *ngIf="previewTitle" class="oppia-thumbnail-preview-title">
               {{ previewTitle }}
             </div>
-            <div class="oppia-thumbnail-preview-description">
+            <div *ngIf="previewDescription" class="oppia-thumbnail-preview-description">
               {{ previewDescription }}
             </div>
             <div *ngIf="previewFooter" class="oppia-thumbnail-preview-footer">

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
@@ -1,0 +1,221 @@
+<div class="oppia-image-uploader-modal-container">
+  <div class="modal-header">
+    <h3>{{ 'I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING' | translate:{ imageName: imageName } }}</h3>
+  </div>
+
+  <div class="modal-body oppia-image-uploader-container">
+    <div *ngIf="(imageName==='Thumbnail' && !uploadedImage && !thumbnailImageDataUrl)">
+      <strong tabindex="0">Please upload an SVG image.</strong>
+      <div class="alert alert-warning" tabindex="0">
+        <span>Here are some guidelines to follow:</span>
+        <ul>
+          <li>Uploaded image should have a transparent background.</li>
+        </ul>
+      </div>
+    </div>
+    <div class="oppia-image-uploader">
+      <div *ngIf="(!uploadedImage && !thumbnailImageDataUrl)">
+        <oppia-image-receiver (fileChanged)="onFileChanged($event)" [allowedImageFormats]="allowedImageFormats"
+          [maxImageSizeInKB]="maxImageSizeInKB">
+        </oppia-image-receiver>
+      </div>
+      <div class="oppia-form-error oppia-form-error-text" *ngIf="invalidImageWarningIsShown">
+        {{ 'I18N_IMAGE_UPLOAD_ERROR' | translate }}
+      </div>
+      <div *ngIf="((imageName === 'Thumbnail') && thumbnailImageDataUrl)">
+        <div [hidden]="!allowedBgColors">
+          <div [hidden]="!(allowedBgColors.length > 1)">Choose background color:</div>
+          <div [hidden]="!(allowedBgColors.length > 1)" class="oppia-thumbnail-colour-select">
+            <div *ngFor="let color of allowedBgColors" [ngStyle]="{'background': color}"
+                 (click)="updateBackgroundColor(color)">
+            </div>
+          </div>
+          <div [hidden]="!(allowedBgColors.length === 1)" class="alert alert-warning">
+            <span>
+              Please check that the {{imageName.toLowerCase()}} below has the following background color:
+              <i class="fa fa-square" [ngStyle]="{'color': allowedBgColors[0]}"></i>.
+              If not, please ensure that you are uploading an image with transparent background. Thanks!
+            </span>
+          </div>
+        </div>
+        <div class="oppia-thumbnail-container e2e-test-thumbnail-container" *ngIf="thumbnailImageDataUrl"
+          [ngStyle]="{'background': previewDescriptionBgColor, 'color': previewDescriptionBgColor ? '#FFFFFF' : '', 'width': aspectRatio === '4:3' ? '248px' : '320px' }">
+          <button class="btn btn-secondary oppia-thumbnail-reset-button e2e-thumbnail-reset-button e2e-test-thumbnail-reset-button"
+                  (click)="reset()">
+            <i class="fas fa-times oppia-vcenter"></i>
+          </button>
+          <div>
+            <oppia-thumbnail-display *ngIf="thumbnailImageDataUrl" [classes]="['oppia-thumbnail-image']"
+              [imgSrc]="thumbnailImageDataUrl" [aspectRatio]="'16:9'" [background]="bgColor">
+            </oppia-thumbnail-display>
+            <div class="oppia-thumbnail-preview-title">
+              {{ previewTitle }}
+            </div>
+            <div class="oppia-thumbnail-preview-description">
+              {{ previewDescription }}
+            </div>
+            <div *ngIf="previewFooter" class="oppia-thumbnail-preview-footer">
+              {{ previewFooter }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div *ngIf="((imageName !== 'Thumbnail') && uploadedImage)">
+        <span>{{ 'I18N_IMAGE_UPLOADER_MODAL_DRAG' | translate }}</span>
+        <div class="oppia-image-uploader-modal-crop-area e2e-test-photo-crop">
+          <button class="btn btn-secondary oppia-image-uploader-modal-reset-button" aria-label="close"
+                  (click)="reset()">
+            <i class="fas fa-times oppia-vcenter"></i>
+          </button>
+          <img id="croppable-image" [src]="uploadedImage" #croppableImage>
+        </div>
+        <div [hidden]="!(allowedBgColors.length > 1)" class="bg-color-text">
+          Choose background color:
+          <div class="oppia-bg-color-container" [ngStyle]="{'background': bgColor}">
+          </div>
+        </div>
+        <div [hidden]="!(allowedBgColors.length > 1)" class="oppia-thumbnail-colour-select">
+          <div *ngFor="let color of allowedBgColors" [ngStyle]="{'background': color}"
+               (click)="updateBackgroundColor(color)">
+          </div>
+        </div>
+        <div *ngIf="invalidTagsAndAttributes.tags.length || invalidTagsAndAttributes.attrs.length"
+             class="oppia-unsupported-svg-tag-attribute-error"
+             [innerHTML]="'I18N_INVALID_TAGS_AND_ATTRIBUTES_ALERT' | translate: { issueURL: svgSanitizerService.getIssueURL(invalidTagsAndAttributes) }">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button class="btn btn-secondary" (click)="cancel()">
+      {{ 'I18N_IMAGE_UPLOADER_MODAL_CANCEL_BUTTON' | translate }}
+    </button>
+    <button class="btn btn-success e2e-test-photo-upload-submit" (click)="confirm()" [disabled]="!uploadedImage">
+      {{ 'I18N_IMAGE_UPLOADER_MODAL_ADD_BUTTON' | translate:{ imageName: imageName } }}
+    </button>
+  </div>
+</div>
+<style>
+  .oppia-image-uploader-modal-container .oppia-image-uploader-modal-crop-area {
+    background: #e4e4e4;
+    height: 350px;
+    margin-top: 20px;
+    max-width: 100%;
+    position: relative;
+    width: 500px;
+  }
+
+  .oppia-image-uploader-modal-container .oppia-image-uploader-modal-reset-button {
+    position: absolute;
+    right: -36px;
+    top: 0;
+  }
+
+  .oppia-image-uploader-modal-container .oppia-image-uploader-container {
+    min-height: 300px;
+  }
+
+  .oppia-image-uploader-modal-container .oppia-form-error-text {
+    margin-top: 15px;
+  }
+
+  .oppia-unsupported-svg-tag-attribute-error {
+    background-color: #fcf8e3;
+    border-color: #faebcc;
+    color: #8a6d3b;
+    margin-top: 15px;
+    padding: 10px;
+  }
+
+  .oppia-thumbnail-container {
+    border-radius: 4px 4px 4px 4px;
+    box-shadow: 0 4.5px 10px rgba(0, 0, 0, 0.25);
+    height: 260px;
+    margin: 0 auto 15px auto;
+    max-width: 100%;
+    position: relative;
+  }
+
+  .oppia-thumbnail-container img {
+    border-radius: 4px 4px 0 0;
+  }
+
+  .oppia-thumbnail-reset-button {
+    position: absolute;
+    right: -50px;
+    top: 0;
+  }
+
+  .oppia-thumbnail-confirm-button {
+    position: absolute;
+    right: -50px;
+    top: 40px;
+  }
+
+  .oppia-thumbnail-colour-select {
+    display: grid;
+    grid-gap: 5px;
+    grid-template-columns: 25px 25px 25px 25px;
+    grid-template-rows: 20px;
+    margin-bottom: 7px;
+  }
+
+  .oppia-thumbnail-colour-select>* {
+    border: 1px solid;
+    border-radius: 10%;
+  }
+
+  .bg-color-text {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+  }
+
+  .oppia-thumbnail-colour-select>*:hover,
+  .oppia-thumbnail-colour-select>*:focus {
+    border: 2px solid;
+    cursor: pointer;
+  }
+
+  .oppia-bg-color-container {
+    border: 1px solid black;
+    border-radius: 10%;
+    height: 20px;
+    width: 25px;
+  }
+
+  .oppia-thumbnail-preview-description {
+    font-size: 16px;
+    line-height: 1.2;
+    overflow: hidden;
+    padding: 0 16px 0 16px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .oppia-thumbnail-preview-footer {
+    bottom: 10px;
+    font-size: 16px;
+    font-style: italic;
+    line-height: 1.2;
+    padding: 0 16px 0 16px;
+    position: absolute;
+  }
+
+  .oppia-thumbnail-preview-title {
+    font-size: 18px;
+    font-weight: bold;
+    overflow: hidden;
+    padding: 10px 16px 10px 16px;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .oppia-thumbnail-uploader-container {
+    min-height: 300px;
+  }
+</style>

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
@@ -4,7 +4,7 @@
   </div>
 
   <div class="modal-body oppia-image-uploader-container">
-    <div *ngIf="(imageName==='Thumbnail' && !uploadedImage && !thumbnailImageDataUrl)">
+    <div *ngIf="(isThumbnail() && imageNotUploaded())">
       <strong tabindex="0">Please upload an SVG image.</strong>
       <div class="alert alert-warning" tabindex="0">
         <span>Here are some guidelines to follow:</span>
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="oppia-image-uploader">
-      <div *ngIf="(!uploadedImage && !thumbnailImageDataUrl)">
+      <div *ngIf="imageNotUploaded()">
         <oppia-image-receiver (fileChanged)="onFileChanged($event)" [allowedImageFormats]="allowedImageFormats"
           [maxImageSizeInKB]="maxImageSizeInKB">
         </oppia-image-receiver>
@@ -22,7 +22,7 @@
       <div class="oppia-form-error oppia-form-error-text" *ngIf="invalidImageWarningIsShown">
         {{ 'I18N_IMAGE_UPLOAD_ERROR' | translate }}
       </div>
-      <div *ngIf="((imageName === 'Thumbnail') && thumbnailImageDataUrl)">
+      <div *ngIf="(isThumbnail() && thumbnailImageDataUrl)">
         <div [hidden]="!allowedBgColors">
           <div [hidden]="!(allowedBgColors.length > 1)">Choose background color:</div>
           <div [hidden]="!(allowedBgColors.length > 1)" class="oppia-thumbnail-colour-select">
@@ -61,7 +61,7 @@
         </div>
       </div>
 
-      <div *ngIf="((imageName !== 'Thumbnail') && uploadedImage)">
+      <div *ngIf="(!isThumbnail() && uploadedImage)">
         <span>{{ 'I18N_IMAGE_UPLOADER_MODAL_DRAG' | translate }}</span>
         <div class="oppia-image-uploader-modal-crop-area e2e-test-photo-crop">
           <button class="btn btn-secondary oppia-image-uploader-modal-reset-button" aria-label="close"

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
@@ -80,7 +80,7 @@
                (click)="updateBackgroundColor(color)">
           </div>
         </div>
-        <div *ngIf="invalidTagsAndAttributes.tags.length || invalidTagsAndAttributes.attrs.length"
+        <div *ngIf="areInvalidTagsOrAttrsPresent()"
              class="oppia-unsupported-svg-tag-attribute-error"
              [innerHTML]="'I18N_INVALID_TAGS_AND_ATTRIBUTES_ALERT' | translate: { issueURL: svgSanitizerService.getIssueURL(invalidTagsAndAttributes) }">
         </div>

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
@@ -22,15 +22,17 @@
       <div class="oppia-form-error oppia-form-error-text" *ngIf="invalidImageWarningIsShown">
         {{ 'I18N_IMAGE_UPLOAD_ERROR' | translate }}
       </div>
-      <div *ngIf="(isThumbnail() && thumbnailImageDataUrl)">
-        <div [hidden]="!allowedBgColors">
-          <div [hidden]="!(allowedBgColors.length > 1)">Choose background color:</div>
-          <div [hidden]="!(allowedBgColors.length > 1)" class="oppia-thumbnail-colour-select">
-            <div *ngFor="let color of allowedBgColors" [ngStyle]="{'background': color}"
-                 (click)="updateBackgroundColor(color)">
+      <div *ngIf="(isThumbnail() && uploadedImage)">
+        <div *ngIf="allowedBgColors.length >= 1">
+          <div *ngIf="hasMoreThanOneBgColor()">
+            <div>Choose background color:</div>
+            <div class="oppia-thumbnail-colour-select">
+              <div *ngFor="let color of allowedBgColors" [ngStyle]="{'background': color}"
+                   (click)="updateBackgroundColor(color)">
+              </div>
             </div>
           </div>
-          <div [hidden]="!(allowedBgColors.length === 1)" class="alert alert-warning">
+          <div *ngIf="allowedBgColors.length === 1" class="alert alert-warning">
             <span>
               Please check that the {{imageName.toLowerCase()}} below has the following background color:
               <i class="fa fa-square" [ngStyle]="{'color': allowedBgColors[0]}"></i>.
@@ -38,15 +40,15 @@
             </span>
           </div>
         </div>
-        <div class="oppia-thumbnail-container e2e-test-thumbnail-container" *ngIf="thumbnailImageDataUrl"
+        <div class="oppia-thumbnail-container e2e-test-thumbnail-container" *ngIf="uploadedImage"
           [ngStyle]="{'background': previewDescriptionBgColor, 'color': previewDescriptionBgColor ? '#FFFFFF' : '', 'width': aspectRatio === '4:3' ? '248px' : '320px' }">
           <button class="btn btn-secondary oppia-thumbnail-reset-button e2e-thumbnail-reset-button e2e-test-thumbnail-reset-button"
                   (click)="reset()">
             <i class="fas fa-times oppia-vcenter"></i>
           </button>
           <div>
-            <oppia-thumbnail-display *ngIf="thumbnailImageDataUrl" [classes]="['oppia-thumbnail-image']"
-              [imgSrc]="thumbnailImageDataUrl" [aspectRatio]="'16:9'" [background]="bgColor">
+            <oppia-thumbnail-display *ngIf="uploadedImage" [classes]="['oppia-thumbnail-image']"
+              [imgSrc]="uploadedImage" [aspectRatio]="'16:9'" [background]="bgColor">
             </oppia-thumbnail-display>
             <div class="oppia-thumbnail-preview-title">
               {{ previewTitle }}
@@ -70,14 +72,15 @@
           </button>
           <img id="croppable-image" [src]="uploadedImage" #croppableImage>
         </div>
-        <div [hidden]="!(allowedBgColors.length > 1)" class="bg-color-text">
-          Choose background color:
-          <div class="oppia-bg-color-container" [ngStyle]="{'background': bgColor}">
+        <div *ngIf="hasMoreThanOneBgColor()">
+          <div class="bg-color-text">
+            Choose background color:
+            <div class="oppia-bg-color-container" [ngStyle]="{'background': bgColor}"></div>
           </div>
-        </div>
-        <div [hidden]="!(allowedBgColors.length > 1)" class="oppia-thumbnail-colour-select">
-          <div *ngFor="let color of allowedBgColors" [ngStyle]="{'background': color}"
-               (click)="updateBackgroundColor(color)">
+          <div class="oppia-thumbnail-colour-select">
+            <div *ngFor="let color of allowedBgColors" [ngStyle]="{'background': color}"
+                 (click)="updateBackgroundColor(color)">
+            </div>
           </div>
         </div>
         <div *ngIf="areInvalidTagsOrAttrsPresent()"

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.spec.ts
@@ -32,6 +32,15 @@ describe('Image Uploader Modal', () => {
   let componentInstance: ImageUploaderModalComponent;
   let windowDimensionsService: WindowDimensionsService;
   let resizeEvent = new Event('resize');
+  const svgString =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1.33ex" height="1.4' +
+    '29ex" viewBox="0 -511.5 572.5 615.4" focusable="false" style="verti' +
+    'cal-align: -0.241ex;"><g stroke="currentColor" fill="currentColor" ' +
+    'stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><path stroke-widt' +
+    'h="1" d="M52289Q59 331 106 386T222 442Q257 442 2864Q412 404 406 402' +
+    'Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T' +
+    '463 140Q466 150 469 151T485 153H489Q504 153 504 145284 52 289Z" ' +
+    'data-name="dataName"/></g><circel></circel></svg>';
 
   class MockChangeDetectorRef {
     detectChanges(): void {}
@@ -155,15 +164,6 @@ describe('Image Uploader Modal', () => {
     () => {
       componentInstance.imageName = 'Thumbnail';
       componentInstance.ngOnInit();
-      const svgString =
-        '<svg xmlns="http://www.w3.org/2000/svg" width="1.33ex" height="1.4' +
-        '29ex" viewBox="0 -511.5 572.5 615.4" focusable="false" style="verti' +
-        'cal-align: -0.241ex;"><g stroke="currentColor" fill="currentColor" ' +
-        'stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><path stroke-widt' +
-        'h="1" d="M52289Q59 331 106 386T222 442Q257 442 2864Q412 404 406 402' +
-        'Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T' +
-        '463 140Q466 150 469 151T485 153H489Q504 153 504 145284 52 289Z" ' +
-        'data-name="dataName"/></g><circel></circel></svg>';
       let file = new File([svgString], 'test.svg', {type: 'image/svg+xml'});
       componentInstance.invalidImageWarningIsShown = false;
 
@@ -172,6 +172,7 @@ describe('Image Uploader Modal', () => {
       expect(componentInstance.invalidImageWarningIsShown).toBeFalse();
 
       const confirmSpy = spyOn(componentInstance, 'confirm').and.callThrough();
+
       componentInstance.confirm();
 
       expect(confirmSpy).toHaveBeenCalled();
@@ -183,15 +184,6 @@ describe('Image Uploader Modal', () => {
 
   it('should remove invalid tags and attributes', () => {
     componentInstance.ngOnInit();
-    const svgString =
-      '<svg xmlns="http://www.w3.org/2000/svg" width="1.33ex" height="1.4' +
-      '29ex" viewBox="0 -511.5 572.5 615.4" focusable="false" style="verti' +
-      'cal-align: -0.241ex;"><g stroke="currentColor" fill="currentColor" ' +
-      'stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><path stroke-widt' +
-      'h="1" d="M52289Q59 331 106 386T222 442Q257 442 2864Q412 404 406 402' +
-      'Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T' +
-      '463 140Q466 150 469 151T485 153H489Q504 153 504 145284 52 289Z" ' +
-      'data-name="dataName"/></g><circel></circel></svg>';
     let file = new File([svgString], 'test.svg', {type: 'image/svg+xml'});
     componentInstance.invalidImageWarningIsShown = false;
 

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.spec.ts
@@ -1,0 +1,191 @@
+// Copyright 2024 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for image uploader modal.
+ */
+
+import {ChangeDetectorRef, ElementRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import Cropper from 'cropperjs';
+import {SvgSanitizerService} from 'services/svg-sanitizer.service';
+import {MockTranslatePipe} from 'tests/unit-test-utils';
+import {ImageUploaderModalComponent} from './image-uploader-modal.component';
+import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
+import {of} from 'rxjs';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+
+describe('Image Uploader Modal', () => {
+  let fixture: ComponentFixture<ImageUploaderModalComponent>;
+  let componentInstance: ImageUploaderModalComponent;
+  let windowDimensionsService: WindowDimensionsService;
+  let resizeEvent = new Event('resize');
+
+  class MockChangeDetectorRef {
+    detectChanges(): void {}
+  }
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ImageUploaderModalComponent, MockTranslatePipe],
+      imports: [HttpClientTestingModule],
+      providers: [
+        NgbActiveModal,
+        SvgSanitizerService,
+        {
+          provide: ChangeDetectorRef,
+          useClass: MockChangeDetectorRef,
+        },
+        {
+          provide: WindowDimensionsService,
+          useValue: {
+            isWindowNarrow: () => true,
+            getResizeEvent: () => of(resizeEvent),
+          },
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ImageUploaderModalComponent);
+    windowDimensionsService = TestBed.inject(WindowDimensionsService);
+    componentInstance = fixture.componentInstance;
+    componentInstance.aspectRatio = '4:3';
+  });
+
+  it('should create', () => {
+    expect(componentInstance).toBeDefined();
+  });
+
+  it('should initialize cropper when window is not narrow', () => {
+    spyOn(windowDimensionsService, 'isWindowNarrow').and.returnValue(false);
+    fixture.detectChanges();
+    componentInstance.croppableImageRef = new ElementRef(
+      document.createElement('img')
+    );
+
+    componentInstance.initializeCropper();
+
+    expect(componentInstance.cropper).toBeDefined();
+  });
+
+  it('should initialize cropper when window is narrow', () => {
+    spyOn(windowDimensionsService, 'isWindowNarrow').and.returnValue(true);
+    fixture.detectChanges();
+    componentInstance.croppableImageRef = new ElementRef(
+      document.createElement('img')
+    );
+
+    componentInstance.initializeCropper();
+
+    expect(componentInstance.cropper).toBeDefined();
+  });
+
+  it('should reset', () => {
+    componentInstance.reset();
+    expect(componentInstance.uploadedImage).toBeNull();
+    expect(componentInstance.croppedImageDataUrl).toBeNull();
+    expect(componentInstance.thumbnailImageDataUrl).toBeNull();
+  });
+
+  it('should handle image', () => {
+    spyOn(componentInstance, 'initializeCropper');
+    // This is just a mock base 64 in order to test the FileReader event.
+    let dataBase64Mock = 'VEhJUyBJUyBUSEUgQU5TV0VSCg==';
+    const arrayBuffer = Uint8Array.from(window.atob(dataBase64Mock), c =>
+      c.charCodeAt(0)
+    );
+    let file = new File([arrayBuffer], 'filename.png');
+    componentInstance.onFileChanged(file);
+    expect(componentInstance.invalidImageWarningIsShown).toBeFalse();
+  });
+
+  it('should remove invalid tags and attributes', () => {
+    const svgString =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1.33ex" height="1.4' +
+      '29ex" viewBox="0 -511.5 572.5 615.4" focusable="false" style="verti' +
+      'cal-align: -0.241ex;"><g stroke="currentColor" fill="currentColor" ' +
+      'stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><path stroke-widt' +
+      'h="1" d="M52289Q59 331 106 386T222 442Q257 442 2864Q412 404 406 402' +
+      'Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T' +
+      '463 140Q466 150 469 151T485 153H489Q504 153 504 145284 52 289Z" ' +
+      'data-name="dataName"/></g><circel></circel></svg>';
+    let file = new File([svgString], 'test.svg', {type: 'image/svg+xml'});
+    componentInstance.invalidImageWarningIsShown = false;
+
+    componentInstance.onFileChanged(file);
+    expect(componentInstance.invalidImageWarningIsShown).toBeFalse();
+  });
+
+  it(
+    'should update background color if the new color is different' +
+      ' from the current color',
+    () => {
+      componentInstance.bgColor = 'red';
+      componentInstance.updateBackgroundColor('blue');
+      expect(componentInstance.bgColor).toBe('blue');
+    }
+  );
+
+  it(
+    'should not update background color if the new color is the same' +
+      'as the current color',
+    () => {
+      componentInstance.bgColor = 'red';
+      componentInstance.updateBackgroundColor('red');
+      expect(componentInstance.bgColor).toBe('red');
+    }
+  );
+
+  it('should set thumbnailImageDataUrl if previewImageUrl is provided', () => {
+    componentInstance.imageName = 'Thumbnail';
+    componentInstance.previewImageUrl = 'test_url';
+    componentInstance.ngOnInit();
+
+    expect(componentInstance.thumbnailImageDataUrl).toBe('test_url');
+
+    componentInstance.confirm();
+
+    expect(componentInstance.croppedImageDataUrl).toBe('test_url');
+  });
+
+  it('should handle invalid image', () => {
+    spyOn(componentInstance, 'reset');
+    componentInstance.onInvalidImageLoaded();
+    expect(componentInstance.reset).toHaveBeenCalled();
+    expect(componentInstance.invalidImageWarningIsShown).toBeTrue();
+  });
+
+  it('should confirm image', () => {
+    let imageDataUrl = 'image_data';
+    componentInstance.cropper = {
+      getCroppedCanvas(options) {
+        return {
+          toDataURL: () => imageDataUrl,
+        };
+      },
+    } as Cropper;
+    componentInstance.confirm();
+    expect(componentInstance.croppedImageDataUrl).toEqual(imageDataUrl);
+  });
+
+  it('should throw error if cropper is not initialized', () => {
+    expect(() => {
+      componentInstance.confirm();
+    }).toThrowError('Cropper has not been initialized');
+  });
+});

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.ts
@@ -85,22 +85,31 @@ export class ImageUploaderModalComponent extends ConfirmOrCancelModal {
     );
   }
 
+  isThumbnail(): boolean {
+    return this.imageName === 'Thumbnail';
+  }
+
+  imageNotUploaded(): boolean {
+    return !this.uploadedImage && !this.thumbnailImageDataUrl;
+  }
+
   initializeCropper(): void {
-    if (this.croppableImageRef) {
-      let imageElement = this.croppableImageRef.nativeElement;
-      if (!this.windowIsNarrow) {
-        this.cropper = new Cropper(imageElement, {
-          minContainerWidth: 500,
-          minContainerHeight: 350,
-          aspectRatio: this._getAspectRatio(),
-        });
-      } else {
-        this.cropper = new Cropper(imageElement, {
-          minContainerWidth: 200,
-          minContainerHeight: 200,
-          aspectRatio: this._getAspectRatio(),
-        });
-      }
+    if (!this.croppableImageRef) {
+      return;
+    }
+    let imageElement = this.croppableImageRef.nativeElement;
+    if (this.windowIsNarrow) {
+      this.cropper = new Cropper(imageElement, {
+        minContainerWidth: 200,
+        minContainerHeight: 200,
+        aspectRatio: this._getAspectRatio(),
+      });
+    } else {
+      this.cropper = new Cropper(imageElement, {
+        minContainerWidth: 500,
+        minContainerHeight: 350,
+        aspectRatio: this._getAspectRatio(),
+      });
     }
   }
 
@@ -173,8 +182,10 @@ export class ImageUploaderModalComponent extends ConfirmOrCancelModal {
   }
 
   confirm(): void {
-    if (this.imageName !== 'Thumbnail') {
-      if (this.cropper === undefined) {
+    if (this.isThumbnail()) {
+      this.croppedImageDataUrl = this.thumbnailImageDataUrl;
+    } else {
+      if (!this.cropper) {
         throw new Error('Cropper has not been initialized');
       }
       this.croppedImageDataUrl = this.cropper
@@ -183,8 +194,6 @@ export class ImageUploaderModalComponent extends ConfirmOrCancelModal {
           width: this.dimensions.width,
         })
         .toDataURL(this.imageType);
-    } else {
-      this.croppedImageDataUrl = this.thumbnailImageDataUrl;
     }
 
     super.confirm({

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.ts
@@ -1,0 +1,208 @@
+// Copyright 2024 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Component for image uploader modal.
+ */
+
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  ViewChild,
+} from '@angular/core';
+import {SafeResourceUrl} from '@angular/platform-browser';
+import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import {ConfirmOrCancelModal} from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
+import Cropper from 'cropperjs';
+import {SvgSanitizerService} from 'services/svg-sanitizer.service';
+import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
+require('cropperjs/dist/cropper.min.css');
+
+@Component({
+  selector: 'oppia-image-uploader-modal',
+  templateUrl: './image-uploader-modal.component.html',
+})
+export class ImageUploaderModalComponent extends ConfirmOrCancelModal {
+  // These properties are initialized using Angular lifecycle hooks
+  // and we need to do non-null assertion. For more information, see
+  // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
+  @Input() allowedImageFormats!: string[];
+  @Input() bgColor!: string;
+  @Input() previewFooter!: string;
+  @Input() previewDescription!: string;
+  @Input() previewTitle!: string;
+  @Input() previewDescriptionBgColor!: string;
+  @Input() imageName!: string;
+  @Input() aspectRatio!: string;
+  @Input() maxImageSizeInKB!: number;
+  @Input() previewImageUrl!: string;
+
+  // 'uploadedImage' will be null if the uploaded svg is invalid or not trusted.
+  uploadedImage: SafeResourceUrl | null = null;
+  thumbnailImageDataUrl: string | null = null;
+  croppedImageDataUrl: string | SafeResourceUrl | null = null;
+  invalidImageWarningIsShown: boolean = false;
+  windowIsNarrow: boolean = false;
+  invalidTagsAndAttributes: {tags: string[]; attrs: string[]} = {
+    tags: [],
+    attrs: [],
+  };
+  dimensions = {height: 0, width: 0};
+  imageType!: string;
+
+  // 'cropper' is initialized before it is to be used, hence we need to do
+  // non-null assertion, for more information see
+  // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
+  cropper!: Cropper;
+  @ViewChild('croppableImage') croppableImageRef!: ElementRef;
+
+  constructor(
+    private changeDetectorRef: ChangeDetectorRef,
+    private ngbActiveModal: NgbActiveModal,
+    private windowDimensionService: WindowDimensionsService,
+    private svgSanitizerService: SvgSanitizerService
+  ) {
+    super(ngbActiveModal);
+  }
+
+  private _getAspectRatio(): number {
+    return (
+      parseInt(this.aspectRatio.split(':')[0]) /
+      parseInt(this.aspectRatio.split(':')[1])
+    );
+  }
+
+  initializeCropper(): void {
+    if (this.croppableImageRef) {
+      let imageElement = this.croppableImageRef.nativeElement;
+      if (!this.windowIsNarrow) {
+        this.cropper = new Cropper(imageElement, {
+          minContainerWidth: 500,
+          minContainerHeight: 350,
+          aspectRatio: this._getAspectRatio(),
+        });
+      } else {
+        this.cropper = new Cropper(imageElement, {
+          minContainerWidth: 200,
+          minContainerHeight: 200,
+          aspectRatio: this._getAspectRatio(),
+        });
+      }
+    }
+  }
+
+  onFileChanged(file: Blob): void {
+    this.invalidImageWarningIsShown = false;
+    let reader = new FileReader();
+    reader.onload = e => {
+      this.invalidTagsAndAttributes = {
+        tags: [],
+        attrs: [],
+      };
+      let imageData = (e.target as FileReader).result as string;
+      if (this.svgSanitizerService.isBase64Svg(imageData)) {
+        this.invalidTagsAndAttributes =
+          this.svgSanitizerService.getInvalidSvgTagsAndAttrsFromDataUri(
+            imageData
+          );
+        this.thumbnailImageDataUrl =
+          this.svgSanitizerService.removeAllInvalidTagsAndAttributes(imageData);
+        this.uploadedImage =
+          this.svgSanitizerService.getTrustedSvgResourceUrl(imageData);
+      }
+      if (!this.uploadedImage) {
+        this.uploadedImage = decodeURIComponent(
+          (e.target as FileReader).result as string
+        );
+      }
+
+      const img = new Image();
+      img.onload = () => {
+        this.dimensions = {height: img.height, width: img.width};
+
+        try {
+          this.changeDetectorRef.detectChanges();
+        } catch (viewDestroyedError) {
+          // This try catch block handles the following error in FE tests:
+          // ViewDestroyedError:
+          //   Attempt to use a destroyed view: detectChanges thrown.
+          // No further action is needed.
+        }
+        if (this.imageName !== 'Thumbnail') {
+          this.initializeCropper();
+        }
+      };
+      img.src = imageData;
+      this.imageType = file.type;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  reset(): void {
+    this.invalidTagsAndAttributes = {
+      tags: [],
+      attrs: [],
+    };
+    this.uploadedImage = null;
+    this.croppedImageDataUrl = null;
+    this.thumbnailImageDataUrl = null;
+  }
+
+  onInvalidImageLoaded(): void {
+    this.reset();
+    this.invalidImageWarningIsShown = true;
+  }
+
+  updateBackgroundColor(color: string): void {
+    if (color !== this.bgColor) {
+      this.bgColor = color;
+    }
+  }
+
+  confirm(): void {
+    if (this.imageName !== 'Thumbnail') {
+      if (this.cropper === undefined) {
+        throw new Error('Cropper has not been initialized');
+      }
+      this.croppedImageDataUrl = this.cropper
+        .getCroppedCanvas({
+          height: this.dimensions.height,
+          width: this.dimensions.width,
+        })
+        .toDataURL(this.imageType);
+    } else {
+      this.croppedImageDataUrl = this.thumbnailImageDataUrl;
+    }
+
+    super.confirm({
+      newImageDataUrl: this.croppedImageDataUrl,
+      dimensions: this.dimensions,
+      newBgColor: this.bgColor,
+    });
+  }
+
+  ngOnInit(): void {
+    if (this.previewImageUrl) {
+      this.thumbnailImageDataUrl = this.previewImageUrl;
+    }
+
+    this.windowIsNarrow = this.windowDimensionService.isWindowNarrow();
+
+    this.windowDimensionService.getResizeEvent().subscribe(() => {
+      this.windowIsNarrow = this.windowDimensionService.isWindowNarrow();
+    });
+  }
+}

--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.ts
@@ -181,6 +181,13 @@ export class ImageUploaderModalComponent extends ConfirmOrCancelModal {
     }
   }
 
+  areInvalidTagsOrAttrsPresent(): boolean {
+    return (
+      this.invalidTagsAndAttributes.tags.length > 0 ||
+      this.invalidTagsAndAttributes.attrs.length > 0
+    );
+  }
+
   confirm(): void {
     if (this.isThumbnail()) {
       this.croppedImageDataUrl = this.thumbnailImageDataUrl;

--- a/core/templates/components/shared-component.module.ts
+++ b/core/templates/components/shared-component.module.ts
@@ -87,6 +87,7 @@ import {ProgressNavComponent} from 'pages/exploration-player-page/layout-directi
 import {QuestionDifficultySelectorComponent} from './question-difficulty-selector/question-difficulty-selector.component';
 import {PreviewThumbnailComponent} from 'pages/topic-editor-page/modal-templates/preview-thumbnail.component';
 import {InputResponsePairComponent} from 'pages/exploration-player-page/learner-experience/input-response-pair.component';
+import {ImageUploaderModalComponent} from './forms/custom-forms-directives/image-uploader-modal.component';
 import {StorySummaryTileComponent} from './summary-tile/story-summary-tile.component';
 import {ExplorationFooterComponent} from 'pages/exploration-player-page/layout-directives/exploration-footer.component';
 import {DisplaySolutionModalComponent} from 'pages/exploration-player-page/modals/display-solution-modal.component';
@@ -266,6 +267,7 @@ import {DirectivesModule} from 'directives/directives.module';
     HintAndSolutionButtonsComponent,
     HintEditorComponent,
     InputResponsePairComponent,
+    ImageUploaderModalComponent,
     KeyboardShortcutHelpModalComponent,
     LearnerAnswerInfoCard,
     LazyLoadingComponent,
@@ -415,6 +417,7 @@ import {DirectivesModule} from 'directives/directives.module';
     HintAndSolutionButtonsComponent,
     HintEditorComponent,
     InputResponsePairComponent,
+    ImageUploaderModalComponent,
     KeyboardShortcutHelpModalComponent,
     ProgressNavComponent,
     PreviewThumbnailComponent,
@@ -545,6 +548,7 @@ import {DirectivesModule} from 'directives/directives.module';
     HintAndSolutionButtonsComponent,
     HintEditorComponent,
     InputResponsePairComponent,
+    ImageUploaderModalComponent,
     LazyLoadingComponent,
     ProfileLinkImageComponent,
     ProfileLinkTextComponent,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #20303 .
2. This PR does the following: Created a new image-uploader-modal component which can be used in any case topic, story, classroom thumbnail and preferences page too.

The component is created with the [edit-profile-picture-modal](https://github.com/oppia/oppia/blob/21dad4e6400643cbacf4d63cf6d74a67d198c7cc/core/templates/pages/preferences-page/modal-templates/edit-profile-picture-modal.component.ts) component taken as a reference.

#### Data returned when closed:
- `newImageDataUrl(string)`
- `dimensions({height: number, width: number})`
- `newBgColor(string)`

#### Props:
- `maxImageSizeInKB (number)`
- `aspectRatio (string)`
- `imageName (string)`
- `bgColor (string)`
- `allowedBgColors (string[])`
- `allowedImageFormats (string[])`
- `previewImageUrl (optional(string))`
- `previewDescriptionBgColor (optional(string))`
- `previewTitle (optional(string))`
- `previewDescription (optional(string))`
- `previewFooter (optional(string))`

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).



## Proof that changes are correct

https://github.com/oppia/oppia/assets/79896602/021e1712-29f6-4524-99b0-9f572bfb69eb

#### When imageName is set to Thumbnail

The flow for thumbnail is that we strictly require SVG images with a transparent background, so we show an additional banner saying "Upload an SVG image with a transparent background."

After uploading, we also display a card. we show the title and description, and it can even be used for any other thumbnail as well.

![image](https://github.com/oppia/oppia/assets/79896602/b32a3841-58d2-4da2-a23b-d1cfadeaf9b8)



#### Thumbnail card with title and description.

![image](https://github.com/oppia/oppia/assets/79896602/a022bcca-83ec-4704-a4e2-7a29a128b718)


#### Thumbnail card with no title and description and bgColor set to transparent.

![Screenshot from 2024-05-29 20-42-21](https://github.com/oppia/oppia/assets/79896602/7dc0f76b-8e77-476e-9ee9-4051d1b6e126)


<!--




Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
N/A
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
N/A
<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language
N/A
<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
