### PR TITLE
removing the function and its uses

### DIFF
--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -699,18 +699,6 @@ class StoryNode:
         Returns:
             StoryNode. The corresponding StoryNode domain object.
         """
-        planned_publication_date_msecs = (
-            node_dict['planned_publication_date_msecs'] if
-            'planned_publication_date_msecs' in node_dict and
-            node_dict['planned_publication_date_msecs'] else None)
-        last_modified_msecs = (
-                node_dict['last_modified_msecs'] if
-                'last_modified_msecs' in node_dict and
-                node_dict['last_modified_msecs'] else None)
-        first_publication_date_msecs = (
-                node_dict['first_publication_date_msecs'] if
-                'first_publication_date_msecs' in node_dict and
-                node_dict['first_publication_date_msecs'] else None)
         node = cls(
             node_dict['id'],
             node_dict['title'],
@@ -725,17 +713,10 @@ class StoryNode:
             node_dict['outline_is_finalized'],
             node_dict['exploration_id'],
             node_dict['status'] if 'status' in node_dict else None,
-            utils.convert_millisecs_time_to_datetime_object(
-                planned_publication_date_msecs) if
-                planned_publication_date_msecs else None,
-            utils.convert_millisecs_time_to_datetime_object(
-                last_modified_msecs) if
-                last_modified_msecs else None,
-            utils.convert_millisecs_time_to_datetime_object(
-                first_publication_date_msecs) if
-                first_publication_date_msecs else None,
-            node_dict['unpublishing_reason'] if
-            'unpublishing_reason' in node_dict else None
+            node_dict['planned_publication_date_msecs'] if 'planned_publication_date_msecs' in node_dict else None,
+            node_dict['last_modified_msecs'] if 'last_modified_msecs' in node_dict else None,
+            node_dict['first_publication_date_msecs'] if 'first_publication_date_msecs' in node_dict else None,
+            node_dict['unpublishing_reason'] if 'unpublishing_reason' in node_dict else None
         )
         return node
 
@@ -2092,9 +2073,7 @@ class Story:
         """
         node_index = self.story_contents.get_node_index(node_id)
         self.story_contents.nodes[node_index].planned_publication_date = (
-            utils.convert_millisecs_time_to_datetime_object(
-                new_planned_publication_date_msecs) if
-                new_planned_publication_date_msecs else None)
+            new_planned_publication_date_msecs if new_planned_publication_date_msecs else None)
 
     def update_node_last_modified(
             self, node_id: str, new_last_modified_msecs: float) -> None:
@@ -2107,8 +2086,7 @@ class Story:
         """
         node_index = self.story_contents.get_node_index(node_id)
         self.story_contents.nodes[node_index].last_modified = (
-            utils.convert_millisecs_time_to_datetime_object(
-            new_last_modified_msecs)) if new_last_modified_msecs else None
+            new_last_modified_msecs) if new_last_modified_msecs else None
 
     def update_node_first_publication_date(
             self, node_id: str, new_publication_date_msecs: float) -> None:
@@ -2121,9 +2099,7 @@ class Story:
         """
         node_index = self.story_contents.get_node_index(node_id)
         self.story_contents.nodes[node_index].first_publication_date = (
-            utils.convert_millisecs_time_to_datetime_object(
-                new_publication_date_msecs) if
-                new_publication_date_msecs else None)
+        new_publication_date_msecs) if new_publication_date_msecs else None
 
     def update_node_unpublishing_reason(
             self, node_id: str, new_unpublishing_reason: str) -> None:

--- a/core/utils.py
+++ b/core/utils.py
@@ -622,20 +622,6 @@ def get_time_in_millisecs(datetime_obj: datetime.datetime) -> float:
     return datetime_obj.timestamp() * 1000.0
 
 
-def convert_millisecs_time_to_datetime_object(
-        date_time_msecs: float) -> datetime.datetime:
-    """Returns the datetime object from the given date time in milliseconds.
-
-    Args:
-        date_time_msecs: float. Date time represented in milliseconds.
-
-    Returns:
-        datetime. An object of type datetime.datetime corresponding to
-        the given milliseconds.
-    """
-    return datetime.datetime.fromtimestamp(date_time_msecs / 1000.0)
-
-
 def convert_naive_datetime_to_string(datetime_obj: datetime.datetime) -> str:
     """Returns a human-readable string representing the naive datetime object.
 

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -779,13 +779,6 @@ class UtilsTests(test_utils.GenericTestBase):
         self.assertEqual(
             dt, datetime.datetime.fromtimestamp(msecs / 1000.0))
 
-    def test_convert_millisecs_time_to_datetime_object(self) -> None:
-        msecs = 1690761600000
-        dt = utils.convert_millisecs_time_to_datetime_object(
-            msecs + 1000.0 * time.timezone)
-        dt2 = datetime.datetime(2023, 7, 31)
-        self.assertEqual(dt, dt2)
-
     def test_grouper(self) -> None:
         self.assertEqual(
             [list(g) for g in utils.grouper(range(7), 3)],


### PR DESCRIPTION
## **Overview**
Removing convert_millisecs_time_to_datetime_object and Updating Timestamp Handling
This PR removes the redundant convert_millisecs_time_to_datetime_object function and updates the code to handle timestamps in milliseconds directly.

**Description**

Removed: The convert_millisecs_time_to_datetime_object function and related test function has been completely removed from the codebase.
Modified: The function used to convert milliseconds to datetime objects has been replaced with the direct assignment of the millisecond value. For example:
self.story_contents.nodes[node_index].planned_publication_date = new_planned_publication_date_msecs if new_planned_publication_date_msecs else None

By eliminating function utilization on demand for solving the following issue https://github.com/oppia/oppia/issues/18795.

**Benefits**

Improved code efficiency and maintainability
Reduced potential for errors related to datetime handling
Enhanced consistency in timestamp management

By directly handling timestamps as milliseconds, avoids unnecessary conversions and potential timezone-related issues. This change aligns with best practices for timestamp handling in Python applications.
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[18795].
2. This PR does the following: [Removing convert_millisecs_time_to_datetime_object and Updating Timestamp Handling
This PR removes the redundant convert_millisecs_time_to_datetime_object function and updates the code to handle timestamps in milliseconds directly.]
3. (For bug-fixing PRs only) The original bug occurred because: [The convert_millisecs_time_to_datetime_object function and related test function has been completely removed from the codebase. The function used to convert milliseconds to datetime objects has been replaced with the direct assignment of the millisecond value. ]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed the changes I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

tests are not 
## Testing doc (for PRs with Beam jobs that modify production server data)
## Testing doc (for PRs with Beam jobs that modify production server data)


## Proof that changes are correct

No proofs are needed, the code which I have written does not affect the main code. The function used to convert milliseconds to datetime objects has been replaced with the direct assignment of the millisecond value. 

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
