### PR TITLE
Revert "Fix #20443: Added validation check for the range in the HasLengthInclusivelyBetween method"

### DIFF
--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.spec.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.spec.ts
@@ -951,37 +951,5 @@ describe('Music Notes Input rules service', () => {
         }
       )
     ).toBe(false);
-
-    expect(
-      mnirs.HasLengthInclusivelyBetween(
-        [
-          {
-            readableNoteName: 'C4',
-            noteDuration: {
-              num: 1,
-              den: 1,
-            },
-          },
-          {
-            readableNoteName: 'D4',
-            noteDuration: {
-              num: 1,
-              den: 1,
-            },
-          },
-          {
-            readableNoteName: 'E4',
-            noteDuration: {
-              num: 1,
-              den: 1,
-            },
-          },
-        ],
-        {
-          a: 7,
-          b: 2,
-        }
-      )
-    ).toBe(false);
   });
 });

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-rules.service.ts
@@ -67,14 +67,11 @@ export class MusicNotesInputRulesService {
     );
   }
 
+  // TODO(#20443): Validate that inputs.a <= inputs.b.
   HasLengthInclusivelyBetween(
     answer: MusicNotesAnswer[],
     inputs: {a: number; b: number}
   ): boolean {
-    // No need to check the actual length if inputs.a is greater than inputs.b in comparison.
-    if (inputs.a > inputs.b) {
-      return false;
-    }
     var answerLength: number =
       MusicNotesInputRulesService._convertSequenceToMidi(answer).length;
     return answerLength >= inputs.a && answerLength <= inputs.b;


### PR DESCRIPTION
This PR reverts oppia/oppia#20977, which does not actually fix the issue it was supposed to. See https://github.com/oppia/oppia/pull/20977#issuecomment-2408907752 for more information.