### PR TITLE
Fix #21046: Images are not getting resized for the small screen size in the blogs

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1943,6 +1943,7 @@ pre.oppia-pre-wrapped-text {
   display: block;
   margin-left: auto;
   margin-right: auto;
+  object-fit: contain;
 }
 
 /* Styles for the statistics page. */


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #21046.
2. This PR does the following: This PR prevents the image from stretching
3. (For bug-fixing PRs only) The original bug occurred because:  The image is displayed without maintaining its aspect ratio, it can become "squeezed" or distorted on smaller screens or when the container size changes.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

## Proof that changes are correct
Issue:
![issue](https://github.com/user-attachments/assets/ca024c35-2940-4514-87c9-4337172df337)

Issue Resolve:
![resolve](https://github.com/user-attachments/assets/344a5a01-dc8e-48e4-8515-7322036938e8)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
