### PR TITLE
Fix #20757: Fix question list pagination

### DIFF
--- a/core/templates/components/question-directives/questions-list/questions-list.component.html
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.html
@@ -227,6 +227,10 @@
   }
   .page-navigation-arrows {
     float: right;
+    margin-top: 5px;
+  }
+  .page-navigation-arrows > i {
+    cursor: pointer;
   }
   .add-question-btn {
     background-color: #008098;

--- a/core/templates/components/question-directives/questions-list/questions-list.component.spec.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.spec.ts
@@ -461,34 +461,36 @@ describe('Questions List Component', () => {
     expect(component.getQuestionIndex(1)).toBe(52);
   });
 
-  it('should fetch question summaries on moving to next page', () => {
+  it('should fetch question summaries and use them on moving to next page', done => {
     component.selectedSkillId = 'skillId1';
     spyOn(questionsListService, 'incrementPageNumber');
-    spyOn(questionsListService, 'getQuestionSummariesAsync');
+    spyOn(questionsListService, 'getQuestionSummariesAsync').and.resolveTo();
+    spyOn(questionsListService, 'getCachedQuestionSummaries');
 
     component.goToNextPage();
 
-    expect(questionsListService.incrementPageNumber).toHaveBeenCalled();
-    expect(questionsListService.getQuestionSummariesAsync).toHaveBeenCalledWith(
-      'skillId1',
-      true,
-      false
-    );
+    // Since goToNextPage calls an async function but is not async itself, we need to let that call finish.
+    setTimeout(() => {
+      expect(questionsListService.incrementPageNumber).toHaveBeenCalled();
+      expect(
+        questionsListService.getQuestionSummariesAsync
+      ).toHaveBeenCalledWith('skillId1', true, false);
+      expect(
+        questionsListService.getCachedQuestionSummaries
+      ).toHaveBeenCalled();
+      done();
+    });
   });
 
-  it('should fetch question summaries on moving to previous page', () => {
+  it('should use cached question summaries on moving to previous page', () => {
     component.selectedSkillId = 'skillId1';
     spyOn(questionsListService, 'decrementPageNumber');
-    spyOn(questionsListService, 'getQuestionSummariesAsync');
+    spyOn(questionsListService, 'getCachedQuestionSummaries');
 
     component.goToPreviousPage();
 
     expect(questionsListService.decrementPageNumber).toHaveBeenCalled();
-    expect(questionsListService.getQuestionSummariesAsync).toHaveBeenCalledWith(
-      'skillId1',
-      false,
-      false
-    );
+    expect(questionsListService.getCachedQuestionSummaries).toHaveBeenCalled();
   });
 
   it(

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -483,16 +483,12 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
       this.selectedSkillId,
       true,
       false
-    );
+    ).then(() => this.getQuestionSummariesForOneSkill());
   }
 
   goToPreviousPage(): void {
     this.questionsListService.decrementPageNumber();
-    this.questionsListService.getQuestionSummariesAsync(
-      this.selectedSkillId,
-      false,
-      false
-    );
+    this.getQuestionSummariesForOneSkill();
   }
 
   showUnaddressedSkillMisconceptionWarning(

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -479,11 +479,9 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
 
   goToNextPage(): void {
     this.questionsListService.incrementPageNumber();
-    this.questionsListService.getQuestionSummariesAsync(
-      this.selectedSkillId,
-      true,
-      false
-    ).then(() => this.getQuestionSummariesForOneSkill());
+    this.questionsListService
+      .getQuestionSummariesAsync(this.selectedSkillId, true, false)
+      .then(() => this.getQuestionSummariesForOneSkill());
   }
 
   goToPreviousPage(): void {

--- a/core/templates/services/questions-list.service.ts
+++ b/core/templates/services/questions-list.service.ts
@@ -78,11 +78,11 @@ export class QuestionsListService {
     );
   }
 
-  getQuestionSummariesAsync(
+  async getQuestionSummariesAsync(
     skillId: string,
     fetchMore: boolean,
     resetHistory: boolean
-  ): void {
+  ): Promise<void> {
     if (resetHistory) {
       this._questionSummariesForOneSkill = [];
       this._nextOffsetForQuestions = 0;
@@ -101,7 +101,7 @@ export class QuestionsListService {
       this._moreQuestionsAvailable === true &&
       fetchMore
     ) {
-      this.questionBackendApiService
+      return this.questionBackendApiService
         .fetchQuestionSummariesAsync(skillId, this._nextOffsetForQuestions)
         .then(response => {
           let questionSummaries = response.questionSummaries.map(summary => {


### PR DESCRIPTION
## Overview

1. This PR fixes #20757 
2. This PR does the following: 
    1. Corrects the logic for pagination in the question list component. When fetching is done, the correct part of the list of questions is shown. The new logic is thus:
        1. Going to next page
            1. Increment page number
            2. Call `getQuestionSummariesAsync` which fetches and caches new question summaries if needed
            3. Call `getQuestionSummariesForOneSkill` when done, which gets the correct cached question summaries and sets these to be the ones shown
        2. Going to previous page
            1. Decrement page number
            2. Call `getQuestionSummariesForOneSkill`, which gets the correct cached question summaries and sets these to be the ones shown
    2. Changes the function used to fetch questions to `async`. From what I could see this won't break the other places where it's used since the fetching itself has always been asyncronous regardless. Also changed tests to accommodate for this. Feedback highly appreciated!
    3. Adds some styling to the pagination arrows that makes them look nicer. Just tell me if these are deemed unrelated to the issue and should not be included in this pull request.
    
    I'm very open to feedback here, because I very well might have misunderstood why things were done as they were in the first place.

3. The original bug occurred because: The forward button only fetched (and then showed) questions if the questions on the next page had not been fetched already – otherwise it did nothing (i.e. it did not show the cached questions). The back button incorrectly called the fetching function (which never has to fetch for going backwards, obviously) and never showed the cached questions regardless. I am honestly having a hard time figuring out when this issue was introduced – to me this logic seems to have been like this for a long time, e.g. even back [2021](https://github.com/oppia/oppia/blob/a2f9d1465f8676e9779b0b8c33ba178e374ff525/core/templates/components/question-directives/questions-list/questions-list.component.ts#L146C12-L146C24).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

**Before:**

https://github.com/user-attachments/assets/3868e6d0-fe60-488b-96ba-03c96128e8c1


**After:**

https://github.com/user-attachments/assets/4c13cb64-211a-4023-bff0-e0b6ae3b9d2f




#### Proof of changes on desktop with slow/throttled network

See proof above.

#### Proof of changes on mobile phone

See proof above.

#### Proof of changes in Arabic language

Not affected by this.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
