### PR TITLE
Fix issue #21069: Added language change option to the embedded exploration player

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -1,5 +1,5 @@
 <div class="navbar-header e2e-test-navbar-header oppia-top-navigation-bar">
-  <a *ngIf="windowIsNarrow"
+  <a *ngIf="windowIsNarrow && !pageIsIframed"
      (click)="toggleSidebar($event)"
      class="navbar-brand oppia-navbar-menu oppia-transition-200 e2e-mobile-test-navbar-button ml-0"
      tabindex="0">
@@ -13,23 +13,38 @@
        &#10005;
     </i>
   </a>
-  <a class="oppia-navbar-brand-name oppia-transition-200 e2e-test-oppia-main-logo d-sm-block"
-     href="/"
-     [smartRouterLink]="'/' + PAGES_REGISTERED_WITH_FRONTEND.SPLASH.ROUTE"
-     [ngClass]="windowIsNarrow ? 'oppia-logo-small ml-0' : 'oppia-logo-wide'">
-    <picture>
-      <source type="image/webp"
-              [srcset]="getStaticImageUrl('/logo/288x128_logo_white.webp')">
-      <source type="image/png"
-              [srcset]="getStaticImageUrl('/logo/288x128_logo_white.png')">
-      <img [src]="getStaticImageUrl('/logo/288x128_logo_white.png')"
-           class="oppia-logo"
-           alt="Oppia Home"
-           [ngStyle]="!windowIsNarrow && {'width': '90px'}">
-    </picture>
-  </a>
+  <div class="oppia-navbar-brand-name oppia-transition-200 e2e-test-oppia-main-logo d-sm-block">
+    <ng-container *ngIf="pageIsIframed; else anchorTemplate">
+      <picture>
+        <source type="image/webp"
+                [srcset]="getStaticImageUrl('/logo/288x128_logo_white.webp')">
+        <source type="image/png"
+                [srcset]="getStaticImageUrl('/logo/288x128_logo_white.png')">
+        <img [src]="getStaticImageUrl('/logo/288x128_logo_white.png')"
+             class="oppia-logo"
+             alt="Oppia Home"
+             [ngStyle]="!windowIsNarrow && {'width': '90px'}">
+      </picture>
+    </ng-container>
+    <ng-template #anchorTemplate>
+      <a href="/"
+         [smartRouterLink]="'/' + PAGES_REGISTERED_WITH_FRONTEND.SPLASH.ROUTE"
+         [ngClass]="windowIsNarrow ? 'oppia-logo-small ml-0' : 'oppia-logo-wide'">
+        <picture>
+          <source type="image/webp"
+                  [srcset]="getStaticImageUrl('/logo/288x128_logo_white.webp')">
+          <source type="image/png"
+                  [srcset]="getStaticImageUrl('/logo/288x128_logo_white.png')">
+          <img [src]="getStaticImageUrl('/logo/288x128_logo_white.png')"
+               class="oppia-logo"
+               alt="Oppia Home"
+               [ngStyle]="!windowIsNarrow && {'width': '90px'}">
+        </picture>
+      </a>
+    </ng-template>
+  </div>
 </div>
-<div *ngIf="!windowIsNarrow" class="nav-mobile-header-text-container oppia-top-navigation-bar">
+<div *ngIf="!windowIsNarrow && !pageIsIframed" class="nav-mobile-header-text-container oppia-top-navigation-bar">
   <span *ngIf="headerText?.length"
         class="nav-mobile-header-editor">
     {{ headerText }}
@@ -45,7 +60,7 @@
   <ul class="nav oppia-navbar-nav"
       *ngIf="standardNavIsShown">
     <li>
-      <ul *ngIf="!windowIsNarrow"
+      <ul *ngIf="!windowIsNarrow && !pageIsIframed"
           class="nav oppia-navbar-tabs">
         <li [ngClass]="{'open' : activeMenuName === 'homeMenu'}"
             *ngIf="userIsLoggedIn"
@@ -318,8 +333,8 @@
           <span class="desktop-view-language-code" *ngIf="!windowIsNarrow"> {{ currentLanguageText }} </span>
         </button>
       </div>
-      <ul ngbDropdownMenu
-          class="dropdown-menu oppia-navbar-dropdown language-dropdown"
+      <ul ngbDropdownMenu class="dropdown-menu oppia-navbar-dropdown language-dropdown"
+          [ngClass]="{'oppia-embedded-navbar-dropdown': pageIsIframed}"
           [style.margin-top]="userIsLoggedIn ? '-10px': '0'"
           (mouseover)="openSubmenu($event, 'languageMenu')"
           (mouseleave)="closeSubmenuIfNotMobile($event)">
@@ -341,7 +356,7 @@
     <li [ngClass]="{'open' : activeMenuName === 'profileMenu'}"
         ngbDropdown
         #profileDropdown="ngbDropdown"
-        *ngIf="userIsLoggedIn"
+        *ngIf="userIsLoggedIn && !pageIsIframed"
         class="nav-item e2e-test-profile-dropdown oppia-navbar-clickable-dropdown profile-dropdown pfl">
       <a [attr.aria-expanded]="profileDropdown.isOpen() ? 'true' : 'false'"
          (click)="profileDropdown.isOpen() ? profileDropdown.close() : profileDropdown.open();"
@@ -496,7 +511,7 @@
     </li>
 
     <li ngbDropdown
-        *ngIf="!userIsLoggedIn && username !== ''"
+        *ngIf="!userIsLoggedIn && username !== '' && !pageIsIframed"
         class="nav-item oppia-navbar-clickable-dropdown dropdown">
       <div class="oppia-navbar-button-container dropdown oppia-navbar-button-container-extra-info sinin">
         <button ngbDropdownToggle
@@ -524,7 +539,7 @@
     </li>
 
     <li ngbDropdown
-        *ngIf="username === ''"
+        *ngIf="username === '' && !pageIsIframed"
         class="oppia-navbar-clickable-dropdown dropdown">
       <div class="oppia-navbar-button-container oppia-navbar-button-container-extra-info">
       </div>
@@ -535,6 +550,18 @@
   .dropdn {
     position: absolute;
     z-index: 500;
+  }
+  /*
+    Added this because Bootstrap was behaving unexpectedly by
+    adding CSS which was breaking the dropdown position while
+    in the embedded player.
+  */
+  .oppia-embedded-navbar-dropdown {
+    left: auto !important;
+    position: absolute;
+    top: auto !important;
+    transform: translate(0, 0) !important;
+    will-change: auto !important;
   }
   @media only screen and (max-width: 335px) {
     :lang(ar) .sinin {

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -316,7 +316,7 @@
       </ul>
     </li>
   </ul>
-  <ul class="nav oppia-navbar-nav oppia-navbar-tabs oppia-navbar-profile">
+  <ul class="nav oppia-navbar-nav oppia-navbar-tabs">
     <li ngbDropdown
         #languageDropdown="ngbDropdown"
         class="nav-item oppia-navbar-clickable-dropdown dropdown"
@@ -327,7 +327,8 @@
       <div class="oppia-navbar-button-container dropdown langbtnContainer">
         <button ngbDropdownToggle
                 class="btn dropdown-toggle oppia-navbar-button oppia-language-dropdown-button e2e-test-language-dropdown langbtn"
-                (keydown)="onMenuKeypress($event, 'languageMenu', {shiftTab: ACTION_CLOSE, enter: ACTION_OPEN})">
+                (keydown)="onMenuKeypress($event, 'languageMenu', {shiftTab: ACTION_CLOSE, enter: ACTION_OPEN})"
+                [ngClass]="{'oppia-language-dropdown-button-embedded': pageIsIframed}">
           <i class="fas fa-globe language-icon langi"></i>
           <span class="mobile-view-language-code lngcd" *ngIf="windowIsNarrow"> {{ currentLanguageCode }} </span>
           <span class="desktop-view-language-code" *ngIf="!windowIsNarrow"> {{ currentLanguageText }} </span>
@@ -631,6 +632,10 @@
     :lang(ar) .pfl {
       position: relative;
       top: 6rem;
+    }
+    .oppia-language-dropdown-button-embedded {
+      margin-top: 8px;
+      padding: 0 1px 2px 2px;
     }
   }
 

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
@@ -26,6 +26,7 @@ import {
   tick,
   waitForAsync,
 } from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 import {DeviceInfoService} from 'services/contextual/device-info.service';
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
@@ -486,6 +487,24 @@ describe('TopNavigationBarComponent', () => {
     expect(component.truncateNavbar()).toBe(undefined);
     expect(component.checkIfI18NCompleted).not.toHaveBeenCalled();
     expect(document.querySelector).not.toHaveBeenCalled();
+  });
+
+  it('should show logo and language dropdown when component is embedded', () => {
+    expect(component.getStaticImageUrl('/logo/288x128_logo_white.webp')).toBe(
+      '/assets/images/logo/288x128_logo_white.webp'
+    );
+    expect(component.getStaticImageUrl('/logo/288x128_logo_white.png')).toBe(
+      '/assets/images/logo/288x128_logo_white.png'
+    );
+
+    component.pageIsIframed = true;
+
+    fixture.detectChanges();
+
+    const languageChangeElement = fixture.debugElement.query(
+      By.css('.oppia-language-dropdown-button')
+    );
+    expect(languageChangeElement).toBeTruthy();
   });
 
   it(

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -45,6 +45,7 @@ import {downgradeComponent} from '@angular/upgrade/static';
 import {FocusManagerService} from 'services/stateful/focus-manager.service';
 import {I18nService} from 'i18n/i18n.service';
 import {CreatorTopicSummary} from 'domain/topic/creator-topic-summary.model';
+import {UrlService} from 'services/contextual/url.service';
 import {PlatformFeatureService} from 'services/platform-feature.service';
 import {LearnerGroupBackendApiService} from 'domain/learner_group/learner-group-backend-api.service';
 import {FeedbackUpdatesBackendApiService} from 'domain/feedback_updates/feedback-updates-backend-api.service';
@@ -80,6 +81,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   isModerator: boolean = false;
   isCurriculumAdmin: boolean = false;
   isTopicManager: boolean = false;
+  pageIsIframed: boolean = false;
   isSuperAdmin: boolean = false;
   isBlogAdmin: boolean = false;
   isBlogPostEditor: boolean = false;
@@ -181,6 +183,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     private windowDimensionsService: WindowDimensionsService,
     private searchService: SearchService,
     private windowRef: WindowRef,
+    private urlService: UrlService,
     private focusManagerService: FocusManagerService,
     private platformFeatureService: PlatformFeatureService,
     private learnerGroupBackendApiService: LearnerGroupBackendApiService
@@ -194,6 +197,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     this.focusManagerService.setFocus(this.labelForClearingFocus);
     this.userMenuIsShown = this.currentUrl !== this.NAV_MODE_SIGNUP;
     this.inClassroomPage = false;
+    this.pageIsIframed = this.urlService.isIframed();
     this.supportedSiteLanguages = AppConstants.SUPPORTED_SITE_LANGUAGES.map(
       (languageInfo: LanguageInfo) => {
         return languageInfo;

--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.html
@@ -10,6 +10,9 @@
   </div>
   <div *ngIf="voiceoversAreLoaded">
     <div class="embedded-body" *ngIf="pageIsIframed">
+      <div class="navbar-container">
+        <oppia-top-navigation-bar></oppia-top-navigation-bar>
+      </div>
       <oppia-conversation-skin></oppia-conversation-skin>
     </div>
     <oppia-conversation-skin *ngIf="!pageIsIframed"></oppia-conversation-skin>
@@ -29,5 +32,9 @@
     position: absolute;
     text-align: center;
     width: 100vw;
-}
+  }
+  .navbar-container {
+    background-color: #00645c;
+    padding: 0 10px;
+  }
 </style>

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.css
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.css
@@ -54,6 +54,10 @@ oppia-conversation-skin .supplemental-card-parent-container {
   width: 100%;
 }
 
+.conversation-skin-cards-container-embedded {
+  padding: 10px 14px 0 !important;
+}
+
 .conversation-skin-help-card-content {
   padding: 12px;
 }

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.html
@@ -1,6 +1,6 @@
 <div role="main" class="oppia-conversation-skin-animate-cards-container position-relative" *ngIf="hasFullyLoaded">
   <div class="conversation-skin-cards-container conversation-skin-animate-cards e2e-test-conversation-skin-cards-container"
-       [ngClass]="{'animate-to-two-cards': isAnimatingToTwoCards, 'animate-to-one-card': isAnimatingToOneCard}">
+       [ngClass]="{'animate-to-two-cards': isAnimatingToTwoCards,'animate-to-one-card': isAnimatingToOneCard,'conversation-skin-cards-container-embedded': isIframed}">
 
     <div class="conversation-skin-tutor-card-container"
          [ngClass]="{'conversation-skin-animate-tutor-card-on-narrow':


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. Fix #21069.
2. This PR does the following: Adds the language change option to the embedded exploration player.

Added a navigation bar to the embedded player view, with conditional rendering to check if the navigation is displayed within an iframe. Minor CSS adjustments were made to enhance responsiveness while preserving the existing appearance.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] **Arabic Language Bug** - opened an issue #21220 
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
- [x] I have added "Proof that changes"

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
[Screen Recording 2024-11-02 at 3.17.22 PM.webm](https://github.com/user-attachments/assets/13a938d8-618a-49bb-b7ca-fcbf9af62927)

`Iframes with a width of > ~840px`
<img width="702" alt="Screenshot 2024-11-02 at 3 18 59 PM" src="https://github.com/user-attachments/assets/c4d18bff-4969-44e7-bf7d-00afe9d995cf">

`Iframes with a width of > ~960px`
<img width="758" alt="Screenshot 2024-11-02 at 3 21 33 PM" src="https://github.com/user-attachments/assets/aa096345-f755-4ae6-b69f-e7200eb3440f">

#### Proof of changes in Arabic language
<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->
As mentioned that Arabic language is not working in the player for now so to test my change I changed the direction of language to RTL but kept the lang to English - to make sure RTL languages are supported.

[Screen Recording 2024-11-02 at 3.26.29 PM.webm](https://github.com/user-attachments/assets/4f337575-6202-4680-a0e4-c68bd3f3a684)

