### PR TITLE
Fix part of #21308: Increase test coverage in core/controllers/practice_sessions_test.py

### DIFF
--- a/core/controllers/practice_sessions_test.py
+++ b/core/controllers/practice_sessions_test.py
@@ -93,6 +93,14 @@ class PracticeSessionsPageTests(BasePracticeSessionsControllerTests):
             '/learn/staging/invalid/practice/session?'
             'selected_subtopic_ids=["1","2"]',
             expected_status_int=302)
+    def test_invalid_input_exception_redirects_correctly(self) -> None:
+        response = self.get_html_response(
+            '/learn/staging/public-topic-name/practice/session?'
+            'selected_subtopic_ids=invalid_json',
+            expected_status_int=302)
+        self.assertEqual(
+            response.headers['location'],
+            'http://localhost/learn/staging/public-topic-name/practice')
 
 
 class PracticeSessionsPageDataHandlerTests(BasePracticeSessionsControllerTests):


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #21308
2. This PR does the following: 
Increase test coverage for the core/controllers/practice_sessions.py file. Note that test coverage increased but **isn't complete at 100%.**

3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

From line 96-105 of the core/controllers/practice_sessions_test.py file, a ChatGPT assisted test case has been included. 
This is the coverage for before the test case has been added and it indicates 91% for the test coverage:
<img width="1465" alt="Screenshot 2024-12-02 at 3 42 53 PM" src="https://github.com/user-attachments/assets/b0a5f1eb-ed8b-421a-aa8d-7add49f44107">

This is the coverage for after the test case has been added and it indicates 98% for the test coverage:
<img width="1160" alt="Screenshot 2024-12-05 at 11 12 26 PM" src="https://github.com/user-attachments/assets/1a3163cf-6961-4bb4-aa08-405216bbc88b">
These below are the only changes made locally, which are the same changes committed here:
<img width="761" alt="Screenshot 2024-12-05 at 11 14 53 PM" src="https://github.com/user-attachments/assets/57ada3f9-9ba0-4097-94dc-395903104d82">

All the test coverage reports are generated using this following command: `make run_tests.backend PYTHON_ARGS="--test_targets=core.controllers.practice_sessions_test --generate_coverage_report --verbose"`

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
