### PR TITLE
Fix #20859: Show only uncovered files in the coverage tests.

### DIFF
--- a/scripts/check_overall_backend_test_coverage.py
+++ b/scripts/check_overall_backend_test_coverage.py
@@ -27,10 +27,15 @@ from scripts import common
 def main() -> None:
     """Checks if backend overall line coverage is 100%."""
     env = os.environ.copy()
+
+    # See the "Report" section at
+    # https://coverage.readthedocs.io/en/latest/cmd.html
+    # for what each of the options mean.
     cmd = [
         sys.executable, '-m', 'coverage', 'report',
         '--omit="%s*","third_party/*","/usr/share/*"'
-        % common.OPPIA_TOOLS_DIR, '--show-missing']
+        % common.OPPIA_TOOLS_DIR, '--show-missing',
+        '--skip-covered', '--skip-empty']
     process = subprocess.run(
         cmd, capture_output=True, encoding='utf-8', env=env,
         check=False)

--- a/scripts/check_overall_backend_test_coverage_test.py
+++ b/scripts/check_overall_backend_test_coverage_test.py
@@ -40,7 +40,8 @@ class CheckOverallBackendTestCoverageTests(test_utils.GenericTestBase):
         self.cmd = [
             sys.executable, '-m', 'coverage', 'report',
             '--omit="%s*","third_party/*","/usr/share/*"'
-            % common.OPPIA_TOOLS_DIR, '--show-missing']
+            % common.OPPIA_TOOLS_DIR, '--show-missing',
+            '--skip-covered', '--skip-empty']
 
     def test_no_data_in_coverage_report_throws_error(self) -> None:
         class MockProcess:


### PR DESCRIPTION
## Overview

1. This PR fixes #20859.
2. This PR does the following: Shows only uncovered files in the coverage tests.
3. (For bug-fixing PRs only) The original bug occurred because: the relevant option wasn't passed to the coverage script. See https://coverage.readthedocs.io/en/latest/cmd.html#cmd-report for the documentation.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

![Screenshot from 2024-11-19 23-26-01](https://github.com/user-attachments/assets/ed5b5032-c13d-42d7-aff2-bb8845cae2e5)

(Note: the files shown above have full line coverage but incomplete branch coverage. I have filed https://github.com/oppia/oppia/issues/21308 to track this and fill in tests for the missing branches.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
