### PR TITLE
Fix #bugnum  TODO(bhenning): Split the validation tests into separate unit tests. #20377

### DIFF
--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -2763,14 +2763,15 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
 
     # TODO(#20377): The validation tests below should be split into separate
     # unit tests. Also, all validation errors should be covered in the tests.
-        def test_non_existing_state_in_default_outcome(self) -> None:
+    def test_non_existing_state_in_default_outcome(self) -> None:
         """Test that a default outcome pointing to a non-existing 
-        state raises a validation error."""
+          state raises a validation error.
+        """
+
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index
         )
-        
         new_state = state_domain.State.create_default_state(
             'ABC',
             content_id_generator.generate(
@@ -2778,7 +2779,6 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             content_id_generator.generate(
                 translation_domain.ContentType.DEFAULT_OUTCOME)
         )
-        
         exploration.states = {
             'initState': new_state,
             'BCD': state_domain.State.create_default_state(
@@ -2801,18 +2801,23 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         )
 
     def test_invalid_character_in_title(self) -> None:
-        """Test that an invalid character in the title raises a validation error."""
+        """Test that an invalid character in the 
+          title raises a validation error.
+        """
+
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         exploration.title = 'Hello #'
         self._assert_validation_error(exploration, 'Invalid character #')
 
     def test_invalid_character_in_state_name(self) -> None:
-        """Test that invalid characters in a state name raise validation errors."""
+        """Test that invalid characters in a state name 
+         raise validation errors.
+        """
+
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index
         )
-        
         bad_state = state_domain.State.create_default_state(
             '/state',
             content_id_generator.generate(
@@ -2826,7 +2831,9 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         )
 
     def test_exploration_with_no_states(self) -> None:
-        """Test that an exploration with no states raises a validation error."""
+        """Test that an exploration with no states raises a 
+            validation error.
+        """
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         exploration.states = {}
         self._assert_validation_error(
@@ -2835,7 +2842,9 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
 
     def test_exploration_with_no_initial_state_name(self) -> None:
         """Test that an exploration with no initial state name raises 
-        a validation error."""
+          a validation error.
+        """
+
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index
@@ -2862,7 +2871,6 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index
         )
-        
         new_state = state_domain.State.create_default_state(
             'ABC',
             content_id_generator.generate(
@@ -2877,10 +2885,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             content_id_generator.generate(
                 translation_domain.ContentType.DEFAULT_OUTCOME)
         )
-        
         exploration.states = {'ABC': new_state, 'BCD': second_state}
         exploration.init_state_name = 'InvalidStateName'
-        
         self._assert_validation_error(
             exploration,
             r'There is no state in \[\'ABC\'\, \'BCD\'\] corresponding to '
@@ -2889,7 +2895,9 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
 
     def test_invalid_answer_group_destination(self) -> None:
         """Test that an invalid answer group destination raises a 
-        validation error."""
+          validation error.
+        """
+
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -2763,8 +2763,9 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
 
     # TODO(#20377): The validation tests below should be split into separate
     # unit tests. Also, all validation errors should be covered in the tests.
-    def test_non_existing_state_in_default_outcome(self) -> None:
-        """Test that a default outcome pointing to a non-existing state raises a validation error."""
+        def test_non_existing_state_in_default_outcome(self) -> None:
+        """Test that a default outcome pointing to a non-existing 
+        state raises a validation error."""
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index
@@ -2808,24 +2809,33 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
     def test_invalid_character_in_state_name(self) -> None:
         """Test that invalid characters in a state name raise validation errors."""
         exploration = exp_domain.Exploration.create_default_exploration('eid')
-        content_id_generator = translation_domain.ContentIdGenerator(exploration.next_content_id_index)
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index
+        )
         
         bad_state = state_domain.State.create_default_state(
             '/state',
-            content_id_generator.generate(translation_domain.ContentType.CONTENT),
-            content_id_generator.generate(translation_domain.ContentType.DEFAULT_OUTCOME)
+            content_id_generator.generate(
+                translation_domain.ContentType.CONTENT),
+            content_id_generator.generate(
+                translation_domain.ContentType.DEFAULT_OUTCOME)
         )
         exploration.states = {'/state': bad_state}
-        self._assert_validation_error(exploration, 'Invalid character / in a state name')
+        self._assert_validation_error(
+            exploration, 'Invalid character / in a state name'
+        )
 
     def test_exploration_with_no_states(self) -> None:
         """Test that an exploration with no states raises a validation error."""
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         exploration.states = {}
-        self._assert_validation_error(exploration, 'exploration has no states')
+        self._assert_validation_error(
+            exploration, 'exploration has no states'
+        )
 
     def test_exploration_with_no_initial_state_name(self) -> None:
-        """Test that an exploration with no initial state name raises a validation error."""
+        """Test that an exploration with no initial state name raises 
+        a validation error."""
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index
@@ -2833,8 +2843,10 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
 
         state = state_domain.State.create_default_state(
             'ABC',
-            content_id_generator.generate(translation_domain.ContentType.CONTENT),
-            content_id_generator.generate(translation_domain.ContentType.DEFAULT_OUTCOME)
+            content_id_generator.generate(
+                translation_domain.ContentType.CONTENT),
+            content_id_generator.generate(
+                translation_domain.ContentType.DEFAULT_OUTCOME)
         )
 
         exploration.states = {'ABC': state}
@@ -2844,21 +2856,26 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             exploration, 'has no initial state name'
         )
 
-
     def test_invalid_initial_state(self) -> None:
         """Test that an invalid initial state name raises a validation error."""
         exploration = exp_domain.Exploration.create_default_exploration('eid')
-        content_id_generator = translation_domain.ContentIdGenerator(exploration.next_content_id_index)
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index
+        )
         
         new_state = state_domain.State.create_default_state(
             'ABC',
-            content_id_generator.generate(translation_domain.ContentType.CONTENT),
-            content_id_generator.generate(translation_domain.ContentType.DEFAULT_OUTCOME)
+            content_id_generator.generate(
+                translation_domain.ContentType.CONTENT),
+            content_id_generator.generate(
+                translation_domain.ContentType.DEFAULT_OUTCOME)
         )
         second_state = state_domain.State.create_default_state(
             'BCD',
-            content_id_generator.generate(translation_domain.ContentType.CONTENT),
-            content_id_generator.generate(translation_domain.ContentType.DEFAULT_OUTCOME)
+            content_id_generator.generate(
+                translation_domain.ContentType.CONTENT),
+            content_id_generator.generate(
+                translation_domain.ContentType.DEFAULT_OUTCOME)
         )
         
         exploration.states = {'ABC': new_state, 'BCD': second_state}
@@ -2866,14 +2883,13 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         
         self._assert_validation_error(
             exploration,
-            r'There is no state in \[\'ABC\'\, \'BCD\'\] corresponding to the exploration\'s initial state name InvalidStateName.'
+            r'There is no state in \[\'ABC\'\, \'BCD\'\] corresponding to '
+            r'the exploration\'s initial state name InvalidStateName.'
         )
 
-
-    
-
     def test_invalid_answer_group_destination(self) -> None:
-        """Test that an invalid answer group destination raises a validation error."""
+        """Test that an invalid answer group destination raises a 
+        validation error."""
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         content_id_generator = translation_domain.ContentIdGenerator(
             exploration.next_content_id_index
@@ -2895,20 +2911,33 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         answer_groups = interaction.answer_groups
         if not answer_groups:
             answer_groups.append(state_domain.AnswerGroup(
-                outcome=state_domain.Outcome(valid_state_name, None, state_domain.SubtitledHtml('feedback_1', 'Feedback'), False, [], None, None),
-                rule_specs=[state_domain.RuleSpec('Contains', {'x': {'contentId': 'rule_input_Contains', 'normalizedStrSet': ['Test']}})],
-                training_data=[],
-                tagged_skill_misconception_id=None
+                outcome=state_domain.Outcome(
+                    valid_state_name, None,
+                    state_domain.SubtitledHtml('feedback_1', 'Feedback'),
+                    False, [], None, None
+                ),
+                rule_specs=[state_domain.RuleSpec(
+                    'Contains', {'x': {
+                        'contentId': 'rule_input_Contains',
+                        'normalizedStrSet': ['Test']
+                    }}
+                )],
+                training_data=[], tagged_skill_misconception_id=None
             ))
 
-        init_state.recorded_voiceovers.add_content_id_for_voiceover('feedback_1')
+        init_state.recorded_voiceovers.add_content_id_for_voiceover(
+            'feedback_1'
+        )
 
-        exploration.update_next_content_id_index(content_id_generator.next_content_id_index)
+        exploration.update_next_content_id_index(
+            content_id_generator.next_content_id_index
+        )
 
         answer_group = answer_groups[0]
         answer_group.outcome.dest = 'DEF'
         self._assert_validation_error(
-            exploration, 'destination DEF is not a valid')
+            exploration, 'destination DEF is not a valid'
+        )
 
     def test_tag_validation(self) -> None:
         """Test validation of exploration tags."""


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes  #20377 
2. This PR does the following: This PR refactors and splits the validation tests in test_validation within the exp_domain_test.py file. By separating these into distinct unit tests, it improves the clarity and maintainability of the validation logic, covering all validation errors more comprehensively. The original test_validation function was lengthy and complex, combining multiple checks, which made it challenging to maintain and verify full coverage of validation scenarios.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)


- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
