### PR TITLE
Fix #20549 : Fix TimeoutError: waiting for selector .e2e-test-partnerships-page-brochure-button failed

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-partnerships-page.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-partnerships-page.spec.ts
@@ -59,19 +59,19 @@ describe('Logged-out User in Partnerships page', function () {
   );
 
   it(
-    'should open the Partnerships form when the "Partner with us" button is clicked at the bottom.',
+    'should open the Partnerships Brochure when the "Download Brochure" button is clicked.',
     async function () {
-      await loggedOutUser.clickPartnerWithUsButtonInPartnershipsPageInGivenLanguage(
-        'pt-br'
-      );
+      await loggedOutUser.clickDownloadBrochureButtonInPartnershipsPage();
     },
     DEFAULT_SPEC_TIMEOUT_MSECS
   );
 
   it(
-    'should open the Partnerships Brochure when the "Download Brochure" button is clicked.',
+    'should open the Partnerships form when the "Partner with us" button is clicked at the bottom.',
     async function () {
-      await loggedOutUser.clickDownloadBrochureButtonInPartnershipsPage();
+      await loggedOutUser.clickPartnerWithUsButtonInPartnershipsPageInGivenLanguage(
+        'pt-br'
+      );
     },
     DEFAULT_SPEC_TIMEOUT_MSECS
   );

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -436,7 +436,7 @@ export class BaseUser {
     selector: string,
     expectedUrl: string
   ): Promise<void> {
-    await this.page.waitForSelector(selector);
+    await this.page.waitForSelector(selector, {visible: true});
     const href = await this.page.$eval(selector, element =>
       element.getAttribute('href')
     );

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -1374,6 +1374,7 @@ export class LoggedOutUser extends BaseUser {
       partnershipsFormInPortugueseUrl,
       'Partnerships Google Form'
     );
+    await this.changeSiteLanguage('en');
   }
 
   /**
@@ -1381,6 +1382,19 @@ export class LoggedOutUser extends BaseUser {
    * and check if it opens the Partnerships Brochure.
    */
   async clickDownloadBrochureButtonInPartnershipsPage(): Promise<void> {
+    const buttonText = (await this.page.$eval(
+      brochureButtonInPartnershipsPage,
+      element => element.textContent
+    )) as string;
+    if (buttonText.trim() !== 'Download Brochure') {
+      throw new Error('The "Download Brochure" button does not exist!');
+    }
+
+    // Scroll into the view to make the button visible.
+    await this.page.$eval(brochureButtonInPartnershipsPage, element =>
+      element.scrollIntoView()
+    );
+
     await this.openExternalPdfLink(
       brochureButtonInPartnershipsPage,
       partnershipsBrochureUrl


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20549 .
2. This PR does the following:  Fix the mentioned flake.
3. (For bug-fixing PRs only) The original bug occurred because: Puppeteer is attempting to locate the button in the current test before closing the new tab from the preceding test (a partnerships form tab), which leads to finding the button in the prior test's new tab. So it fails to find the button in the new tab.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

I have run that particular  suite locally 5 times in headless mode and also on the [CI of my fork](https://github.com/AkashPaloju/oppia/actions/runs/9723534108/job/26839512637?pr=1) with these changes . It passesd all the times.

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
