### PR TITLE
Fix: TODO (Jacob) #20433 - Added a descriptive docstring to get_empty…

### DIFF
--- a/core/feconf.py
+++ b/core/feconf.py
@@ -504,11 +504,23 @@ _EMPTY_RATINGS = {'1': 0, '2': 0, '3': 0, '4': 0, '5': 0}
 
 
 def get_empty_ratings() -> Dict[str, int]:
-    """Returns a copy of the empty ratings object.
+    """Returns a deep copy of the empty ratings dictionary.
+    This function is used to obtain a fresh copy of the empty ratings
+    dictionary. This can be useful in scenarios where a new ratings
+    dictionary is needed without any pre-existing data.
 
     Returns:
-        dict. Copy of the '_EMPTY_RATINGS' dict object which contains the empty
-        ratings.
+        dict. A deep copy of the _EMPTY_RATINGS dictionary. The structure
+        of this dictionary is as follows:
+        {
+            '5': 0,
+            '4': 0,
+            '3': 0,
+            '2': 0,
+            '1': 0
+        }
+        Each key represents a rating value, and the corresponding value
+        represents the count of ratings for that value, initialized to 0.
     """
     return copy.deepcopy(_EMPTY_RATINGS)
 


### PR DESCRIPTION
…_ratings.

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20433
2. This PR does the following: This PR modifies the `get_empty_ratings` function in `core/feconf.py` to provide a deep copy of `_EMPTY_RATINGS` dictionary. The purpose of this change is to ensure that each call to `get_empty_ratings`returns a fresh copy of the empty ratings dictionary, which is useful when a new ratings dictionary is needed without any pre-existing data.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


https://github.com/user-attachments/assets/268fd2a9-653c-4527-a1fd-e0191175249d



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
