### PR TITLE
Fix #21116: Watch A Video acceptance test Facebook URL mismatch

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/common/test-constants.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/test-constants.ts
@@ -53,8 +53,6 @@ export default {
     Donate: 'http://localhost:8181/donate',
     DonatePageThanksModalURL: 'http://localhost:8181/donate?thanks=',
     AboutPageThanksModalURL: 'http://localhost:8181/about?thanks=',
-    DesktopExternalLinkWatchAVideo:
-      'https://www.facebook.com/oppiaorg/videos/189487953721583/',
     EmbeddingAnExploration: 'https://oppia.github.io/#/EmbeddingAnExploration',
     ExplorationDesignTips: 'http://oppia.github.io/#/DesignTips',
     ExternalLink61MillionChildren:
@@ -75,8 +73,6 @@ export default {
     Login: 'http://localhost:8181/login',
     Logout: 'http://localhost:8181/logout',
     MathClassroom: 'http://localhost:8181/learn/math',
-    MobileExternalLinkWatchAVideo:
-      'https://m.facebook.com/watch/?v=189487953721583&vanity=oppiaorg',
     ModeratorPage: 'http://localhost:8181/moderator',
     Partnerships: 'http://localhost:8181/partnerships',
     PartnershipsBrochure:

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -36,7 +36,6 @@ const splashPageUrl = testConstants.URLs.splash;
 const contactUrl = testConstants.URLs.Contact;
 const creatingAnExplorationUrl = testConstants.URLs.CreatingAnExploration;
 const classroomsPageUrl = testConstants.URLs.ClassroomsPage;
-const desktopWatchAVideoUrl = testConstants.URLs.DesktopExternalLinkWatchAVideo;
 const donateUrl = testConstants.URLs.Donate;
 const electromagnetismUrl = testConstants.URLs.Electromagnetism;
 const embeddingAnExplorationUrl = testConstants.URLs.EmbeddingAnExploration;
@@ -55,7 +54,6 @@ const googleSignUpUrl = testConstants.URLs.ExternalLink.GoogleSignUp;
 const getStartedUrl = testConstants.URLs.GetStarted;
 const homeUrl = testConstants.URLs.Home;
 const mathClassroomUrl = testConstants.URLs.MathClassroom;
-const mobileWatchAVideoUrl = testConstants.URLs.MobileExternalLinkWatchAVideo;
 const OppiaAnnounceGoogleGroupUrl = testConstants.URLs.OppiaAnnounceGoogleGroup;
 const partnershipsBrochureUrl = testConstants.URLs.PartnershipsBrochure;
 const partnershipsFormInPortugueseUrl =
@@ -801,10 +799,7 @@ export class LoggedOutUser extends BaseUser {
     await this.waitForPageToFullyLoad();
 
     const url = this.page.url();
-    const expectedWatchAVideoUrl = this.isViewportAtMobileWidth()
-      ? mobileWatchAVideoUrl
-      : desktopWatchAVideoUrl;
-    if (url !== expectedWatchAVideoUrl) {
+    if (!url.includes(testConstants.OppiaSocials.FaceBook.Domain)) {
       throw new Error(
         `The Watch A Video button should open the right page,
           but it opens ${url} instead.`


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #21116
2. This PR does the following: Makes the URL check less strict since Facebook can redirect users clicking on video links to different URLs, which is completely out of our control
3. (For bug-fixing PRs only) The original bug occurred because: Facebook redirects being out of our control

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
