### PR TITLE
Fix #21323 & #21322: Duplicate learner dashboard headers 

### DIFF
--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
@@ -120,7 +120,7 @@
     <div [ngClass]="{'oppia-learner-dashboard-mobile-mode': windowIsNarrow, 'oppia-learner-dashboard-main-content col-md-8' : !isShowRedesignedLearnerDashboardActive(), 'oppia-learner-dash-tab overflow-hidden px-4 px-md-0' : isShowRedesignedLearnerDashboardActive() }">
       <div class="d-flex flex-column w-100"
            [ngClass]="{'oppia-learner-dashboard-main-content-container pl-5': !windowIsNarrow && !isShowRedesignedLearnerDashboardActive(), 'justify-content-center': windowIsNarrow}">
-        <p class="oppia-learner-dash-greeting mt-4"> {{ getDashboardTabHeading() | translate: {username: username} }} </p>
+        <p *ngIf="isShowRedesignedLearnerDashboardActive()" class="oppia-learner-dash-greeting mt-4"> {{ getDashboardTabHeading() | translate: {username: username} }} </p>
         <div class="w-100" *ngIf="activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.HOME">
           <oppia-home-tab [currentGoals]="topicsToLearn"
                           [redesignFeatureFlag]="isShowRedesignedLearnerDashboardActive()"


### PR DESCRIPTION
## Overview
This PR fixes #21323 & #21322. I forgot to add the learner dashboard feature flag to gate the new header. The "No valid I18N key for heading error" is expected and serves as a placeholder for the redesigned tabs. 

Note: I don't have learner groups in the video, but the code only shows the header for all tabs if the appropriate flag is on. 


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly)..

## Proof that changes are correct


https://github.com/user-attachments/assets/1d9872fe-17ae-4dc5-9273-4e84abdab519



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
