### PR TITLE
Fix #20918: Add recaptcha console error to exclusion list for acceptance tests

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/common/console-reporter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/console-reporter.ts
@@ -75,6 +75,10 @@ const CONSOLE_ERRORS_TO_IGNORE = [
   new RegExp(
     /https:\/\/content\.googleapis\.com\/drive\/v2internal\/viewerimpressions\?key=[^&]+&alt=json/
   ),
+  // Error related to Donorbox ReCaptcha not being iframe-able in
+  // acceptance tests. This is outside our control because it is
+  // controlled by Donorbox.
+  escapeRegExp("[Report Only] Refused to frame 'https://www.recaptcha.net/'"),
 ];
 
 const CONSOLE_ERRORS_TO_FIX = [


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #20918.
2. This PR does the following: Adds the recaptcha console error to our console logs exclusion list.
3. (For bug-fixing PRs only) The original bug occurred because: (suspected) Donorbox introduced recaptcha on their site and this is breaking our acceptance tests.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This will be determined by looking at the CI checks.

