### PR TITLE
Fixes #21301 : add blur features to subject interests

### DIFF
--- a/core/templates/pages/preferences-page/form-fields/subject-interests.component.html
+++ b/core/templates/pages/preferences-page/form-fields/subject-interests.component.html
@@ -21,6 +21,7 @@
            [matAutocomplete]="auto"
            [matChipInputFor]="chipList"
            [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+           (blur)="addOnBlur(subjectInterestInput)" 
            (matChipInputTokenEnd)="add($event)">
   </mat-chip-list>
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">

--- a/core/templates/pages/preferences-page/form-fields/subject-interests.component.html
+++ b/core/templates/pages/preferences-page/form-fields/subject-interests.component.html
@@ -21,7 +21,7 @@
            [matAutocomplete]="auto"
            [matChipInputFor]="chipList"
            [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-           (blur)="addOnBlur(subjectInterestInput)" 
+           (blur)="addOnBlur(subjectInterestInput)"
            (matChipInputTokenEnd)="add($event)">
   </mat-chip-list>
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">

--- a/core/templates/pages/preferences-page/form-fields/subject-interests.component.ts
+++ b/core/templates/pages/preferences-page/form-fields/subject-interests.component.ts
@@ -129,8 +129,8 @@ export class SubjectInterestsComponent implements ControlValueAccessor {
     const inputValue = inputElement.value.trim();
     if (inputValue) {
       this.subjectInterests.push(inputValue);
-      inputElement.value = ''; // Clear the input field
-      this.formCtrl.setValue(''); // Reset form control
+      inputElement.value = '';
+      this.formCtrl.setValue('');
     }
   }
 

--- a/core/templates/pages/preferences-page/form-fields/subject-interests.component.ts
+++ b/core/templates/pages/preferences-page/form-fields/subject-interests.component.ts
@@ -96,6 +96,7 @@ export class SubjectInterestsComponent implements ControlValueAccessor {
       } else {
         this.chipList.errorState = false;
       }
+      this.onChange(this.subjectInterests);
     });
     this.allSubjectInterests = cloneDeep(this.subjectInterests);
   }
@@ -121,6 +122,15 @@ export class SubjectInterestsComponent implements ControlValueAccessor {
       }
       this.onChange(this.subjectInterests);
       this.subjectInterestInput.nativeElement.value = '';
+    }
+  }
+
+  addOnBlur(inputElement: HTMLInputElement): void {
+    const inputValue = inputElement.value.trim();
+    if (inputValue) {
+      this.subjectInterests.push(inputValue);
+      inputElement.value = ''; // Clear the input field
+      this.formCtrl.setValue(''); // Reset form control
     }
   }
 


### PR DESCRIPTION
This PR fixes part of #21301.
This PR does the following: 
a)
/core/templates/pages/preferences-page/form-fields/subject-interests.html
=>The line added is :  (blur)="addOnBlur(subjectInterestInput)" When the user types in subject interest field and then clicks or tabs away (causing it to lose focus), the blur event is triggered.
b)
 /core/templates/pages/preferences-page/form-fields/subject-interests.component.ts
The addOnBlur method is defined in this file. If the input value to subject interest is valid then it gets added to the array subjectInterests. This typescript activates the save Button by calling this.onChange(this.subjectInterests);

The original bug occurred because the existing codebase has no corresponding code to handle conditions in which the user enters their subject interest and then loses focus, which happens when the user types the subject interest and moves away from the field (without pressing enter key). Because the existing code is only set to detect a change when the enter button is clicked, the save button stays disabled when the subject simply loses focus by clicking or tabbing away.

Video of the issue before fix:


https://github.com/user-attachments/assets/48652da4-e7fd-4a8e-a9fb-04ef88773cd4


## Proof that changes are correct after fix


https://github.com/user-attachments/assets/c3c398f1-e2fb-4dfd-b38a-3c60819963c3

