### PR TITLE
Fix #20947: Fix backend flake for check_tests_are_captured_in_ci_test.

### DIFF
--- a/scripts/check_tests_are_captured_in_ci.py
+++ b/scripts/check_tests_are_captured_in_ci.py
@@ -68,7 +68,10 @@ def get_acceptance_test_suites_from_ci_config_file() -> List[TestSuiteDict]:
         acceptance_test_suite_config = json.load(f)
         acceptance_test_suites: List[TestSuiteDict] = (
             acceptance_test_suite_config['suites'])
-    return acceptance_test_suites
+    return sorted(
+        acceptance_test_suites,
+        key=lambda x: x['name']
+    )
 
 
 def get_e2e_test_suites_from_ci_config_file() -> List[TestSuiteDict]:
@@ -165,7 +168,10 @@ def get_e2e_test_suites_from_webdriverio_config_file() -> List[TestSuiteDict]:
                     'module': test_suite_module
                 }
             )
-    return e2e_test_suites
+    return sorted(
+        e2e_test_suites,
+        key=lambda x: x['name']
+    )
 
 
 def get_acceptance_test_suites_from_acceptance_directory() -> List[TestSuiteDict]: # pylint: disable=line-too-long
@@ -193,7 +199,10 @@ def get_acceptance_test_suites_from_acceptance_directory() -> List[TestSuiteDict
             'name': acceptance_test_suite_name,
             'module': os.path.relpath(module, os.getcwd())
         })
-    return acceptance_test_suites
+    return sorted(
+        acceptance_test_suites,
+        key=lambda x: x['name']
+    )
 
 
 def compute_test_suites_difference(

--- a/scripts/check_tests_are_captured_in_ci_test.py
+++ b/scripts/check_tests_are_captured_in_ci_test.py
@@ -269,10 +269,7 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
                 check_tests_are_captured_in_ci
                     .get_acceptance_test_suites_from_acceptance_directory())
             self.assertEqual(
-                sorted(acceptance_test_suites, key=lambda x: x['name']),
-                sorted(ACCEPTANCE_TEST_SUITES, key=lambda x: x['name']),
-                ACCEPTANCE_TEST_SUITES
-            )
+                acceptance_test_suites, ACCEPTANCE_TEST_SUITES)
 
     def test_get_acceptance_test_suites_from_acceptance_directory_with_exclusion(self) -> None: # pylint: disable=line-too-long
         def mock_get_cwd() -> str:

--- a/scripts/check_tests_are_captured_in_ci_test.py
+++ b/scripts/check_tests_are_captured_in_ci_test.py
@@ -269,7 +269,10 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
                 check_tests_are_captured_in_ci
                     .get_acceptance_test_suites_from_acceptance_directory())
             self.assertEqual(
-                acceptance_test_suites, ACCEPTANCE_TEST_SUITES)
+                sorted(acceptance_test_suites, key=lambda x: x['name']),
+                sorted(ACCEPTANCE_TEST_SUITES, key=lambda x: x['name']),
+                ACCEPTANCE_TEST_SUITES
+            )
 
     def test_get_acceptance_test_suites_from_acceptance_directory_with_exclusion(self) -> None: # pylint: disable=line-too-long
         def mock_get_cwd() -> str:


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20947.
2. This PR does the following: Sorts the suites by name to ensure that they are always in order.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
