### PR TITLE
Fix #20090: Responsive translation page in exploration editor 

### DIFF
--- a/core/templates/base-components/base-content.component.css
+++ b/core/templates/base-components/base-content.component.css
@@ -43,7 +43,7 @@
 }
 @media (max-width: 992px) {
   .navbar-collapse {
-    display: flex !important; 
+    display: flex; 
   }
 }
 

--- a/core/templates/base-components/base-content.component.css
+++ b/core/templates/base-components/base-content.component.css
@@ -41,6 +41,11 @@
     display: none;
   }
 }
+@media (max-width: 992px) {
+  .navbar-collapse {
+    display: flex !important; 
+  }
+}
 
 .show-mobile-navbar-icon {
   background-color: #e6e6e6;

--- a/core/templates/base-components/base-content.component.html
+++ b/core/templates/base-components/base-content.component.html
@@ -51,7 +51,7 @@
                 <oppia-top-navigation-bar [headerText]="getHeaderText()"
                                           [subheaderText]="getSubheaderText()">
                 </oppia-top-navigation-bar>
-                <div class="collapse d-lg-inline-flex navbar-collapse oppia-navbar-collapse ng-cloak navbar-options-display">
+                <div class="collapse d-inline-flex navbar-collapse oppia-navbar-collapse ng-cloak navbar-options-display">
                   <div [ngClass]="{'mr-auto': !isLanguageRTL(), 'ml-auto': isLanguageRTL()}">
                     <ng-content select="navbar-breadcrumb"></ng-content>
                   </div>

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -430,10 +430,10 @@
     cursor: pointer;
     display: flex;
     margin-bottom: 5px;
-    width: -webkit-calc(100% / 4);
-    width: -moz-calc(100% / 4);
-    width: -o-calc(100% / 4);
-    width: calc(100% / 4);
+    width: -webkit-calc(100% / 5);
+    width: -moz-calc(100% / 5);
+    width: -o-calc(100% / 5);
+    width: calc(100% / 5);
   }
 
   @media screen and (max-width: 768px) {
@@ -476,7 +476,8 @@
     border-bottom-width: 2px;
     border-top-width: 3px;
     color: #009688;
-    padding: 10px;
+    font-size: 1.3rem;
+    padding: 10px 10px 10px 2px;
     text-decoration: none;
     width: 100%;
   }
@@ -499,7 +500,7 @@
     padding: 20px 30px 20px 30px;
   }
   .oppia-audio-translation-bar {
-    height: 50px;
+    height: 60px;
   }
   .oppia-rte-editor-focused:focus > p {
     outline: solid 2px #009688;


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #20090.
2. This PR does the following: I have adjusted the css.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct


https://github.com/user-attachments/assets/ac60d2ad-4a92-4b5a-b518-bfc354188004



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
