### PR TITLE
Added a flag that can be used to check the coverage for only the changed files. 

### DIFF
--- a/run_coverage_on_changed_files.sh
+++ b/run_coverage_on_changed_files.sh
@@ -1,0 +1,13 @@
+# Get the list of changed Python files
+changed_files=$(git diff --name-only --diff-filter=ACM HEAD~1 HEAD | grep -E '\.py$')
+
+if [ -z "$changed_files" ]; then
+  echo "No Python files have changed."
+  exit 0
+fi
+
+coverage run --source=. -m unittest discover
+
+coverage report --include=$(echo $changed_files | tr ' ' ',')
+
+coverage html --include=$(echo $changed_files | tr ' ' ',')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#hi
 """This file is used to build a Python package that can then by used by
 Google Cloud Dataflow workers (Apache Beam).
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#hi
 """This file is used to build a Python package that can then by used by
 Google Cloud Dataflow workers (Apache Beam).
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR adds a flag #20859.
2. A flag in the backend coverage report to display only the changed, uncovered files.
