### PR TITLE
Update Docker to use slim-bookworm

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,5 +1,6 @@
 # Added platform flag here because -- https://stackoverflow.com/questions/71040681/qemu-x86-64-could-not-open-lib64-ld-linux-x86-64-so-2-no-such-file-or-direc
-FROM --platform=linux/amd64 python:3.9.20-bullseye AS backend
+# Note that "bookworm" corresponds to Debian 12.
+FROM --platform=linux/amd64 python:3.9.20-slim-bookworm AS backend
 
 ENV OPPIA_IS_DOCKERIZED="true"
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: As a follow-on to #21020, this PR uses python:3.9.20-slim-bookworm for Docker. Per @gp201 this is for maximizing forward compatibility (buster is Debian 10, bullseye is Debien 11, bookworm is Debian 12).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] ~~I have written tests for my code.~~ (Not applicable)
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This will be demonstrated by the CI tests passing, since some of them run on Docker.