### PR TITLE
Fixes #20958: Fixes `wait timeout` flake in contributorAdminDashboard

### DIFF
--- a/core/tests/webdriverio_desktop/contributorAdminDashboard.js
+++ b/core/tests/webdriverio_desktop/contributorAdminDashboard.js
@@ -98,6 +98,7 @@ describe('Contributor Admin Dashboard', function () {
     await adminPage.addLanguageToCoordinator('translation', 'shqip (Albanian)');
     await adminPage.addLanguageToCoordinator('translation', 'العربية (Arabic)');
     await adminPage.addRole('question', 'translation admin');
+    await adminPage.addRole(QUESTION_ADMIN_USERNAME, 'question admin');
     await users.logout();
 
     await users.login(QUESTION_COORDINATOR_EMAIL);
@@ -143,9 +144,6 @@ describe('Contributor Admin Dashboard', function () {
       SKILL_DESCRIPTIONS[1],
       REVIEW_MATERIALS[1]
     );
-
-    await adminPage.get();
-    await adminPage.addRole(QUESTION_ADMIN_USERNAME, 'question admin');
 
     // Creating an exploration with an image.
     await creatorDashboardPage.get();


### PR DESCRIPTION
## Overview

1. This PR fixes #20958.
2. This PR does the following: puts all role assignment task in one place to reduce excessive switching between different pages, which was causing `waitUntil` timeout situation.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
