### PR TITLE
Fix issue #20294: fixed invisible input field for promo bar message release coordinator

### DIFF
--- a/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
+++ b/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
@@ -122,8 +122,8 @@
   .oppia-promo-bar-config-field input {
     border: 2px solid #ccc;
     box-sizing: border-box;
-    padding: 8px;
     outline: none;
+    padding: 8px;
   }
   .oppia-promo-bar-config-field input:focus {
     border-color: #00376d;

--- a/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
+++ b/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
@@ -113,19 +113,19 @@
   }
   .oppia-promo-bar-config-field {
     align-items: center;
-    visibility: visible;
     display: flex;
     justify-content: space-between;
     margin-bottom: 20px;
+    visibility: visible;
     width: 100%;
   }
-  .oppia-promo-bar-config-field input{
+  .oppia-promo-bar-config-field input {
     border: 2px solid #ccc;
-    padding: 8px;
     box-sizing: border-box;
+    padding: 8px;
     outline: none;
   }
-  .oppia-promo-bar-config-field input:focus{
+  .oppia-promo-bar-config-field input:focus {
     border-color: #00376d;
     outline: 1px solid #00376d;
   }

--- a/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
+++ b/core/templates/pages/release-coordinator-page/release-coordinator-page.component.html
@@ -113,9 +113,21 @@
   }
   .oppia-promo-bar-config-field {
     align-items: center;
+    visibility: visible;
     display: flex;
     justify-content: space-between;
     margin-bottom: 20px;
     width: 100%;
   }
+  .oppia-promo-bar-config-field input{
+    border: 2px solid #ccc;
+    padding: 8px;
+    box-sizing: border-box;
+    outline: none;
+  }
+  .oppia-promo-bar-config-field input:focus{
+    border-color: #00376d;
+    outline: 1px solid #00376d;
+  }
+
 </style>


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #20294 
2. This PR does the following: fixes the invisible input field for promo bar message on release coordinator
3. The bug was introduced right from when the `release-coordinator-page-component.html` file was created

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct


https://github.com/oppia/oppia/assets/102523109/84210043-a989-43f8-9132-5c441a74d6dd


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
