### PR TITLE
Upgrade actions/{up,down}load-artifact to v4, since Artifacts v3 will soon be deprecated.

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -40,14 +40,14 @@ jobs:
           message: "A backend test failed on the upstream develop branch."
           webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}
       - name: Upload time report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ format('backend_test_time_shard_{0}', matrix.shard) }}
           path: backend_test_time_report.json
           retention-days: 1
       - name: Upload coverage report
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ format('backend_test_coverage_shard_{0}', matrix.shard) }}
           include-hidden-files: true
@@ -76,31 +76,31 @@ jobs:
           make stop
       - name: Download coverage report for shard 1
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_coverage_shard_1
           path: coverage/coverage_1
       - name: Download coverage report for shard 2
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_coverage_shard_2
           path: coverage/coverage_2
       - name: Download coverage report for shard 3
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_coverage_shard_3
           path: coverage/coverage_3
       - name: Download coverage report for shard 4
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_coverage_shard_4
           path: coverage/coverage_4
       - name: Download coverage report for shard 5
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_coverage_shard_5
           path: coverage/coverage_5
@@ -136,27 +136,27 @@ jobs:
           python-version: '3.9.20'
           architecture: 'x64'
       - name: Download time report for shard 1
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_time_shard_1
           path: backend_test_time_reports_artifacts/backend_test_time_1
       - name: Download time report for shard 2
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_time_shard_2
           path: backend_test_time_reports_artifacts/backend_test_time_2
       - name: Download time report for shard 3
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_time_shard_3
           path: backend_test_time_reports_artifacts/backend_test_time_3
       - name: Download time report for shard 4
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_time_shard_4
           path: backend_test_time_reports_artifacts/backend_test_time_4
       - name: Download time report for shard 5
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: backend_test_time_shard_5
           path: backend_test_time_reports_artifacts/backend_test_time_5
@@ -170,7 +170,7 @@ jobs:
         shell: bash
       - name: Upload test times artifact
         if: ${{ github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: backend_test_times
           path: backend_test_times.txt

--- a/.github/workflows/check_test_suites_to_run.yml
+++ b/.github/workflows/check_test_suites_to_run.yml
@@ -43,7 +43,7 @@ jobs:
           --github_base_ref="origin/${{ github.event.pull_request.base.ref }}"
           ${{ env.SHOULD_OUTPUT_ALL_TESTS == 'true' && '--output_all_test_suites' || '' }}
       - name: Upload root files mapping as a github artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: root-files-mapping
           path: root-files-mapping.json

--- a/.github/workflows/e2e_lighthouse_performance_acceptance_tests.yml
+++ b/.github/workflows/e2e_lighthouse_performance_acceptance_tests.yml
@@ -67,7 +67,7 @@ jobs:
           zip -rqy build_files.zip oppia/third_party oppia_tools oppia/build oppia/webpack_bundles oppia/proto_files oppia/app.yaml oppia/assets/hashes.json oppia/proto_files oppia/extensions/classifiers/proto/* oppia/backend_prod_files oppia/dist
         working-directory: /home/runner/work/oppia
       - name: Upload build files artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_files
           path: /home/runner/work/oppia/build_files.zip
@@ -110,7 +110,7 @@ jobs:
             ${{ runner.os }}-
       - name: Attempt to download build files artifact
         id: download_artifact_1
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: build_files
@@ -166,19 +166,19 @@ jobs:
             --skip-build --suite=${{ matrix.suite.name }} --prod_env
       - name: Uploading webdriverio-video as Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webdriverio-video
           path: /home/runner/work/oppia/webdriverio-video
       - name: Uploading webdriverio screenshots as Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webdriverio-screenshots
           path: /home/runner/work/oppia/webdriverio-screenshots
       - name: Uploading webpack bundles as an artifact
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
@@ -220,7 +220,7 @@ jobs:
             ${{ runner.os }}-
       - name: Attempt to download build files artifact
         id: download_artifact_1
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: build_files
@@ -268,7 +268,7 @@ jobs:
         run: python -m scripts.run_lighthouse_tests --mode performance --skip_build --record_screen --pages ${{ join(matrix.suite.pages_to_run, ',') }}
       - name: Uploading puppeteer video as Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: lhci-puppeteer-video
           path: /home/runner/work/oppia/lhci-puppeteer-video/video.mp4
@@ -316,7 +316,7 @@ jobs:
               ${{ runner.os }}-
         - name: Attempt to download build files artifact
           id: download_artifact_1
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           continue-on-error: true
           with:
             name: build_files
@@ -360,7 +360,7 @@ jobs:
           run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_acceptance_tests --skip-build --suite=${{ matrix.suite.name }} --prod_env
         - name: Uploading generated test to angular module mapping as an artifact
           if: ${{ failure() }}
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: generated-test-to-angular-module-mapping
             path: /home/runner/work/oppia/oppia/core/tests/test-modules-mappings/acceptance/${{ matrix.suite.name }}.txt
@@ -368,7 +368,7 @@ jobs:
           run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_acceptance_tests --skip-build --suite=${{ matrix.suite.name }} --prod_env --mobile
         - name: Uploading webpack bundles as an artifact
           if: ${{ failure() }}
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: webpack-bundles
             path: /home/runner/work/oppia/oppia/build

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: make run_tests.frontend PYTHON_ARGS="--check_coverage"
       - name: Uploading fronted coverage reports as an artifact
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage-${{ matrix.num_runs }}
           path: /home/runner/work/oppia/karma_coverage_reports


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: Upgrades actions/upload-artifact and actions/download-artifact to v4, per the instructions [here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) and [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). Per the email we received from GitHub, Actions v3 will be deprecated by 5 Dec 2024.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

If the CI checks pass, and the artifacts are shown in the CI summary view, that should indicate that this change is safe.