### PR TITLE
FIX: #18795removing the function convert_millisecs_time_to_datetime_object and its uses

### DIFF
--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -699,18 +699,6 @@ class StoryNode:
         Returns:
             StoryNode. The corresponding StoryNode domain object.
         """
-        planned_publication_date_msecs = (
-            node_dict['planned_publication_date_msecs'] if
-            'planned_publication_date_msecs' in node_dict and
-            node_dict['planned_publication_date_msecs'] else None)
-        last_modified_msecs = (
-                node_dict['last_modified_msecs'] if
-                'last_modified_msecs' in node_dict and
-                node_dict['last_modified_msecs'] else None)
-        first_publication_date_msecs = (
-                node_dict['first_publication_date_msecs'] if
-                'first_publication_date_msecs' in node_dict and
-                node_dict['first_publication_date_msecs'] else None)
         node = cls(
             node_dict['id'],
             node_dict['title'],
@@ -725,17 +713,10 @@ class StoryNode:
             node_dict['outline_is_finalized'],
             node_dict['exploration_id'],
             node_dict['status'] if 'status' in node_dict else None,
-            utils.convert_millisecs_time_to_datetime_object(
-                planned_publication_date_msecs) if
-                planned_publication_date_msecs else None,
-            utils.convert_millisecs_time_to_datetime_object(
-                last_modified_msecs) if
-                last_modified_msecs else None,
-            utils.convert_millisecs_time_to_datetime_object(
-                first_publication_date_msecs) if
-                first_publication_date_msecs else None,
-            node_dict['unpublishing_reason'] if
-            'unpublishing_reason' in node_dict else None
+            node_dict['planned_publication_date_msecs'] if 'planned_publication_date_msecs' in node_dict else None,
+            node_dict['last_modified_msecs'] if 'last_modified_msecs' in node_dict else None,
+            node_dict['first_publication_date_msecs'] if 'first_publication_date_msecs' in node_dict else None,
+            node_dict['unpublishing_reason'] if 'unpublishing_reason' in node_dict else None
         )
         return node
 
@@ -2092,9 +2073,7 @@ class Story:
         """
         node_index = self.story_contents.get_node_index(node_id)
         self.story_contents.nodes[node_index].planned_publication_date = (
-            utils.convert_millisecs_time_to_datetime_object(
-                new_planned_publication_date_msecs) if
-                new_planned_publication_date_msecs else None)
+            new_planned_publication_date_msecs if new_planned_publication_date_msecs else None)
 
     def update_node_last_modified(
             self, node_id: str, new_last_modified_msecs: float) -> None:
@@ -2107,8 +2086,7 @@ class Story:
         """
         node_index = self.story_contents.get_node_index(node_id)
         self.story_contents.nodes[node_index].last_modified = (
-            utils.convert_millisecs_time_to_datetime_object(
-            new_last_modified_msecs)) if new_last_modified_msecs else None
+            new_last_modified_msecs) if new_last_modified_msecs else None
 
     def update_node_first_publication_date(
             self, node_id: str, new_publication_date_msecs: float) -> None:
@@ -2121,9 +2099,7 @@ class Story:
         """
         node_index = self.story_contents.get_node_index(node_id)
         self.story_contents.nodes[node_index].first_publication_date = (
-            utils.convert_millisecs_time_to_datetime_object(
-                new_publication_date_msecs) if
-                new_publication_date_msecs else None)
+        new_publication_date_msecs) if new_publication_date_msecs else None
 
     def update_node_unpublishing_reason(
             self, node_id: str, new_unpublishing_reason: str) -> None:

--- a/core/utils.py
+++ b/core/utils.py
@@ -622,20 +622,6 @@ def get_time_in_millisecs(datetime_obj: datetime.datetime) -> float:
     return datetime_obj.timestamp() * 1000.0
 
 
-def convert_millisecs_time_to_datetime_object(
-        date_time_msecs: float) -> datetime.datetime:
-    """Returns the datetime object from the given date time in milliseconds.
-
-    Args:
-        date_time_msecs: float. Date time represented in milliseconds.
-
-    Returns:
-        datetime. An object of type datetime.datetime corresponding to
-        the given milliseconds.
-    """
-    return datetime.datetime.fromtimestamp(date_time_msecs / 1000.0)
-
-
 def convert_naive_datetime_to_string(datetime_obj: datetime.datetime) -> str:
     """Returns a human-readable string representing the naive datetime object.
 

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -779,13 +779,6 @@ class UtilsTests(test_utils.GenericTestBase):
         self.assertEqual(
             dt, datetime.datetime.fromtimestamp(msecs / 1000.0))
 
-    def test_convert_millisecs_time_to_datetime_object(self) -> None:
-        msecs = 1690761600000
-        dt = utils.convert_millisecs_time_to_datetime_object(
-            msecs + 1000.0 * time.timezone)
-        dt2 = datetime.datetime(2023, 7, 31)
-        self.assertEqual(dt, dt2)
-
     def test_grouper(self) -> None:
         self.assertEqual(
             [list(g) for g in utils.grouper(range(7), 3)],


### PR DESCRIPTION
Removing **convert_millisecs_time_to_datetime_object** and Updating Timestamp Handling
This PR removes the redundant convert_millisecs_time_to_datetime_object function and updates the code to directly handle timestamps in milliseconds.

**Changes:**

Removed: The convert_millisecs_time_to_datetime_object function and related test function has been completely removed from the codebase.
Modified: The function usage for converting milliseconds to datetime objects has been replaced with direct assignment of the millisecond value. For example:
self.story_contents.nodes[node_index].planned_publication_date = new_planned_publication_date_msecs if new_planned_publication_date_msecs else None

By eliminates function utilization on demand for solving following issue https://github.com/oppia/oppia/issues/18795.

**Benefits:**

Improved code efficiency and maintainability
Reduced potential for errors related to datetime handling
Enhanced consistency in timestamp management

By directly handling timestamps as milliseconds, avoids unnecessary conversions and potential timezone-related issues. This change aligns with best practices for timestamp handling in Python applications.