### PR TITLE
Fix #20475: Acceptance test flake

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -1383,7 +1383,7 @@ export class LoggedOutUser extends BaseUser {
       // This reload is required to ensure the language dropdown is visible in mobile view,
       // if the earlier movements of the page have hidden it and since the inbuilt
       // scrollIntoView function call of the clickOn function didn't work as expected.
-      await this.page.reload();
+      await this.page.reload({waitUntil: 'domcontentloaded'});
     }
     await this.page.waitForSelector(languageDropdown);
     const languageDropdownElement = await this.page.$(languageDropdown);


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes 20475.
2. Reason: The error occured in the 'reload' function call in the partnerships page
3. Fix: The "reload" function by default waits for the page to fully load ( including all images, fonts loading). It is timing out when there are some issues to load all the images, fonts etc in the parnerships page ( I haven't redesigned this page). However, we only need the buttons to be clickable, so changed the implementation to wait for the all the domcontent to be present.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
No proof of changes needed because not Ui related

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
