### PR TITLE
Fix #19732: Avoid reading from playerPositionService at outset to mitigate e2e flake.

### DIFF
--- a/core/templates/pages/exploration-player-page/modals/flag-exploration-modal.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/modals/flag-exploration-modal.component.spec.ts
@@ -63,7 +63,6 @@ describe('Flag Exploration modal', () => {
 
   it('should create', () => {
     expect(component).toBeDefined();
-    expect(component.stateName).toEqual(stateName);
   });
 
   it('should show flag message textarea', () => {

--- a/core/templates/pages/exploration-player-page/modals/flag-exploration-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/modals/flag-exploration-modal.component.ts
@@ -37,7 +37,6 @@ export class FlagExplorationModalComponent extends ConfirmOrCancelModal {
   // and we need to do non-null assertion. For more information, see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
   flagMessage!: string;
-  stateName!: string;
   flagMessageTextareaIsShown: boolean = false;
   flag: boolean = false;
 
@@ -47,7 +46,6 @@ export class FlagExplorationModalComponent extends ConfirmOrCancelModal {
     private playerPositionService: PlayerPositionService
   ) {
     super(ngbActiveModal);
-    this.stateName = this.playerPositionService.getCurrentStateName();
   }
 
   showFlagMessageTextarea(value: boolean): void {
@@ -62,7 +60,7 @@ export class FlagExplorationModalComponent extends ConfirmOrCancelModal {
       this.ngbActiveModal.close({
         report_type: this.flag,
         report_text: this.flagMessageTextareaIsShown,
-        state: this.stateName,
+        state: this.playerPositionService.getCurrentStateName(),
       });
     }
   }


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #19732.
2. This PR does the following: Moves the read from playerPositionService to later in the flow, to avoid a flake on opening the report exploration modal before the lesson information loads.
3. (For bug-fixing PRs only) The original bug occurred because: The playerPositionInfo was being accessed before it loaded, resulting an error in the report-exploration modal.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This will be confirmed by the CI tests on this PR.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
