### PR TITLE
Fix part of 21214: changed typing.Text into str and import collections.abc into answer_summarizers/models.py

### DIFF
--- a/extensions/answer_summarizers/models.py
+++ b/extensions/answer_summarizers/models.py
@@ -40,6 +40,7 @@ calculation may look like this:
 from __future__ import annotations
 
 import collections
+import collections.abc
 import itertools
 import operator
 

--- a/stubs/proto_files/text_classifier_pb2.pyi
+++ b/stubs/proto_files/text_classifier_pb2.pyi
@@ -13,14 +13,14 @@ DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 class TextClassifierFrozenModel(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
     MODEL_JSON_FIELD_NUMBER: builtins.int
-    model_json: typing.Text
+    model_json: str
     """The parameters of a trained text classifier model which are necessary
     for inference.
     """
 
     def __init__(self,
         *,
-        model_json: typing.Text = ...,
+        model_json: str = ...,
         ) -> None: ...
     def ClearField(
         self,

--- a/stubs/proto_files/training_job_response_payload_pb2.pyi
+++ b/stubs/proto_files/training_job_response_payload_pb2.pyi
@@ -24,14 +24,14 @@ class TrainingJobResponsePayload(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
         JOB_ID_FIELD_NUMBER: builtins.int
         TEXT_CLASSIFIER_FIELD_NUMBER: builtins.int
-        job_id: typing.Text
+        job_id: str
         """Id of the training job whose data is being stored."""
 
         @property
         def text_classifier(self) -> text_classifier_pb2.TextClassifierFrozenModel: ...
         def __init__(self,
             *,
-            job_id: typing.Text = ...,
+            job_id: str = ...,
             text_classifier: typing.Optional[text_classifier_pb2.TextClassifierFrozenModel] = ...,
             ) -> None: ...
         def HasField(self, field_name: typing_extensions.Literal["classifier_frozen_model",b"classifier_frozen_model","text_classifier",b"text_classifier"]) -> builtins.bool: ...
@@ -43,17 +43,17 @@ class TrainingJobResponsePayload(google.protobuf.message.Message):
     SIGNATURE_FIELD_NUMBER: builtins.int
     @property
     def job_result(self) -> global___TrainingJobResponsePayload.JobResult: ...
-    vm_id: typing.Text
+    vm_id: str
     """Id of the VM instance that trained the job."""
 
-    signature: typing.Text
+    signature: str
     """Signature of the job data for authenticated communication."""
 
     def __init__(self,
         *,
         job_result: typing.Optional[global___TrainingJobResponsePayload.JobResult] = ...,
-        vm_id: typing.Text = ...,
-        signature: typing.Text = ...,
+        vm_id: str = ...,
+        signature: str = ...,
         ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["job_result",b"job_result"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal["job_result",b"job_result","signature",b"signature","vm_id",b"vm_id"]) -> None: ...


### PR DESCRIPTION


## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[21214].
2. This PR does the following: [Fixes some deprecated functionality moving from Python 3.9 to 3.12]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

typing.Text is interchangeable with str but str was chosen as the correct syntax, change typing.Text to str should require no tests

import collections.abc shouldn't change anything in answer_summarizers/models.py. collections is also imported and used for a different purpose so i have left it alone.