### PR TITLE
Fix issue #20574: Disable "done" button when no Youtube video URL/ID is provided

### DIFF
--- a/core/templates/services/rte-helper-modal.controller.ts
+++ b/core/templates/services/rte-helper-modal.controller.ts
@@ -242,11 +242,13 @@ export class RteHelperModalComponent {
     } else if (this.componentId === this.COMPONENT_ID_VIDEO) {
       let start: number = value[1];
       let end: number = value[2];
-      if (start === 0 && end === 0) {
+      if (value[0] === '') {
+        this.updateRteErrorMessage(
+          'Please ensure that the Youtube URL or id is valid.'
+        );
         return;
       }
-
-      if (start >= end) {
+      if (start !== 0 && start >= end) {
         this.updateRteErrorMessage(
           'Please ensure that the start time of the video is earlier than ' +
             'the end time.'


### PR DESCRIPTION
## Overview

1. This PR fixes  #20574.
2. This PR does the following: Make RTE video component show error message when no Youtube video URL/ID is provided. 
3. The original bug occurred because: The Done button was always enabled, except when start time was greater than end time. 

## Essential Checklist

- [X ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

https://github.com/user-attachments/assets/53518840-90b6-4561-b973-327ae2ca1850


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
