### PR TITLE
Fixes 20293: Removes the save-default button from platform parameters page

### DIFF
--- a/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.html
+++ b/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.html
@@ -1,11 +1,4 @@
 <oppia-loading-message [message]="loadingMessage"></oppia-loading-message>
-<div class="save-default-values-button">
-  <button
-          class="btn btn-primary"
-          (click)="saveDefaultValueToStorage()">
-    Save default values to storage
-  </button>
-</div>
 <div *ngFor="let platformParameter of platformParameters;" class="container oppia-page-card oppia-long-text oppia-admin-parameters e2e-test-platform-param">
   <div class="row oppia-parameter-name">
     <div class="col-10">
@@ -293,15 +286,6 @@
     display: flex;
     justify-content: space-between;
     padding: 16px;
-  }
-
-  .save-default-values-button {
-    align-items: center;
-    display: flex;
-    float: right;
-    font-size: 12px;
-    justify-content: space-between;
-    margin-top: 20px;
   }
 
   .oppia-admin-parameters .oppia-flex-center {

--- a/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.spec.ts
+++ b/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.spec.ts
@@ -480,26 +480,6 @@ describe('Admin page platform parameters tab', () => {
     });
   });
 
-  describe('.saveDefaultValueToStorage', () => {
-    it('should save the changes', fakeAsync(() => {
-      spyOn(mockWindowRef.nativeWindow, 'confirm').and.returnValue(true);
-
-      component.saveDefaultValueToStorage();
-
-      expect(updateApiSpy).toHaveBeenCalled();
-    }));
-
-    it("should not proceed if the user doesn't confirm", fakeAsync(() => {
-      spyOn(mockWindowRef.nativeWindow, 'confirm').and.returnValue(false);
-
-      component.saveDefaultValueToStorage();
-
-      flushMicrotasks();
-
-      expect(updateApiSpy).not.toHaveBeenCalled();
-    }));
-  });
-
   describe('.updateParameterRulesAsync', () => {
     let setStatusSpy: jasmine.Spy;
     let promptSpy: jasmine.Spy;

--- a/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
+++ b/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
@@ -246,16 +246,6 @@ export class AdminPlatformParametersTabComponent implements OnInit {
     this.platformParametersInEditMode.set(param.name, false);
   }
 
-  async saveDefaultValueToStorage(): Promise<void> {
-    if (!this.windowRef.nativeWindow.confirm('This action is irreversible.')) {
-      return;
-    }
-    for (const param of this.platformParameters) {
-      const commitMessage = `Update default value for '${param.name}'.`;
-      await this.updatePlatformParameter(param, commitMessage);
-    }
-  }
-
   async updatePlatformParameter(
     param: PlatformParameter,
     commitMessage: string

--- a/core/tests/puppeteer-acceptance-tests/specs/super-admin/edit-platform-parameters.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/super-admin/edit-platform-parameters.spec.ts
@@ -56,7 +56,6 @@ describe('Super Admin', function () {
         'always'
       );
 
-      await superAdmin.saveChangesToStorage();
       await superAdmin.expectActionSuccessMessage('Saved successfully.');
     },
     DEFAULT_SPEC_TIMEOUT_MSECS

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/super-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/super-admin.ts
@@ -68,8 +68,6 @@ const paramSaveChangesButton = '.save-button-container';
 const paramValueInput = '.e2e-test-text-input';
 const platformParameterNameSelector = '.e2e-test-parameter-name';
 const platformParameterSelector = '.e2e-test-platform-param';
-const saveValuesToStorageButton =
-  '.save-default-values-button .btn.btn-primary';
 const serverModeSelector = '.e2e-test-server-mode-selector';
 
 // Skills and Topics.
@@ -949,13 +947,6 @@ export class SuperAdmin extends BaseUser {
         `Expected "${expectedValue}" but got "${value}" for platform parameter "${parameter}".`
       );
     }
-  }
-
-  /**
-   * Clicks the button to save changes to storage.
-   */
-  async saveChangesToStorage(): Promise<void> {
-    await this.clickOn(saveValuesToStorageButton);
   }
 
   /**


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #20293.
3. This PR does the following: Removes the "Save default values" button from the platform parameters page.
4. (For bug-fixing PRs only) The original bug occurred because: Originally this button was required for saving the values in the storage layer but after the task got completed we missed out on removing the button.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

![Screenshot from 2024-08-22 18-05-20](https://github.com/user-attachments/assets/baee7a2b-176e-4938-a4fc-c860036ba6b8)


#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
