### PR TITLE
Suppress unnecessary gunicorn and grpc logs.

### DIFF
--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -4,8 +4,9 @@ instance_class: F2
 # #6534 on oppia/oppia).
 version: default
 # Timeout is set to 60 so that the gunicorn workers don't die while sending
-# the Apache Beam jobs to Google Cloud Dataflow.
-entrypoint: gunicorn --timeout 60 --bind :$PORT main:app
+# the Apache Beam jobs to Google Cloud Dataflow. Log level is set to 'warning'
+# because the info logs are very noisy.
+entrypoint: gunicorn --timeout 60 --log-level warning --bind :$PORT main:app
 
 inbound_services:
 - warmup
@@ -181,3 +182,7 @@ env_variables:
   DATASTORE_PROJECT_ID: "dev-project-id"
   DATASTORE_USE_PROJECT_ID_AS_APP_ID: "true"
   SECRETS: "{\"ANDROID_BUILD_SECRET\": \"android-build-secret\", \"VM_ID\": \"vm_default\", \"SHARED_SECRET_KEY\": \"1a2b3c4e\"}"
+# These environment variables control GRPC logging verbosity. See
+# https://stackoverflow.com/a/78803598.
+  GRPC_VERBOSITY: "ERROR"
+  GLOG_minloglevel: "2"

--- a/app_dev_docker.yaml
+++ b/app_dev_docker.yaml
@@ -6,8 +6,9 @@ instance_class: F2
 # #6534 on oppia/oppia).
 version: default
 # Timeout is set to 60 so that the gunicorn workers don't die while sending
-# the Apache Beam jobs to Google Cloud Dataflow.
-entrypoint: gunicorn --timeout 60 --bind :$PORT main:app
+# the Apache Beam jobs to Google Cloud Dataflow. Log level is set to 'warning'
+# because the info logs are very noisy.
+entrypoint: gunicorn --timeout 60 --log-level warning --bind :$PORT main:app
 
 inbound_services:
 - warmup
@@ -188,3 +189,7 @@ env_variables:
   DATASTORE_PROJECT_ID: "dev-project-id"
   DATASTORE_USE_PROJECT_ID_AS_APP_ID: "true"
   SECRETS: "{\"ANDROID_BUILD_SECRET\": \"android-build-secret\", \"VM_ID\": \"vm_default\", \"SHARED_SECRET_KEY\": \"1a2b3c4e\"}"
+# These environment variables control GRPC logging verbosity. See
+# https://stackoverflow.com/a/78803598.
+  GRPC_VERBOSITY: "ERROR"
+  GLOG_minloglevel: "2"

--- a/main.py
+++ b/main.py
@@ -101,7 +101,7 @@ datastore_services = models.Registry.import_datastore_services()
 # Cloud Logging is disabled in emulator mode, since it is unnecessary and
 # creates a lot of noise.
 if not constants.EMULATOR_MODE:
-    # Instantiates a client and rtrieves a Cloud Logging handler based on the
+    # Instantiates a client and retrieves a Cloud Logging handler based on the
     # environment you're running in and integrates the handler with the Python
     # logging module.
     client = google.cloud.logging.Client()


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: The server logs are quite noisy; this PR removes some of those so that it's easier to focus on the request/response logs.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before:

```
INFO     2024-11-19 11:31:27,687 instance.py:293] Instance PID: 1563738
INFO     2024-11-19 11:31:28,646 module.py:830] default: "GET /_ah/warmup HTTP/1.1" 200 -
INFO     2024-11-19 11:31:28,692 instance.py:555] Detected GOOGLE_CLOUD_PROJECT=dev-project-id in environment variables
[2024-11-19 19:31:28 +0800] [1563762] [INFO] Starting gunicorn 20.1.0
[2024-11-19 19:31:28 +0800] [1563762] [INFO] Listening at: http://0.0.0.0:40913 (1563762)
[2024-11-19 19:31:28 +0800] [1563762] [INFO] Using worker: sync
[2024-11-19 19:31:28 +0800] [1563764] [INFO] Booting worker with pid: 1563764
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1732015889.265562 1563764 config.cc:230] gRPC experiments enabled: call_status_override_on_cancellation, event_engine_dns, event_engine_listener, http2_stats_fix, monitoring_experiment, pick_first_new, trace_record_callops, work_serializer_clears_time_cache
INFO     2024-11-19 11:31:29,709 instance.py:293] Instance PID: 1563762
INFO     2024-11-19 11:31:30,703 module.py:830] default: "GET /_ah/warmup HTTP/1.1" 200 -
[2024-11-19 19:31:43 +0800] [1563688] [INFO] Parent changed, shutting down: <Worker 1563688>
[2024-11-19 19:31:43 +0800] [1563688] [INFO] Worker exiting (pid: 1563688)
[2024-11-19 19:31:47 +0800] [1563711] [INFO] Parent changed, shutting down: <Worker 1563711>
[2024-11-19 19:31:47 +0800] [1563711] [INFO] Worker exiting (pid: 1563711)
INFO     2024-11-19 11:33:50,029 module.py:413] [default] Detected file changes:
  /opensource/oppia/app_dev.yaml
  /opensource/oppia/app_dev_docker.yaml
  /opensource/oppia/core/controllers/base.py
  /opensource/oppia/main.py
[2024-11-19 19:33:58 +0800] [1563740] [INFO] Parent changed, shutting down: <Worker 1563740>
[2024-11-19 19:33:58 +0800] [1563740] [INFO] Worker exiting (pid: 1563740)
INFO     2024-11-19 11:33:59,111 instance.py:555] Detected GOOGLE_CLOUD_PROJECT=dev-project-id in environment variables
INFO     2024-11-19 11:34:00,133 instance.py:293] Instance PID: 1564150
INFO     2024-11-19 11:34:00,234 module.py:413] [default] Detected file changes:
  /opensource/oppia/__pycache__/main.cpython-39.pyc.137463657499872
  /opensource/oppia/core/controllers/__pycache__/admin.cpython-39.pyc.137463651411504
  /opensource/oppia/core/controllers/__pycache__/base.cpython-39.pyc.137463644057136
  /opensource/oppia/core/controllers/admin.py
INFO     2024-11-19 11:34:00,237 instance.py:555] Detected GOOGLE_CLOUD_PROJECT=dev-project-id in environment variables
[2024-11-19 19:34:00 +0800] [1563764] [INFO] Parent changed, shutting down: <Worker 1563764>
[2024-11-19 19:34:00 +0800] [1563764] [INFO] Worker exiting (pid: 1563764)
INFO     2024-11-19 11:34:01,252 instance.py:293] Instance PID: 1564173
INFO     2024-11-19 11:34:02,304 module.py:830] default: "GET /_ah/warmup HTTP/1.1" 200 -
INFO     2024-11-19 11:34:05,156 module.py:830] default: "GET /admin HTTP/1.1" 200 7836
INFO     2024-11-19 11:34:05,164 module.py:830] default: "GET /third_party/generated/webfonts/fa-solid-900.woff2 HTTP/1.1" 304 -
INFO     2024-11-19 11:34:05,167 module.py:830] default: "GET /third_party/generated/webfonts/fa-brands-400.woff2 HTTP/1.1" 304 -
INFO     2024-11-19 11:34:05,177 module.py:830] default: "GET /third_party/generated/css/third_party.css HTTP/1.1" 304 -
```

After:

```
INFO     2024-11-19 11:39:32,227 module.py:830] default: "GET /webpack_bundles/4.cd48015fe479016a6e9e.css HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,228 module.py:830] default: "GET /webpack_bundles/2.19e6ed4f0a9149af5f03.css HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,230 module.py:830] default: "GET /csrfhandler HTTP/1.1" 200 102
INFO     2024-11-19 11:39:32,296 module.py:830] default: "GET /feature_flags_evaluation_handler HTTP/1.1" 200 858
INFO     2024-11-19 11:39:32,313 module.py:830] default: "GET /webpack_bundles/9.bundle.js HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,313 module.py:830] default: "GET /webpack_bundles/17.bundle.js HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,313 module.py:830] default: "GET /webpack_bundles/43.bundle.js HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,314 module.py:830] default: "GET /webpack_bundles/33.bundle.js HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,456 module.py:830] default: "GET /userinfohandler HTTP/1.1" 200 294
INFO     2024-11-19 11:39:32,465 module.py:830] default: "GET /assets/i18n/en.json HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,493 module.py:830] default: "GET /assets/images/logo/288x128_logo_white.webp HTTP/1.1" 304 -
INFO     2024-11-19 11:39:32,503 module.py:830] default: "GET /assets/images/avatar/user_blue_150px.webp?2364.4000000953674 HTTP/1.1" 200 3448
INFO     2024-11-19 11:39:32,509 module.py:830] default: "GET /adminhandler HTTP/1.1" 200 10199
```

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
