### PR TITLE
Fix #18696 "In the skill editor, it should not be possible to add X, or an existing prerequisite skill, as the prerequisite of skill X." 

### DIFF
--- a/core/templates/components/skill-selector/merge-skill-modal.component.html
+++ b/core/templates/components/skill-selector/merge-skill-modal.component.html
@@ -10,6 +10,7 @@
                         [categorizedSkills]="categorizedSkills"
                         [untriagedSkillSummaries]="untriagedSkillSummaries"
                         [allowSkillsFromOtherTopics]="allowSkillsFromOtherTopics"
+                        [skillIdsToExclude]="skillIdsToExclude"
                         (selectedSkillIdChange)="setSelectedSkillId($event)">
   </oppia-skill-selector>
 </div>

--- a/core/templates/components/skill-selector/select-skill-modal.component.html
+++ b/core/templates/components/skill-selector/select-skill-modal.component.html
@@ -11,6 +11,7 @@
                         [categorizedSkills]="categorizedSkills"
                         [untriagedSkillSummaries]="untriagedSkillSummaries"
                         [allowSkillsFromOtherTopics]="allowSkillsFromOtherTopics"
+                        [skillIdsToExclude]="skillIdsToExclude"
                         (selectedSkillIdChange)="setSelectedSkillId($event)">
   </oppia-skill-selector>
 </div>

--- a/core/templates/components/skill-selector/skill-selector.component.spec.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.spec.ts
@@ -410,7 +410,9 @@ describe('SkillSelectorComponent', () => {
           skill_model_last_updated: 124444,
         }),
       ];
-
+      component.skillIdsToExclude = {
+        1: true,
+      };
       expect(
         component.searchInUntriagedSkillSummaries('skill summary 2')
       ).toEqual([
@@ -427,4 +429,57 @@ describe('SkillSelectorComponent', () => {
       ]);
     }
   );
+  it('should search in untriaged skill summaries and not return already' +
+    ' added prerequisite skills or selected skill', () => {
+    component.untriagedSkillSummaries = [
+      SkillSummary.createFromBackendDict({
+        id: '1',
+        description: 'This is untriaged skill summary 1',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      }),
+      SkillSummary.createFromBackendDict({
+        id: '2',
+        description: 'This is untriaged skill summary 2',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      }),
+      SkillSummary.createFromBackendDict({
+        id: '3',
+        description: 'This is untriaged skill summary 3',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      })
+    ];
+    component.skillIdsToExclude = {
+      1: true,
+      2: true,
+    };
+
+    expect(component.searchInUntriagedSkillSummaries(
+      '')).toEqual([
+      SkillSummary.createFromBackendDict({
+        id: '3',
+        description: 'This is untriaged skill summary 3',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      })
+    ]);
+  });
 });

--- a/core/templates/components/skill-selector/skill-selector.component.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.ts
@@ -48,6 +48,7 @@ export class SkillSelectorComponent implements OnInit {
   @Input() categorizedSkills!: CategorizedSkills;
   @Input() untriagedSkillSummaries!: SkillSummary[];
   @Input() allowSkillsFromOtherTopics!: boolean;
+  @Input() skillIdsToExclude!: { [key: string]: boolean };
   @Output() selectedSkillIdChange: EventEmitter<string> = new EventEmitter();
   currCategorizedSkills!: CategorizedSkills;
   selectedSkill!: string;
@@ -200,7 +201,9 @@ export class SkillSelectorComponent implements OnInit {
   }
 
   searchInUntriagedSkillSummaries(searchText: string): SkillSummary[] {
-    let skills: string[] = this.untriagedSkillSummaries.map(val => {
+    let skills: string[] = this.untriagedSkillSummaries
+    .filter(val => !this.skillIdsToExclude.hasOwnProperty(val.id))
+    .map(val => {
       return val.description;
     });
     let filteredSkills = this.filterForMatchingSubstringPipe.transform(

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
@@ -79,7 +79,12 @@ export class SkillPrerequisiteSkillsEditorComponent implements OnInit {
       this.groupedSkillSummaries.others
     );
     const allowSkillsFromOtherTopics = true;
-
+    const skillIdsToExclude = {
+      [this.skill.getId()]: true
+    };
+    this.skill.getPrerequisiteSkillIds().forEach(prerequisiteSkillId => {
+      skillIdsToExclude[prerequisiteSkillId] = true;
+    });
     const modalRef: NgbModalRef = this.ngbModal.open(
       SelectSkillModalComponent,
       {
@@ -96,6 +101,7 @@ export class SkillPrerequisiteSkillsEditorComponent implements OnInit {
       allowSkillsFromOtherTopics;
     modalRef.componentInstance.untriagedSkillSummaries =
       this.untriagedSkillSummaries;
+    modalRef.componentInstance.skillIdsToExclude = skillIdsToExclude;
 
     const whenResolved = (summary: SkillSummary): void => {
       let skillId = summary.id;

--- a/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
@@ -261,6 +261,7 @@ export class SkillsListComponent {
       this.skillsCategorizedByTopics;
     let untriagedSkillSummaries: SkillSummary[] = this.untriagedSkillSummaries;
     let allowSkillsFromOtherTopics: boolean = true;
+    const skillIdsToExclude = {};
 
     let modalRef: NgbModalRef = this.ngbModal.open(MergeSkillModalComponent, {
       backdrop: 'static',
@@ -270,10 +271,11 @@ export class SkillsListComponent {
     modalRef.componentInstance.skillSummaries = skillSummaries;
     modalRef.componentInstance.skill = skill;
     modalRef.componentInstance.categorizedSkills = categorizedSkills;
-    modalRef.componentInstance.allowSkillsFromOtherTopics =
-      allowSkillsFromOtherTopics;
-    modalRef.componentInstance.untriagedSkillSummaries =
-      untriagedSkillSummaries;
+    modalRef.componentInstance.allowSkillsFromOtherTopics = (
+      allowSkillsFromOtherTopics);
+    modalRef.componentInstance.untriagedSkillSummaries = (
+      untriagedSkillSummaries);
+    modalRef.componentInstance.skillIdsToExclude = skillIdsToExclude;
 
     modalRef.result.then(
       (result: MergeModalResult) => {


### PR DESCRIPTION

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18689.
2. This PR does the following: Basically it does what the PR #19103 tended to do. 
3. The original bug occurred because: In the skill editor, it should not be possible to add X, or an existing prerequisite skill, as the prerequisite of skill X. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

https://github.com/user-attachments/assets/ace9c871-5106-44c7-aee4-ed47d1376ab2


