### PR TITLE
Fix part of #18384: Refactored card-display & tab headings and added minor fixes

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -925,6 +925,7 @@
     "I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION": "Recommended for you",
     "I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION": "Lesson you saved for later",
     "I18N_LEARNER_DASHBOARD_HOME_SECTION": "Home",
+    "I18N_LEARNER_DASHBOARD_HOME_SECTION_HEADING": "Welcome, <[username]>!",
     "I18N_LEARNER_DASHBOARD_INCOMPLETE": "Incomplete",
     "I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION": "In Progress",
     "I18N_LEARNER_DASHBOARD_INTRO_MESSAGE_PART_ONE": "It looks like you haven't tried any of our explorations yet.",

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -925,6 +925,7 @@
 	"I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION": "Text for the recommended section in the learner dashboard",
 	"I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION": "Text for the saved lessons section in the learner dashboard",
 	"I18N_LEARNER_DASHBOARD_HOME_SECTION": "Text for the home section in the learner dashboard.",
+	"I18N_LEARNER_DASHBOARD_HOME_SECTION_HEADING": "Heading text for the home tab in the learner dashboard",
 	"I18N_LEARNER_DASHBOARD_INCOMPLETE": "Title of the section that shows incomplete explorations in the learner dashboard.",
 	"I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION": "Text for the incomplete section in the learner dashboard.",
 	"I18N_LEARNER_DASHBOARD_INTRO_MESSAGE_PART_ONE": "First part of the introductory message that appears on the learner dashboard when there is no activity.",

--- a/core/templates/components/summary-tile/learner-topic-summary-tile.component.html
+++ b/core/templates/components/summary-tile/learner-topic-summary-tile.component.html
@@ -25,7 +25,7 @@
   </mat-card>
   <a *ngIf="redesignFeatureFlag" class="d-flex flex-column flex-shrink-0 oppia-class-card text-decoration-none" [href]="getTopicLink()" target="{{ openInNewWindow ? '_blank' : '_self' }}">
     <div class="oppia-class-card-img rounded-top" [ngStyle]="{'background-color': thumbnailBgColor}">
-      <img alt="" class="oppia-thumbnail-image" [src]="thumbnailUrl">
+      <img alt="" class="h-100 oppia-thumbnail-image" [src]="thumbnailUrl">
     </div>
     <div class="oppia-class-card-info">
       <p class="mb-2 oppia-class-card-title e2e-test-learner-topic-summary-tile-title">

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex flex-column h-100 mb-4 w-100" [ngStyle]="{'max-width': displayMaxWidth}">
   <div class="d-flex justify-content-between">
     <p class="card-display-heading"> {{ headingI18n | translate }} </p>
-    <div class="card-display-button-container" *ngIf="(numCards > 1) && ((numCards - 1) * cardWidth + (cardWidth - 32) > cards.offsetWidth) && (controlType.includes('arrows'))">
+    <div class="card-display-button-container" *ngIf="(numCards > 1) && ((numCards - 1) * cardWidth + (cardWidth - 32) > cards.offsetWidth) && (controlType.includes('arrow'))">
       <button [disabled]="currentShift === 0" class="px-0 card-display-button" (click)="moveCard(currentShift - 1)">
         <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'right' : 'left')"></span>
       </button>

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
@@ -1,11 +1,11 @@
 <div class="d-flex flex-column h-100 mb-4 w-100" [ngStyle]="{'max-width': displayMaxWidth}">
   <div class="d-flex justify-content-between">
     <p class="card-display-heading"> {{ headingI18n | translate }} </p>
-    <div class="card-display-button-container" *ngIf="arrowButtonVisibility">
-      <button [disabled]="currentShift === 0" class="px-0 card-display-button" (click)="moveCard(currentShift - 1)">
+    <div class="card-display-arrow-button-container" *ngIf="arrowButtonVisibility">
+      <button [disabled]="currentShift === 0" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift - 1)">
         <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'right' : 'left')"></span>
       </button>
-      <button [disabled]="currentShift === getMaxShifts(cards.offsetWidth)" class="px-0 card-display-button" (click)="moveCard(currentShift + 1)">
+      <button [disabled]="currentShift === getMaxShifts(cards.offsetWidth)" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift + 1)">
         <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'left' : 'right')"></span>
       </button>
     </div>
@@ -24,7 +24,7 @@
     overflow: hidden;
   }
 
-  .card-display-button {
+  .card-display-arrow-button {
     align-items: center;
     background-color: #00645c;
     border: none;
@@ -37,11 +37,11 @@
     width: 24px;
   }
 
-  .card-display-button:disabled {
+  .card-display-arrow-button:disabled {
     background-color: #667085;
   }
 
-  .card-display-button:not(:disabled):hover {
+  .card-display-arrow-button:not(:disabled):hover {
     background-color: #429488;
   }
 
@@ -73,7 +73,7 @@
     margin-bottom: 0;
   }
 
-  .card-display-button-container {
+  .card-display-arrow-button-container {
     display: flex;
     gap: 0 5px;
   }

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex flex-column h-100 mb-4 w-100" [ngStyle]="{'max-width': displayMaxWidth}">
   <div class="d-flex justify-content-between">
     <p class="card-display-heading"> {{ headingI18n | translate }} </p>
-    <div class="card-display-button-container" *ngIf="(numCards > 1) && ((numCards - 1) * cardWidth + (cardWidth - 32) > cards.offsetWidth) && (controlType.includes('arrow'))">
+    <div class="card-display-button-container" *ngIf="arrowButtonVisibility">
       <button [disabled]="currentShift === 0" class="px-0 card-display-button" (click)="moveCard(currentShift - 1)">
         <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'right' : 'left')"></span>
       </button>

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
@@ -1,7 +1,7 @@
-<div class="d-flex flex-column h-100 mb-4 w-100" [ngStyle]="{'max-width': (tabType === 'homeFull' || tabType.includes('progress') ? '100%' : 'fit-content')}">
+<div class="d-flex flex-column h-100 mb-4 w-100" [ngStyle]="{'max-width': displayMaxWidth}">
   <div class="d-flex justify-content-between">
     <p class="card-display-heading"> {{ headingI18n | translate }} </p>
-    <div class="card-display-button-container" *ngIf="(numCards > 1) && ((numCards - 1) * cardWidth + (cardWidth - 32) > cards.offsetWidth) && (tabType.includes('home'))">
+    <div class="card-display-button-container" *ngIf="(numCards > 1) && ((numCards - 1) * cardWidth + (cardWidth - 32) > cards.offsetWidth) && (controlType.includes('arrows'))">
       <button [disabled]="currentShift === 0" class="px-0 card-display-button" (click)="moveCard(currentShift - 1)">
         <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'right' : 'left')"></span>
       </button>

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
@@ -392,7 +392,7 @@ describe('CardDisplayComponent', () => {
   it('should return false for isArrowButtonVisible if controlType is arrow', () => {
     component.controlType = 'arrow';
     fixture.detectChanges();
-    //expect(component.isArrowButtonVisible()).toBeTrue();
+    expect(component.isArrowButtonVisible()).toBeTrue();
   });
 
   it('should return false for isArrowButtonVisible if controlType is arrow and all the cards fit', () => {
@@ -401,12 +401,12 @@ describe('CardDisplayComponent', () => {
     component.numCards = 2;
     fixture.detectChanges();
 
-    //expect(component.isArrowButtonVisible()).toBeFalse();
+    expect(component.isArrowButtonVisible()).toBeFalse();
   });
 
   it('should return true for isArrowButtonVisible if controlType is arrow and all the cards do not fit', () => {
     component.controlType = 'arrow';
-    //expect(component.isArrowButtonVisible()).toBeTrue();
+    expect(component.isArrowButtonVisible()).toBeTrue();
   });
 
   it('should resize and be able to fit number of cards, hiding arrow buttons', () => {
@@ -414,31 +414,31 @@ describe('CardDisplayComponent', () => {
     component.numCards = 3;
     offsetWidthGetterSpy.and.returnValue(1000);
 
-    //spyOn(component, 'isArrowButtonVisible').and.callThrough();
+    spyOn(component, 'isArrowButtonVisible').and.callThrough();
     spyOn(component, 'onResize').and.callThrough();
     window.dispatchEvent(new Event('resize'));
     fixture.detectChanges();
 
     expect(component.onResize).toHaveBeenCalled();
-    //expect(component.isArrowButtonVisible).toHaveBeenCalled();
-    //expect(component.arrowButtonVisibility).toBeFalse();
+    expect(component.isArrowButtonVisible).toHaveBeenCalled();
+    expect(component.arrowButtonVisibility).toBeFalse();
   });
 
   it('should resize to smaller screen and be no longer able to fit cards, showing arrow buttons', () => {
     component.controlType = 'arrow';
     component.numCards = 3;
-    //component.arrowButtonVisibility = false;
+    component.arrowButtonVisibility = false;
     offsetWidthGetterSpy.and.returnValue(1000);
     fixture.detectChanges();
 
     offsetWidthGetterSpy.and.returnValue(500);
-    //spyOn(component, 'isArrowButtonVisible').and.callThrough();
+    spyOn(component, 'isArrowButtonVisible').and.callThrough();
     spyOn(component, 'onResize').and.callThrough();
     window.dispatchEvent(new Event('resize'));
     fixture.detectChanges();
 
     expect(component.onResize).toHaveBeenCalled();
-    //expect(component.isArrowButtonVisible).toHaveBeenCalled();
-    //expect(component.arrowButtonVisibility).toBeTrue();
+    expect(component.isArrowButtonVisible).toHaveBeenCalled();
+    expect(component.arrowButtonVisibility).toBeTrue();
   });
 });

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
@@ -388,4 +388,57 @@ describe('CardDisplayComponent', () => {
     expect(component.isToggleButtonVisible).toHaveBeenCalled();
     expect(component.toggleButtonVisibility).toBeTrue();
   });
+
+  it('should return false for isArrowButtonVisible if controlType is arrow', () => {
+    component.controlType = 'arrow';
+    fixture.detectChanges();
+    //expect(component.isArrowButtonVisible()).toBeTrue();
+  });
+
+  it('should return false for isArrowButtonVisible if controlType is arrow and all the cards fit', () => {
+    component.controlType = 'arrow';
+    offsetWidthGetterSpy.and.returnValue(600);
+    component.numCards = 2;
+    fixture.detectChanges();
+
+    //expect(component.isArrowButtonVisible()).toBeFalse();
+  });
+
+  it('should return true for isArrowButtonVisible if controlType is arrow and all the cards do not fit', () => {
+    component.controlType = 'arrow';
+    //expect(component.isArrowButtonVisible()).toBeTrue();
+  });
+
+  it('should resize and be able to fit number of cards, hiding arrow buttons', () => {
+    component.controlType = 'arrow';
+    component.numCards = 3;
+    offsetWidthGetterSpy.and.returnValue(1000);
+
+    //spyOn(component, 'isArrowButtonVisible').and.callThrough();
+    spyOn(component, 'onResize').and.callThrough();
+    window.dispatchEvent(new Event('resize'));
+    fixture.detectChanges();
+
+    expect(component.onResize).toHaveBeenCalled();
+    //expect(component.isArrowButtonVisible).toHaveBeenCalled();
+    //expect(component.arrowButtonVisibility).toBeFalse();
+  });
+
+  it('should resize to smaller screen and be no longer able to fit cards, showing arrow buttons', () => {
+    component.controlType = 'arrow';
+    component.numCards = 3;
+    //component.arrowButtonVisibility = false;
+    offsetWidthGetterSpy.and.returnValue(1000);
+    fixture.detectChanges();
+
+    offsetWidthGetterSpy.and.returnValue(500);
+    //spyOn(component, 'isArrowButtonVisible').and.callThrough();
+    spyOn(component, 'onResize').and.callThrough();
+    window.dispatchEvent(new Event('resize'));
+    fixture.detectChanges();
+
+    expect(component.onResize).toHaveBeenCalled();
+    //expect(component.isArrowButtonVisible).toHaveBeenCalled();
+    //expect(component.arrowButtonVisibility).toBeTrue();
+  });
 });

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
@@ -312,8 +312,8 @@ describe('CardDisplayComponent', () => {
     });
   });
 
-  it('should return empty string for getVisibility if controlType is arrows', () => {
-    component.controlType = 'arrows';
+  it('should return empty string for getVisibility if controlType is arrow', () => {
+    component.controlType = 'arrow';
     fixture.detectChanges();
     expect(component.getVisibility()).toEqual('');
   });
@@ -340,8 +340,8 @@ describe('CardDisplayComponent', () => {
     });
   });
 
-  it('should return false for isToggleButtonVisible if controlType is arrows', () => {
-    component.controlType = 'arrows';
+  it('should return false for isToggleButtonVisible if controlType is arrow', () => {
+    component.controlType = 'arrow';
     fixture.detectChanges();
     expect(component.isToggleButtonVisible()).toBeFalse();
   });

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
@@ -61,7 +61,7 @@ describe('CardDisplayComponent', () => {
     TestBed.inject(TranslateService);
 
     component.numCards = 5;
-    component.tabType = 'progress';
+    component.controlType = 'view';
     component.headingI18n = 'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION';
     component.isLanguageRTL = false;
     component.toggleButtonVisibility = false;
@@ -312,17 +312,17 @@ describe('CardDisplayComponent', () => {
     });
   });
 
-  it('should return empty string for getVisibility if tabType is not progress', () => {
-    component.tabType = 'home';
+  it('should return empty string for getVisibility if controlType is arrows', () => {
+    component.controlType = 'arrows';
     fixture.detectChanges();
     expect(component.getVisibility()).toEqual('');
   });
 
-  it('should return hidden class for getVisibility if tabType is progress', () => {
+  it('should return hidden class for getVisibility if controlType is view', () => {
     expect(component.getVisibility()).toEqual('card-display-content-hidden');
   });
 
-  it('should return shown class for getVisibility after toggling if tabType is progress', () => {
+  it('should return shown class for getVisibility after toggling if controlType is view', () => {
     expect(component.currentToggleState).toBeFalse();
 
     fixture.whenRenderingDone().then(() => {
@@ -340,13 +340,13 @@ describe('CardDisplayComponent', () => {
     });
   });
 
-  it('should return false for isToggleButtonVisible if tabType is not progress', () => {
-    component.tabType = 'home';
+  it('should return false for isToggleButtonVisible if controlType is arrows', () => {
+    component.controlType = 'arrows';
     fixture.detectChanges();
     expect(component.isToggleButtonVisible()).toBeFalse();
   });
 
-  it('should return false for isToggleButtonVisible if tabType is progress and all the cards fit', () => {
+  it('should return false for isToggleButtonVisible if controlType is view and all the cards fit', () => {
     offsetWidthGetterSpy.and.returnValue(600);
     component.numCards = 2;
     fixture.detectChanges();
@@ -354,7 +354,7 @@ describe('CardDisplayComponent', () => {
     expect(component.isToggleButtonVisible()).toBeFalse();
   });
 
-  it('should return true for isToggleButtonVisible if tabType is progress and all the cards do not fit', () => {
+  it('should return true for isToggleButtonVisible if controlType is view and all the cards do not fit', () => {
     expect(component.isToggleButtonVisible()).toBeTrue();
   });
 

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.spec.ts
@@ -61,7 +61,7 @@ describe('CardDisplayComponent', () => {
     TestBed.inject(TranslateService);
 
     component.numCards = 5;
-    component.controlType = 'view';
+    component.controlType = 'toggle';
     component.headingI18n = 'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION';
     component.isLanguageRTL = false;
     component.toggleButtonVisibility = false;
@@ -318,11 +318,11 @@ describe('CardDisplayComponent', () => {
     expect(component.getVisibility()).toEqual('');
   });
 
-  it('should return hidden class for getVisibility if controlType is view', () => {
+  it('should return hidden class for getVisibility if controlType is toggle', () => {
     expect(component.getVisibility()).toEqual('card-display-content-hidden');
   });
 
-  it('should return shown class for getVisibility after toggling if controlType is view', () => {
+  it('should return shown class for getVisibility after toggling if controlType is toggle', () => {
     expect(component.currentToggleState).toBeFalse();
 
     fixture.whenRenderingDone().then(() => {
@@ -346,7 +346,7 @@ describe('CardDisplayComponent', () => {
     expect(component.isToggleButtonVisible()).toBeFalse();
   });
 
-  it('should return false for isToggleButtonVisible if controlType is view and all the cards fit', () => {
+  it('should return false for isToggleButtonVisible if controlType is toggle and all the cards fit', () => {
     offsetWidthGetterSpy.and.returnValue(600);
     component.numCards = 2;
     fixture.detectChanges();
@@ -354,7 +354,7 @@ describe('CardDisplayComponent', () => {
     expect(component.isToggleButtonVisible()).toBeFalse();
   });
 
-  it('should return true for isToggleButtonVisible if controlType is view and all the cards do not fit', () => {
+  it('should return true for isToggleButtonVisible if controlType is toggle and all the cards do not fit', () => {
     expect(component.isToggleButtonVisible()).toBeTrue();
   });
 

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
@@ -113,7 +113,7 @@ export class CardDisplayComponent implements AfterContentInit {
   }
 
   getVisibility(): string {
-    if (!this.tabType.includes('progress')) {
+    if (this.controlType === 'arrows') {
       return '';
     }
     return this.currentToggleState
@@ -122,7 +122,7 @@ export class CardDisplayComponent implements AfterContentInit {
   }
 
   isToggleButtonVisible(): boolean {
-    if (this.tabType.includes('home')) {
+    if (this.controlType === 'arrows') {
       return false;
     }
 

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
@@ -45,6 +45,7 @@ export class CardDisplayComponent implements AfterContentInit {
   isLanguageRTL: boolean = false;
   currentToggleState: boolean = false;
   toggleButtonVisibility: boolean = false;
+  arrowButtonVisibility: boolean = false;
 
   constructor(
     private I18nLanguageCodeService: I18nLanguageCodeService,
@@ -58,12 +59,14 @@ export class CardDisplayComponent implements AfterContentInit {
   ngAfterContentInit(): void {
     this.ngZone.onStable.subscribe(() => {
       this.toggleButtonVisibility = this.isToggleButtonVisible();
+      this.arrowButtonVisibility = this.isArrowButtonVisible();
     });
   }
 
   @HostListener('window:resize', ['$event'])
   onResize(): void {
     this.toggleButtonVisibility = this.isToggleButtonVisible();
+    this.arrowButtonVisibility = this.isArrowButtonVisible();
     if (!this.toggleButtonVisibility) {
       this.currentToggleState = false;
     }
@@ -129,6 +132,20 @@ export class CardDisplayComponent implements AfterContentInit {
       this.cards &&
       this.cards.nativeElement &&
       this.numCards * this.cardWidth - 16 > this.cards.nativeElement.offsetWidth
+    );
+  }
+
+  isArrowButtonVisible(): boolean {
+    if (this.controlType === 'toggle') {
+      return false;
+    }
+
+    return (
+      this.cards &&
+      this.cards.nativeElement &&
+      this.numCards > 1 &&
+      (this.numCards - 1) * this.cardWidth + (this.cardWidth - 32) >
+        this.cards.nativeElement.offsetWidth
     );
   }
 }

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
@@ -33,6 +33,8 @@ import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 export class CardDisplayComponent implements AfterContentInit {
   @Input() headingI18n!: string;
   @Input() numCards!: number;
+  @Input() controlType: string = 'arrows';
+  @Input() displayMaxWidth: string = '100%';
   @Input() tabType!: string;
   @Input() cardWidth: number = 232;
 

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
@@ -35,7 +35,6 @@ export class CardDisplayComponent implements AfterContentInit {
   @Input() numCards!: number;
   @Input() controlType: string = 'arrows';
   @Input() displayMaxWidth: string = '100%';
-  @Input() tabType!: string;
   @Input() cardWidth: number = 232;
 
   @ViewChild('cards', {static: false}) cards!: ElementRef;

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
@@ -33,7 +33,7 @@ import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 export class CardDisplayComponent implements AfterContentInit {
   @Input() headingI18n!: string;
   @Input() numCards!: number;
-  @Input() controlType: string = 'arrows';
+  @Input() controlType: string = 'arrow';
   @Input() displayMaxWidth: string = '100%';
   @Input() cardWidth: number = 232;
 
@@ -112,7 +112,7 @@ export class CardDisplayComponent implements AfterContentInit {
   }
 
   getVisibility(): string {
-    if (this.controlType === 'arrows') {
+    if (this.controlType === 'arrow') {
       return '';
     }
     return this.currentToggleState
@@ -121,7 +121,7 @@ export class CardDisplayComponent implements AfterContentInit {
   }
 
   isToggleButtonVisible(): boolean {
-    if (this.controlType === 'arrows') {
+    if (this.controlType === 'arrow') {
       return false;
     }
 

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -401,13 +401,13 @@
       <div tabindex="0" class="oppia-learner-dash-section">
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>
         <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
-          <oppia-card-display *ngIf="totalIncompleteLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalIncompleteLessonsList.length" [controlType]="'view'" [tabType]="'progress'">
+          <oppia-card-display *ngIf="totalIncompleteLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalIncompleteLessonsList.length" [controlType]="'view'">
             <ng-container *ngFor="let summaryTile of displayIncompleteLessonsList">
               <lesson-card [story]="summaryTile"> </lesson-card>
             </ng-container>
           </oppia-card-display>
            <!--TODO(#18384): Find max number of skill cards-->
-          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="partialTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'" [tabType]="'progress'">
+          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="partialTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'">
             <ng-container *ngFor="let topicObj of partialTopicMastery">
               <ng-container *ngFor="let subtopic of topicObj.topic.subtopics; index as i">
                 <oppia-skill-card [topic]="topicObj.topic" [progress]="topicObj.progress[i]" [subtopic]="subtopic"></oppia-skill-card>
@@ -418,13 +418,13 @@
       </div>
       <div tabindex="0" class="oppia-learner-dash-section e2e-test-completed-community-lessons-section w-100" *ngIf="totalCompletedLessonsList.length !== 0 || learntTopicsList.length !== 0">
         <p class="oppia-learner-dash-section-heading"> {{ 'I18N_LEARNER_DASHBOARD_COMPLETED_SECTION' | translate }} </p>
-        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'view'" [tabType]="'progress'">
+        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'view'">
           <ng-container *ngFor="let summaryTile of displayCompletedLessonsList">
             <lesson-card [story]="summaryTile" [isCommunityLessonComplete]="true"> </lesson-card>
           </ng-container>
         </oppia-card-display>
          <!--TODO(#18384): Find max number of skill cards-->
-        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="learntTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'" [tabType]="'progress'">
+        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="learntTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'">
           <ng-container *ngFor="let topicObj of learntTopicMastery">
             <ng-container *ngFor="let subtopic of topicObj.topic.subtopics; index as i">
               <oppia-skill-card [topic]="topicObj.topic" [progress]="topicObj.progress[i]" [subtopic]="subtopic"></oppia-skill-card>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -401,13 +401,13 @@
       <div tabindex="0" class="oppia-learner-dash-section">
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>
         <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
-          <oppia-card-display *ngIf="totalIncompleteLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalIncompleteLessonsList.length" [controlType]="'view'">
+          <oppia-card-display *ngIf="totalIncompleteLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalIncompleteLessonsList.length" [controlType]="'toggle'">
             <ng-container *ngFor="let summaryTile of displayIncompleteLessonsList">
               <lesson-card [story]="summaryTile"> </lesson-card>
             </ng-container>
           </oppia-card-display>
            <!--TODO(#18384): Find max number of skill cards-->
-          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="partialTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'">
+          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="partialTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'toggle'">
             <ng-container *ngFor="let topicObj of partialTopicMastery">
               <ng-container *ngFor="let subtopic of topicObj.topic.subtopics; index as i">
                 <oppia-skill-card [topic]="topicObj.topic" [progress]="topicObj.progress[i]" [subtopic]="subtopic"></oppia-skill-card>
@@ -418,13 +418,13 @@
       </div>
       <div tabindex="0" class="oppia-learner-dash-section e2e-test-completed-community-lessons-section w-100" *ngIf="totalCompletedLessonsList.length !== 0 || learntTopicsList.length !== 0">
         <p class="oppia-learner-dash-section-heading"> {{ 'I18N_LEARNER_DASHBOARD_COMPLETED_SECTION' | translate }} </p>
-        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'view'">
+        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'toggle'">
           <ng-container *ngFor="let summaryTile of displayCompletedLessonsList">
             <lesson-card [story]="summaryTile" [isCommunityLessonComplete]="true"> </lesson-card>
           </ng-container>
         </oppia-card-display>
          <!--TODO(#18384): Find max number of skill cards-->
-        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="learntTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'">
+        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="learntTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'toggle'">
           <ng-container *ngFor="let topicObj of learntTopicMastery">
             <ng-container *ngFor="let subtopic of topicObj.topic.subtopics; index as i">
               <oppia-skill-card [topic]="topicObj.topic" [progress]="topicObj.progress[i]" [subtopic]="subtopic"></oppia-skill-card>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -397,7 +397,6 @@
     </div>
   </ng-container>
   <div *ngIf="learnerDashboardRedesignFeatureFlag">
-    <p class="oppia-learner-dash-greeting mt-4"> {{ 'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_HEADING' | translate: {username: username} }} </p>
     <ng-container *ngIf="!isLearnerStateEmpty(); else empty">
       <div tabindex="0" class="oppia-learner-dash-section">
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -401,13 +401,13 @@
       <div tabindex="0" class="oppia-learner-dash-section">
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>
         <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
-          <oppia-card-display *ngIf="totalIncompleteLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalIncompleteLessonsList.length" [tabType]="'progress'">
+          <oppia-card-display *ngIf="totalIncompleteLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalIncompleteLessonsList.length" [controlType]="'view'" [tabType]="'progress'">
             <ng-container *ngFor="let summaryTile of displayIncompleteLessonsList">
               <lesson-card [story]="summaryTile"> </lesson-card>
             </ng-container>
           </oppia-card-display>
            <!--TODO(#18384): Find max number of skill cards-->
-          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="partialTopicMastery.reduce(getTotalSkillCards, 0)" [tabType]="'progress'">
+          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="partialTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'" [tabType]="'progress'">
             <ng-container *ngFor="let topicObj of partialTopicMastery">
               <ng-container *ngFor="let subtopic of topicObj.topic.subtopics; index as i">
                 <oppia-skill-card [topic]="topicObj.topic" [progress]="topicObj.progress[i]" [subtopic]="subtopic"></oppia-skill-card>
@@ -418,13 +418,13 @@
       </div>
       <div tabindex="0" class="oppia-learner-dash-section e2e-test-completed-community-lessons-section w-100" *ngIf="totalCompletedLessonsList.length !== 0 || learntTopicsList.length !== 0">
         <p class="oppia-learner-dash-section-heading"> {{ 'I18N_LEARNER_DASHBOARD_COMPLETED_SECTION' | translate }} </p>
-        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [tabType]="'progress'">
+        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'view'" [tabType]="'progress'">
           <ng-container *ngFor="let summaryTile of displayCompletedLessonsList">
             <lesson-card [story]="summaryTile" [isCommunityLessonComplete]="true"> </lesson-card>
           </ng-container>
         </oppia-card-display>
          <!--TODO(#18384): Find max number of skill cards-->
-        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="learntTopicMastery.reduce(getTotalSkillCards, 0)" [tabType]="'progress'">
+        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_SKILLS'" [numCards]="learntTopicMastery.reduce(getTotalSkillCards, 0)" [controlType]="'view'" [tabType]="'progress'">
           <ng-container *ngFor="let topicObj of learntTopicMastery">
             <ng-container *ngFor="let subtopic of topicObj.topic.subtopics; index as i">
               <oppia-skill-card [topic]="topicObj.topic" [progress]="topicObj.progress[i]" [subtopic]="subtopic"></oppia-skill-card>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.ts
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.ts
@@ -63,7 +63,6 @@ export class CommunityLessonsTabComponent {
   @Input() subscriptionsList!: ProfileSummary[];
   @Input() completedToIncompleteCollections!: string[];
   @Input() learnerDashboardRedesignFeatureFlag!: boolean;
-  @Input() username!: string;
   @Input() partiallyLearntTopicsList!: LearnerTopicSummary[];
   @Input() learntTopicsList!: LearnerTopicSummary[];
   selectedSection!: string;

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -100,9 +100,7 @@
         <oppia-card-display *ngIf="continueWhereYouLeftOffList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_PROGRESS_SECTION'" [numCards]="1" [tabType]="'home'">
           <ng-container *ngFor="let topicSummaryTile of partiallyLearntTopicsList">
             <ng-container *ngFor="let storySummaryTile of topicSummaryTile.canonicalStorySummaryDicts">
-              <oppia-learner-story-summary-tile [storySummary]="storySummaryTile" [redesignFeatureFlag]="redesignFeatureFlag" [displayArea]="'homeTab'"
-                [topicName]="topicSummaryTile.name">
-              </oppia-learner-story-summary-tile>
+              <lesson-card [story]="storySummaryTile" [topic]="topicSummaryTile.name"> </lesson-card>
             </ng-container>
           </ng-container>
         </oppia-card-display>

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -126,8 +126,8 @@
         <oppia-classroom-button [classroom]="item.key" [variant]="'blue'"></oppia-classroom-button>
       </ng-container>
        <!--TODO(#18384): Replace with saved lessons data (placeholder with explorations); affects numCards and ng-content-->
-      <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION'" [numCards]="incompleteExplorationsList.length">
-        <ng-container *ngFor="let lesson of incompleteExplorationsList">
+      <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION'" [numCards]="totalLessonsInPlaylists.length">
+        <ng-container *ngFor="let lesson of totalLessonsInPlaylists">
           <lesson-card [story]="lesson"></lesson-card>
         </ng-container>
       </oppia-card-display>

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -126,7 +126,7 @@
         <oppia-classroom-button [classroom]="item.key" [variant]="'blue'"></oppia-classroom-button>
       </ng-container>
        <!--TODO(#18384): Replace with saved lessons data (placeholder with explorations); affects numCards and ng-content-->
-      <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION'" [numCards]="totalLessonsInPlaylists.length">
+      <oppia-card-display *ngIf="totalLessonsInPlaylists.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION'" [numCards]="totalLessonsInPlaylists.length">
         <ng-container *ngFor="let lesson of totalLessonsInPlaylists">
           <lesson-card [story]="lesson"></lesson-card>
         </ng-container>

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -96,7 +96,7 @@
       </p>
       <div class="d-flex flex-wrap justify-content-between w-100">
         <!--TODO(#18384): Replace with all lessons in progress data (only contains classroom cards); affects ngIf, numCards, ng-content-->
-        <oppia-card-display *ngIf="continueWhereYouLeftOffList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_PROGRESS_SECTION'" [numCards]="1" [tabType]="'home'">
+        <oppia-card-display *ngIf="continueWhereYouLeftOffList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_PROGRESS_SECTION'" [numCards]="1" [displayMaxWidth]="'fit-content'" [tabType]="'home'">
           <ng-container *ngFor="let topicSummaryTile of partiallyLearntTopicsList">
             <ng-container *ngFor="let storySummaryTile of topicSummaryTile.canonicalStorySummaryDicts">
               <lesson-card [story]="storySummaryTile" [topic]="topicSummaryTile.name"> </lesson-card>
@@ -105,7 +105,7 @@
         </oppia-card-display>
         <!--TODO(#18384): Replace with recommended lessons data (placeholder with explorations); affects numCards and ng-content-->
         <!--TODO(#18384): Styling: https://shorturl.at/oAUY5 (links to Figma frame) -->
-        <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION'" [numCards]="incompleteExplorationsList.length" [tabType]="'home'">
+        <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION'" [numCards]="incompleteExplorationsList.length" [displayMaxWidth]="'fit-content'" [tabType]="'home'">
           <ng-container *ngFor="let lesson of incompleteExplorationsList">
             <lesson-card [story]="lesson"></lesson-card>
           </ng-container>

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -96,7 +96,7 @@
       </p>
       <div class="d-flex flex-wrap justify-content-between w-100">
         <!--TODO(#18384): Replace with all lessons in progress data (only contains classroom cards); affects ngIf, numCards, ng-content-->
-        <oppia-card-display *ngIf="continueWhereYouLeftOffList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_PROGRESS_SECTION'" [numCards]="1" [displayMaxWidth]="'fit-content'" [tabType]="'home'">
+        <oppia-card-display *ngIf="continueWhereYouLeftOffList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_PROGRESS_SECTION'" [numCards]="1" [displayMaxWidth]="'fit-content'">
           <ng-container *ngFor="let topicSummaryTile of partiallyLearntTopicsList">
             <ng-container *ngFor="let storySummaryTile of topicSummaryTile.canonicalStorySummaryDicts">
               <lesson-card [story]="storySummaryTile" [topic]="topicSummaryTile.name"> </lesson-card>
@@ -105,7 +105,7 @@
         </oppia-card-display>
         <!--TODO(#18384): Replace with recommended lessons data (placeholder with explorations); affects numCards and ng-content-->
         <!--TODO(#18384): Styling: https://shorturl.at/oAUY5 (links to Figma frame) -->
-        <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION'" [numCards]="incompleteExplorationsList.length" [displayMaxWidth]="'fit-content'" [tabType]="'home'">
+        <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION'" [numCards]="incompleteExplorationsList.length" [displayMaxWidth]="'fit-content'">
           <ng-container *ngFor="let lesson of incompleteExplorationsList">
             <lesson-card [story]="lesson"></lesson-card>
           </ng-container>
@@ -117,7 +117,7 @@
       <!--TODO(#18384): Add search bar -->
       <!--TODO(#18384): Replace with classroom topic data, only untracked topics at the moment; affects heading-->
       <ng-container *ngFor="let item of untrackedTopics | keyvalue">
-        <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_CLASSROOM_SECTION'" [numCards]="item.value.length" [tabType]="'homeFull'" [cardWidth]="226">
+        <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_CLASSROOM_SECTION'" [numCards]="item.value.length" [cardWidth]="226">
           <ng-container *ngFor="let topicSummaryTile of item.value">
             <oppia-learner-topic-summary-tile [topicSummary]="topicSummaryTile" [redesignFeatureFlag]="redesignFeatureFlag">
             </oppia-learner-topic-summary-tile>
@@ -126,7 +126,7 @@
         <oppia-classroom-button [classroom]="item.key" [variant]="'blue'"></oppia-classroom-button>
       </ng-container>
        <!--TODO(#18384): Replace with saved lessons data (placeholder with explorations); affects numCards and ng-content-->
-      <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION'" [tabType]="'homeFull'" [numCards]="incompleteExplorationsList.length">
+      <oppia-card-display [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_SAVED_SECTION'" [numCards]="incompleteExplorationsList.length">
         <ng-container *ngFor="let lesson of incompleteExplorationsList">
           <lesson-card [story]="lesson"></lesson-card>
         </ng-container>

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -85,7 +85,6 @@
   </ng-container>
 
   <div *ngIf="redesignFeatureFlag">
-    <p class="oppia-learner-dash-greeting mt-4"> {{ getTimeOfDay() | translate }}, {{ username }}! </p>
     <div class="oppia-learner-dash-section" *ngIf="isNonemptyObject(untrackedTopics) || continueWhereYouLeftOffList.length !== 0">
       <p class="oppia-learner-dash-section-heading">
         {{ (continueWhereYouLeftOffList.length !== 0 ?

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.ts
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.ts
@@ -48,6 +48,10 @@ export class HomeTabComponent {
   @Input() untrackedTopics!: Record<string, LearnerTopicSummary[]>;
   @Input() username!: string;
   @Input() redesignFeatureFlag!: boolean;
+  @Input() totalLessonsInPlaylists!: (
+    | LearnerExplorationSummary
+    | CollectionSummary
+  )[];
   currentGoalsLength!: number;
   classroomUrlFragment!: string;
   goalTopicsLength!: number;

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
@@ -115,7 +115,7 @@
       </mat-card>
     </div>
     <div [ngClass]="{'oppia-learner-dashboard-mobile-mode': windowIsNarrow, 'oppia-learner-dashboard-main-content col-md-8' : !isShowRedesignedLearnerDashboardActive(), 'oppia-learner-dash-tab overflow-hidden px-4 px-md-0' : isShowRedesignedLearnerDashboardActive() }">
-      <div class="d-flex w-100"
+      <div class="d-flex flex-column w-100"
            [ngClass]="{'oppia-learner-dashboard-main-content-container pl-5': !windowIsNarrow && !isShowRedesignedLearnerDashboardActive(), 'justify-content-center': windowIsNarrow}">
         <p class="oppia-learner-dash-greeting mt-4"> {{ getDashboardTabHeading() | translate: {username: username} }} </p>
         <div class="w-100" *ngIf="activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.HOME">

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
@@ -117,6 +117,7 @@
     <div [ngClass]="{'oppia-learner-dashboard-mobile-mode': windowIsNarrow, 'oppia-learner-dashboard-main-content col-md-8' : !isShowRedesignedLearnerDashboardActive(), 'oppia-learner-dash-tab overflow-hidden px-4 px-md-0' : isShowRedesignedLearnerDashboardActive() }">
       <div class="d-flex w-100"
            [ngClass]="{'oppia-learner-dashboard-main-content-container pl-5': !windowIsNarrow && !isShowRedesignedLearnerDashboardActive(), 'justify-content-center': windowIsNarrow}">
+        <p class="oppia-learner-dash-greeting mt-4"> {{ getDashboardTabHeading() | translate: {username: username} }} </p>
         <div class="w-100" *ngIf="activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.HOME">
           <oppia-home-tab [currentGoals]="topicsToLearn"
                           [redesignFeatureFlag]="isShowRedesignedLearnerDashboardActive()"
@@ -169,8 +170,7 @@
                                        [partiallyLearntTopicsList]="partiallyLearntTopicsList"
                                        [learntTopicsList]="learntTopicsList"
                                        [completedToIncompleteCollections]="completedToIncompleteCollections"
-                                       [learnerDashboardRedesignFeatureFlag]="isShowRedesignedLearnerDashboardActive()"
-                                       [username]="username">
+                                       [learnerDashboardRedesignFeatureFlag]="isShowRedesignedLearnerDashboardActive()">
           </oppia-community-lessons-tab>
         </div>
       </div>

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
@@ -127,6 +127,7 @@
                           [partiallyLearntTopicsList]="partiallyLearntTopicsList"
                           [untrackedTopics]="untrackedTopics"
                           [username]="username"
+                          [totalLessonsInPlaylists]="totalLessonsInPlaylists"
                           (setActiveSection)="setActiveSection($event)">
           </oppia-home-tab>
         </div>

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.spec.ts
@@ -1107,6 +1107,35 @@ describe('Learner dashboard page', () => {
       })
     );
 
+    it('should return home greeting when current tab is set to home', () => {
+      component.activeSection = 'I18N_LEARNER_DASHBOARD_HOME_SECTION';
+      fixture.detectChanges();
+
+      expect(component.getDashboardTabHeading()).toBe(
+        'I18N_LEARNER_DASHBOARD_HOME_SECTION_HEADING'
+      );
+    });
+
+    it('should return goal greeting when current tab is set to goals', () => {
+      component.activeSection = 'I18N_LEARNER_DASHBOARD_GOALS_SECTION';
+      fixture.detectChanges();
+
+      expect(component.getDashboardTabHeading()).toBe(
+        'I18N_LEARNER_DASHBOARD_GOALS_SECTION_HEADING'
+      );
+    });
+
+    // TODO(#18384): Change community-lessons to progress.
+    it('should return progress greeting when current tab is set to progress', () => {
+      component.activeSection =
+        'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION';
+      fixture.detectChanges();
+
+      expect(component.getDashboardTabHeading()).toBe(
+        'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_HEADING'
+      );
+    });
+
     it('should unsubscribe upon component destruction', () => {
       spyOn(component.directiveSubscriptions, 'unsubscribe');
 

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.spec.ts
@@ -1136,6 +1136,16 @@ describe('Learner dashboard page', () => {
       );
     });
 
+    // TODO(#18384): Change community-lessons to progress.
+    it('should return default greeting when current tab is not valid', () => {
+      component.activeSection = 'I18N_LEARNER_DASHBOARD_PLAYLIST_SECTION';
+      fixture.detectChanges();
+
+      expect(component.getDashboardTabHeading()).toBe(
+        'No valid I18N key for heading of I18N_LEARNER_DASHBOARD_PLAYLIST_SECTION'
+      );
+    });
+
     it('should unsubscribe upon component destruction', () => {
       spyOn(component.directiveSubscriptions, 'unsubscribe');
 

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -580,6 +580,8 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
       case LearnerDashboardPageConstants.LEARNER_DASHBOARD_SECTION_I18N_IDS
         .GOALS:
         return 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_HEADING';
+      default:
+        return `No valid I18N key for heading of ${this.activeSection}`;
     }
   }
 }

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -172,6 +172,8 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
   windowIsNarrow: boolean = false;
   directiveSubscriptions = new Subscription();
   LEARNER_GROUP_FEATURE_IS_ENABLED: boolean = false;
+  totalLessonsInPlaylists: (LearnerExplorationSummary | CollectionSummary)[] =
+    [];
 
   constructor(
     private alertsService: AlertsService,
@@ -552,6 +554,10 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
         setTimeout(() => {
           this.loaderService.hideLoadingScreen();
           this.communityLessonsDataLoaded = true;
+          this.totalLessonsInPlaylists = [
+            ...this.explorationPlaylist,
+            ...this.collectionPlaylist,
+          ];
           // So that focus is applied after the loading screen has dissapeared.
           this.focusManagerService.setFocusWithoutScroll('ourLessonsBtn');
         }, 0);

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -564,8 +564,16 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
   getDashboardTabHeading(): string {
     switch (this.activeSection) {
       // TODO(#18384): Change community-lessons to progress.
-      case 'LEARNER_DASHBOARD_SECTION_I18N_IDS.COMMUNITY_LESSONS':
+      case LearnerDashboardPageConstants.LEARNER_DASHBOARD_SECTION_I18N_IDS
+        .HOME:
+        return 'I18N_LEARNER_DASHBOARD_HOME_SECTION_HEADING';
+      case LearnerDashboardPageConstants.LEARNER_DASHBOARD_SECTION_I18N_IDS
+        .COMMUNITY_LESSONS:
         return 'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_HEADING';
+      // TODO(#18384): I18N key is in en.json & qqq.json after #21143.
+      case LearnerDashboardPageConstants.LEARNER_DASHBOARD_SECTION_I18N_IDS
+        .GOALS:
+        return 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_HEADING';
     }
   }
 }

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -560,4 +560,12 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
         // This is placed here in order to satisfy Unit tests.
       });
   }
+
+  getDashboardTabHeading(): string {
+    switch (this.activeSection) {
+      // TODO(#18384): Change community-lessons to progress.
+      case 'LEARNER_DASHBOARD_SECTION_I18N_IDS.COMMUNITY_LESSONS':
+        return 'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_HEADING';
+    }
+  }
 }


### PR DESCRIPTION
## Overview

This PR addresses part of #18384. Previously, I used the tabType variable to control the button appearance and width of card-display. However, there wasn't a clear relationship between the states ('homeFull', 'home', 'progress') and these UI changes. To fix this, I divided their concerns into two variables: displayMaxWidth and controlType. In addition, I extracted the logic for displaying the arrow buttons to make the code cleaner and align it with how the toggle button was being handled.

I also realized it was unnecessary to pass the username to all the tabs. Instead, I could move the heading to the learner-dashboard and have it change there depending on the activeSection

Some other changes:
- Minor UI fix for the classroom cards. 
- Moving saved lesson data to the home tab (no saved lessons in the video)
- Renamed CSS classes to differentiate between arrow and toggle styling

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

https://github.com/user-attachments/assets/dfa545f9-d7e4-45ca-ae8f-124c21d4662e




