### PR TITLE
Fix #20903: Make learner dashboard responsive

### DIFF
--- a/core/templates/pages/learner-dashboard-page/home-tab.component.css
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.css
@@ -142,11 +142,11 @@
 @media screen and (max-width: 767px) {
   .home-tab .greeting {
     font-size: 23px;
-    margin: 24px 0 0 20px;
+    margin: 24px 0 0 67px;
   }
   .home-tab .continue-where-you-left-off, .home-tab .suggested-for-you,
   .home-tab .empty-suggested-for-you {
-    margin-left: auto;
+    margin-left: 67px;
     width: 465px;
   }
   .home-tab .continue-where-you-left-off .continue-where-you-left-off-heading,
@@ -184,7 +184,7 @@
   .home-tab .empty-suggested-for-you {
     margin: 18px 0 25px 0;
     padding: 40px 0 20px 32px;
-    width: 500px;
+    width: 487px;
   }
   .home-tab .continue-where-you-left-off .continue-where-you-left-off-heading,
   .home-tab .suggested-for-you .suggested-for-you-heading {

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.css
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.css
@@ -97,7 +97,7 @@ oppia-learner-dashboard-page .oppia-svg-image {
 }
 
 .oppia-learner-dashboard-side-content {
-  min-width: 270px;
+  min-width: 266px;
   padding-left: 80px;
   width: 20%;
 }


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #20903.
2. This PR does the following: i have adjusted css a little
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct


https://github.com/user-attachments/assets/90f12e67-0f2e-49ba-92f6-49fd7d0bcdaf





## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
