### PR TITLE
Adds feature flag to hide voiceover regeneration feature from exp editor page and voice artist accent labeling feature from voiceover admin page

### DIFF
--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -59,6 +59,9 @@ class FeatureNames(enum.Enum):
         'exploration_editor_can_tag_misconceptions')
     ENABLE_MULTIPLE_CLASSROOMS = 'enable_multiple_classrooms'
     REDESIGNED_TOPIC_VIEWER_PAGE = 'redesigned_topic_viewer_page'
+    AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP = (
+        'automatic_voiceover_regeneration_from_exp')
+    LABEL_ACCENT_TO_VOICE_ARTIST = 'label_accent_to_voice_artist'
 
 
 # Names of feature objects defined in FeatureNames should be added
@@ -84,7 +87,8 @@ DEV_FEATURES_LIST = [
     FeatureNames.SHOW_REDESIGNED_LEARNER_DASHBOARD,
     FeatureNames.SHOW_TRANSLATION_SIZE,
     FeatureNames.NEW_LESSON_PLAYER,
-    FeatureNames.REDESIGNED_TOPIC_VIEWER_PAGE
+    FeatureNames.REDESIGNED_TOPIC_VIEWER_PAGE,
+    FeatureNames.AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -111,6 +115,7 @@ PROD_FEATURES_LIST: List[FeatureNames] = [
     FeatureNames.DIAGNOSTIC_TEST,
     FeatureNames.EXPLORATION_EDITOR_CAN_MODIFY_TRANSLATIONS,
     FeatureNames.EXPLORATION_EDITOR_CAN_TAG_MISCONCEPTIONS,
+    FeatureNames.LABEL_ACCENT_TO_VOICE_ARTIST
 ]
 
 # Names of features that should not be used anymore, e.g. features that are
@@ -263,6 +268,20 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
             'This flag activates the redesigned topic viewer page'
             'and makes it accessible to learners.',
             feature_flag_domain.ServerMode.DEV
+        )
+    ),
+    FeatureNames.AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP.value: (
+        (
+            'The flag enables the automatic regeneration of voiceovers '
+            'directly from the exploration editor page.',
+            feature_flag_domain.ServerMode.DEV
+        )
+    ),
+    FeatureNames.LABEL_ACCENT_TO_VOICE_ARTIST.value: (
+        (
+            'The flag enables the voice artist accent labeling feature '
+            'on the voiceover admin page.',
+            feature_flag_domain.ServerMode.PROD
         )
     )
 }

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -44,6 +44,8 @@ export enum FeatureNames {
   ExplorationEditorCanTagMisconceptions = 'exploration_editor_can_tag_misconceptions',
   EnableMultipleClassrooms = 'enable_multiple_classrooms',
   RedesignedTopicViewerPage = 'redesigned_topic_viewer_page',
+  AutomaticVoiceoverRegenerationFromExp = 'automatic_voiceover_regeneration_from_exp',
+  LabelAccentToVoiceArtist = 'label_accent_to_voice_artist',
 }
 
 export interface FeatureStatusSummaryBackendDict {

--- a/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.html
+++ b/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.html
@@ -66,7 +66,7 @@
   </div>
 </mat-card>
 
-<mat-card class="oppia-page-card oppia-long-text-card">
+<mat-card class="oppia-page-card oppia-long-text-card" *ngIf="isLabelingVoiceArtistFeatureEnabled()">
   <h3>Label manual voiceovers</h3>
 
   <p *ngIf="voiceArtistsDataCount == 0">

--- a/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.spec.ts
+++ b/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.spec.ts
@@ -33,6 +33,8 @@ import {MaterialModule} from 'modules/material.module';
 import {MockTranslatePipe} from 'tests/unit-test-utils';
 import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {MatTableModule} from '@angular/material/table';
+import {PlatformFeatureService} from 'services/platform-feature.service';
+import {FeatureStatusChecker} from 'domain/feature-flag/feature-status-summary.model';
 
 class MockNgbModal {
   open() {
@@ -42,11 +44,22 @@ class MockNgbModal {
   }
 }
 
+class MockPlatformFeatureService {
+  get status(): object {
+    return {
+      LabelAccentToVoiceArtist: {
+        isEnabled: true,
+      },
+    };
+  }
+}
+
 describe('Voiceover Admin Page component ', () => {
   let component: VoiceoverAdminPageComponent;
   let fixture: ComponentFixture<VoiceoverAdminPageComponent>;
   let voiceoverBackendApiService: VoiceoverBackendApiService;
   let ngbModal: NgbModal;
+  let platformFeatureService: PlatformFeatureService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -66,6 +79,10 @@ describe('Voiceover Admin Page component ', () => {
           provide: NgbModal,
           useClass: MockNgbModal,
         },
+        {
+          provide: PlatformFeatureService,
+          useClass: MockPlatformFeatureService,
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -73,6 +90,7 @@ describe('Voiceover Admin Page component ', () => {
     component = fixture.componentInstance;
     voiceoverBackendApiService = TestBed.inject(VoiceoverBackendApiService);
     ngbModal = TestBed.inject(NgbModal);
+    platformFeatureService = TestBed.inject(PlatformFeatureService);
   });
 
   it('should initialize the component', fakeAsync(() => {
@@ -319,4 +337,24 @@ describe('Voiceover Admin Page component ', () => {
       ''
     );
   }));
+
+  it('should disable voice artist accent labeling feature flag', () => {
+    spyOnProperty(platformFeatureService, 'status', 'get').and.returnValue({
+      LabelAccentToVoiceArtist: {
+        isEnabled: false,
+      },
+    } as FeatureStatusChecker);
+
+    expect(component.isLabelingVoiceArtistFeatureEnabled()).toBeFalse();
+  });
+
+  it('should enable voice artist accent labeling feature flag', () => {
+    spyOnProperty(platformFeatureService, 'status', 'get').and.returnValue({
+      LabelAccentToVoiceArtist: {
+        isEnabled: true,
+      },
+    } as FeatureStatusChecker);
+
+    expect(component.isLabelingVoiceArtistFeatureEnabled()).toBeTrue();
+  });
 });

--- a/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.ts
+++ b/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.ts
@@ -29,6 +29,7 @@ import {
 import {VoiceoverRemovalConfirmModalComponent} from './modals/language-accent-removal-confirm-modal.component';
 import {VoiceArtistLanguageMapping} from './voice-artist-language-mapping.model';
 import {AddAccentToVoiceoverLanguageModalComponent} from './modals/add-accent-to-voiceover-language-modal.component';
+import {PlatformFeatureService} from 'services/platform-feature.service';
 
 interface LanguageAccentCodeToLanguageCode {
   [languageAccentCode: string]: string;
@@ -48,7 +49,8 @@ export class VoiceoverAdminPageComponent implements OnInit {
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
   constructor(
     private ngbModal: NgbModal,
-    private voiceoverBackendApiService: VoiceoverBackendApiService
+    private voiceoverBackendApiService: VoiceoverBackendApiService,
+    private platformFeatureService: PlatformFeatureService
   ) {}
 
   languageAccentCodeToLanguageCode!: LanguageAccentCodeToLanguageCode;
@@ -101,6 +103,11 @@ export class VoiceoverAdminPageComponent implements OnInit {
         this.voiceArtistIdToVoiceArtistName =
           response.voiceArtistIdToVoiceArtistName;
       });
+  }
+
+  isLabelingVoiceArtistFeatureEnabled(): boolean {
+    return this.platformFeatureService.status.LabelAccentToVoiceArtist
+      .isEnabled;
   }
 
   addLanguageAccentForVoiceArtist(


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->
The PR adds two feature flags:
**First**, to hide the functionality of automatic voiceover regeneration for a single content from the exploration editor page (voiceover tab).
**Second**, to hide accent labeling to voice artist functionality from the voiceover admin page. (Fixes: https://github.com/oppia/oppia/issues/20951)
The feature to label accents to voice artists is already present in the PROD, since we wanted to gate this functionality hence the feature flag is directly added in the PROD mode. PTAL at this issue: #20951.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct


https://github.com/user-attachments/assets/dea70f83-bbbf-47f4-bb9c-08bc248fedf0



<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
