### PR TITLE
Fix #20986: Unable to compare to branches if no remote

### DIFF
--- a/scripts/git_changes_utils_test.py
+++ b/scripts/git_changes_utils_test.py
@@ -804,6 +804,24 @@ class GitChangesUtilsTests(test_utils.GenericTestBase):
                                 remote_sha1='remote_sha1'
                             )])
 
+    def test_get_refs_with_empty_remote_sha(self) -> None:
+        with tempfile.NamedTemporaryFile() as temp_stdin_file:
+            with utils.open_file(temp_stdin_file.name, 'w') as f:
+                f.write(
+                    'local_ref local_sha1 remote_ref %s' %
+                    git_changes_utils.EMPTY_SHA1)
+            with utils.open_file(temp_stdin_file.name, 'r') as f:
+                with self.swap(sys, 'stdin', f):
+                    self.assertEqual(
+                        git_changes_utils.get_refs(),
+                        [
+                            git_changes_utils.GitRef(
+                                local_ref='local_ref', local_sha1='local_sha1',
+                                remote_ref=None, remote_sha1=None
+                            )
+                        ]
+                    )
+
     def test_get_refs_without_stdin_should_use_current_branch(self) -> None:
         def mock_get_branch() -> str:
             return 'branch1'


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20986.
2. This PR does the following: Checks if the remote sha is empty and sets the remote ref and remote sha to None if it is as the pre-push hook provides an empty remote sha when there is not remote branch present.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
https://github.com/user-attachments/assets/becd96b5-4edd-4c2d-b4cb-8188f63cbb88

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
