### PR TITLE
Fix #20497: Update button CSS in creator-guidelines page

### DIFF
--- a/core/templates/pages/participation-playbook/playbook.component.css
+++ b/core/templates/pages/participation-playbook/playbook.component.css
@@ -21,12 +21,29 @@
   margin-left: 25px;
 }
 .playbook .oppia-about-buttons-container {
+  display: flex;
+  justify-content: space-evenly;
   text-align: center;
+}
+.playbook .btn.oppia-about-button {
+  background-color: rgba(0, 0, 0, 0.3);
+  color: rgba(255, 255, 255, 1.0);
+  font-weight: 500;
+  letter-spacing: 0.7px;
+  margin: 0 auto 4%;
+  max-width: 80%;
+  min-width: 40%;
+  padding: 10px 30px;
+  text-transform: uppercase;
+}
+.playbook .btn.oppia-about-button:hover {
+  background-color: #fff;
+  color: #009688;
 }
 .playbook .oppia-about-extra-info {
   background-color: #009788;
   color: #fff;
-  height: 245px;
+  height: 160px;
   width: 100%;
 }
 
@@ -43,6 +60,15 @@
 .playbook .oppia-about-extra-container h3 {
   color: #fff;
   text-align: center;
+}
+
+@media(max-width: 1000px) {
+  .playbook .oppia-about-buttons-container {
+    flex-direction: column;
+  }
+  .playbook .btn.oppia-about-button {
+    min-width: 80%;
+  }
 }
 
 @media only screen and (min-width: 1400px) {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes issue #20497 .
2. This PR does the following: This PR applies CSS properties of a button to the buttons present in creator-guidelines page and makes them responsive to fit any screen.
3. The original bug occurred because: Several CSS properties of a button were not applied to the buttons present in creator-guidelines page.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Before:

![Screenshot 2024-09-30 172626](https://github.com/user-attachments/assets/1e7ad2aa-e23c-45c4-a7bf-f8d6e6f0a046)

#### After:

https://github.com/user-attachments/assets/a6bdb692-17f6-4eed-86ff-0e278261fa5b


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

![Screenshot 2024-09-30 171426](https://github.com/user-attachments/assets/8540ef85-ac23-4d65-828b-05c4bfa4a8af)
<!--
## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
-->
@seanlip  PTAL