### PR TITLE
Change CODEOWNERS for core/tests/test-modules-mappings/acceptance to Acceptance Reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -752,7 +752,7 @@
 # Acceptance Tests.
 /core/tests/puppeteer-acceptance-tests/ @oppia/acceptance-test-reviewers
 /core/tests/puppeteer/ @oppia/acceptance-test-reviewers
-/core/tests/test-to-module-mappings/acceptance/ @oppia/acceptance-test-reviewers
+/core/tests/test-modules-mappings/acceptance/ @oppia/acceptance-test-reviewers
 /scripts/run_acceptance_tests_test.py @oppia/acceptance-test-reviewers
 /scripts/run_acceptance_tests.py @oppia/acceptance-test-reviewers
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -752,6 +752,7 @@
 # Acceptance Tests.
 /core/tests/puppeteer-acceptance-tests/ @oppia/acceptance-test-reviewers
 /core/tests/puppeteer/ @oppia/acceptance-test-reviewers
+/core/tests/test-to-module-mappings/acceptance/ @oppia/acceptance-test-reviewers
 /scripts/run_acceptance_tests_test.py @oppia/acceptance-test-reviewers
 /scripts/run_acceptance_tests.py @oppia/acceptance-test-reviewers
 


### PR DESCRIPTION
Changes the CODEOWNERS for the core/tests/test-to-modules-mappings/acceptance folder from the `@oppia/dev-workflow-reviewers` to the `@oppia/acceptance-test-reviewers`.