### PR TITLE
Fix issue #21136: Prerequisite and Acquired skills appear blank in the editor

### DIFF
--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.html
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.html
@@ -168,7 +168,7 @@
             <div>
               <div class="skills-card-item" *ngFor="let skillId of prerequisiteSkillIds">
                 <div class="skill-description-card e2e-test-prerequisite-skill-description-card">
-                  <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ skillIdToSummaryMap[skillId] }}</a>
+                  <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ prerequisiteSkillIdToSummaryMap[skillId] }}</a>
                   <span class="e2e-test-remove-prerequisite-skill" (click)="removePrerequisiteSkillId(skillId)" aria-hidden="true">
                     <i class="fas fa-times md-18"></i>
                   </span>
@@ -184,7 +184,7 @@
             <div>
               <div class="skills-card-item" *ngFor="let skillId of acquiredSkillIds">
                 <div class="skill-description-card e2e-test-acquired-skill-description-card">
-                  <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ skillIdToSummaryMap[skillId] }}</a>
+                  <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ acquiredSkillIdToSummaryMap[skillId] }}</a>
                   <span class="e2e-test-remove-acquired-skill" (click)="removeAcquiredSkillId(skillId)" aria-hidden="true">
                     <i class="fas fa-times md-18"></i>
                   </span>
@@ -221,7 +221,7 @@
               <div>
                 <div class="skills-card-item" *ngFor="let skillId of prerequisiteSkillIds">
                   <div class="skill-description-card">
-                    <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ skillIdToSummaryMap[skillId] }}</a>
+                    <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ prerequisiteSkillIdToSummaryMap[skillId] }}</a>
                     <span class="e2e-test-remove-prerequisite-skill" (click)="removePrerequisiteSkillId(skillId)" aria-hidden="true">
                       <i class="fas fa-times md-18"></i>
                     </span>
@@ -257,7 +257,7 @@
               <div>
                 <div class="skills-card-item" *ngFor="let skillId of acquiredSkillIds">
                   <div class="skill-description-card">
-                    <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ skillIdToSummaryMap[skillId] }}</a>
+                    <a [href]="getSkillEditorUrl(skillId)" target="_blank" rel="noopener">{{ acquiredSkillIdToSummaryMap[skillId] }}</a>
                     <span class="e2e-test-remove-acquired-skill" (click)="removeAcquiredSkillId(skillId)" aria-hidden="true">
                       <i class="fas fa-times md-18"></i>
                     </span>

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.spec.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.spec.ts
@@ -309,21 +309,56 @@ describe('Story node editor component', () => {
   it('should fetch the descriptions for prerequisite skills', fakeAsync(() => {
     component.prerequisiteSkillIds = ['1', '2', '3'];
 
-    component.getPrerequisiteSkillsDescription();
+    component.getSkillsDescription(
+      component.prerequisiteSkillIds,
+      component.prerequisiteSkillIdToSummaryMap
+    );
     tick();
 
-    expect(component.skillIdToSummaryMap).toEqual({
+    expect(component.prerequisiteSkillIdToSummaryMap).toEqual({
       1: 'test',
       2: 'test2',
       3: 'test3',
     });
   }));
 
-  it('should call Alerts Service if getting skill desc. fails', fakeAsync(() => {
+  it('should fetch the descriptions for acquired skills', fakeAsync(() => {
+    component.acquiredSkillIds = ['1', '2', '3'];
+
+    component.getSkillsDescription(
+      component.acquiredSkillIds,
+      component.acquiredSkillIdToSummaryMap
+    );
+    tick();
+
+    expect(component.acquiredSkillIdToSummaryMap).toEqual({
+      1: 'test',
+      2: 'test2',
+      3: 'test3',
+    });
+  }));
+
+  it('should call Alerts Service if getting acquired skill desc. fails', fakeAsync(() => {
+    component.acquiredSkillIds = ['2'];
+    let alertsSpy = spyOn(alertsService, 'addWarning').and.callThrough();
+
+    component.getSkillsDescription(
+      component.acquiredSkillIds,
+      component.acquiredSkillIdToSummaryMap
+    );
+    tick();
+
+    expect(alertsSpy).toHaveBeenCalled();
+  }));
+
+  it('should call Alerts Service if getting prerequisite skill desc. fails', fakeAsync(() => {
     component.prerequisiteSkillIds = ['2'];
     let alertsSpy = spyOn(alertsService, 'addWarning').and.callThrough();
 
-    component.getPrerequisiteSkillsDescription();
+    component.getSkillsDescription(
+      component.prerequisiteSkillIds,
+      component.prerequisiteSkillIdToSummaryMap
+    );
     tick();
 
     expect(alertsSpy).toHaveBeenCalled();
@@ -376,6 +411,14 @@ describe('Story node editor component', () => {
     component.togglePrerequisiteSkillsList();
 
     expect(component.prerequisiteSkillIsShown).toBeFalse();
+  });
+
+  it('should toggle acquired skill list', () => {
+    component.acquiredSkillIsShown = true;
+
+    component.toggleAcquiredSkillsList();
+
+    expect(component.acquiredSkillIsShown).toBeFalse();
   });
 
   it('should call StoryUpdate service to set story thumbnail filename', () => {

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.spec.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.spec.ts
@@ -338,7 +338,7 @@ describe('Story node editor component', () => {
     });
   }));
 
-  it('should call Alerts Service if getting acquired skill desc. fails', fakeAsync(() => {
+  it('should call Alerts Service if getting acquired skill description fails', fakeAsync(() => {
     component.acquiredSkillIds = ['2'];
     let alertsSpy = spyOn(alertsService, 'addWarning').and.callThrough();
 
@@ -351,7 +351,7 @@ describe('Story node editor component', () => {
     expect(alertsSpy).toHaveBeenCalled();
   }));
 
-  it('should call Alerts Service if getting prerequisite skill desc. fails', fakeAsync(() => {
+  it('should call Alerts Service if getting prerequisite skill description fails', fakeAsync(() => {
     component.prerequisiteSkillIds = ['2'];
     let alertsSpy = spyOn(alertsService, 'addWarning').and.callThrough();
 

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
@@ -190,7 +190,7 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
       this.skillBackendApiService.fetchMultiSkillsAsync(skillIds).then(
         response => {
           for (let skill of response) {
-            targetMap[skill._id] = skill._description;
+            targetSkillIdToSummaryMap[skill._id] = skill._description;
           }
         },
         error => {

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
@@ -184,7 +184,7 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
 
   getSkillsDescription(
     skillIds: string[],
-    targetMap: {[key: string]: string}
+    targetSkillIdToSummaryMap: {[key: string]: string}
   ): void {
     if (skillIds && skillIds.length > 0) {
       this.skillBackendApiService.fetchMultiSkillsAsync(skillIds).then(

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
@@ -63,7 +63,8 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
   mainChapterCardIsShown = true;
   explorationInputButtonsAreShown = false;
   chapterOutlineButtonsAreShown = false;
-  skillIdToSummaryMap = {};
+  acquiredSkillIdToSummaryMap = {};
+  prerequisiteSkillIdToSummaryMap = {};
   chapterOutlineIsShown: boolean = false;
   chapterTodoCardIsShown: boolean = false;
   prerequisiteSkillIsShown: boolean = false;
@@ -138,8 +139,6 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
 
     this._recalculateAvailableNodes();
 
-    let skillSummaries = this.storyEditorStateService.getSkillSummaries();
-
     this.topicsAndSkillsDashboardBackendApiService
       .fetchDashboardDataAsync()
       .then(response => {
@@ -148,10 +147,14 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
         this.skillInfoHasLoaded = true;
       });
 
-    for (let idx in skillSummaries) {
-      this.skillIdToSummaryMap[skillSummaries[idx].id] =
-        skillSummaries[idx].description;
-    }
+    this.getSkillsDescription(
+      this.prerequisiteSkillIds,
+      this.prerequisiteSkillIdToSummaryMap
+    );
+    this.getSkillsDescription(
+      this.acquiredSkillIds,
+      this.acquiredSkillIdToSummaryMap
+    );
 
     this.isStoryPublished = this.storyEditorStateService.isStoryPublished;
     this.currentTitle = this.nodeIdToTitleMap[this.nodeId];
@@ -179,15 +182,15 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
     return '/skill_editor/' + skillId;
   }
 
-  getPrerequisiteSkillsDescription(): void {
-    const skills = this.prerequisiteSkillIds;
-
-    if (skills && skills.length > 0) {
-      this.skillBackendApiService.fetchMultiSkillsAsync(skills).then(
+  getSkillsDescription(
+    skillIds: string[],
+    targetMap: {[key: string]: string}
+  ): void {
+    if (skillIds && skillIds.length > 0) {
+      this.skillBackendApiService.fetchMultiSkillsAsync(skillIds).then(
         response => {
-          for (let idx in response) {
-            this.skillIdToSummaryMap[response[idx].getId()] =
-              response[idx].getDescription();
+          for (let skill of response) {
+            targetMap[skill._id] = skill._description;
           }
         },
         error => {
@@ -414,7 +417,8 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
     modalRef.result.then(
       summary => {
         try {
-          this.skillIdToSummaryMap[summary.id] = summary.description;
+          this.prerequisiteSkillIdToSummaryMap[summary.id] =
+            summary.description;
           this.storyUpdateService.addPrerequisiteSkillIdToNode(
             this.story,
             this.nodeId,
@@ -462,6 +466,7 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
     modalRef.result.then(
       summary => {
         try {
+          this.acquiredSkillIdToSummaryMap[summary.id] = summary.description;
           this.storyUpdateService.addAcquiredSkillIdToNode(
             this.story,
             this.nodeId,


### PR DESCRIPTION
## Overview

1. Fix #21136 
2. This PR fixes prerequisite and acquired skills appearing blank in the editor.
3. The bug occurred due to an incomplete implementation and insufficient test coverage for the feature. 

## Essential Checklist
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network
[Screen Recording 2024-10-30 at 10.00.19 PM.webm](https://github.com/user-attachments/assets/9e042da1-5043-4192-8b90-1c33e1cc5c76)

#### Proof of changes on mobile phone
[Screen Recording 2024-10-30 at 10.05.36 PM.webm](https://github.com/user-attachments/assets/b6cc40b6-48cd-49d3-b223-624c8195755e)

#### Proof of changes in Arabic language
[Screen Recording 2024-10-30 at 10.08.08 PM.webm](https://github.com/user-attachments/assets/8a57d50c-3b27-469b-ad6b-be151aa8aa9c)