### PR TITLE
Fix #19655: RTE use default value when link text contains only whitespace

### DIFF
--- a/core/templates/services/rte-helper-modal.controller.spec.ts
+++ b/core/templates/services/rte-helper-modal.controller.spec.ts
@@ -258,6 +258,37 @@ describe('RteHelperModalComponent', () => {
       expect(component.customizationArgsForm.value[1]).toBe('oppia.org');
       flush();
     }));
+
+    it('should make the text equal to url when text contain only whitespace', fakeAsync(() => {
+      component.ngOnInit();
+      flush();
+      component.customizationArgsForm.value[0] = 'oppia.org';
+      component.customizationArgsForm.value[1] = ' ';
+      component.onCustomizationArgsFormChange(
+        component.customizationArgsForm.value
+      );
+      expect(component.isErrorMessageNonempty()).toBe(false);
+      expect(component.customizationArgsForm.value[1]).toBe('oppia.org');
+      flush();
+    }));
+
+    it('should make the text equal to url when text contain only whitespace', fakeAsync(() => {
+      const whitespaceChars =
+        '\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000' +
+        '\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008' +
+        '\u2009\u200A\u2028\u2029\u202F\u205F\u3000';
+
+      component.ngOnInit();
+      flush();
+      component.customizationArgsForm.value[0] = 'oppia.org';
+      component.customizationArgsForm.value[1] = whitespaceChars;
+      component.onCustomizationArgsFormChange(
+        component.customizationArgsForm.value
+      );
+      expect(component.isErrorMessageNonempty()).toBe(false);
+      expect(component.customizationArgsForm.value[1]).toBe('oppia.org');
+      flush();
+    }));
   });
 
   describe('when there are validation errors in video form control', function () {

--- a/core/templates/services/rte-helper-modal.controller.ts
+++ b/core/templates/services/rte-helper-modal.controller.ts
@@ -279,7 +279,7 @@ export class RteHelperModalComponent {
     } else if (this.componentId === this.COMPONENT_ID_LINK) {
       let url: string = value[0];
       let text: string = value[1];
-      if (text === '') {
+      if (!text.trim()) {
         value[1] = url;
         text = url;
       } else {
@@ -438,13 +438,6 @@ export class RteHelperModalComponent {
               this.extractVideoIdFromVideoUrl(
                 this.tmpCustomizationArgs[i].value.toString()
               );
-          }
-        } else if (this.componentId === this.COMPONENT_ID_LINK) {
-          if (caName === 'text') {
-            // Set the link `text` to the link `url` if the `text` is empty.
-            this.tmpCustomizationArgs[i].value =
-              this.tmpCustomizationArgs[i].value ||
-              this.tmpCustomizationArgs[i - 1].value;
           }
         }
         (


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19655.
2. This PR does the following: In RTE Non-interactive-links this PR makes sure that the default value (link url) is used if  link text is empty or contain only whitespace, in order to avoid creating a RTE component which in not visible.  This PR also remove code that has not been in use since PR #20071 . 
3. The original bug occurred because: The bug has been there as long as the RTE link-component. 


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct


https://github.com/user-attachments/assets/dd4b90d1-4e74-4925-bf5f-4a12503a650a

