### PR TITLE
Fix #21060: Fix trash icon moving if question text is too long in question editor question list

### DIFF
--- a/core/templates/components/question-directives/questions-list/questions-list.component.html
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.html
@@ -64,7 +64,7 @@
           <div *ngIf="!deletedQuestionIds.includes(questionSummaryForOneSkill.getQuestionSummary().getQuestionId())"
                (click)="editQuestion(questionSummaryForOneSkill.getQuestionSummary(), questionSummaryForOneSkill.getSkillDescription(), questionSummaryForOneSkill.getSkillDifficulty())">
             <div class="question-data e2e-test-edit-question-button">
-              <oppia-rte-output-display class="e2e-test-question-text" classStr="question-text"
+              <oppia-rte-output-display class="e2e-test-question-text question-text"
                             [rteString]="questionSummaryForOneSkill.getQuestionSummary().getQuestionContent()">
               </oppia-rte-output-display>
               <span *ngIf="!showUnaddressedSkillMisconceptionWarning(questionSummaryForOneSkill.getQuestionSummary().getMisconceptionIds())"

--- a/core/templates/components/question-directives/questions-list/questions-list.component.html
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.html
@@ -214,6 +214,7 @@
     cursor: pointer;
     display: flex;
     flex-wrap: wrap;
+    gap: 4px;
     justify-content: space-between;
   }
   .create-question-header {
@@ -221,7 +222,8 @@
     margin: 0;
   }
   .question-text {
-    width: 90%;
+    flex: 1;
+    max-width: 90%;
   }
   .page-navigation-arrows {
     float: right;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #21060 
2. This PR does the following: Correctly use the `class` attribute for a CSS class instead of erroneously using `classStr`, for the question text in the questions list component. Also modifies the existing CSS to be more responsive, preventing the issue to occur for any screen size.
3. (For bug-fixing PRs only) The original bug occurred because: incorrectly used `classStr` instead of `class` so the existing `question-text` CSS class was not applied. Also not ideal CSS to begin with. Introduced in PR #15768 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

Before:

![Screenshot 2024-10-12 215846](https://github.com/user-attachments/assets/b6b2bef9-c944-4ec6-bc86-d8ccd0d911e8)

After:

https://github.com/user-attachments/assets/253e7c4b-ad08-4438-b05c-cf598658e9eb



<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

N/A

#### Proof of changes on mobile phone

See video above

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

Not affected by this.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
