### PR TITLE
Fix part of #19849: Fix classroom name overflow and carousel

### DIFF
--- a/core/templates/pages/classroom-admin-page/modals/update-classrooms-order-modal.component.html
+++ b/core/templates/pages/classroom-admin-page/modals/update-classrooms-order-modal.component.html
@@ -5,8 +5,7 @@
     <div *ngFor="let classroom of classroomIdToClassroomNameIndex"
          class="classroom-tile"
          cdkDrag
-         (cdkDragStarted)="onDragStarted($event)"
-         (cdkDragEnded)="onDragEnded($event)">
+    >
       {{ classroom.classroom_name }}
     </div>
   </div>

--- a/core/templates/pages/library-page/classroom-card/classroom-card.component.html
+++ b/core/templates/pages/library-page/classroom-card/classroom-card.component.html
@@ -17,7 +17,9 @@
     display: flex;
     flex-direction: column;
     gap: 24px;
+    position: relative;
     text-align: center;
+    top: 18%;
     width: 158px;
   }
 

--- a/core/templates/pages/library-page/classroom-card/classroom-card.component.html
+++ b/core/templates/pages/library-page/classroom-card/classroom-card.component.html
@@ -19,7 +19,7 @@
     gap: 24px;
     position: relative;
     text-align: center;
-    top: 18%;
+    top: 12%;
     width: 158px;
   }
 
@@ -36,12 +36,13 @@
   .classroom-name {
     color: #005240;
     font-family: 'Capriola', 'Roboto', Arial, sans-serif;
-    font-size: 14px;
+    font-size: 20px;
     font-style: normal;
     font-weight: 400;
     letter-spacing: 0.0075em;
     margin: 0;
     text-align: center;
+    word-break: break-all;
   }
 
   .classroom-card-dropshadow {
@@ -113,6 +114,10 @@
   }
 
   @media only screen and (max-width: 575px) {
+    .classroom-text-container {
+      max-width: 134px;
+    }
+
     .oppia-classroom-card-container .classroom-content {
       justify-content: space-around;
     }

--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -83,7 +83,8 @@ oppia-library-page .oppia-group-page-header {
   top: 195px;
 }
 
-.navigation-dots span {
+.navigation-dots span,
+.mobile-navigation-dots span {
   background-color: #d9d9d9;
   border-radius: 50%;
   cursor: pointer;
@@ -92,7 +93,8 @@ oppia-library-page .oppia-group-page-header {
   width: 8px;
 }
 
-.navigation-dots span.active {
+.navigation-dots span.active,
+.mobile-navigation-dots span.active {
   background-color: #005240;
 }
 
@@ -458,8 +460,11 @@ oppia-library-page .community-library-breadcrumbs-container {
 
   .mobile-buttons {
     display: flex;
+    gap: 6px;
     justify-content: space-between;
     margin-top: 10px;
+    position: relative;
+    top: 10px;
   }
 
   .desktop-carousel-btn {
@@ -467,7 +472,19 @@ oppia-library-page .community-library-breadcrumbs-container {
   }
 
   .navigation-dots {
-    top: 180px;
+    display: none;
+  }
+
+  .mobile-navigation-dots {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+  }
+
+  oppia-library-page .classroom-cards-wrapper .classroom-cards-inner-container .classrooms-carousel {
+    flex-direction: column;
+    height: 194px;
+    width: 444px;
   }
 
   oppia-library-page .desktop-carousel-btn {
@@ -525,10 +542,6 @@ oppia-library-page .community-library-breadcrumbs-container {
     width: 442px;
   }
 
-  oppia-library-page .classroom-cards-wrapper .classroom-cards-inner-container .classrooms-carousel {
-    width: 444px;
-  }
-
   oppia-library-page .classrooms-carousel .carousel-indicators {
     bottom: -14px;
     display: flex;
@@ -548,7 +561,6 @@ oppia-library-page .community-library-breadcrumbs-container {
     font-size: 24px;
     height: auto;
     padding: 0;
-    position: absolute;
     width: auto;
     z-index: 1;
   }
@@ -681,7 +693,7 @@ oppia-library-page .community-library-breadcrumbs-container {
 
 @media only screen and (max-width: 416px) {
   .mobile-buttons {
-    top: 180px;
+    top: 122px;
   }
 
   oppia-library-page .classroom-cards-wrapper {

--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -84,12 +84,12 @@ oppia-library-page .oppia-group-page-header {
 }
 
 .navigation-dots span {
-  background-color: #ccc;
+  background-color: #d9d9d9;
   border-radius: 50%;
   cursor: pointer;
-  height: 10px;
-  margin: 0 5px;
-  width: 10px;
+  height: 8px;
+  margin: 0 3px;
+  width: 8px;
 }
 
 .navigation-dots span.active {

--- a/core/templates/pages/library-page/library-page.component.html
+++ b/core/templates/pages/library-page/library-page.component.html
@@ -1,11 +1,10 @@
 <div class="classroom-cards-wrapper" *ngIf="publicClassroomsCount > 0">
   <div class="classroom-cards-inner-container"
-    [ngClass]="{
-      'classroom-width-1': publicClassroomsCount === 1,
-      'classroom-width-2': publicClassroomsCount === 2,
-      'classroom-width-more': publicClassroomsCount > 2
-    }"
-  >
+       [ngClass]="{
+         'classroom-width-1': publicClassroomsCount === 1,
+         'classroom-width-2': publicClassroomsCount === 2,
+         'classroom-width-more': publicClassroomsCount > 2
+       }">
     <div class="classroom-cards-text-container">
       <h1>{{ 'I18N_COMMUNITY_LIBRARY_PAGE_CLASSROOMS_HINT_TEXT' | translate }}</h1>
       <p>{{ 'I18N_BROWSE_LESSONS_TEXT' | translate }}</p>
@@ -57,14 +56,12 @@
       <div class="mobile-buttons" *ngIf="publicClassroomsCount > 3">
         <button class="mobile-carousel-btn mobile-prev-btn"
                 (click)="moveClassroomCarouselToPreviousSlide()"
-                *ngIf="publicClassroomsCount > 3"
                 [disabled]="!shouldShowPreviousClassroomChunkButton()"
                 aria-label="Previous Slide">
           <i class="fa fa-angle-left"></i>
         </button>
         <button class="mobile-carousel-btn mobile-next-btn"
                 (click)="moveClassroomCarouselToNextSlide()"
-                *ngIf="publicClassroomsCount > 3"
                 [disabled]="!shouldShowNextClassroomChunkButton()"
                 aria-label="Next Slide">
           <i class="fa fa-angle-right"></i>

--- a/core/templates/pages/library-page/library-page.component.html
+++ b/core/templates/pages/library-page/library-page.component.html
@@ -60,6 +60,12 @@
                 aria-label="Previous Slide">
           <i class="fa fa-angle-left"></i>
         </button>
+        <div class="mobile-navigation-dots" *ngIf="publicClassroomsCount > 3">
+          <span *ngFor="let dot of dots; let i = index"
+                [class.active]="dot === 1"
+                (click)="moveToSlide(i)">
+          </span>
+        </div>
         <button class="mobile-carousel-btn mobile-next-btn"
                 (click)="moveClassroomCarouselToNextSlide()"
                 [disabled]="!shouldShowNextClassroomChunkButton()"

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -104,6 +104,16 @@ describe('Library Page Component', () => {
   let classroomBackendApiService: ClassroomBackendApiService;
   let siteAnalyticsService: SiteAnalyticsService;
 
+  const dummyClassroomSummary = {
+    classroom_id: 'mathclassroom',
+    name: 'math',
+    url_fragment: 'math',
+    teaser_text: 'Learn math',
+    is_published: true,
+    thumbnail_filename: 'thumbnail.svg',
+    thumbnail_bg_color: 'transparent',
+  };
+
   let explorationList: CreatorExplorationSummaryBackendDict[] = [
     {
       category: '',
@@ -793,17 +803,7 @@ describe('Library Page Component', () => {
     componentInstance.translateX = 0;
     componentInstance.currentCardIndex = 0;
     componentInstance.dots = [];
-
-    const classroomTemplate = {
-      classroom_id: 'mathclassroom',
-      name: 'math',
-      url_fragment: 'math',
-      teaser_text: 'Learn math',
-      is_published: true,
-      thumbnail_filename: 'thumbnail.svg',
-      thumbnail_bg_color: 'transparent',
-    };
-    componentInstance.classroomSummaries = Array(5).fill(classroomTemplate);
+    componentInstance.classroomSummaries = Array(5).fill(dummyClassroomSummary);
     componentInstance.updateActiveDot();
 
     componentInstance.moveClassroomCarouselToNextSlide();

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -150,45 +150,6 @@ describe('Library Page Component', () => {
     },
   ];
 
-  const dummyClassroomSummaries = [
-    {
-      classroom_id: 'mathclassroom',
-      name: 'math',
-      url_fragment: 'math',
-      teaser_text: 'Learn math',
-      is_published: true,
-      thumbnail_filename: 'thumbnail.svg',
-      thumbnail_bg_color: 'transparent',
-    },
-    {
-      classroom_id: 'scienceclassroom',
-      name: 'science',
-      url_fragment: 'science',
-      teaser_text: 'Learn science',
-      is_published: true,
-      thumbnail_filename: 'thumbnail.svg',
-      thumbnail_bg_color: 'transparent',
-    },
-    {
-      classroom_id: 'history',
-      name: 'history',
-      url_fragment: 'history',
-      teaser_text: 'Learn history',
-      is_published: true,
-      thumbnail_filename: 'thumbnail.svg',
-      thumbnail_bg_color: 'transparent',
-    },
-    {
-      classroom_id: 'english',
-      name: 'english',
-      url_fragment: 'english',
-      teaser_text: 'Learn english',
-      is_published: true,
-      thumbnail_filename: 'thumbnail.svg',
-      thumbnail_bg_color: 'transparent',
-    },
-  ];
-
   let libraryIndexData: LibraryIndexData = {
     activity_summary_dicts_by_category: [
       {

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -827,63 +827,43 @@ describe('Library Page Component', () => {
     expect(componentInstance.publicClassroomsCount).toEqual(1);
   }));
 
-  it('should handle more than 3 classrooms correctly in the classroom carousel', () => {
-    componentInstance.classroomSummaries = [...dummyClassroomSummaries];
-    componentInstance.publicClassroomsCount =
-      componentInstance.classroomSummaries.length;
+  it('should handle carousel navigation correctly', () => {
     componentInstance.cardsToShow = 3;
+    componentInstance.translateX = 0;
+    componentInstance.currentCardIndex = 0;
+    componentInstance.dots = [];
 
+    const classroomTemplate = {
+      classroom_id: 'mathclassroom',
+      name: 'math',
+      url_fragment: 'math',
+      teaser_text: 'Learn math',
+      is_published: true,
+      thumbnail_filename: 'thumbnail.svg',
+      thumbnail_bg_color: 'transparent',
+    };
+    componentInstance.classroomSummaries = Array(5).fill(classroomTemplate);
     componentInstance.updateActiveDot();
 
-    expect(componentInstance.shouldShowNextClassroomChunkButton()).toBe(true);
-    expect(componentInstance.shouldShowPreviousClassroomChunkButton()).toBe(
-      false
-    );
-    expect(componentInstance.dots).toEqual([1, 0]);
-
     componentInstance.moveClassroomCarouselToNextSlide();
-    expect(componentInstance.currentCardIndex).toEqual(1);
-    expect(componentInstance.dots).toEqual([0, 1]);
+    expect(componentInstance.currentCardIndex).toBe(1);
+    expect(componentInstance.translateX).toBe(
+      -componentInstance.getCardWidth()
+    );
+    expect(componentInstance.dots).toEqual([0, 1, 0]);
 
     componentInstance.moveClassroomCarouselToPreviousSlide();
-    expect(componentInstance.currentCardIndex).toEqual(0);
-    expect(componentInstance.dots).toEqual([1, 0]);
+    expect(componentInstance.currentCardIndex).toBe(0);
+    expect(componentInstance.translateX).toBe(0);
+    expect(componentInstance.dots).toEqual([1, 0, 0]);
 
-    componentInstance.moveClassroomCarouselToNextSlide();
-    componentInstance.moveClassroomCarouselToNextSlide();
-    expect(componentInstance.currentCardIndex).toEqual(1);
-    expect(componentInstance.shouldShowNextClassroomChunkButton()).toBe(false);
-    expect(componentInstance.shouldShowPreviousClassroomChunkButton()).toBe(
-      true
+    const middleIndex = 2;
+    componentInstance.moveToSlide(middleIndex);
+    expect(componentInstance.currentCardIndex).toBe(middleIndex);
+    expect(componentInstance.translateX).toBe(
+      -middleIndex * componentInstance.getCardWidth()
     );
-    expect(componentInstance.dots).toEqual([0, 1]);
-
-    componentInstance.moveClassroomCarouselToPreviousSlide();
-    expect(componentInstance.currentCardIndex).toEqual(0);
-    expect(componentInstance.shouldShowNextClassroomChunkButton()).toBe(true);
-    expect(componentInstance.shouldShowPreviousClassroomChunkButton()).toBe(
-      false
-    );
-    expect(componentInstance.dots).toEqual([1, 0]);
-
-    componentInstance.moveToSlide(1);
-    expect(componentInstance.currentCardIndex).toEqual(1);
-    expect(componentInstance.dots).toEqual([0, 1]);
-
-    componentInstance.moveToSlide(0);
-    expect(componentInstance.currentCardIndex).toEqual(0);
-    expect(componentInstance.dots).toEqual([1, 0]);
-  });
-
-  it('should handle less than 3 classrooms correctly in the classroom carousel', () => {
-    componentInstance.classroomSummaries = dummyClassroomSummaries.slice(0, 2);
-    componentInstance.publicClassroomsCount =
-      componentInstance.classroomSummaries.length;
-
-    expect(componentInstance.shouldShowNextClassroomChunkButton()).toBe(false);
-    expect(componentInstance.shouldShowPreviousClassroomChunkButton()).toBe(
-      false
-    );
+    expect(componentInstance.dots).toEqual([0, 0, 1]);
   });
 
   it('should record analytics when classroom card is clicked', () => {

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -825,6 +825,18 @@ describe('Library Page Component', () => {
       -middleIndex * componentInstance.getCardWidth()
     );
     expect(componentInstance.dots).toEqual([0, 0, 1]);
+
+    componentInstance.currentCardIndex = 0;
+    expect(
+      componentInstance.shouldShowPreviousClassroomChunkButton()
+    ).toBeFalse();
+    expect(componentInstance.shouldShowNextClassroomChunkButton()).toBeTrue();
+
+    componentInstance.currentCardIndex = 2;
+    expect(
+      componentInstance.shouldShowPreviousClassroomChunkButton()
+    ).toBeTrue();
+    expect(componentInstance.shouldShowNextClassroomChunkButton()).toBeFalse();
   });
 
   it('should record analytics when classroom card is clicked', () => {

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -529,7 +529,7 @@ export class LibraryPageComponent {
   }
 
   updateActiveDot(): void {
-    const numberOfDots = this.classroomSummaries.length - 2;
+    const numberOfDots = Math.max(1, this.classroomSummaries.length - 2);
     this.dots = Array(numberOfDots)
       .fill(0)
       .map((_, i) => (i === this.currentCardIndex ? 1 : 0));

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -509,10 +509,7 @@ export class LibraryPageComponent {
   }
 
   moveClassroomCarouselToNextSlide(): void {
-    if (
-      this.currentCardIndex <
-      this.classroomSummaries.length - this.cardsToShow
-    ) {
+    if (this.currentCardIndex < this.classroomSummaries.length - 1) {
       this.currentCardIndex += 1;
       this.translateX -= this.getCardWidth();
       this.updateActiveDot();
@@ -532,28 +529,18 @@ export class LibraryPageComponent {
   }
 
   updateActiveDot(): void {
-    const numberOfDots = Math.ceil(
-      this.classroomSummaries.length / this.cardsToShow
-    );
+    const numberOfDots = this.classroomSummaries.length - 2;
     this.dots = Array(numberOfDots)
       .fill(0)
       .map((_, i) => (i === this.currentCardIndex ? 1 : 0));
   }
 
   shouldShowNextClassroomChunkButton(): boolean {
-    const numberOfClassroomSlides = Math.ceil(
-      this.classroomSummaries.length / this.cardsToShow
-    );
-    return (
-      this.publicClassroomsCount > this.cardsToShow &&
-      this.currentCardIndex < numberOfClassroomSlides - 1
-    );
+    return this.currentCardIndex < this.classroomSummaries.length - 3;
   }
 
   shouldShowPreviousClassroomChunkButton(): boolean {
-    return (
-      this.publicClassroomsCount > this.cardsToShow && this.currentCardIndex > 0
-    );
+    return this.currentCardIndex > 0;
   }
 
   registerClassroomCardClickEvent(classroomName: string): void {

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -509,7 +509,10 @@ export class LibraryPageComponent {
   }
 
   moveClassroomCarouselToNextSlide(): void {
-    if (this.currentCardIndex < this.classroomSummaries.length - 1) {
+    if (
+      this.currentCardIndex <
+      this.classroomSummaries.length - this.cardsToShow
+    ) {
       this.currentCardIndex += 1;
       this.translateX -= this.getCardWidth();
       this.updateActiveDot();
@@ -529,17 +532,27 @@ export class LibraryPageComponent {
   }
 
   updateActiveDot(): void {
-    const numberOfDots = Math.max(1, this.classroomSummaries.length - 2);
+    // We subtract (cardsToShow - 1) because the last dot represents the last set of cards
+    // that can be fully displayed. This creates a sliding window of size n-(cardsToShow-1).
+    const numberOfDots = Math.max(
+      1,
+      this.classroomSummaries.length - (this.cardsToShow - 1)
+    );
     this.dots = Array(numberOfDots)
       .fill(0)
       .map((_, i) => (i === this.currentCardIndex ? 1 : 0));
   }
 
   shouldShowNextClassroomChunkButton(): boolean {
-    return this.currentCardIndex < this.classroomSummaries.length - 3;
+    // We subtract cardsToShow from the total length because the last viable
+    // starting index is when cardsToShow number of cards can still be displayed.
+    return (
+      this.currentCardIndex < this.classroomSummaries.length - this.cardsToShow
+    );
   }
 
   shouldShowPreviousClassroomChunkButton(): boolean {
+    // Checks if we're not at the beginning of the carousel.
     return this.currentCardIndex > 0;
   }
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19849 .
2. This PR does the following: Fix the classroom name overflow and update carousel to show all the public classrooms earlier it was missing some classrooms and fix console errors in classroom-admin page.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

![Screenshot from 2024-08-23 17-22-43](https://github.com/user-attachments/assets/72cc275f-3de8-494b-994a-0d81dce0571e)


https://github.com/user-attachments/assets/ece442de-8d18-45dd-ae12-d3ba66273d4d



<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
N/A
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
![Screenshot from 2024-08-23 17-23-05](https://github.com/user-attachments/assets/2afe539d-45aa-4ef3-a43c-dcbc99199dc6)

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
