### PR TITLE
[GSoC'24] M1.6, Fix a part of #20374: Acceptance test coverage for the Misc tab of release coordinator.

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/release-coordinator/update-promo-bar-message.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/release-coordinator/update-promo-bar-message.spec.ts
@@ -1,0 +1,57 @@
+// Copyright 2024 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Acceptance tests for the functionality of enabling and saving
+ * a promo bar message by a release coordinator.
+ */
+
+import {UserFactory} from '../../utilities/common/user-factory';
+import testConstants from '../../utilities/common/test-constants';
+import {ReleaseCoordinator} from '../../utilities/user/release-coordinator';
+
+const DEFAULT_SPEC_TIMEOUT_MSECS = testConstants.DEFAULT_SPEC_TIMEOUT_MSECS;
+const ROLES = testConstants.Roles;
+const promoMessage =
+  'New Features Alert! Check out our latest updates and enhancements. Explore now!';
+
+describe('Release Coordinator', function () {
+  let releaseCoordinator: ReleaseCoordinator;
+
+  beforeAll(async function () {
+    releaseCoordinator = await UserFactory.createNewUser(
+      'releaseCoordinator',
+      'release_coordinator@example.com',
+      [ROLES.RELEASE_COORDINATOR]
+    );
+  }, DEFAULT_SPEC_TIMEOUT_MSECS);
+
+  it(
+    'should navigate to the Promo Bar tab, enable the promo bar and save a promo bar message',
+    async function () {
+      await releaseCoordinator.navigateToReleaseCoordinatorPage();
+      await releaseCoordinator.navigateToPromoBarTab();
+      await releaseCoordinator.enablePromoBar();
+      await releaseCoordinator.enterPromoBarMessage(promoMessage);
+      await releaseCoordinator.savePromoBarMessage();
+      await releaseCoordinator.navigateToSplashPage();
+      await releaseCoordinator.expectPromoMessageToBe(promoMessage);
+    },
+    DEFAULT_SPEC_TIMEOUT_MSECS
+  );
+
+  afterAll(async function () {
+    await UserFactory.closeAllBrowsers();
+  });
+});

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/test-constants.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/test-constants.ts
@@ -25,6 +25,7 @@ export default {
     AboutFoundation: 'http://localhost:8181/about-foundation',
     AdminPage: 'http://localhost:8181/admin',
     AdminPageRolesTab: 'http://localhost:8181/admin#/roles',
+    AdminPageActivitiesTab: 'http://localhost:8181/admin#/activities',
     Android: 'http://localhost:8181/android',
     Blog: 'http://localhost:8181/blog',
     BlogAdmin: 'http://localhost:8181/blog-admin',
@@ -68,6 +69,8 @@ export default {
     PartnershipsFormInPortuguese:
       'https://docs-google-com.translate.goog/forms/d/e/1FAIpQLSdL5mjFO7RxDtg8yfXluEtciYj8WnAqTL9fZWnwPgOqXV-9lg/viewform?_x_tr_sl=en&_x_tr_tl=pt&_x_tr_hl=en-US&_x_tr_pto=wapp',
     PartnershipsFormShortUrl: 'https://forms.gle/Y71U8FdhQwZpicJj8',
+    releaseCoordinatorPage: 'http://localhost:8181/release-coordinator',
+    splashPage: 'http://localhost:8181/splash',
     Teach: 'http://localhost:8181/teach',
     TopicAndSkillsDashboard:
       'http://localhost:8181/topics-and-skills-dashboard',
@@ -95,6 +98,7 @@ export default {
     VOICEOVER_ADMIN: 'voiceover admin',
     TOPIC_MANAGER: 'topic manager',
     MODERATOR: 'moderator',
+    RELEASE_COORDINATOR: 'release coordinator',
   } as const,
   BlogRights: {
     BLOG_ADMIN: 'BLOG_ADMIN',

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.ts
@@ -32,6 +32,7 @@ import {CurriculumAdminFactory} from '../user/curriculum-admin';
 import {TopicManagerFactory} from '../user/topic-manager';
 import {LoggedInUserFactory, LoggedInUser} from '../user/logged-in-user';
 import {ModeratorFactory} from '../user/moderator';
+import {ReleaseCoordinatorFactory} from '../user/release-coordinator';
 import testConstants from './test-constants';
 
 const ROLES = testConstants.Roles;
@@ -51,6 +52,7 @@ const USER_ROLE_MAPPING = {
   [ROLES.VOICEOVER_ADMIN]: VoiceoverAdminFactory,
   [ROLES.TOPIC_MANAGER]: TopicManagerFactory,
   [ROLES.MODERATOR]: ModeratorFactory,
+  [ROLES.RELEASE_COORDINATOR]: ReleaseCoordinatorFactory,
 } as const;
 
 /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/release-coordinator.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/release-coordinator.ts
@@ -1,0 +1,61 @@
+// Copyright 2024 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Utility functions for the release coordinator page.
+ */
+
+import {BaseUser} from '../common/puppeteer-utils';
+import testConstants from '../common/test-constants';
+import {showMessage} from '../common/show-message';
+
+export class ReleaseCoordinator extends BaseUser {
+  async navigateToReleaseCoordinatorPage(): Promise<void> {
+    await this.page.goto(testConstants.URLs.releaseCoordinatorPage);
+  }
+
+  async navigateToPromoBarTab(): Promise<void> {
+    await this.clickAndWaitForNavigation(' Misc');
+  }
+
+  async enablePromoBar(): Promise<void> {
+    await this.page.waitForSelector('#mat-slide-toggle-2');
+    await this.clickOn('#mat-slide-toggle-2');
+  }
+
+  async enterPromoBarMessage(promoMessage: string): Promise<void> {
+    await this.page.waitForSelector('.mat-input-element');
+    await this.page.type('.mat-input-element', promoMessage);
+  }
+
+  async savePromoBarMessage(): Promise<void> {
+    await this.clickOn(' Save changes ');
+  }
+
+  async navigateToSplashPage(): Promise<void> {
+    await this.page.goto(testConstants.URLs.splashPage);
+  }
+
+  async expectPromoMessageToBe(expectedMessage: string): Promise<void> {
+    await this.page.waitForSelector('.promo-bar-message');
+    const actualMessage = await this.page.$eval(
+      '.promo-bar-message',
+      el => el.textContent
+    );
+    expect(actualMessage).toEqual(expectedMessage);
+  }
+}
+
+export let ReleaseCoordinatorFactory = (): ReleaseCoordinator =>
+  new ReleaseCoordinator();


### PR DESCRIPTION
## Overview
This PR fixes or fixes part of https://github.com/oppia/oppia/issues/20374 .
This PR does the following: Acceptance test coverage for:
      6.3. flush and get profile of redis cache
      6.4. update promo bar message

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
N/A

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
