### PR TITLE
Fix part of #18384: Goal tags for lesson card, few accessibility fixes

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -957,6 +957,7 @@
     "I18N_LEARNER_DASHBOARD_PAGE_TITLE": "Learner Dashboard | Oppia",
     "I18N_LEARNER_DASHBOARD_PLAYLIST_SECTION": "Play Later",
     "I18N_LEARNER_DASHBOARD_PROGRESS_SECTION": "Progress",
+    "I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM": "Classroom Lessons",
     "I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_EMPTY_DESC": "It looks like you don't have any lessons in progress or completed. Head over to Oppia's Classroom to start your first lesson!",
     "I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_HEADING": "<[username]>'s Progress",
     "I18N_LEARNER_DASHBOARD_REARRANGE_LEARNER_PLAYLIST_MESSAGE": "Drag and rearrange the activities in the order in which you want to play them!",

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -957,6 +957,7 @@
 	"I18N_LEARNER_DASHBOARD_PAGE_TITLE": "Text displayed on the browser tab when on the Learner dashboard page.",
 	"I18N_LEARNER_DASHBOARD_PLAYLIST_SECTION": "Text for the playlist section in the learner dashboard. Will contain all the explorations and collections which the user wants to play later but doesn't have the time at the moment.",
 	"I18N_LEARNER_DASHBOARD_PROGRESS_SECTION": "Text for the progress section in the learner dashboard. Will contain all the topics in progress and stories completed by the user.\n{{identical|Progress}}",
+	"I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM": "Text for classroom lessons section in progress tab of learner dashboard",
 	"I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_EMPTY_DESC": "Text description for progress section when there are no in-progress or completed lessons - describes navigating to math classroom",
 	"I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_HEADING": "Heading text for the progress tab in the learner dashboard",
 	"I18N_LEARNER_DASHBOARD_REARRANGE_LEARNER_PLAYLIST_MESSAGE": "Text that appears in the learner playlist section. It tells the learner that he/she can rearrage the activities in the order he/she wants to play them.",

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -2,11 +2,11 @@
   <div class="align-items-center d-flex justify-content-center lesson-card-img relative rounded-top w-100" [ngStyle]="{'background-color': imgColor}">
     <img alt="" class="h-100" [src]="imgUrl">
     <div class="d-flex flex-column lesson-card-tags w-100">
-     <!--TODO(#18384): Learner group tags-->
+      <!--TODO(#18384): Learner group tags-->
       <!--TODO(#18384): Should goal tags display if completed?-->
-     <div *ngIf="isGoal" class="lesson-card-tags-container">
-      <span class="fas fa-bullseye lesson-card-tags-icon"></span>
-      <p class="lesson-card-tags-text"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION' | translate }} </p>
+      <div *ngIf="isGoal" class="lesson-card-tags-container">
+        <span class="fas fa-bullseye lesson-card-tags-icon"></span>
+        <p class="lesson-card-tags-text"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION' | translate }} </p>
      </div>
     </div>
   </div>
@@ -79,7 +79,7 @@
 
   .lesson-card-tags-container {
     align-items: center;
-    background-color: #ffffff99;
+    background-color: #fff9;
     border-radius: 4px;
     display: flex;
     gap: 0 4px;

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -5,7 +5,7 @@
       <!--TODO(#18384): Learner group tags-->
       <!--TODO(#18384): Should goal tags display if completed?-->
       <div *ngIf="isGoal" class="lesson-card-tags-container">
-        <span class="fas fa-bullseye lesson-card-tags-icon"></span>
+        <span aria-hidden="true" class="fas fa-bullseye lesson-card-tags-icon"></span>
         <p class="lesson-card-tags-text"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION' | translate }} </p>
       </div>
     </div>

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -7,7 +7,7 @@
       <div *ngIf="isGoal" class="lesson-card-tags-container">
         <span class="fas fa-bullseye lesson-card-tags-icon"></span>
         <p class="lesson-card-tags-text"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION' | translate }} </p>
-     </div>
+      </div>
     </div>
   </div>
   <div class="bg-white d-flex flex-column lesson-card-info justify-content-between">

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -2,7 +2,11 @@
   <div class="align-items-center d-flex justify-content-center lesson-card-img relative rounded-top w-100" [ngStyle]="{'background-color': imgColor}">
     <img alt="" class="h-100" [src]="imgUrl">
     <div class="d-flex flex-column lesson-card-tags w-100">
-     <!--TODO(#18384): Learner group and goal tags-->
+     <!--TODO(#18384): Learner group tags-->
+     <div *ngIf="isGoal" class="lesson-card-tags-container">
+      <span class="fas fa-bullseye lesson-card-tags-icon"></span>
+      <p class="lesson-card-tags-text"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION' | translate }} </p>
+     </div>
     </div>
   </div>
   <div class="bg-white d-flex flex-column lesson-card-info justify-content-between">
@@ -69,6 +73,28 @@
     left: 0;
     padding: 8px;
     position: absolute;
+  }
+
+  .lesson-card-tags-container {
+    align-items: center;
+    background-color: #ffffff99;
+    border-radius: 4px;
+    display: flex;
+    gap: 0 4px;
+    padding: 2px 4px;
+  }
+
+  .lesson-card-tags-icon {
+    color: #00645c;
+    font-size: 16px;
+    height: 20px;
+    width: 20px;
+  }
+
+  .lesson-card-tags-text {
+    font-family: 'Roboto', Arial, sans-serif;
+    font-size: 12px;
+    font-weight: 500;
   }
 
   .lesson-card-title {

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -3,6 +3,7 @@
     <img alt="" class="h-100" [src]="imgUrl">
     <div class="d-flex flex-column lesson-card-tags w-100">
      <!--TODO(#18384): Learner group tags-->
+      <!--TODO(#18384): Should goal tags display if completed?-->
      <div *ngIf="isGoal" class="lesson-card-tags-container">
       <span class="fas fa-bullseye lesson-card-tags-icon"></span>
       <p class="lesson-card-tags-text"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION' | translate }} </p>
@@ -73,6 +74,7 @@
     left: 0;
     padding: 8px;
     position: absolute;
+    top: 0;
   }
 
   .lesson-card-tags-container {
@@ -81,14 +83,13 @@
     border-radius: 4px;
     display: flex;
     gap: 0 4px;
-    padding: 2px 4px;
+    padding: 4px;
+    width: fit-content;
   }
 
   .lesson-card-tags-icon {
     color: #00645c;
     font-size: 16px;
-    height: 20px;
-    width: 20px;
   }
 
   .lesson-card-tags-text {

--- a/core/templates/components/summary-tile/lesson-card.component.ts
+++ b/core/templates/components/summary-tile/lesson-card.component.ts
@@ -35,6 +35,7 @@ export class LessonCardComponent implements OnInit {
   @Input() story!: StorySummary | LearnerExplorationSummary | CollectionSummary;
   @Input() topic!: string;
   @Input() isCommunityLessonComplete?: boolean;
+  @Input() isGoal?: boolean;
 
   desc!: string;
   imgColor!: string;

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
@@ -3,10 +3,10 @@
     <p class="card-display-heading"> {{ headingI18n | translate }} </p>
     <div class="card-display-arrow-button-container" *ngIf="arrowButtonVisibility">
       <button [attr.aria-label]="'Shift cards to the ' + (isLanguageRTL ? 'right' : 'left')" [disabled]="currentShift === 0" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift - 1)">
-        <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'right' : 'left')"></span>
+        <span aria-hidden="true" [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'right' : 'left')"></span>
       </button>
       <button [attr.aria-label]="'Shift cards to the ' + (isLanguageRTL ? 'left' : 'right')" [disabled]="currentShift === getMaxShifts(cards.offsetWidth)" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift + 1)">
-        <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'left' : 'right')"></span>
+        <span aria-hidden="true" [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'left' : 'right')"></span>
       </button>
     </div>
   </div>

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.html
@@ -2,10 +2,10 @@
   <div class="d-flex justify-content-between">
     <p class="card-display-heading"> {{ headingI18n | translate }} </p>
     <div class="card-display-arrow-button-container" *ngIf="arrowButtonVisibility">
-      <button [disabled]="currentShift === 0" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift - 1)">
+      <button [attr.aria-label]="'Shift cards to the ' + (isLanguageRTL ? 'right' : 'left')" [disabled]="currentShift === 0" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift - 1)">
         <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'right' : 'left')"></span>
       </button>
-      <button [disabled]="currentShift === getMaxShifts(cards.offsetWidth)" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift + 1)">
+      <button [attr.aria-label]="'Shift cards to the ' + (isLanguageRTL ? 'left' : 'right')" [disabled]="currentShift === getMaxShifts(cards.offsetWidth)" class="px-0 card-display-arrow-button" (click)="moveCard(currentShift + 1)">
         <span [ngClass]="'fas fa-chevron-' + (isLanguageRTL ? 'left' : 'right')"></span>
       </button>
     </div>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -434,7 +434,7 @@
             </ng-container>
           </ng-container>
         </oppia-card-display>
-         <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'toggle'">
+        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'toggle'">
           <ng-container *ngFor="let summaryTile of displayCompletedLessonsList">
             <lesson-card [story]="summaryTile" [isCommunityLessonComplete]="true"> </lesson-card>
           </ng-container>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -402,7 +402,7 @@
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>
         <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
           <!--TODO(#18384): Display all lessons in topic or just the most recent/last?-->
-          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="partialTopicMastery.length" [controlType]="'toggle'">>
+          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="partialTopicMastery.length" [controlType]="'toggle'">
             <ng-container *ngFor="let topicObj of partialTopicMastery">
               <ng-container *ngFor="let story of topicObj.topic.canonicalStorySummaryDicts; index as i">
                 <lesson-card [story]="story" [topic]="topicObj.topic.name" [isGoal]="currentGoalIds.has(topicObj.topic.id)"> </lesson-card>
@@ -427,7 +427,7 @@
       <div tabindex="0" class="oppia-learner-dash-section e2e-test-completed-community-lessons-section w-100" *ngIf="totalCompletedLessonsList.length !== 0 || learntTopicsList.length !== 0">
         <p class="oppia-learner-dash-section-heading"> {{ 'I18N_LEARNER_DASHBOARD_COMPLETED_SECTION' | translate }} </p>
          <!--TODO(#18384): Display all lessons in topic or just the most recent/last?-->
-        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="learntTopicMastery.length" [controlType]="'toggle'">>
+        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="learntTopicMastery.length" [controlType]="'toggle'">
           <ng-container *ngFor="let topicObj of learntTopicMastery">
             <ng-container *ngFor="let story of topicObj.topic.canonicalStorySummaryDicts; index as i">
               <lesson-card [story]="story" [topic]="topicObj.topic.name"> </lesson-card>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -401,6 +401,14 @@
       <div tabindex="0" class="oppia-learner-dash-section">
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>
         <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
+          <!--TODO(#18384): Display all lessons in topic or just the most recent/last?-->
+          <oppia-card-display *ngIf="partialTopicMastery.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="partialTopicMastery.length" [controlType]="'toggle'">>
+            <ng-container *ngFor="let topicObj of partialTopicMastery">
+              <ng-container *ngFor="let story of topicObj.topic.canonicalStorySummaryDicts; index as i">
+                <lesson-card [story]="story" [topic]="topicObj.topic.name" [isGoal]="currentGoalIds.has(topicObj.topic.id)"> </lesson-card>
+              </ng-container>
+            </ng-container>
+          </oppia-card-display>
           <oppia-card-display *ngIf="totalIncompleteLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalIncompleteLessonsList.length" [controlType]="'toggle'">
             <ng-container *ngFor="let summaryTile of displayIncompleteLessonsList">
               <lesson-card [story]="summaryTile"> </lesson-card>
@@ -418,7 +426,15 @@
       </div>
       <div tabindex="0" class="oppia-learner-dash-section e2e-test-completed-community-lessons-section w-100" *ngIf="totalCompletedLessonsList.length !== 0 || learntTopicsList.length !== 0">
         <p class="oppia-learner-dash-section-heading"> {{ 'I18N_LEARNER_DASHBOARD_COMPLETED_SECTION' | translate }} </p>
-        <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'toggle'">
+         <!--TODO(#18384): Display all lessons in topic or just the most recent/last?-->
+        <oppia-card-display *ngIf="partialTopicMastery.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="learntTopicMastery.length" [controlType]="'toggle'">>
+          <ng-container *ngFor="let topicObj of learntTopicMastery">
+            <ng-container *ngFor="let story of topicObj.topic.canonicalStorySummaryDicts; index as i">
+              <lesson-card [story]="story" [topic]="topicObj.topic.name"> </lesson-card>
+            </ng-container>
+          </ng-container>
+        </oppia-card-display>
+         <oppia-card-display *ngIf="totalCompletedLessonsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_COMMUNITY_LESSONS_SECTION'" [numCards]="totalCompletedLessonsList.length" [controlType]="'toggle'">
           <ng-container *ngFor="let summaryTile of displayCompletedLessonsList">
             <lesson-card [story]="summaryTile" [isCommunityLessonComplete]="true"> </lesson-card>
           </ng-container>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.html
@@ -402,7 +402,7 @@
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>
         <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
           <!--TODO(#18384): Display all lessons in topic or just the most recent/last?-->
-          <oppia-card-display *ngIf="partialTopicMastery.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="partialTopicMastery.length" [controlType]="'toggle'">>
+          <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="partialTopicMastery.length" [controlType]="'toggle'">>
             <ng-container *ngFor="let topicObj of partialTopicMastery">
               <ng-container *ngFor="let story of topicObj.topic.canonicalStorySummaryDicts; index as i">
                 <lesson-card [story]="story" [topic]="topicObj.topic.name" [isGoal]="currentGoalIds.has(topicObj.topic.id)"> </lesson-card>
@@ -427,7 +427,7 @@
       <div tabindex="0" class="oppia-learner-dash-section e2e-test-completed-community-lessons-section w-100" *ngIf="totalCompletedLessonsList.length !== 0 || learntTopicsList.length !== 0">
         <p class="oppia-learner-dash-section-heading"> {{ 'I18N_LEARNER_DASHBOARD_COMPLETED_SECTION' | translate }} </p>
          <!--TODO(#18384): Display all lessons in topic or just the most recent/last?-->
-        <oppia-card-display *ngIf="partialTopicMastery.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="learntTopicMastery.length" [controlType]="'toggle'">>
+        <oppia-card-display *ngIf="learntTopicsList.length !== 0 && dataLoaded" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="learntTopicMastery.length" [controlType]="'toggle'">>
           <ng-container *ngFor="let topicObj of learntTopicMastery">
             <ng-container *ngFor="let story of topicObj.topic.canonicalStorySummaryDicts; index as i">
               <lesson-card [story]="story" [topic]="topicObj.topic.name"> </lesson-card>

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.spec.ts
@@ -337,6 +337,7 @@ describe('Community lessons tab Component', () => {
     component.completedToIncompleteCollections = [];
     component.totalCompletedLessonsList = [];
     component.totalIncompleteLessonsList = [];
+    component.currentGoals = [];
     explorationSummary =
       LearnerExplorationSummary.createFromBackendDict(sampleExploration);
     component.partialTopicMastery = [];

--- a/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.ts
+++ b/core/templates/pages/learner-dashboard-page/community-lessons-tab.component.ts
@@ -65,6 +65,7 @@ export class CommunityLessonsTabComponent {
   @Input() learnerDashboardRedesignFeatureFlag!: boolean;
   @Input() partiallyLearntTopicsList!: LearnerTopicSummary[];
   @Input() learntTopicsList!: LearnerTopicSummary[];
+  @Input() currentGoals!: LearnerTopicSummary[];
   selectedSection!: string;
   noCommunityLessonActivity: boolean = false;
   noPlaylistActivity: boolean = false;
@@ -99,6 +100,7 @@ export class CommunityLessonsTabComponent {
 
   partialTopicMastery: {topic: LearnerTopicSummary; progress: number[]}[] = [];
   learntTopicMastery: {topic: LearnerTopicSummary; progress: number[]}[] = [];
+  currentGoalIds: Set<string> = new Set();
 
   completed: string = 'Completed';
   incomplete: string = 'Incomplete';
@@ -186,6 +188,7 @@ export class CommunityLessonsTabComponent {
     this.displayInCommunityLessons = this.allCommunityLessons;
     this.selectedSection = this.all;
     this.dropdownEnabled = false;
+    this.currentGoalIds = new Set(this.currentGoals.map(g => g.id));
 
     this.getSubtopicMasteryData();
   }

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -99,7 +99,7 @@
         <oppia-card-display *ngIf="continueWhereYouLeftOffList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_PROGRESS_SECTION'" [numCards]="1" [displayMaxWidth]="'fit-content'">
           <ng-container *ngFor="let topicSummaryTile of partiallyLearntTopicsList">
             <ng-container *ngFor="let storySummaryTile of topicSummaryTile.canonicalStorySummaryDicts">
-              <lesson-card [story]="storySummaryTile" [topic]="topicSummaryTile.name"> </lesson-card>
+              <lesson-card [story]="storySummaryTile" [topic]="topicSummaryTile.name" [isGoal]="currentGoalIds.has(topicSummaryTile.id)"> </lesson-card>
             </ng-container>
           </ng-container>
         </oppia-card-display>

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.ts
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.ts
@@ -63,6 +63,7 @@ export class HomeTabComponent {
   continueWhereYouLeftOffList: LearnerTopicSummary[] = [];
   windowIsNarrow: boolean = false;
   directiveSubscriptions = new Subscription();
+  currentGoalIds: Set<string> = new Set();
 
   constructor(
     private i18nLanguageCodeService: I18nLanguageCodeService,
@@ -76,6 +77,7 @@ export class HomeTabComponent {
     var allGoals = [...this.currentGoals, ...this.partiallyLearntTopicsList];
     this.currentGoalsLength = this.currentGoals.length;
     this.goalTopicsLength = this.goalTopics.length;
+    this.currentGoalIds = new Set(this.currentGoals.map(g => g.id));
 
     if (allGoals.length !== 0) {
       var allGoalIds = [];

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
@@ -172,7 +172,8 @@
                                        [partiallyLearntTopicsList]="partiallyLearntTopicsList"
                                        [learntTopicsList]="learntTopicsList"
                                        [completedToIncompleteCollections]="completedToIncompleteCollections"
-                                       [learnerDashboardRedesignFeatureFlag]="isShowRedesignedLearnerDashboardActive()">
+                                       [learnerDashboardRedesignFeatureFlag]="isShowRedesignedLearnerDashboardActive()"
+                                       [currentGoals]="topicsToLearn">
           </oppia-community-lessons-tab>
         </div>
       </div>

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
@@ -50,29 +50,32 @@
           </picture>
         </li>
         <li>
-          <button class="align-items-center d-inline-flex e2e-test-home-section rounded oppia-learner-dash-sidebar_btn text-left w-100" tabindex="0"
+          <button aria-label="Go to home tab"
+                  class="align-items-center d-inline-flex e2e-test-home-section rounded oppia-learner-dash-sidebar_btn text-left w-100" tabindex="0"
                   [ngClass]="{'oppia-learner-dash-sidebar_btn--active': activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.HOME}"
                   (click)="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.HOME)"
                   (keyup.enter)="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.HOME)">
-            <span class="fas fa-home fa-lg"></span>
+            <span aria-hidden="true" class="fas fa-home fa-lg"></span>
             {{ LEARNER_DASHBOARD_SECTION_I18N_IDS.HOME | translate }}
           </button>
         </li>
         <li>
-          <button class="align-items-center d-inline-flex e2e-test-goals-section rounded oppia-learner-dash-sidebar_btn text-left w-100" tabindex="0"
+          <button aria-label="Go to goals tab"
+                  class="align-items-center d-inline-flex e2e-test-goals-section rounded oppia-learner-dash-sidebar_btn text-left w-100" tabindex="0"
                   [ngClass]="{'oppia-learner-dash-sidebar_btn--active': activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.GOALS}"
                   (click)="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.GOALS)"
                   (keyup.enter)="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.GOALS)">
-            <span class="fas fa-bullseye fa-lg"></span>
+            <span aria-hidden="true" class="fas fa-bullseye fa-lg"></span>
             {{ LEARNER_DASHBOARD_SECTION_I18N_IDS.GOALS | translate }}
           </button>
         </li>
         <li>
-          <button class="align-items-center d-inline-flex e2e-test-community-lessons-section rounded oppia-learner-dash-sidebar_btn text-left w-100" tabindex="0"
+          <button aria-label="Go to progress tab"
+                  class="align-items-center d-inline-flex e2e-test-community-lessons-section rounded oppia-learner-dash-sidebar_btn text-left w-100" tabindex="0"
                   [ngClass]="{'oppia-learner-dash-sidebar_btn--active': activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.COMMUNITY_LESSONS}"
                   (click)="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.COMMUNITY_LESSONS)"
                   (keyup.enter)="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.COMMUNITY_LESSONS)">
-            <span class="fas fa-chart-line fa-lg"></span>
+            <span aria-hidden="true" class="fas fa-chart-line fa-lg"></span>
             {{ LEARNER_DASHBOARD_SECTION_I18N_IDS.PROGRESS | translate }}
           </button>
         </li>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

This PR addresses part of #18384. Lessons can now be tagged as goals. I also added ARIA attributes for buttons with icons in several places: card-display, content-toggle-button, goals-tab, and goal-list.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

https://github.com/user-attachments/assets/0d47cdfb-7219-4eb8-9a05-f85e8bfc2b68




## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
