### PR TITLE
FIX #20892 fixed undefined (reading 'length') at ClassroomAdminPageComponent.getPrerequisiteLength

### DIFF
--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
@@ -849,7 +849,7 @@ export class ClassroomAdminPageComponent implements OnInit {
   }
 
   getPrerequisiteLength(topicName: string): number {
-    return this.topicNameToPrerequisiteTopicNames[topicName].length;
+    return this.topicNameToPrerequisiteTopicNames[topicName]?.length?? 0;
   }
 
   ngOnDestory(): void {


### PR DESCRIPTION
## Overview:
**Error**:Attempted to access .length on an undefined value in this.topicNameToPrerequisiteTopicNames[topicName], causing a runtime error.
**Solution:**: Added optional chaining (?.) and a fallback (?? 0) to safely handle undefined prerequisites.

1. This PR fixes or fixes part of #[20892].
2. This PR does the following: [Ensured getPrerequisiteLength safely handles undefined prerequisites using optional chaining and a fallback value of 0.]
3. (For bug-fixing PRs only) The original bug occurred because: [The bug was caused by trying to access .length on an undefined value in this.topicNameToPrerequisiteTopicNames[topicName]]
