### PR TITLE
Fix #20044, added input validation for repeating user units entered.

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -845,6 +845,7 @@
     "I18N_INTERACTIONS_NUMBER_WITH_UNITS_INVALID_UNIT_CHARS": "Please ensure that the unit only contains numbers, alphabets, (, ), *, ^, /, -",
     "I18N_INTERACTIONS_NUMBER_WITH_UNITS_INVALID_VALUE": "Please ensure that the value is either a fraction or a number",
     "I18N_INTERACTIONS_NUMBER_WITH_UNITS_POSSIBLE_UNIT_FORMATS": "Possible unit formats",
+    "I18N_INTERACTIONS_NUMBER_WITH_DOUBLE_UNITS": "The unit type must only be used once",
     "I18N_INTERACTIONS_NUMERIC_INPUT_ATMOST_1_DECIMAL": "At most 1 decimal point should be present.",
     "I18N_INTERACTIONS_NUMERIC_INPUT_ATMOST_1_EXPONENT": "At most 1 exponent sign (e) should be present.",
     "I18N_INTERACTIONS_NUMERIC_INPUT_ATMOST_1_MINUS": "At most 1 minus (-) sign should be present.",

--- a/core/templates/domain/objects/NumberWithUnitsObjectFactory.ts
+++ b/core/templates/domain/objects/NumberWithUnitsObjectFactory.ts
@@ -315,6 +315,14 @@ export class NumberWithUnitsObjectFactory {
     }
 
     const unitsObj = this.unitsFactory.fromRawInputString(units);
+    let possibleDuplicated = this.unitsFactory.fromRawInputString(units);
+    if (possibleDuplicated !== " "){
+      throw new Error(
+
+          ObjectsDomainConstants.NUMBER_WITH_DOUBLE_UNITS.INVALID_VALUE + ' ' + possibleDuplicated
+      );
+    }
+
     return new NumberWithUnits(type, real, fractionObj, unitsObj);
   }
 

--- a/core/templates/domain/objects/UnitsObjectFactory.ts
+++ b/core/templates/domain/objects/UnitsObjectFactory.ts
@@ -264,6 +264,43 @@ export class UnitsObjectFactory {
     }
     return new Units(this.fromStringToList(units));
   }
+
+  getPossibleUnits(units: string[]): string[]{
+    var newUnits: string[] = [];
+      units.forEach(entry => {
+        newUnits.push(entry.replace([0-9]/g,));
+      })
+
+      return units;
+  }
+
+  findDuplicatedUnit(units: string): string{
+    let unitsP: string[] = ["km","kg","m","s"];
+    var listedUnits= this.getPossibleUnits(units);
+    let unitCount: int[] = [0,0,0,0];
+
+    for(var i in listedUnits){
+      if(i == unitsP[0]){
+        unitCount[0] += 1;
+      }
+      else if(i == unitsP[0]){
+        unitCount[1] += 1;
+      }
+      else if(i == unitsP[0]){
+        unitCount[2] += 1;
+      }
+      else if(i == unitsP[0]){
+        unitCount[3] += 1;
+      }
+    }
+    for(j in unitCount){
+      if (j >= 2){
+        return " ";
+      }
+    }
+
+  }
+
 }
 
 angular

--- a/core/templates/domain/objects/UnitsObjectFactorySpec.ts
+++ b/core/templates/domain/objects/UnitsObjectFactorySpec.ts
@@ -307,4 +307,10 @@ describe('UnitsObjectFactory', () => {
       units.fromRawInputString('cent %mol$');
     }).toThrowError('Unit "dollarcent" not found.');
   });
+//Updated Here
+  it('should return the dupplicated unit in a input string or an empty string', ()=> {
+    expect(units.duplicatedUnit('km km')).toEqual('km');
+    expect(units.duplicatedUnit('kg/kg^4*K*mol')).toEqual('kg');
+    expect(units.duplicatedUnit('kg/km^4*K*mol')).toEqual('');
+  });
 });


### PR DESCRIPTION
1. This PR fixes or fixes part of #[20044].
2. This PR does the following: Check whether measurements are repeated within the user input to display them and the appropriate error messages.
3. The original bug occurred because: the only way to type the correct measurements for answers on the website was to insert the measurement twice.
