### PR TITLE
Fix issue ##21024 : Correct script being called in make run_tests.check_e2e_tests_are_captured_in_ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,11 +233,11 @@ run_tests.e2e: ## Runs the e2e tests for the parsed suite
 	@echo '------------------------------------------------------'
 	$(MAKE) stop
 
-run_tests.check_e2e_tests_are_captured_in_ci: ## Runs the check to ensure that all e2e tests are captured in CI
+run_tests.check_tests_are_captured_in_ci: ## Runs the check to ensure that all e2e and acceptence tests are captured in CI
 	@echo 'Shutting down any previously started server.'
 	$(MAKE) stop
 	docker compose up dev-server -d --no-deps
-	$(SHELL_PREFIX) dev-server python -m scripts.check_e2e_tests_are_captured_in_ci
+	$(SHELL_PREFIX) dev-server python -m scripts.check_tests_are_captured_in_ci
 	$(MAKE) stop
 
 run_tests.lighthouse_accessibility: ## Runs the lighthouse accessibility tests for the parsed shard


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #21024.
3. This PR does the following: Makes correct script to be run in `make run_tests.check_e2e_tests_are_captured_in_ci`

4. The original bug occurred because: There the test was refactored into a new file in PR #20500 


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.


## Proof that changes are correct

**Before:** Caused an error since there was no file named check_e2e_tests_are_captured_in_ci

![before](https://github.com/user-attachments/assets/38754ade-94ec-4364-a724-e1cd30a4c296)

**After:** Script could be ran and successfully so (by the looks of it)

![after](https://github.com/user-attachments/assets/905cb5ab-af18-479b-a3f2-6c3fa3e91848)


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
