### PR TITLE
Draft PR: Add validation tests for music notes

### DIFF
--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
@@ -72,11 +72,6 @@ export class MusicNotesInputRulesService {
     answer: MusicNotesAnswer[],
     inputs: {a: number; b: number}
   ): boolean {
-    
-    //No need to check the actual length if a is greater than b
-    if(inputs.a > inputs.b) {
-      return false;
-    }
 
     var answerLength: number =
       MusicNotesInputRulesService._convertSequenceToMidi(answer).length;

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
@@ -72,6 +72,12 @@ export class MusicNotesInputRulesService {
     answer: MusicNotesAnswer[],
     inputs: {a: number; b: number}
   ): boolean {
+    
+    //No need to check the actual length if a is greater than b
+    if(inputs.a > inputs.b) {
+      return false;
+    }
+
     var answerLength: number =
       MusicNotesInputRulesService._convertSequenceToMidi(answer).length;
     return answerLength >= inputs.a && answerLength <= inputs.b;

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
@@ -72,7 +72,6 @@ export class MusicNotesInputRulesService {
     answer: MusicNotesAnswer[],
     inputs: {a: number; b: number}
   ): boolean {
-
     var answerLength: number =
       MusicNotesInputRulesService._convertSequenceToMidi(answer).length;
     return answerLength >= inputs.a && answerLength <= inputs.b;

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
@@ -67,7 +67,7 @@ export class MusicNotesInputRulesService {
     );
   }
 
-  // TODO(#20443): Validate that inputs.a <= inputs.b.
+  // TODO(#20443): Validate that inputs.a <= inputs.b before checking actual length.
   HasLengthInclusivelyBetween(
     answer: MusicNotesAnswer[],
     inputs: {a: number; b: number}


### PR DESCRIPTION
## Overview

This PR fixes #20443

The issue is being fixed by adding a validation check for the range in the HasLengthInclusivelyBetween method

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

Tested the changes by running the frontend tests:

<img width="816" alt="Oppia-Frontend-Tests-Screenshot-2024-09-19" src="https://github.com/user-attachments/assets/e311981a-484f-45f4-a535-928103f6dd55">

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
