### PR TITLE
Fix issue #21081: changed drop-down to heading in the question editor.

### DIFF
--- a/core/templates/components/question-directives/questions-list/questions-list.component.html
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.html
@@ -1,6 +1,6 @@
 <div class="question-editor-container">
   <div *ngIf="editorIsOpen" class="question-editor-parent">
-    <mat-card class="oppia-page-card oppia-mobile-collapsible-card">
+    <mat-card class="oppia-page-card oppia-question-editor-page-card oppia-mobile-collapsible-card">
       <div class="difficulty-card-header oppia-mobile-collapsible-card-header" (click)="toggleDifficultyCard()">
         <h3>Difficulty</h3>
         <i class="fa fa-caret-down"
@@ -328,6 +328,10 @@
   }
   .list-group {
     gap: 10px;
+  }
+  .oppia-question-editor-page-card {
+    margin-bottom: 0;
+    margin-top: 0;
   }
   @media screen and (max-width: 768px) {
     .question-editor-container {

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -170,6 +170,10 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
     this.questionStateData = this.question.getStateData();
     this.questionIsBeingUpdated = false;
     this.newQuestionIsBeingCreated = true;
+    this.topicEditorStateService.toggleQuestionEditor(
+      true,
+      this.newQuestionIsBeingCreated
+    );
     this.editorIsOpen = true;
 
     this.skillLinkageModificationsArray = [];

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -63,6 +63,7 @@ import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {QuestionsListService} from 'services/questions-list.service';
 import {QuestionValidationService} from 'services/question-validation.service';
 import {SkillEditorRoutingService} from 'pages/skill-editor-page/services/skill-editor-routing.service';
+import {TopicEditorStateService} from 'pages/topic-editor-page/services/topic-editor-state.service';
 import {UtilsService} from 'services/utils.service';
 import {LoggerService} from 'services/contextual/logger.service';
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
@@ -131,7 +132,8 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
     private skillEditorRoutingService: SkillEditorRoutingService,
     private utilsService: UtilsService,
     private windowDimensionsService: WindowDimensionsService,
-    private windowRef: WindowRef
+    private windowRef: WindowRef,
+    private topicEditorStateService: TopicEditorStateService
   ) {}
 
   createQuestion(): void {
@@ -282,6 +284,7 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
   openQuestionEditor(): void {
     this.questionUndoRedoService.clearChanges();
     this.editorIsOpen = true;
+    this.topicEditorStateService.toggleQuestionEditor(true);
     this.imageLocalStorageService.flushStoredImagesData();
     if (this.newQuestionIsBeingCreated) {
       this.contextService.setImageSaveDestinationToLocalStorage();
@@ -622,6 +625,7 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
         () => {
           this.contextService.resetImageSaveDestination();
           this.editorIsOpen = false;
+          this.topicEditorStateService.toggleQuestionEditor(false);
           this.windowRef.nativeWindow.location.hash = null;
           this.skillEditorRoutingService.questionIsBeingCreated = false;
         },
@@ -685,6 +689,7 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
               this.contextService.resetImageSaveDestination();
               this.saveAndPublishQuestion(commitMessage);
             }
+            this.topicEditorStateService.toggleQuestionEditor(false);
           },
           () => {
             this.questionIsBeingSaved = false;
@@ -749,6 +754,9 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
         this.getQuestionSummariesForOneSkill();
         this.changeDetectorRef.detectChanges();
       })
+    );
+    this.directiveSubscriptions.add(
+      this.topicEditorStateService.onQuestionEditorOpened.subscribe()
     );
 
     this.showDifficultyChoices = false;

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -700,6 +700,7 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
           }
         );
     } else {
+      this.topicEditorStateService.toggleQuestionEditor(false);
       this.contextService.resetImageSaveDestination();
       this.saveAndPublishQuestion(null);
       this.skillEditorRoutingService.creatingNewQuestion(false);

--- a/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.html
+++ b/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.html
@@ -1,6 +1,6 @@
 <div class="question-editor-header-container" *ngIf="questionEditorOpened">
   <mat-card class="oppia-page-card oppia-mobile-collapsible-card question-editor-header">
-    <h3>Editing question for skill: {{ selectedSkillName }}</h3>
+    <h3>{{ getEditorAction() }} question for skill: {{ selectedSkillName }}</h3>
   </mat-card>
 </div>
 <div class="select-skill-dropdown-container" *ngIf="!questionEditorOpened">

--- a/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.html
+++ b/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.html
@@ -1,4 +1,9 @@
-<div class="select-skill-dropdown-container">
+<div class="question-editor-header-container" *ngIf="questionEditorOpened">
+  <mat-card class="oppia-page-card oppia-mobile-collapsible-card question-editor-header">
+    <h3>Editing question for skill: {{ selectedSkillName }}</h3>
+  </mat-card>
+</div>
+<div class="select-skill-dropdown-container" *ngIf="!questionEditorOpened">
   <mat-form-field class="form-field e2e-test-select-skill-dropdown"
                   appearance="fill"
                   *ngIf="allSkillSummaries.length > 0">
@@ -42,6 +47,7 @@
     margin: 0 auto;
     width: 70%;
   }
+  .question-editor-header-container,
   .select-skill-dropdown-container {
     margin: 0 auto;
     width: 70%;
@@ -51,5 +57,13 @@
   }
   .question-list-container {
     margin-top: -30px;
+  }
+  @media screen and (max-width: 768px) {
+    .question-editor-header-container {
+      width: 100%;
+    }
+    .question-editor-header {
+      margin-bottom: 45px;
+    }
   }
 </style>

--- a/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.spec.ts
@@ -32,6 +32,7 @@ import {
 } from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {TopicQuestionsTabComponent} from './topic-questions-tab.component';
+import {QuestionsListComponent} from '../../../components/question-directives/questions-list/questions-list.component';
 import {TopicEditorStateService} from '../services/topic-editor-state.service';
 import {Topic} from 'domain/topic/topic-object.model';
 
@@ -101,6 +102,7 @@ class MockTopicsAndSkillsDashboardBackendApiService {
 
 describe('Topic questions tab', () => {
   let component: TopicQuestionsTabComponent;
+  let questionsListComponent: QuestionsListComponent;
   let fixture: ComponentFixture<TopicQuestionsTabComponent>;
   let topicEditorStateService: TopicEditorStateService;
   let focusManagerService: FocusManagerService;
@@ -113,7 +115,7 @@ describe('Topic questions tab', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      declarations: [TopicQuestionsTabComponent],
+      declarations: [TopicQuestionsTabComponent, QuestionsListComponent],
       providers: [
         TopicsAndSkillsDashboardBackendApiService,
         {
@@ -128,6 +130,10 @@ describe('Topic questions tab', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TopicQuestionsTabComponent);
     component = fixture.componentInstance;
+    const questionsListFixture = TestBed.createComponent(
+      QuestionsListComponent
+    );
+    questionsListComponent = questionsListFixture.componentInstance;
     qls = TestBed.inject(QuestionsListService);
     focusManagerService = TestBed.inject(FocusManagerService);
     topicEditorStateService = TestBed.inject(TopicEditorStateService);
@@ -267,5 +273,30 @@ describe('Topic questions tab', () => {
     expect(component.allSkillSummaries).toEqual(allSkillSummaries);
     expect(component.topicRights).toEqual(topicRights);
     expect(component.topic).toBe(topic);
+  });
+
+  describe('should change drop-down to a heading when the questionEditor is opened', () => {
+    it('should return "Creating new" when creating a new question', () => {
+      spyOn(questionsListComponent, 'createQuestion').and.callThrough();
+      spyOn(topicEditorStateService, 'toggleQuestionEditor').and.callThrough();
+
+      questionsListComponent.createQuestion();
+      expect(topicEditorStateService.toggleQuestionEditor).toHaveBeenCalledWith(
+        true,
+        true
+      );
+      expect(component.getEditorAction()).toBe('Creating new');
+    });
+
+    it('should return "Editing" when editing a question', () => {
+      spyOn(questionsListComponent, 'openQuestionEditor').and.callThrough();
+      spyOn(topicEditorStateService, 'toggleQuestionEditor').and.callThrough();
+
+      questionsListComponent.openQuestionEditor();
+      expect(topicEditorStateService.toggleQuestionEditor).toHaveBeenCalledWith(
+        true
+      );
+      expect(component.getEditorAction()).toBe('Editing');
+    });
   });
 });

--- a/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.ts
@@ -45,6 +45,7 @@ export class TopicQuestionsTabComponent
   allSkillSummaries!: ShortSkillSummary[];
   canEditQuestion!: boolean;
   questionEditorOpened: boolean = false;
+  newQuestionEditor: boolean = false;
   selectedSkillName!: string;
   selectedSkillId!: string;
   getSkillsCategorizedByTopics!: CategorizedSkills;
@@ -85,10 +86,15 @@ export class TopicQuestionsTabComponent
     this.canEditQuestion = this.topicRights.canEditTopic();
     this.questionEditorOpened =
       this.topicEditorStateService.isQuestionEditorOpened();
+    this.newQuestionEditor = this.topicEditorStateService.isNewQuestionEditor();
     this.selectedSkillName = this.topicEditorStateService.getSelectedSkillName(
       this.selectedSkillId,
       this.allSkillSummaries
     );
+  }
+
+  getEditorAction(): string {
+    return this.newQuestionEditor ? 'Creating new' : 'Editing';
   }
 
   reinitializeQuestionsList(skillId: string): void {

--- a/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/questions-tab/topic-questions-tab.component.ts
@@ -44,6 +44,8 @@ export class TopicQuestionsTabComponent
   skillIdToRubricsObject!: object;
   allSkillSummaries!: ShortSkillSummary[];
   canEditQuestion!: boolean;
+  questionEditorOpened: boolean = false;
+  selectedSkillName!: string;
   selectedSkillId!: string;
   getSkillsCategorizedByTopics!: CategorizedSkills;
   getUntriagedSkillSummaries!: SkillSummary[];
@@ -81,6 +83,12 @@ export class TopicQuestionsTabComponent
         this.getUntriagedSkillSummaries = response.untriagedSkillSummaries;
       });
     this.canEditQuestion = this.topicRights.canEditTopic();
+    this.questionEditorOpened =
+      this.topicEditorStateService.isQuestionEditorOpened();
+    this.selectedSkillName = this.topicEditorStateService.getSelectedSkillName(
+      this.selectedSkillId,
+      this.allSkillSummaries
+    );
   }
 
   reinitializeQuestionsList(skillId: string): void {
@@ -108,11 +116,17 @@ export class TopicQuestionsTabComponent
         this._initTab()
       )
     );
+    this.directiveSubscriptions.add(
+      this.topicEditorStateService.onQuestionEditorOpened.subscribe(() =>
+        this._initTab()
+      )
+    );
     this._initTab();
   }
 
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
+    this.topicEditorStateService.toggleQuestionEditor(false);
   }
 }
 

--- a/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
+++ b/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
@@ -48,6 +48,7 @@ import {
 } from 'domain/editor/undo_redo/change.model';
 import {LoaderService} from 'services/loader.service';
 import {SubtopicPageContents} from 'domain/topic/subtopic-page-contents.model';
+import {ShortSkillSummary} from 'domain/skill/short-skill-summary.model';
 
 interface GroupedSkillSummaryDict {
   current: SkillSummaryBackendDict[];
@@ -87,6 +88,7 @@ export class TopicEditorStateService {
   private _classroomUrlFragment: string | null = null;
   private _curriculumAdminUsernames: string[] = [];
   private _classroomName: string | null = null;
+  private _questionEditorOpened: boolean = false;
   private _storySummariesInitializedEventEmitter: EventEmitter<void> =
     new EventEmitter();
 
@@ -98,6 +100,9 @@ export class TopicEditorStateService {
 
   private _topicReinitializedEventEmitter: EventEmitter<void> =
     new EventEmitter();
+
+  private _questionEditorOpenedEventEmitter: EventEmitter<boolean> =
+    new EventEmitter<boolean>();
 
   constructor(
     private alertsService: AlertsService,
@@ -317,6 +322,10 @@ export class TopicEditorStateService {
     );
   }
 
+  isQuestionEditorOpened(): boolean {
+    return this._questionEditorOpened;
+  }
+
   getGroupedSkillSummaries(): object {
     return cloneDeep(this._groupedSkillSummaries);
   }
@@ -464,6 +473,11 @@ export class TopicEditorStateService {
     }
   }
 
+  toggleQuestionEditor(editorOpened: boolean): void {
+    this._questionEditorOpened = editorOpened;
+    this._questionEditorOpenedEventEmitter.emit(this._questionEditorOpened);
+  }
+
   deleteSubtopicPage(topicId: string, subtopicId: number): void {
     let subtopicPageId = this._getSubtopicPageId(topicId, subtopicId);
     let index = this._getSubtopicPageIndex(subtopicPageId);
@@ -605,6 +619,10 @@ export class TopicEditorStateService {
     return this._topicReinitializedEventEmitter;
   }
 
+  get onQuestionEditorOpened(): EventEmitter<boolean> {
+    return this._questionEditorOpenedEventEmitter;
+  }
+
   /**
    * Returns the classroom url fragment if the topic is assigned to any
    * classroom, else null.
@@ -623,6 +641,22 @@ export class TopicEditorStateService {
 
   getCurriculumAdminUsernames(): string[] {
     return this._curriculumAdminUsernames;
+  }
+
+  /**
+   * Retrieves the name of the skill associated with the given skill ID,
+   * typically the skill whose question is currently being edited.
+   * The skill description will always be present in allSkillSummaries,
+   * but to ensure robustness, the skill ID will be displayed in case of a failure.
+   */
+  getSelectedSkillName(
+    skillId: string,
+    allSkillSummaries: ShortSkillSummary[]
+  ): string {
+    return (
+      allSkillSummaries?.find(skill => skill.id === skillId)?.description ||
+      skillId
+    );
   }
 
   /**

--- a/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
+++ b/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
@@ -89,6 +89,7 @@ export class TopicEditorStateService {
   private _curriculumAdminUsernames: string[] = [];
   private _classroomName: string | null = null;
   private _questionEditorOpened: boolean = false;
+  private _newQuestionEditor: boolean = false;
   private _storySummariesInitializedEventEmitter: EventEmitter<void> =
     new EventEmitter();
 
@@ -326,6 +327,10 @@ export class TopicEditorStateService {
     return this._questionEditorOpened;
   }
 
+  isNewQuestionEditor(): boolean {
+    return this._newQuestionEditor;
+  }
+
   getGroupedSkillSummaries(): object {
     return cloneDeep(this._groupedSkillSummaries);
   }
@@ -473,9 +478,26 @@ export class TopicEditorStateService {
     }
   }
 
-  toggleQuestionEditor(editorOpened: boolean): void {
-    this._questionEditorOpened = editorOpened;
-    this._questionEditorOpenedEventEmitter.emit(this._questionEditorOpened);
+  /**
+   * When the editor is opened (editorOpened is true),
+   * assign the value of newQuestion to _newQuestionEditor,
+   * and set _questionEditorOpened to true.
+   * When the editor is closed (editorOpened is false),
+   * both flags are set to false.
+   */
+  toggleQuestionEditor(
+    editorOpened: boolean,
+    newQuestion: boolean = false
+  ): void {
+    if (editorOpened) {
+      this._newQuestionEditor = newQuestion;
+      this._questionEditorOpened = true;
+    } else {
+      this._newQuestionEditor = false;
+      this._questionEditorOpened = false;
+    }
+
+    this._questionEditorOpenedEventEmitter.emit();
   }
 
   deleteSubtopicPage(topicId: string, subtopicId: number): void {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. Fix #21081.
2. **This PR does the following:** Toggle between drop-down and heading when a new question is being added to a skill or while a question is being edited. Both action have different heading for more clear explanation.
4. **The original bug occurred because:** There was no conditonal rending over the drop-down element.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

[Screen Recording 2024-10-20 at 12.45.07 AM.webm](https://github.com/user-attachments/assets/a7fa4b58-8491-4304-9713-a6d41938e862)

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
<img width="427" alt="Screenshot 2024-10-20 at 12 48 45 AM" src="https://github.com/user-attachments/assets/969f8877-4dff-4678-8051-7b53c8284e21">
<img width="425" alt="Screenshot 2024-10-20 at 12 48 57 AM" src="https://github.com/user-attachments/assets/73d900d2-e467-4b74-9269-90ffb5f33a11">

#### Proof of changes in Arabic language
<img width="1470" alt="Screenshot 2024-10-20 at 12 50 52 AM" src="https://github.com/user-attachments/assets/d226ed27-78cd-4fb4-8d9c-15f9c115147d">

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
