### PR TITLE
PR fixes issue #21274

### DIFF
--- a/.github/workflows/image_compression_check.yml
+++ b/.github/workflows/image_compression_check.yml
@@ -1,0 +1,51 @@
+name: Image Compression Check
+
+on:
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches:
+      - develop
+      - release-*
+  pull_request:
+    branches:
+      - develop
+      - release-*
+
+jobs:
+  run_tests:
+    name: Run Image Compression Checks
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python 3.9.20
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9.20'
+          architecture: 'x64'
+
+      - name: Merge develop branch into the current branch
+        uses: ./.github/actions/merge
+
+      - name: Initialize Containers
+        run: |
+          make build
+          make stop
+
+      - name: Run Image Compression Check
+        if: startsWith(github.head_ref, 'update-changelog-for-release') == false
+        run: make run_tests.image_compression_check
+
+      - name: Report failure if image size exceeds limit on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "Image compression check failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}
+

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ logs.%: ## Shows the logs of the given docker service. Example: make logs.datast
 
 restart.%: ## Restarts the given docker service. Example: make restart.datastore
 	docker compose restart $*
+	
+run_tests.image_compression_check: ## Runs the image compression checks
+	docker compose run --no-deps --entrypoint "python -m scripts.image_compression_check" dev-server
 
 run_tests.prettier: ## Runs the prettier checks
 	docker compose run --no-deps --entrypoint "npx prettier --check ." dev-server

--- a/scripts/image_compression_check.py
+++ b/scripts/image_compression_check.py
@@ -10,22 +10,18 @@ def check_image_sizes(repo_path):
     failed_images = []
     print("Scanning images for compression...")
 
-    # Iterate through all image files
     for file_path in repo_path.glob("**/*.*"):
         if file_path.suffix.lower() in {".png", ".jpg", ".jpeg"}:
             try:
                 with Image.open(file_path) as img:
                     original_size = file_path.stat().st_size
-                    # Convert RGBA to RGB for compatibility
+                    
                     if img.mode == "RGBA":
                         img = img.convert("RGB")
-                    # Save compressed image to temporary file
                     img.save("temp.jpg", optimize=True, quality=85)
                     compressed_size = Path("temp.jpg").stat().st_size
-                    # Remove temporary file
                     Path("temp.jpg").unlink()
 
-                    # Check size difference
                     if compressed_size > original_size * 1.01:
                         failed_images.append(file_path)
                         print(
@@ -49,7 +45,7 @@ def main():
             "\nPlease compress these images using a tool like `trimage` and replace them in your PR. "
             "You can install Trimage using your package manager (e.g., `sudo apt install trimage` on Ubuntu)."
         )
-        exit(1)  # Fail CI
+        exit(1) 
     else:
         print("\nAll images passed the compression check.")
 

--- a/scripts/image_compression_check.py
+++ b/scripts/image_compression_check.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+from PIL import Image
+
+def check_image_sizes(repo_path):
+    """
+    Check the sizes of all images in the repository. Report any images
+    where the compressed size exceeds the original size by 1% or more.
+    """
+    failed_images = []
+    print("Scanning images for compression...")
+
+    # Iterate through all image files
+    for file_path in repo_path.glob("**/*.*"):
+        if file_path.suffix.lower() in {".png", ".jpg", ".jpeg"}:
+            try:
+                with Image.open(file_path) as img:
+                    original_size = file_path.stat().st_size
+                    # Convert RGBA to RGB for compatibility
+                    if img.mode == "RGBA":
+                        img = img.convert("RGB")
+                    # Save compressed image to temporary file
+                    img.save("temp.jpg", optimize=True, quality=85)
+                    compressed_size = Path("temp.jpg").stat().st_size
+                    # Remove temporary file
+                    Path("temp.jpg").unlink()
+
+                    # Check size difference
+                    if compressed_size > original_size * 1.01:
+                        failed_images.append(file_path)
+                        print(
+                            f"[FAILED] {file_path} - Original: {original_size} bytes, "
+                            f"Compressed: {compressed_size} bytes"
+                        )
+            except Exception as e:
+                print(f"[ERROR] Could not process {file_path}: {e}")
+
+    return failed_images
+
+def main():
+    repo_path = Path(".")
+    failed_images = check_image_sizes(repo_path)
+
+    if failed_images:
+        print("\nThe following images exceed the compression threshold:")
+        for file in failed_images:
+            print(f"- {file}")
+        print(
+            "\nPlease compress these images using a tool like `trimage` and replace them in your PR. "
+            "You can install Trimage using your package manager (e.g., `sudo apt install trimage` on Ubuntu)."
+        )
+        exit(1)  # Fail CI
+    else:
+        print("\nAll images passed the compression check.")
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This PR fixes [[Feature Request]: Include a CI check that ensures Oppia's images are fully compressed. #21274](https://github.com/oppia/oppia/issues/21274)
In this solution I successfully implemented a CI check which scans all image in the codebase and if size of any image get exceeds by 1% it will get logged. 

Proposed solution is: 
1) to make a python script wihch takes care of all the logics of checking size of image and return responses accordingly. 
2) using this script inside the CI check 

Following the same architecture as used in oppia itself in many places e.g. lint, python type check, etc. 
Attached the image of final output came after running script over the repo. 
![Uploading Screenshot from 2024-11-19 19-03-01.png…]()
![Uploading Screenshot from 2024-11-19 19-03-14.png…]()
