### PR TITLE
Fix #14054: Remove duplicate error logging.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -805,9 +805,6 @@ class BaseHandler(
                 self.redirect(user_services.create_login_url(self.request.uri))
             return
 
-        logging.exception(
-            'Exception raised at %s: %s', self.request.uri, exception)
-
         if isinstance(exception, self.NotFoundException):
             logging.warning('Invalid URL requested: %s', self.request.uri)
             self.error(404)
@@ -818,7 +815,8 @@ class BaseHandler(
             self._render_exception(values)
             return
 
-        logging.exception('Exception raised: %s', exception)
+        logging.exception(
+            'Exception raised at %s: %s', self.request.uri, exception)
 
         if isinstance(exception, self.UnauthorizedUserException):
             self.error(401)

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1148,9 +1148,9 @@ class StateInteractionStatsHandlerTests(test_utils.GenericTestBase):
                     exp_id, 'invalid_state_name'),
                 expected_status_int=404)
 
-        self.assertEqual(len(observed_log_messages), 3)
+        self.assertEqual(len(observed_log_messages), 2)
         self.assertEqual(
-            observed_log_messages[:2],
+            observed_log_messages,
             [
                 'Could not find state: invalid_state_name',
                 'Available states: [\'Introduction\']'


### PR DESCRIPTION
## Overview

1. This PR fixes #14054.
2. This PR does the following: Remove duplicate error logs.
3. (For bug-fixing PRs only) The original bug occurred because: There were two logging statements within a few lines of each PR in base.py. This PR removes one of them.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

(Following the repro steps in #14054)

Before:

```
INFO     2024-11-19 11:29:52,917 module.py:413] [default] Detected file changes:
  /opensource/oppia/core/controllers/admin.py
INFO     2024-11-19 11:29:57,387 instance.py:555] Detected GOOGLE_CLOUD_PROJECT=dev-project-id in environment variables
INFO     2024-11-19 11:29:58,414 instance.py:293] Instance PID: 1563478
ERROR:root:Exception raised at http://localhost:8181/adminhandler: Temporary exception
Traceback (most recent call last):
  File "/tmp/tmpgb5gb304/lib/python3.9/site-packages/webapp2.py", line 604, in dispatch
    return method(*args, **kwargs)
  File "/opensource/oppia/core/controllers/acl_decorators.py", line 1207, in test_super_admin
    return handler(self, **kwargs)
  File "/opensource/oppia/core/controllers/admin.py", line 457, in post
    raise Exception("Temporary exception")
Exception: Temporary exception
ERROR:root:Exception raised: Temporary exception
Traceback (most recent call last):
  File "/tmp/tmpgb5gb304/lib/python3.9/site-packages/webapp2.py", line 604, in dispatch
    return method(*args, **kwargs)
  File "/opensource/oppia/core/controllers/acl_decorators.py", line 1207, in test_super_admin
    return handler(self, **kwargs)
  File "/opensource/oppia/core/controllers/admin.py", line 457, in post
    raise Exception("Temporary exception")
Exception: Temporary exception
INFO     2024-11-19 11:29:59,445 module.py:830] default: "POST /adminhandler HTTP/1.1" 500 57
```

After:

```
563686] [INFO] Using worker: sync
[2024-11-19 19:31:11 +0800] [1563688] [INFO] Booting worker with pid: 1563688
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1732015871.967639 1563688 config.cc:230] gRPC experiments enabled: call_status_override_on_cancellation, event_engine_dns, event_engine_listener, http2_stats_fix, monitoring_experiment, pick_first_new, trace_record_callops, work_serializer_clears_time_cache
INFO     2024-11-19 11:31:12,394 instance.py:293] Instance PID: 1563686
ERROR:root:Exception raised at http://localhost:8181/adminhandler: Temporary exception
Traceback (most recent call last):
  File "/tmp/tmpgb5gb304/lib/python3.9/site-packages/webapp2.py", line 604, in dispatch
    return method(*args, **kwargs)
  File "/opensource/oppia/core/controllers/acl_decorators.py", line 1207, in test_super_admin
    return handler(self, **kwargs)
  File "/opensource/oppia/core/controllers/admin.py", line 457, in post
    raise Exception("Temporary exception")
Exception: Temporary exception
INFO     2024-11-19 11:31:13,399 module.py:830] default: "POST /adminhandler HTTP/1.1" 500 57
INFO     2024-11-19 11:31:15,516 instance.py:555] Detected GOOGLE_CLOUD_PROJECT=dev-project-id in environmen
```

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
