### PR TITLE
Fix #18696 "In the skill editor, it should not be possible to add X, ...

### DIFF
--- a/core/templates/components/skill-selector/merge-skill-modal.component.html
+++ b/core/templates/components/skill-selector/merge-skill-modal.component.html
@@ -10,6 +10,7 @@
                         [categorizedSkills]="categorizedSkills"
                         [untriagedSkillSummaries]="untriagedSkillSummaries"
                         [allowSkillsFromOtherTopics]="allowSkillsFromOtherTopics"
+                        [skillIdsToExclude]="skillIdsToExclude"
                         (selectedSkillIdChange)="setSelectedSkillId($event)">
   </oppia-skill-selector>
 </div>

--- a/core/templates/components/skill-selector/select-skill-modal.component.html
+++ b/core/templates/components/skill-selector/select-skill-modal.component.html
@@ -11,6 +11,7 @@
                         [categorizedSkills]="categorizedSkills"
                         [untriagedSkillSummaries]="untriagedSkillSummaries"
                         [allowSkillsFromOtherTopics]="allowSkillsFromOtherTopics"
+                        [skillIdsToExclude]="skillIdsToExclude"
                         (selectedSkillIdChange)="setSelectedSkillId($event)">
   </oppia-skill-selector>
 </div>

--- a/core/templates/components/skill-selector/skill-selector.component.spec.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.spec.ts
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {HttpClientTestingModule} from '@angular/common/http/testing';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
-import {ShortSkillSummary} from 'domain/skill/short-skill-summary.model';
-import {SkillSummary} from 'domain/skill/skill-summary.model';
-import {UserService} from 'services/user.service';
-import {SkillSelectorComponent} from './skill-selector.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ShortSkillSummary } from 'domain/skill/short-skill-summary.model';
+import { SkillSummary } from 'domain/skill/skill-summary.model';
+import { UserService } from 'services/user.service';
+import { SkillSelectorComponent } from './skill-selector.component';
 
 /**
  * @fileoverview Unit tests for SkillSelectorComponent.
@@ -139,7 +139,7 @@ describe('SkillSelectorComponent', () => {
 
   it(
     'should display subtopics from all topics in the subtopic filter if' +
-      ' no topic is checked',
+    ' no topic is checked',
     () => {
       component.categorizedSkills = {
         topic1: {
@@ -248,7 +248,7 @@ describe('SkillSelectorComponent', () => {
 
   it(
     'should update skill list when user filters skills by' +
-      ' topics and subtopics',
+    ' topics and subtopics',
     () => {
       component.categorizedSkills = {
         topic1: {
@@ -386,7 +386,7 @@ describe('SkillSelectorComponent', () => {
 
   it(
     'should search in untriaged skill summaries and return' +
-      ' filtered skills',
+    ' filtered skills',
     () => {
       component.untriagedSkillSummaries = [
         SkillSummary.createFromBackendDict({
@@ -431,55 +431,55 @@ describe('SkillSelectorComponent', () => {
   );
   it('should search in untriaged skill summaries and not return already' +
     ' added prerequisite skills or selected skill', () => {
-    component.untriagedSkillSummaries = [
-      SkillSummary.createFromBackendDict({
-        id: '1',
-        description: 'This is untriaged skill summary 1',
-        language_code: '',
-        version: 1,
-        misconception_count: 2,
-        worked_examples_count: 2,
-        skill_model_created_on: 121212,
-        skill_model_last_updated: 124444
-      }),
-      SkillSummary.createFromBackendDict({
-        id: '2',
-        description: 'This is untriaged skill summary 2',
-        language_code: '',
-        version: 1,
-        misconception_count: 2,
-        worked_examples_count: 2,
-        skill_model_created_on: 121212,
-        skill_model_last_updated: 124444
-      }),
-      SkillSummary.createFromBackendDict({
-        id: '3',
-        description: 'This is untriaged skill summary 3',
-        language_code: '',
-        version: 1,
-        misconception_count: 2,
-        worked_examples_count: 2,
-        skill_model_created_on: 121212,
-        skill_model_last_updated: 124444
-      })
-    ];
-    component.skillIdsToExclude = {
-      1: true,
-      2: true,
-    };
+      component.untriagedSkillSummaries = [
+        SkillSummary.createFromBackendDict({
+          id: '1',
+          description: 'This is untriaged skill summary 1',
+          language_code: '',
+          version: 1,
+          misconception_count: 2,
+          worked_examples_count: 2,
+          skill_model_created_on: 121212,
+          skill_model_last_updated: 124444
+        }),
+        SkillSummary.createFromBackendDict({
+          id: '2',
+          description: 'This is untriaged skill summary 2',
+          language_code: '',
+          version: 1,
+          misconception_count: 2,
+          worked_examples_count: 2,
+          skill_model_created_on: 121212,
+          skill_model_last_updated: 124444
+        }),
+        SkillSummary.createFromBackendDict({
+          id: '3',
+          description: 'This is untriaged skill summary 3',
+          language_code: '',
+          version: 1,
+          misconception_count: 2,
+          worked_examples_count: 2,
+          skill_model_created_on: 121212,
+          skill_model_last_updated: 124444
+        })
+      ];
+      component.skillIdsToExclude = {
+        1: true,
+        2: true,
+      };
 
-    expect(component.searchInUntriagedSkillSummaries(
-      '')).toEqual([
-      SkillSummary.createFromBackendDict({
-        id: '3',
-        description: 'This is untriaged skill summary 3',
-        language_code: '',
-        version: 1,
-        misconception_count: 2,
-        worked_examples_count: 2,
-        skill_model_created_on: 121212,
-        skill_model_last_updated: 124444
-      })
-    ]);
-  });
+      expect(component.searchInUntriagedSkillSummaries(
+        '')).toEqual([
+          SkillSummary.createFromBackendDict({
+            id: '3',
+            description: 'This is untriaged skill summary 3',
+            language_code: '',
+            version: 1,
+            misconception_count: 2,
+            worked_examples_count: 2,
+            skill_model_created_on: 121212,
+            skill_model_last_updated: 124444
+          })
+        ]);
+    });
 });

--- a/core/templates/components/skill-selector/skill-selector.component.spec.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.spec.ts
@@ -410,7 +410,9 @@ describe('SkillSelectorComponent', () => {
           skill_model_last_updated: 124444,
         }),
       ];
-
+      component.skillIdsToExclude = {
+        1: true,
+      };
       expect(
         component.searchInUntriagedSkillSummaries('skill summary 2')
       ).toEqual([
@@ -427,4 +429,57 @@ describe('SkillSelectorComponent', () => {
       ]);
     }
   );
+  it('should search in untriaged skill summaries and not return already' +
+    ' added prerequisite skills or selected skill', () => {
+    component.untriagedSkillSummaries = [
+      SkillSummary.createFromBackendDict({
+        id: '1',
+        description: 'This is untriaged skill summary 1',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      }),
+      SkillSummary.createFromBackendDict({
+        id: '2',
+        description: 'This is untriaged skill summary 2',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      }),
+      SkillSummary.createFromBackendDict({
+        id: '3',
+        description: 'This is untriaged skill summary 3',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      })
+    ];
+    component.skillIdsToExclude = {
+      1: true,
+      2: true,
+    };
+
+    expect(component.searchInUntriagedSkillSummaries(
+      '')).toEqual([
+      SkillSummary.createFromBackendDict({
+        id: '3',
+        description: 'This is untriaged skill summary 3',
+        language_code: '',
+        version: 1,
+        misconception_count: 2,
+        worked_examples_count: 2,
+        skill_model_created_on: 121212,
+        skill_model_last_updated: 124444
+      })
+    ]);
+  });
 });

--- a/core/templates/components/skill-selector/skill-selector.component.spec.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.spec.ts
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { ShortSkillSummary } from 'domain/skill/short-skill-summary.model';
-import { SkillSummary } from 'domain/skill/skill-summary.model';
-import { UserService } from 'services/user.service';
-import { SkillSelectorComponent } from './skill-selector.component';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ShortSkillSummary} from 'domain/skill/short-skill-summary.model';
+import {SkillSummary} from 'domain/skill/skill-summary.model';
+import {UserService} from 'services/user.service';
+import {SkillSelectorComponent} from './skill-selector.component';
 
 /**
  * @fileoverview Unit tests for SkillSelectorComponent.
@@ -139,7 +139,7 @@ describe('SkillSelectorComponent', () => {
 
   it(
     'should display subtopics from all topics in the subtopic filter if' +
-    ' no topic is checked',
+      ' no topic is checked',
     () => {
       component.categorizedSkills = {
         topic1: {
@@ -248,7 +248,7 @@ describe('SkillSelectorComponent', () => {
 
   it(
     'should update skill list when user filters skills by' +
-    ' topics and subtopics',
+      ' topics and subtopics',
     () => {
       component.categorizedSkills = {
         topic1: {
@@ -386,7 +386,7 @@ describe('SkillSelectorComponent', () => {
 
   it(
     'should search in untriaged skill summaries and return' +
-    ' filtered skills',
+      ' filtered skills',
     () => {
       component.untriagedSkillSummaries = [
         SkillSummary.createFromBackendDict({
@@ -429,8 +429,10 @@ describe('SkillSelectorComponent', () => {
       ]);
     }
   );
-  it('should search in untriaged skill summaries and not return already' +
-    ' added prerequisite skills or selected skill', () => {
+  it(
+    'should search in untriaged skill summaries and not return already' +
+      ' added prerequisite skills or selected skill',
+    () => {
       component.untriagedSkillSummaries = [
         SkillSummary.createFromBackendDict({
           id: '1',
@@ -440,7 +442,7 @@ describe('SkillSelectorComponent', () => {
           misconception_count: 2,
           worked_examples_count: 2,
           skill_model_created_on: 121212,
-          skill_model_last_updated: 124444
+          skill_model_last_updated: 124444,
         }),
         SkillSummary.createFromBackendDict({
           id: '2',
@@ -450,7 +452,7 @@ describe('SkillSelectorComponent', () => {
           misconception_count: 2,
           worked_examples_count: 2,
           skill_model_created_on: 121212,
-          skill_model_last_updated: 124444
+          skill_model_last_updated: 124444,
         }),
         SkillSummary.createFromBackendDict({
           id: '3',
@@ -460,26 +462,26 @@ describe('SkillSelectorComponent', () => {
           misconception_count: 2,
           worked_examples_count: 2,
           skill_model_created_on: 121212,
-          skill_model_last_updated: 124444
-        })
+          skill_model_last_updated: 124444,
+        }),
       ];
       component.skillIdsToExclude = {
         1: true,
         2: true,
       };
 
-      expect(component.searchInUntriagedSkillSummaries(
-        '')).toEqual([
-          SkillSummary.createFromBackendDict({
-            id: '3',
-            description: 'This is untriaged skill summary 3',
-            language_code: '',
-            version: 1,
-            misconception_count: 2,
-            worked_examples_count: 2,
-            skill_model_created_on: 121212,
-            skill_model_last_updated: 124444
-          })
-        ]);
-    });
+      expect(component.searchInUntriagedSkillSummaries('')).toEqual([
+        SkillSummary.createFromBackendDict({
+          id: '3',
+          description: 'This is untriaged skill summary 3',
+          language_code: '',
+          version: 1,
+          misconception_count: 2,
+          worked_examples_count: 2,
+          skill_model_created_on: 121212,
+          skill_model_last_updated: 124444,
+        }),
+      ]);
+    }
+  );
 });

--- a/core/templates/components/skill-selector/skill-selector.component.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.ts
@@ -48,6 +48,7 @@ export class SkillSelectorComponent implements OnInit {
   @Input() categorizedSkills!: CategorizedSkills;
   @Input() untriagedSkillSummaries!: SkillSummary[];
   @Input() allowSkillsFromOtherTopics!: boolean;
+  @Input() skillIdsToExclude!: { [key: string]: boolean };
   @Output() selectedSkillIdChange: EventEmitter<string> = new EventEmitter();
   currCategorizedSkills!: CategorizedSkills;
   selectedSkill!: string;
@@ -200,7 +201,9 @@ export class SkillSelectorComponent implements OnInit {
   }
 
   searchInUntriagedSkillSummaries(searchText: string): SkillSummary[] {
-    let skills: string[] = this.untriagedSkillSummaries.map(val => {
+    let skills: string[] = this.untriagedSkillSummaries
+    .filter(val => !this.skillIdsToExclude.hasOwnProperty(val.id))
+    .map(val => {
       return val.description;
     });
     let filteredSkills = this.filterForMatchingSubstringPipe.transform(

--- a/core/templates/components/skill-selector/skill-selector.component.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.ts
@@ -16,18 +16,18 @@
  * @fileoverview Controller for the skill-selector component.
  */
 
-import {Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
-import {ShortSkillSummary} from 'core/templates/domain/skill/short-skill-summary.model';
-import {SkillSummary} from 'core/templates/domain/skill/skill-summary.model';
-import {CategorizedSkills} from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import {FilterForMatchingSubstringPipe} from 'filters/string-utility-filters/filter-for-matching-substring.pipe';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { downgradeComponent } from '@angular/upgrade/static';
+import { ShortSkillSummary } from 'core/templates/domain/skill/short-skill-summary.model';
+import { SkillSummary } from 'core/templates/domain/skill/skill-summary.model';
+import { CategorizedSkills } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
+import { FilterForMatchingSubstringPipe } from 'filters/string-utility-filters/filter-for-matching-substring.pipe';
 import cloneDeep from 'lodash/cloneDeep';
-import {GroupedSkillSummaries} from 'pages/skill-editor-page/services/skill-editor-state.service';
-import {UserService} from 'services/user.service';
+import { GroupedSkillSummaries } from 'pages/skill-editor-page/services/skill-editor-state.service';
+import { UserService } from 'services/user.service';
 
 interface SubTopicFilterDict {
-  [topicName: string]: {subTopicName: string; checked: boolean}[];
+  [topicName: string]: { subTopicName: string; checked: boolean }[];
 }
 
 @Component({
@@ -53,7 +53,7 @@ export class SkillSelectorComponent implements OnInit {
   currCategorizedSkills!: CategorizedSkills;
   selectedSkill!: string;
   skillFilterText: string = '';
-  topicFilterList: {topicName: string; checked: boolean}[] = [];
+  topicFilterList: { topicName: string; checked: boolean }[] = [];
   subTopicFilterDict: SubTopicFilterDict = {};
   initialSubTopicFilterDict: SubTopicFilterDict = {};
   userCanEditSkills: boolean = false;
@@ -61,7 +61,7 @@ export class SkillSelectorComponent implements OnInit {
   constructor(
     private filterForMatchingSubstringPipe: FilterForMatchingSubstringPipe,
     private userService: UserService
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.currCategorizedSkills = this.categorizedSkills;
@@ -117,7 +117,7 @@ export class SkillSelectorComponent implements OnInit {
       for (var i = 0; i < subTopics.length; i++) {
         if (subTopics[i].checked) {
           if (!updatedSkillsDict.hasOwnProperty(topicName)) {
-            updatedSkillsDict[topicName] = {uncategorized: []};
+            updatedSkillsDict[topicName] = { uncategorized: [] };
           }
           let tempCategorizedSkills: CategorizedSkills = this.categorizedSkills;
           let subTopicName: string = subTopics[i].subTopicName;
@@ -202,10 +202,10 @@ export class SkillSelectorComponent implements OnInit {
 
   searchInUntriagedSkillSummaries(searchText: string): SkillSummary[] {
     let skills: string[] = this.untriagedSkillSummaries
-    .filter(val => !this.skillIdsToExclude.hasOwnProperty(val.id))
-    .map(val => {
-      return val.description;
-    });
+      .filter(val => !this.skillIdsToExclude.hasOwnProperty(val.id))
+      .map(val => {
+        return val.description;
+      });
     let filteredSkills = this.filterForMatchingSubstringPipe.transform(
       skills,
       searchText
@@ -233,5 +233,5 @@ angular
   .module('oppia')
   .directive(
     'oppiaSkillSelector',
-    downgradeComponent({component: SkillSelectorComponent})
+    downgradeComponent({ component: SkillSelectorComponent })
   );

--- a/core/templates/components/skill-selector/skill-selector.component.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.ts
@@ -16,18 +16,18 @@
  * @fileoverview Controller for the skill-selector component.
  */
 
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { downgradeComponent } from '@angular/upgrade/static';
-import { ShortSkillSummary } from 'core/templates/domain/skill/short-skill-summary.model';
-import { SkillSummary } from 'core/templates/domain/skill/skill-summary.model';
-import { CategorizedSkills } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import { FilterForMatchingSubstringPipe } from 'filters/string-utility-filters/filter-for-matching-substring.pipe';
+import {Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
+import {downgradeComponent} from '@angular/upgrade/static';
+import {ShortSkillSummary} from 'core/templates/domain/skill/short-skill-summary.model';
+import {SkillSummary} from 'core/templates/domain/skill/skill-summary.model';
+import {CategorizedSkills} from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
+import {FilterForMatchingSubstringPipe} from 'filters/string-utility-filters/filter-for-matching-substring.pipe';
 import cloneDeep from 'lodash/cloneDeep';
-import { GroupedSkillSummaries } from 'pages/skill-editor-page/services/skill-editor-state.service';
-import { UserService } from 'services/user.service';
+import {GroupedSkillSummaries} from 'pages/skill-editor-page/services/skill-editor-state.service';
+import {UserService} from 'services/user.service';
 
 interface SubTopicFilterDict {
-  [topicName: string]: { subTopicName: string; checked: boolean }[];
+  [topicName: string]: {subTopicName: string; checked: boolean}[];
 }
 
 @Component({
@@ -48,12 +48,12 @@ export class SkillSelectorComponent implements OnInit {
   @Input() categorizedSkills!: CategorizedSkills;
   @Input() untriagedSkillSummaries!: SkillSummary[];
   @Input() allowSkillsFromOtherTopics!: boolean;
-  @Input() skillIdsToExclude!: { [key: string]: boolean };
+  @Input() skillIdsToExclude!: {[key: string]: boolean};
   @Output() selectedSkillIdChange: EventEmitter<string> = new EventEmitter();
   currCategorizedSkills!: CategorizedSkills;
   selectedSkill!: string;
   skillFilterText: string = '';
-  topicFilterList: { topicName: string; checked: boolean }[] = [];
+  topicFilterList: {topicName: string; checked: boolean}[] = [];
   subTopicFilterDict: SubTopicFilterDict = {};
   initialSubTopicFilterDict: SubTopicFilterDict = {};
   userCanEditSkills: boolean = false;
@@ -61,7 +61,7 @@ export class SkillSelectorComponent implements OnInit {
   constructor(
     private filterForMatchingSubstringPipe: FilterForMatchingSubstringPipe,
     private userService: UserService
-  ) { }
+  ) {}
 
   ngOnInit(): void {
     this.currCategorizedSkills = this.categorizedSkills;
@@ -117,7 +117,7 @@ export class SkillSelectorComponent implements OnInit {
       for (var i = 0; i < subTopics.length; i++) {
         if (subTopics[i].checked) {
           if (!updatedSkillsDict.hasOwnProperty(topicName)) {
-            updatedSkillsDict[topicName] = { uncategorized: [] };
+            updatedSkillsDict[topicName] = {uncategorized: []};
           }
           let tempCategorizedSkills: CategorizedSkills = this.categorizedSkills;
           let subTopicName: string = subTopics[i].subTopicName;
@@ -233,5 +233,5 @@ angular
   .module('oppia')
   .directive(
     'oppiaSkillSelector',
-    downgradeComponent({ component: SkillSelectorComponent })
+    downgradeComponent({component: SkillSelectorComponent})
   );

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
@@ -79,7 +79,12 @@ export class SkillPrerequisiteSkillsEditorComponent implements OnInit {
       this.groupedSkillSummaries.others
     );
     const allowSkillsFromOtherTopics = true;
-
+    const skillIdsToExclude = {
+      [this.skill.getId()]: true
+    };
+    this.skill.getPrerequisiteSkillIds().forEach(prerequisiteSkillId => {
+      skillIdsToExclude[prerequisiteSkillId] = true;
+    });
     const modalRef: NgbModalRef = this.ngbModal.open(
       SelectSkillModalComponent,
       {
@@ -96,6 +101,7 @@ export class SkillPrerequisiteSkillsEditorComponent implements OnInit {
       allowSkillsFromOtherTopics;
     modalRef.componentInstance.untriagedSkillSummaries =
       this.untriagedSkillSummaries;
+    modalRef.componentInstance.skillIdsToExclude = skillIdsToExclude;
 
     const whenResolved = (summary: SkillSummary): void => {
       let skillId = summary.id;

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
@@ -16,24 +16,24 @@
  * @fileoverview Component for the skill prerequisite skills editor.
  */
 
-import {CategorizedSkills} from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import {GroupedSkillSummaries} from 'pages/skill-editor-page/services/skill-editor-state.service';
-import {SkillSummary} from 'domain/skill/skill-summary.model';
-import {SelectSkillModalComponent} from 'components/skill-selector/select-skill-modal.component';
-import {NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
-import {Skill} from 'domain/skill/SkillObjectFactory';
-import {SkillUpdateService} from 'domain/skill/skill-update.service';
-import {SkillEditorStateService} from 'pages/skill-editor-page/services/skill-editor-state.service';
-import {AlertsService} from 'services/alerts.service';
+import { CategorizedSkills } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
+import { GroupedSkillSummaries } from 'pages/skill-editor-page/services/skill-editor-state.service';
+import { SkillSummary } from 'domain/skill/skill-summary.model';
+import { SelectSkillModalComponent } from 'components/skill-selector/select-skill-modal.component';
+import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { Skill } from 'domain/skill/SkillObjectFactory';
+import { SkillUpdateService } from 'domain/skill/skill-update.service';
+import { SkillEditorStateService } from 'pages/skill-editor-page/services/skill-editor-state.service';
+import { AlertsService } from 'services/alerts.service';
 import {
   TopicsAndSkillsDashboardBackendApiService,
   TopicsAndSkillDashboardData,
 } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
-import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
-import {Component, OnInit} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
-import {Subscription} from 'rxjs';
+import { WindowDimensionsService } from 'services/contextual/window-dimensions.service';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Component, OnInit } from '@angular/core';
+import { downgradeComponent } from '@angular/upgrade/static';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'oppia-skill-prerequisite-skills-editor',
@@ -61,7 +61,7 @@ export class SkillPrerequisiteSkillsEditorComponent implements OnInit {
     private topicsAndSkillsDashboardBackendApiService: TopicsAndSkillsDashboardBackendApiService,
     private windowDimensionsService: WindowDimensionsService,
     private ngbModal: NgbModal
-  ) {}
+  ) { }
 
   removeSkillId(skillId: string): void {
     this.skillUpdateService.deletePrerequisiteSkill(this.skill, skillId);

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.component.ts
@@ -16,24 +16,24 @@
  * @fileoverview Component for the skill prerequisite skills editor.
  */
 
-import { CategorizedSkills } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import { GroupedSkillSummaries } from 'pages/skill-editor-page/services/skill-editor-state.service';
-import { SkillSummary } from 'domain/skill/skill-summary.model';
-import { SelectSkillModalComponent } from 'components/skill-selector/select-skill-modal.component';
-import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { Skill } from 'domain/skill/SkillObjectFactory';
-import { SkillUpdateService } from 'domain/skill/skill-update.service';
-import { SkillEditorStateService } from 'pages/skill-editor-page/services/skill-editor-state.service';
-import { AlertsService } from 'services/alerts.service';
+import {CategorizedSkills} from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
+import {GroupedSkillSummaries} from 'pages/skill-editor-page/services/skill-editor-state.service';
+import {SkillSummary} from 'domain/skill/skill-summary.model';
+import {SelectSkillModalComponent} from 'components/skill-selector/select-skill-modal.component';
+import {NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
+import {Skill} from 'domain/skill/SkillObjectFactory';
+import {SkillUpdateService} from 'domain/skill/skill-update.service';
+import {SkillEditorStateService} from 'pages/skill-editor-page/services/skill-editor-state.service';
+import {AlertsService} from 'services/alerts.service';
 import {
   TopicsAndSkillsDashboardBackendApiService,
   TopicsAndSkillDashboardData,
 } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import { WindowDimensionsService } from 'services/contextual/window-dimensions.service';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { Component, OnInit } from '@angular/core';
-import { downgradeComponent } from '@angular/upgrade/static';
-import { Subscription } from 'rxjs';
+import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {Component, OnInit} from '@angular/core';
+import {downgradeComponent} from '@angular/upgrade/static';
+import {Subscription} from 'rxjs';
 
 @Component({
   selector: 'oppia-skill-prerequisite-skills-editor',
@@ -61,7 +61,7 @@ export class SkillPrerequisiteSkillsEditorComponent implements OnInit {
     private topicsAndSkillsDashboardBackendApiService: TopicsAndSkillsDashboardBackendApiService,
     private windowDimensionsService: WindowDimensionsService,
     private ngbModal: NgbModal
-  ) { }
+  ) {}
 
   removeSkillId(skillId: string): void {
     this.skillUpdateService.deletePrerequisiteSkill(this.skill, skillId);
@@ -80,7 +80,7 @@ export class SkillPrerequisiteSkillsEditorComponent implements OnInit {
     );
     const allowSkillsFromOtherTopics = true;
     const skillIdsToExclude = {
-      [this.skill.getId()]: true
+      [this.skill.getId()]: true,
     };
     this.skill.getPrerequisiteSkillIds().forEach(prerequisiteSkillId => {
       skillIdsToExclude[prerequisiteSkillId] = true;

--- a/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
@@ -261,6 +261,7 @@ export class SkillsListComponent {
       this.skillsCategorizedByTopics;
     let untriagedSkillSummaries: SkillSummary[] = this.untriagedSkillSummaries;
     let allowSkillsFromOtherTopics: boolean = true;
+    const skillIdsToExclude = {};
 
     let modalRef: NgbModalRef = this.ngbModal.open(MergeSkillModalComponent, {
       backdrop: 'static',
@@ -270,10 +271,11 @@ export class SkillsListComponent {
     modalRef.componentInstance.skillSummaries = skillSummaries;
     modalRef.componentInstance.skill = skill;
     modalRef.componentInstance.categorizedSkills = categorizedSkills;
-    modalRef.componentInstance.allowSkillsFromOtherTopics =
-      allowSkillsFromOtherTopics;
-    modalRef.componentInstance.untriagedSkillSummaries =
-      untriagedSkillSummaries;
+    modalRef.componentInstance.allowSkillsFromOtherTopics = (
+      allowSkillsFromOtherTopics);
+    modalRef.componentInstance.untriagedSkillSummaries = (
+      untriagedSkillSummaries);
+    modalRef.componentInstance.skillIdsToExclude = skillIdsToExclude;
 
     modalRef.result.then(
       (result: MergeModalResult) => {

--- a/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
@@ -16,23 +16,23 @@
  * @fileoverview Component for the skills list viewer.
  */
 
-import {Component, Input} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
-import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
-import {MergeSkillModalComponent} from 'components/skill-selector/merge-skill-modal.component';
-import {BackendChangeObject} from 'domain/editor/undo_redo/change.model';
-import {AugmentedSkillSummary} from 'domain/skill/augmented-skill-summary.model';
-import {ShortSkillSummary} from 'domain/skill/short-skill-summary.model';
-import {SkillBackendApiService} from 'domain/skill/skill-backend-api.service';
-import {SkillSummary} from 'domain/skill/skill-summary.model';
-import {EditableTopicBackendApiService} from 'domain/topic/editable-topic-backend-api.service';
-import {CreatorTopicSummary} from 'domain/topic/creator-topic-summary.model';
-import {TopicsAndSkillsDashboardBackendApiService} from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
-import {Subscription} from 'rxjs';
-import {AlertsService} from 'services/alerts.service';
-import {AssignSkillToTopicModalComponent} from '../modals/assign-skill-to-topic-modal.component';
-import {DeleteSkillModalComponent} from '../modals/delete-skill-modal.component';
+import { Component, Input } from '@angular/core';
+import { downgradeComponent } from '@angular/upgrade/static';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { MergeSkillModalComponent } from 'components/skill-selector/merge-skill-modal.component';
+import { BackendChangeObject } from 'domain/editor/undo_redo/change.model';
+import { AugmentedSkillSummary } from 'domain/skill/augmented-skill-summary.model';
+import { ShortSkillSummary } from 'domain/skill/short-skill-summary.model';
+import { SkillBackendApiService } from 'domain/skill/skill-backend-api.service';
+import { SkillSummary } from 'domain/skill/skill-summary.model';
+import { EditableTopicBackendApiService } from 'domain/topic/editable-topic-backend-api.service';
+import { CreatorTopicSummary } from 'domain/topic/creator-topic-summary.model';
+import { TopicsAndSkillsDashboardBackendApiService } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
+import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
+import { Subscription } from 'rxjs';
+import { AlertsService } from 'services/alerts.service';
+import { AssignSkillToTopicModalComponent } from '../modals/assign-skill-to-topic-modal.component';
+import { DeleteSkillModalComponent } from '../modals/delete-skill-modal.component';
 import {
   TopicAssignmentsSummary,
   UnassignSkillFromTopicsModalComponent,
@@ -84,7 +84,7 @@ export class SkillsListComponent {
     private editableTopicBackendApiService: EditableTopicBackendApiService,
     private skillBackendApiService: SkillBackendApiService,
     private topicsAndSkillsDashboardBackendApiService: TopicsAndSkillsDashboardBackendApiService
-  ) {}
+  ) { }
 
   getSkillEditorUrl(skillId: string): string {
     let SKILL_EDITOR_URL_TEMPLATE: string = '/skill_editor/<skill_id>#/';
@@ -141,7 +141,7 @@ export class SkillsListComponent {
           // No further action is needed.
         }
       )
-      .then(() => {});
+      .then(() => { });
   }
 
   unassignSkill(skillId: string): void {
@@ -153,7 +153,7 @@ export class SkillsListComponent {
     );
     modalRef.componentInstance.skillId = skillId;
     modalRef.result.then(
-      (topicsToUnassign: {[key: string]: TopicAssignmentsSummary}) => {
+      (topicsToUnassign: { [key: string]: TopicAssignmentsSummary }) => {
         for (let topic in topicsToUnassign) {
           let changeList: BackendChangeObject[] = [];
           if (topicsToUnassign[topic].subtopicId) {
@@ -332,5 +332,5 @@ angular
   .module('oppia')
   .directive(
     'oppiaSkillsList',
-    downgradeComponent({component: SkillsListComponent})
+    downgradeComponent({ component: SkillsListComponent })
   );

--- a/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.ts
@@ -16,23 +16,23 @@
  * @fileoverview Component for the skills list viewer.
  */
 
-import { Component, Input } from '@angular/core';
-import { downgradeComponent } from '@angular/upgrade/static';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { MergeSkillModalComponent } from 'components/skill-selector/merge-skill-modal.component';
-import { BackendChangeObject } from 'domain/editor/undo_redo/change.model';
-import { AugmentedSkillSummary } from 'domain/skill/augmented-skill-summary.model';
-import { ShortSkillSummary } from 'domain/skill/short-skill-summary.model';
-import { SkillBackendApiService } from 'domain/skill/skill-backend-api.service';
-import { SkillSummary } from 'domain/skill/skill-summary.model';
-import { EditableTopicBackendApiService } from 'domain/topic/editable-topic-backend-api.service';
-import { CreatorTopicSummary } from 'domain/topic/creator-topic-summary.model';
-import { TopicsAndSkillsDashboardBackendApiService } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
-import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
-import { Subscription } from 'rxjs';
-import { AlertsService } from 'services/alerts.service';
-import { AssignSkillToTopicModalComponent } from '../modals/assign-skill-to-topic-modal.component';
-import { DeleteSkillModalComponent } from '../modals/delete-skill-modal.component';
+import {Component, Input} from '@angular/core';
+import {downgradeComponent} from '@angular/upgrade/static';
+import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
+import {MergeSkillModalComponent} from 'components/skill-selector/merge-skill-modal.component';
+import {BackendChangeObject} from 'domain/editor/undo_redo/change.model';
+import {AugmentedSkillSummary} from 'domain/skill/augmented-skill-summary.model';
+import {ShortSkillSummary} from 'domain/skill/short-skill-summary.model';
+import {SkillBackendApiService} from 'domain/skill/skill-backend-api.service';
+import {SkillSummary} from 'domain/skill/skill-summary.model';
+import {EditableTopicBackendApiService} from 'domain/topic/editable-topic-backend-api.service';
+import {CreatorTopicSummary} from 'domain/topic/creator-topic-summary.model';
+import {TopicsAndSkillsDashboardBackendApiService} from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
+import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
+import {Subscription} from 'rxjs';
+import {AlertsService} from 'services/alerts.service';
+import {AssignSkillToTopicModalComponent} from '../modals/assign-skill-to-topic-modal.component';
+import {DeleteSkillModalComponent} from '../modals/delete-skill-modal.component';
 import {
   TopicAssignmentsSummary,
   UnassignSkillFromTopicsModalComponent,
@@ -84,7 +84,7 @@ export class SkillsListComponent {
     private editableTopicBackendApiService: EditableTopicBackendApiService,
     private skillBackendApiService: SkillBackendApiService,
     private topicsAndSkillsDashboardBackendApiService: TopicsAndSkillsDashboardBackendApiService
-  ) { }
+  ) {}
 
   getSkillEditorUrl(skillId: string): string {
     let SKILL_EDITOR_URL_TEMPLATE: string = '/skill_editor/<skill_id>#/';
@@ -141,7 +141,7 @@ export class SkillsListComponent {
           // No further action is needed.
         }
       )
-      .then(() => { });
+      .then(() => {});
   }
 
   unassignSkill(skillId: string): void {
@@ -153,7 +153,7 @@ export class SkillsListComponent {
     );
     modalRef.componentInstance.skillId = skillId;
     modalRef.result.then(
-      (topicsToUnassign: { [key: string]: TopicAssignmentsSummary }) => {
+      (topicsToUnassign: {[key: string]: TopicAssignmentsSummary}) => {
         for (let topic in topicsToUnassign) {
           let changeList: BackendChangeObject[] = [];
           if (topicsToUnassign[topic].subtopicId) {
@@ -271,10 +271,10 @@ export class SkillsListComponent {
     modalRef.componentInstance.skillSummaries = skillSummaries;
     modalRef.componentInstance.skill = skill;
     modalRef.componentInstance.categorizedSkills = categorizedSkills;
-    modalRef.componentInstance.allowSkillsFromOtherTopics = (
-      allowSkillsFromOtherTopics);
-    modalRef.componentInstance.untriagedSkillSummaries = (
-      untriagedSkillSummaries);
+    modalRef.componentInstance.allowSkillsFromOtherTopics =
+      allowSkillsFromOtherTopics;
+    modalRef.componentInstance.untriagedSkillSummaries =
+      untriagedSkillSummaries;
     modalRef.componentInstance.skillIdsToExclude = skillIdsToExclude;
 
     modalRef.result.then(
@@ -332,5 +332,5 @@ angular
   .module('oppia')
   .directive(
     'oppiaSkillsList',
-    downgradeComponent({ component: SkillsListComponent })
+    downgradeComponent({component: SkillsListComponent})
   );


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18689.
2. This PR does the following: Basically it does what the PR #19103 tended to do. 
3. The original bug occurred because: In the skill editor, it should not be possible to add X, or an existing prerequisite skill, as the prerequisite of skill X. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

https://github.com/user-attachments/assets/ace9c871-5106-44c7-aee4-ed47d1376ab2


