### PR TITLE
Fix #20958 partially: improve error message for nonexistent elements and simplify CD admin e2e test.

### DIFF
--- a/core/tests/webdriverio_desktop/contributorAdminDashboard.js
+++ b/core/tests/webdriverio_desktop/contributorAdminDashboard.js
@@ -17,20 +17,20 @@
  */
 
 let action = require('../webdriverio_utils/action.js');
+let forms = require('../webdriverio_utils/forms.js');
 let users = require('../webdriverio_utils/users.js');
 let general = require('../webdriverio_utils/general.js');
 let waitFor = require('../webdriverio_utils/waitFor.js');
+let workflow = require('../webdriverio_utils/workflow.js');
 
 let ReleaseCoordinatorPage = require('../webdriverio_utils/ReleaseCoordinatorPage.js');
 let AdminPage = require('../webdriverio_utils/AdminPage.js');
-let forms = require('../webdriverio_utils/forms.js');
 let ContributorDashboardPage = require('../webdriverio_utils/ContributorDashboardPage.js');
 let ContributorDashboardAdminPage = require('../webdriverio_utils/ContributorDashboardAdminPage.js');
 let TopicsAndSkillsDashboardPage = require('../webdriverio_utils/TopicsAndSkillsDashboardPage.js');
 let SkillEditorPage = require('../webdriverio_utils/SkillEditorPage.js');
 let ExplorationEditorPage = require('../webdriverio_utils/ExplorationEditorPage.js');
 let StoryEditorPage = require('../webdriverio_utils/StoryEditorPage.js');
-let workflow = require('../webdriverio_utils/workflow.js');
 let TopicEditorPage = require('../webdriverio_utils/TopicEditorPage.js');
 let CreatorDashboardPage = require('../webdriverio_utils/CreatorDashboardPage.js');
 let Constants = require('../webdriverio_utils/WebdriverioConstants.js');
@@ -145,27 +145,23 @@ describe('Contributor Admin Dashboard', function () {
       REVIEW_MATERIALS[1]
     );
 
-    // Creating an exploration with an image.
+    // Create a simple exploration.
     await creatorDashboardPage.get();
     await workflow.createExploration(true);
-    await explorationEditorMainTab.setContent(async function (richTextEditor) {
-      await richTextEditor.addRteComponent(
-        'Image',
-        'create',
-        ['rectangle', 'bezier', 'piechart', 'svgupload'],
-        'An svg diagram.'
-      );
-    }, true);
+    await explorationEditorMainTab.setContent(
+      await forms.toRichText('Select the right option.'),
+      true
+    );
     await explorationEditorMainTab.setInteraction('EndExploration');
     let explorationEditorSettingsTab = explorationEditorPage.getSettingsTab();
     await explorationEditorPage.navigateToSettingsTab();
-    let basicSettings = $('.e2e-test-settings-container');
+    let basicSettings = await $('.e2e-test-settings-container');
     await action.click('Basic Settings', basicSettings);
     await explorationEditorSettingsTab.setTitle('exp1');
     await explorationEditorSettingsTab.setCategory('Algebra');
     await explorationEditorSettingsTab.setLanguage('English');
     await explorationEditorSettingsTab.setObjective(
-      'Dummy exploration for testing images'
+      'Dummy exploration for testing'
     );
     await explorationEditorPage.saveChanges('Done!');
     await workflow.publishExploration();
@@ -190,25 +186,22 @@ describe('Contributor Admin Dashboard', function () {
     await storyEditorPage.saveStory('Saving Story');
     await storyEditorPage.publishStory();
 
-    let opportunityActionButtonCss = $(
-      '.e2e-test-opportunity-list-item-button'
-    );
     await contributorDashboardPage.get();
     await waitFor.pageToFullyLoad();
     await contributorDashboardPage.navigateToTranslateTextTab();
     await contributorDashboardTranslateTextTab.changeLanguage(
       'shqip (Albanian)'
     );
-    await contributorDashboardPage.waitForOpportunitiesToLoad();
-    await action.click('Opportunity button', opportunityActionButtonCss);
-    let image = $('.e2e-test-image');
-    await waitFor.visibilityOf(image, 'Test image taking too long to appear.');
-    let images = await $$('.e2e-test-image');
-    expect(images.length).toEqual(1);
-    await contributorDashboardAdminPage.copyElementWithClassName(
-      'image',
-      images[0]
+    let opportunityActionButton = await $(
+      '.e2e-test-opportunity-list-item-button'
     );
+    await contributorDashboardPage.waitForOpportunitiesToLoad();
+    await action.click('Opportunity button', opportunityActionButton);
+    await contributorDashboardPage.setTranslation(
+      await forms.toRichText('Zgjidhni opsionin e duhur.'),
+      true
+    );
+    await users.logout();
 
     // Accept suggestion as user1.
     await users.login(USER_EMAILS[1]);
@@ -223,11 +216,11 @@ describe('Contributor Admin Dashboard', function () {
     );
 
     await contributorDashboardPage.clickOpportunityActionButton(
-      '[Image]',
+      'Zgjidhni opsionin e duhur.',
       'Topic 0 for contribution / Story Title / Chapter 1'
     );
 
-    await contributorDashboardAdminPage.acceptTranslation();
+    await contributorDashboardPage.clickAcceptTranslationSuggestionButton();
     await users.logout();
 
     await users.login(USER_EMAILS[0]);

--- a/core/tests/webdriverio_utils/ContributorDashboardAdminPage.js
+++ b/core/tests/webdriverio_utils/ContributorDashboardAdminPage.js
@@ -19,7 +19,6 @@
 
 var action = require('./action.js');
 var waitFor = require('./waitFor.js');
-var users = require('./users.js');
 
 var ContributorDashboardAdminPage = function () {
   var CD_USER_RIGHTS_CATEGORY_REVIEW_TRANSLATION = 'REVIEW_TRANSLATION';
@@ -48,11 +47,6 @@ var ContributorDashboardAdminPage = function () {
   };
   var statsTable = $('.e2e-test-stats-table');
   var expandedRow = $('.e2e-test-expanded-row');
-  var copyButton = $('.e2e-test-copy-button');
-  var doneButton = $('.e2e-test-close-rich-text-component-editor');
-  var saveButton = $('.e2e-test-save-button');
-  var textbox = $('.e2e-test-description-box');
-  var acceptButton = $('.e2e-test-translation-accept-button');
   var questionSubmitterTab = $('.e2e-test-question-submitters-tab');
   var questionReviewerTab = $('.e2e-test-question-reviewers-tab');
   var translationSubmitterTab = $('.e2e-test-translation-submitters-tab');
@@ -153,26 +147,6 @@ var ContributorDashboardAdminPage = function () {
     } else if (category === CATEGORY_SUBMIT_QUESTION) {
       return $(userQuestionContributorCss);
     }
-  };
-
-  this.copyElementWithClassName = async function (
-    elementDescription,
-    elementClassName
-  ) {
-    await action.click('Copy button', copyButton);
-    await action.click(elementDescription, elementClassName);
-    await action.setValue(
-      'Set Image description',
-      textbox,
-      'An example description'
-    );
-    await action.click('Copy Done button', doneButton);
-    await action.click('Save button', saveButton);
-    await users.logout();
-  };
-
-  this.acceptTranslation = async function () {
-    await action.click('Translation accept button', acceptButton);
   };
 
   this.navigateToQuestionSubmitterTab = async function () {

--- a/core/tests/webdriverio_utils/ContributorDashboardPage.js
+++ b/core/tests/webdriverio_utils/ContributorDashboardPage.js
@@ -18,6 +18,7 @@
  */
 var waitFor = require('./waitFor.js');
 var action = require('./action.js');
+var forms = require('./forms.js');
 
 var ContributorDashboardTranslateTextTab = require('../webdriverio_utils/ContributorDashboardTranslateTextTab.js');
 
@@ -43,6 +44,9 @@ var ContributorDashboardPage = function () {
   var opportunityLabelCss = '.e2e-test-opportunity-list-item-label';
   var opportunityProgressPercentageCss =
     '.e2e-test-opportunity-list-item-progress-percentage';
+  var acceptTranslationSuggestionButton = $(
+    '.e2e-test-translation-accept-button'
+  );
   var acceptQuestionSuggestionButton = $(
     '.e2e-test-question-suggestion-review-accept-button'
   );
@@ -55,6 +59,8 @@ var ContributorDashboardPage = function () {
   var questionReviewModalHeader = $(
     '.e2e-test-question-suggestion-review-modal-header'
   );
+  var translationRichTextEditorTag = $('.e2e-test-state-translation-editor');
+  var saveTranslationButton = $('.e2e-test-save-button');
   var usernameContainer = $('.e2e-test-username');
   var reviewRightsDiv = $('.e2e-test-review-rights');
   var selectorContainer = $('.e2e-test-language-selector');
@@ -206,14 +212,14 @@ var ContributorDashboardPage = function () {
       var headingElement = opportunity.$(opportunityHeadingCss);
       await waitFor.visibilityOf(
         headingElement,
-        'Opportunity heading is taking too much time to appear'
+        'Opportunity heading ' + i + ' is taking too much time to ' + 'appear'
       );
       var heading = await headingElement.getText();
 
       var subheadingElement = opportunity.$(opportunitySubheadingCss);
       await waitFor.visibilityOf(
         subheadingElement,
-        'Opportunity subheading is taking too much time to appear'
+        'Opportunity subheading ' + i + ' is taking too much time to appear'
       );
       var subheading = await subheadingElement.getText();
 
@@ -276,6 +282,22 @@ var ContributorDashboardPage = function () {
     await action.click(
       'Opportunity action button',
       opportunity.$(opportunityActionButtonCss)
+    );
+  };
+
+  this.setTranslation = async function (richTextInstructions) {
+    var richTextEditor = await forms.RichTextEditor(
+      translationRichTextEditorTag
+    );
+    await richTextEditor.clear();
+    await richTextInstructions(richTextEditor);
+    await action.click('Save Translation button', saveTranslationButton);
+  };
+
+  this.clickAcceptTranslationSuggestionButton = async function () {
+    await action.click(
+      'Translation accept button',
+      acceptTranslationSuggestionButton
     );
   };
 

--- a/core/tests/webdriverio_utils/waitFor.js
+++ b/core/tests/webdriverio_utils/waitFor.js
@@ -127,6 +127,12 @@ var presenceOf = async function (element, errorMessage) {
  * @param {string} errorMessage - Error message when element is invisible.
  */
 var visibilityOf = async function (element, errorMessage) {
+  // Per https://webdriver.io/docs/api/element/waitForDisplayed, webdriverIO
+  // does not wait for the element to exist in order to execute this command.
+  // So we need to check for it manually. This will also give a better error
+  // message (otherwise the error message just ends up being "cannot read
+  // properties of undefined (reading 'waitForDisplayed')")
+  await presenceOf(element, errorMessage);
   await element.waitForDisplayed({
     timeout: DEFAULT_WAIT_TIME_MSECS,
     timeoutMsg: errorMessage + '\n' + new Error().stack + '\n',


### PR DESCRIPTION
## Overview

1. This PR fixes #20958 partially.
2. This PR does the following: 
     - Improve error message for nonexistent elements, so that there is more information than just "cannot read property waitForDisplayed of undefined"
     - Simplify the CD admin e2e test to not use an image in the exploration that's being translated. This functionality is not actually covered in the CD e2e test so this helps expand our testing coverage a bit as well.
     - Moved some logic that was supposed to be in the CD page to the CD file (it was previously in the CD admin utils file).
3. (For bug-fixing PRs only) The original bug occurred because: waitForDisplayed, according to the [webdriverio docs](https://webdriver.io/docs/api/element/waitForDisplayed/), doesn't check for the presence of an element before executing. This results in it sometimes being called on a null element and giving an unhelpful error message.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This will be determined by the CI runs on this PR.