### PR TITLE
Fix #20958: Waiting for element to appear before checking for its existance

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
@@ -46,7 +46,7 @@
     </div>
   </div>
   <div class="oppia-contributions-show-review-side-navbar-container" >
-    <div class="oppia-contributions-side-navbar-part" *ngIf="reviewTabs.length > 0" tabindex="0">
+    <div class="oppia-contributions-side-navbar-part e2e-test-available-task-label" *ngIf="reviewTabs.length > 0" tabindex="0">
       <div class="oppia-contributions-navbar-items-list" navbar-label="Available Tasks" aria-label="Available tasks">
         <div class="oppia-contributions-navbar-item e2e-test-review-buttons" *ngFor="let tab of reviewTabs">
           <button class="oppia-contributions-navbar-button"

--- a/core/tests/webdriverio_desktop/contributorAdminDashboard.js
+++ b/core/tests/webdriverio_desktop/contributorAdminDashboard.js
@@ -206,6 +206,7 @@ describe('Contributor Admin Dashboard', function () {
     // Accept suggestion as user1.
     await users.login(USER_EMAILS[1]);
     await contributorDashboardPage.get();
+    await contributorDashboardPage.waitForAvailableTaskLabelToAppear();
     await contributorDashboardPage.selectTranslationReviewButton();
     await contributorDashboardPage.waitForOpportunitiesToLoad();
     await contributorDashboardPage.selectReviewLanguage('shqip (Albanian)');

--- a/core/tests/webdriverio_utils/ContributorDashboardPage.js
+++ b/core/tests/webdriverio_utils/ContributorDashboardPage.js
@@ -26,6 +26,7 @@ var ContributorDashboardPage = function () {
   var navigateToTranslateTextTabButton = $('.e2e-test-translateTextTab');
   var submitQuestionTabButton = $('.e2e-test-submitQuestionTab');
   var myContributionTabButton = $('.e2e-test-myContributionTab');
+  var availableTaskLabel = $('e2e-test-available-task-label');
   var opportunityLoadingPlaceholder = $(
     '.e2e-test-opportunity-loading-placeholder'
   );
@@ -339,6 +340,13 @@ var ContributorDashboardPage = function () {
   this.navigateToMyContributionTab = async function () {
     await action.click('My Contribution tab button', myContributionTabButton);
     await this.waitForOpportunitiesToLoad();
+  };
+
+  this.waitForAvailableTaskLabelToAppear = async function () {
+    await waitFor.visibilityOf(
+      availableTaskLabel,
+      'Opportunity taking too long to appear.'
+    );
   };
 
   this.selectTranslationReviewButton = async function () {

--- a/core/tests/webdriverio_utils/ContributorDashboardPage.js
+++ b/core/tests/webdriverio_utils/ContributorDashboardPage.js
@@ -26,7 +26,7 @@ var ContributorDashboardPage = function () {
   var navigateToTranslateTextTabButton = $('.e2e-test-translateTextTab');
   var submitQuestionTabButton = $('.e2e-test-submitQuestionTab');
   var myContributionTabButton = $('.e2e-test-myContributionTab');
-  var availableTaskLabel = $('e2e-test-available-task-label');
+  var availableTaskLabel = $('.e2e-test-available-task-label');
   var opportunityLoadingPlaceholder = $(
     '.e2e-test-opportunity-loading-placeholder'
   );


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20958.
2. This PR does the following: This PR adds wait condition to `core/tests/webdriverio_utils/ContributorDashboardPage.js` for the translation review button before checking for its existence. On `/contributor-dashboard` page, sometimes translation review button might take few extra time units to load.
![Screenshot (237)](https://github.com/user-attachments/assets/bea62ac9-25a9-4fdb-8772-df7b24076992)


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
