### PR TITLE
Correctly load pencil code editor in solution interface

### DIFF
--- a/extensions/interactions/PencilCodeEditor/directives/oppia-interactive-pencil-code-editor.component.ts
+++ b/extensions/interactions/PencilCodeEditor/directives/oppia-interactive-pencil-code-editor.component.ts
@@ -110,7 +110,7 @@ export class PencilCodeEditor implements OnInit, OnDestroy {
       ) as PencilCodeEditorCustomizationArgs;
     this.someInitialCode = this.interactionIsActive
       ? initialCode.value
-      : this.lastAnswer.code;
+      : this.lastAnswer.code || initialCode.value;
 
     this.pce.beginLoad(this.someInitialCode);
     this.pce.on('load', () => {


### PR DESCRIPTION
Overview
This PR fixes or fixes part of #21123.
This PR does the following:
Fixes a bug where the PencilCodeEditor interaction fails to load due to an undefined value for lastAnswer.code. Updated the ngOnInit method in oppia-interactive-pencil-code-editor.component.ts to handle undefined lastAnswer gracefully, ensuring proper initialization of the editor.
(For bug-fixing PRs only) The original bug occurred because:
The component assumed that lastAnswer was always defined. In cases where lastAnswer was undefined, attempting to access lastAnswer.code caused a runtime error.
Essential Checklist
[x]I have linked the issue that this PR fixes in the "Development" section of the sidebar.
[x]I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
[x] I have written tests for my code.
[x]The PR title starts with "Fix #21123: ", followed by a short, clear summary of the changes.
[x] LaCE Quality Team is being assigned.
Testing doc (for PRs with Beam jobs that modify production server data)
N/A

Proof that changes are correct
Proof of changes on desktop with slow/throttled network
Before:
<img width="646" alt="Screenshot 2024-12-04 at 1 11 37 AM" src="https://github.com/user-attachments/assets/db13f91e-2c11-4315-8940-9e2a96c6910d">

After:
<img width="1509" alt="Screenshot 2024-12-04 at 1 05 39 AM" src="https://github.com/user-attachments/assets/78201631-9df7-4cc4-b789-b0b689316dbd">

Proof of changes on mobile phone
N/A

Proof of changes in Arabic language
N/A

N/A (UI changes are not language-dependent in this case)

