### PR TITLE
Fix #20475, Fix #20519 Fix the timeout errors

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/check-all-user-flow-of-partner.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/check-all-user-flow-of-partner.spec.ts
@@ -66,8 +66,6 @@ describe('Partner', function () {
 
       // Opening the partnerships form by clicking the "Partner with us" button at the top of the partnerships page.
       await loggedOutUser.clickPartnerWithUsButtonInPartnershipsPage();
-      // Navigating back to partnerships page for the next test.
-      await loggedOutUser.navigateToPartnershipsPage();
       // Opening the partnerships form by clicking the "Partner with us" button at the bottom
       // of the partnerships page after changing the language to Portuguese.
       await loggedOutUser.clickPartnerWithUsButtonInPartnershipsPageInGivenLanguage(

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -55,7 +55,6 @@ const OppiaAnnounceGoogleGroupUrl = testConstants.URLs.OppiaAnnounceGoogleGroup;
 const partnershipsBrochureUrl = testConstants.URLs.PartnershipsBrochure;
 const partnershipsFormInPortugueseUrl =
   testConstants.URLs.PartnershipsFormInPortuguese;
-const partnershipsFormShortUrl = testConstants.URLs.PartnershipsFormShortUrl;
 const partnershipsFormUrl = testConstants.URLs.PartnershipsForm;
 const partnershipsUrl = testConstants.URLs.Partnerships;
 const privacyPolicyUrl = testConstants.URLs.PrivacyPolicy;
@@ -64,21 +63,9 @@ const programmingWithCarlaUrl = testConstants.URLs.ProgrammingWithCarla;
 const teachUrl = testConstants.URLs.Teach;
 const termsUrl = testConstants.URLs.Terms;
 const thanksForDonatingUrl = testConstants.URLs.DonateWithThanksModal;
-const volunteerFormShortUrl = testConstants.URLs.VolunteerFormShortUrl;
 const volunteerFormUrl = testConstants.URLs.VolunteerForm;
 const volunteerUrl = testConstants.URLs.Volunteer;
 const welcomeToOppiaUrl = testConstants.URLs.WelcomeToOppia;
-
-const allowedVolunteerFormUrls = [
-  volunteerFormUrl,
-  `${volunteerFormUrl}?usp=send_form`,
-  volunteerFormShortUrl,
-];
-const allowedPartnershipsFormUrls = [
-  partnershipsFormShortUrl,
-  partnershipsFormUrl,
-  `${partnershipsFormUrl}?usp=send_form`,
-];
 const impactReportUrl = testConstants.URLs.ImpactReportUrl;
 
 const navbarLearnTab = 'a.e2e-test-navbar-learn-menu';
@@ -1290,35 +1277,6 @@ export class LoggedOutUser extends BaseUser {
   }
 
   /**
-   * Function to click a button and check if it opens any of the allowedUrls
-   * in a new tab. Closes the tab afterwards. This function is useful when we try to
-   * verify Google Form URLs which changes in a short span of time.
-   */
-  private async clickLinkButtonToNewTabAndVerifyAllowedUrls(
-    button: string,
-    buttonName: string,
-    allowedUrls: string[],
-    expectedDestinationPageName: string
-  ): Promise<void> {
-    const pageTarget = this.page.target();
-    await this.clickOn(button);
-    const newTarget = await this.browserObject.waitForTarget(
-      target => target.opener() === pageTarget
-    );
-    const newTabPage = await newTarget.page();
-
-    expect(newTabPage).toBeDefined();
-    const newTabPageUrl = newTabPage?.url() as string;
-    if (!allowedUrls.includes(newTabPageUrl)) {
-      throw new Error(
-        `${buttonName} should open ${expectedDestinationPageName} page` +
-          `but it opens ${newTabPageUrl} instead.`
-      );
-    }
-    await newTabPage?.close();
-  }
-
-  /**
    * Function to change the site language to the given language code.
    * @param langCode - The language code to change the site language to. Example: 'pt-br', 'en'
    */
@@ -1343,13 +1301,10 @@ export class LoggedOutUser extends BaseUser {
    * The button is in the first section of the page.
    */
   async clickPartnerWithUsButtonInPartnershipsPage(): Promise<void> {
-    // The Google Form URL changes from the 1st to the 2nd and from 2nd to the
-    // 3rd in a short span of 500-1000 ms for it's own reasons which we can't
-    // control.So we need to check for all the 3 URLs as all of them are valid.
-    await this.clickLinkButtonToNewTabAndVerifyAllowedUrls(
+    await this.clickLinkButtonToNewTab(
       partnerWithUsButtonAtTheTopOfPartnershipsPage,
       'Partner With Us button at the bottom of the Partnerships page',
-      allowedPartnershipsFormUrls,
+      partnershipsFormUrl,
       'Partnerships Google Form'
     );
   }
@@ -1365,9 +1320,6 @@ export class LoggedOutUser extends BaseUser {
   ): Promise<void> {
     await this.changeSiteLanguage(langCode);
 
-    // Here we are not verifying the 3 URLs as we did in the English version
-    // because we have put the direct translated Google Form URL in the page itself.
-    // Refer core/templates/pages/partnerships-page/partnerships-page.component.ts to see how it's done.
     await this.clickLinkButtonToNewTab(
       partnerWithUsButtonAtTheBottomOfPartnershipsPage,
       'Partner With Us button at the bottom of the Partnerships page',
@@ -1432,14 +1384,10 @@ export class LoggedOutUser extends BaseUser {
    * and check if it opens the Volunteer form.
    */
   async clickApplyToVolunteerAtTheTopOfVolunteerPage(): Promise<void> {
-    // The Google Form URL changes from the 1st to the 2nd and from 2nd to the
-    // 3rd in a short span of 500-1000 ms for it's own reasons which we can't
-    // control.So we need to check for all the 3 URLs in the 'allowedVolunteerFormUrls' array
-    // as all of them are valid.
-    await this.clickLinkButtonToNewTabAndVerifyAllowedUrls(
+    await this.clickLinkButtonToNewTab(
       applyToVolunteerButtonAtTheTopOfVolunteerPage,
       'Apply To Volunteer at the top of the Volunteer page',
-      allowedVolunteerFormUrls,
+      volunteerFormUrl,
       'Volunteer Form'
     );
   }
@@ -1449,14 +1397,10 @@ export class LoggedOutUser extends BaseUser {
    * and check if it opens the Volunteer form.
    */
   async clickApplyToVolunteerAtTheBottomOfVolunteerPage(): Promise<void> {
-    // The Google Form URL changes from the 1st to the 2nd and from 2nd to the
-    // 3rd in a short span of 500-1000 ms for it's own reasons which we can't
-    // control.So we need to check for all the 3 URLs in the 'allowedVolunteerFormUrls' array
-    // as all of them are valid.
-    await this.clickLinkButtonToNewTabAndVerifyAllowedUrls(
+    await this.clickLinkButtonToNewTab(
       applyToVolunteerButtonAtTheBottomOfVolunteerPage,
       'Apply To Volunteer at the bottom of the Volunteer page',
-      allowedVolunteerFormUrls,
+      volunteerFormUrl,
       'Volunteer Form'
     );
   }
@@ -1731,14 +1675,10 @@ export class LoggedOutUser extends BaseUser {
     const volunteerWithOppiaButtonInAboutPage = this.isViewportAtMobileWidth()
       ? volunteerWithOppiaMobileButtonInAboutPage
       : volunteerWithOppiaDesktopButtonInAboutPage;
-    // The Google Form URL changes from the 1st to the 2nd and from 2nd to the
-    // 3rd in a short span of 500-1000 ms for it's own reasons which we can't
-    // control.So we need to check for all the 3 URLs in the 'allowedVolunteerFormUrls' array
-    // as all of them are valid.
-    await this.clickLinkButtonToNewTabAndVerifyAllowedUrls(
+    await this.clickLinkButtonToNewTab(
       volunteerWithOppiaButtonInAboutPage,
       'Apply To Volunteer at the top of the Volunteer page',
-      allowedVolunteerFormUrls,
+      volunteerFormUrl,
       'Volunteer Form'
     );
   }
@@ -1789,20 +1729,8 @@ export class LoggedOutUser extends BaseUser {
       ? partnerMobileTabInAboutPage
       : partnerDesktopTabInAboutPage;
 
-    const partnerWithUsButtonInAboutPage = this.isViewportAtMobileWidth()
-      ? partnerWithUsMobileButtonInAboutPage
-      : partnerWithUsDesktopButtonInAboutPage;
-
     await this.clickOn(partnerTab);
-    // The Google Form URL changes from the 1st to the 2nd and from 2nd to the
-    // 3rd in a short span of 500-1000 ms for it's own reasons which we can't
-    // control.So we need to check for all the 3 URLs as all of them are valid.
-    await this.clickLinkButtonToNewTabAndVerifyAllowedUrls(
-      partnerWithUsButtonInAboutPage,
-      'Partner With Us button at the bottom of the Partnerships page',
-      allowedPartnershipsFormUrls,
-      'Partnerships Google Form'
-    );
+    await this.clickLinkAnchorToNewTab('Partner with us', partnershipsFormUrl);
   }
 
   /**
@@ -1825,12 +1753,9 @@ export class LoggedOutUser extends BaseUser {
       : partnerWithUsDesktopButtonInAboutPage;
 
     await this.clickOn(partnerTab);
-    // Here we are not verifying the 3 URLs as we did in the English version
-    // because we have put the direct translated Google Form URL in the page itself.
-    // Refer core/templates/pages/partnerships-page/partnerships-page.component.ts to see how it's done.
     await this.clickLinkButtonToNewTab(
       partnerWithUsButtonInAboutPage,
-      'Partner With Us button at the bottom of the Partnerships page',
+      `Partner With Us button in About page, after changing the language to ${langCode},`,
       partnershipsFormInPortugueseUrl,
       'Partnerships Google Form'
     );


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20475 , #20519 .
2. This PR does the following: Fixes the 2 flakes 
3. The original bug occurred because: 
a ) The first is error due to puppeteer attempting to parnterships page when it is already in partnerships page, so removed that line of code.
b) The 2nd error is due to error in this function "clickLinkButtonToNewTabAndVerifyAllowedUrls()". I have replaced that with the old function "clickLinkButtonToNewTab".
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Not required as this not deals with UI.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
