### PR TITLE
Fix #14322: Reinstante missing-type-doc pylint rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -151,8 +151,6 @@ disable=abstract-method,
         not-an-iterable,
         unnecessary-pass,
         consider-using-f-string,
-# TODO(#14322): Reinstate this.
-        missing-type-doc,
         # Pylint considers imports to be cyclic even when the cycle is
         # broken by putting imports inside functions so they aren't
         # executed upon module import.


### PR DESCRIPTION
## Overview

1. This PR fixes #14322
2. This PR does the following: reenable the missing-type-doc pylint rule

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

I've run the lint task with `PYTHON_ARGS="--shard other" make run_tests.lint` 3 times and no errors were raised:
![image](https://github.com/user-attachments/assets/cbc1a6f7-18e0-4042-9094-e135a2bd9b5d)

Job passing here at GitHub:
https://github.com/oppia/oppia/actions/runs/11846418128/job/33014008879

The failure example in the original issue is not available anymore, but looking at the discussion/comments it seems those issues were with the older Python-based setup. I've had no issues with the new Docker setup, so I think this isn't an issue anymore.
