### PR TITLE
Fix #17485 animations when hover on cards

### DIFF
--- a/core/templates/components/summary-tile/topic-summary-tile.component.html
+++ b/core/templates/components/summary-tile/topic-summary-tile.component.html
@@ -10,7 +10,7 @@
         <img [src]="thumbnailUrl" alt="" class="img-thumbnail" [ngStyle]="{background: topicSummary.getThumbnailBgColor()}">
       </picture>
     </div>
-    <div class="topic-details" [ngStyle]="{'background-color': getDarkerThumbnailBgColor()}" ng-class="{'mask-effect': !isPublished}">
+    <div class="topic-details" (mouseover)="hover=true" (mouseleave)="hover=false" [ngStyle]="hover ? {'background-color': '#4c807c'} : {'background-color': getDarkerThumbnailBgColor()}" ng-class="{'mask-effect': !isPublished}">
       <span class="topic-name e2e-test-topic-name" *ngIf="!isHackyTopicNameTranslationDisplayed()">
         {{ topicSummary.getName() }}
       </span>


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #17485 

2. This PR does the following: Whenever hovered on a card it changes to the correct colour based on the design suggestions mentioned in the issue.


## Co-authors
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

* [x]  I have linked the issue that this PR fixes in the "Development" section of the sidebar.

* [x]  I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.

* [x]  I have written tests for my code.

* [x]  The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
> 
* [x]  I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
https://github.com/oppia/oppia/assets/62446005/b39da9c9-2aa4-4c26-8b0d-9f84f5b3e200
## PR Pointers

* Never force push! If you do, your PR will be closed.

* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve

* Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).

* See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


