### PR TITLE
Fix #20285 Changes not reflected in preview of concept card or preview tab of skill editor page

### DIFF
--- a/core/templates/pages/skill-editor-page/editor-tab/skill-concept-card-editor/skill-concept-card-editor.component.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-concept-card-editor/skill-concept-card-editor.component.ts
@@ -102,6 +102,10 @@ export class SkillConceptCardEditorComponent implements OnInit {
       this.skill,
       explanationObject
     );
+    this.bindableFieldsDict.displayedConceptCardExplanation = this.skill
+      .getConceptCard()
+      .getExplanation().html;
+    this.getConceptCardChange.emit();
   }
 
   onSaveDescription(): void {

--- a/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.ts
+++ b/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.ts
@@ -31,7 +31,6 @@ import {ExplorationPlayerStateService} from 'pages/exploration-player-page/servi
 import {QuestionPlayerEngineService} from 'pages/exploration-player-page/services/question-player-engine.service';
 import {Subscription} from 'rxjs';
 import {ContextService} from 'services/context.service';
-import {UrlService} from 'services/contextual/url.service';
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
 import {SkillEditorStateService} from '../services/skill-editor-state.service';
 
@@ -41,7 +40,6 @@ import {SkillEditorStateService} from '../services/skill-editor-state.service';
 })
 export class SkillPreviewTabComponent implements OnInit, OnDestroy {
   constructor(
-    private urlService: UrlService,
     private skillEditorStateService: SkillEditorStateService,
     private questionBackendApiService: QuestionBackendApiService,
     private contextService: ContextService,
@@ -79,8 +77,6 @@ export class SkillPreviewTabComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const that = this;
-    this.skillId = this.urlService.getSkillIdFromUrl();
-    this.skillEditorStateService.loadSkill(this.skillId);
     this.questionTextFilter = '';
     this.interactionFilter = this.INTERACTION_TYPES.ALL;
     this.questionsFetched = false;

--- a/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.ts
+++ b/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.ts
@@ -31,6 +31,7 @@ import {ExplorationPlayerStateService} from 'pages/exploration-player-page/servi
 import {QuestionPlayerEngineService} from 'pages/exploration-player-page/services/question-player-engine.service';
 import {Subscription} from 'rxjs';
 import {ContextService} from 'services/context.service';
+import {UrlService} from 'services/contextual/url.service';
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
 import {SkillEditorStateService} from '../services/skill-editor-state.service';
 
@@ -40,6 +41,7 @@ import {SkillEditorStateService} from '../services/skill-editor-state.service';
 })
 export class SkillPreviewTabComponent implements OnInit, OnDestroy {
   constructor(
+    private urlService: UrlService,
     private skillEditorStateService: SkillEditorStateService,
     private questionBackendApiService: QuestionBackendApiService,
     private contextService: ContextService,
@@ -77,6 +79,7 @@ export class SkillPreviewTabComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const that = this;
+    this.skillId = this.urlService.getSkillIdFromUrl();
     this.questionTextFilter = '';
     this.interactionFilter = this.INTERACTION_TYPES.ALL;
     this.questionsFetched = false;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20285.
2. This PR does the following: updates the bindableFieldsDict in the skill-concept-card-editor.component.ts when editing the skill's explanation, so that the new explanation shows up in the preview window. Also removed the unnecessary reloading of the skill in the skill-preview-tab.component.ts. The skill should be loaded only once in the parent element- loading it again in the preview tab was erasing all unsaved changes from the skill.
3. (For bug-fixing PRs only) The original bug occurred because: the bindableFieldsDict was not being updated properly; and also because the skill in the skill-preview-tab.component.ts was reloading the skill in its ngOnInit function.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

https://github.com/oppia/oppia/assets/26415062/dd442f49-285d-44f9-a6be-0dcd4b62adf2


#### Proof of changes on desktop with slow/throttled network
#### Proof of changes on mobile phone

Proof of the fix working on slow network and mobile screen size. Note that the "content pane" in the skill-preview-tab does not show up on mobile, because it is set to "display:none;" on small screen sizes.

https://github.com/oppia/oppia/assets/26415062/47aacea0-44fe-4be5-a7c6-8a52ea9744cd

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->



<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
