### PR TITLE
Fix #20923: Add character limits to chapter editor for title and description

### DIFF
--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
@@ -57,6 +57,8 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
   @Input() acquiredSkillIds: string[];
   @Input() plannedPublicationDateMsecs: number;
 
+  MAX_CHARS_IN_EXPLORATION_TITLE = 36; 
+  MAX_CHARS_IN_CHAPTER_DESCRIPTION = 156; 
   chapterPreviewCardIsShown = false;
   mainChapterCardIsShown = true;
   explorationInputButtonsAreShown = false;


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #20923.
2. This PR adds character limits to the chapter editor for both the title (36 characters) and description (156 characters). It ensures the UI properly displays these limits to guide users.
3. The original bug occurred because: The chapter editor was missing the character limit variables in the template, causing the limits to not be displayed in the UI.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

### Proof that changes are correct

reference -> https://github.com/oppia/oppia/issues/20923

[Screencast from 11-09-24 10:10:26 PM IST.webm](https://github.com/user-attachments/assets/d8179892-f3c0-419e-8353-bee0ae943471)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
