### PR TITLE
Fix part of #21308: Add tests to fully cover all branches of the backend code (story_fetchers.py)

### DIFF
--- a/core/domain/story_fetchers_test.py
+++ b/core/domain/story_fetchers_test.py
@@ -365,3 +365,41 @@ class StoryFetchersUnitTests(test_utils.GenericTestBase):
         self.assertEqual(user_progress[0]['exploration_id'], exp_id_1)
         self.assertEqual(user_progress[0]['visited_checkpoints_count'], 1)
         self.assertEqual(user_progress[0]['total_checkpoints_count'], 1)
+
+    def test_get_completed_nodes_in_story_none(self) -> None:
+        completed_nodes = story_fetchers.get_completed_nodes_in_story(
+                    self.USER_ID, self.story_id)
+        self.assertEqual(completed_nodes, [])
+
+    def test_get_user_progress_in_story_chapters_none(self) -> None:
+        user_id = self.USER_ID
+        user_progress = story_fetchers.get_user_progress_in_story_chapters(
+            user_id, ['invalid_id','invalid_id'])
+        
+        self.assertEqual(user_progress, [])
+    
+    def test_get_user_progress_in_story_chapters_no_most_recent(
+        self) -> None:
+        story_id = self.story_id
+        exp_id_1 = 'expid1'
+        learner_id = 'learner1'
+
+        self.save_new_valid_exploration(exp_id_1, self.USER_ID)
+        change_list = [
+            story_domain.StoryChange({
+                'cmd': story_domain.CMD_UPDATE_STORY_NODE_PROPERTY,
+                'property_name': (
+                    story_domain.STORY_NODE_PROPERTY_EXPLORATION_ID),
+                'node_id': '%s1' % story_domain.NODE_ID_PREFIX,
+                'old_value': None,
+                'new_value': exp_id_1
+            })
+        ]
+        story_services.update_story(
+            self.USER_ID, self.story_id, change_list,
+            'Added node.')
+        
+        user_progress = story_fetchers.get_user_progress_in_story_chapters(
+            learner_id, [story_id,'invalid_id'])
+        
+        self.assertEqual(user_progress[0]['visited_checkpoints_count'], 0)

--- a/core/domain/story_fetchers_test.py
+++ b/core/domain/story_fetchers_test.py
@@ -374,10 +374,10 @@ class StoryFetchersUnitTests(test_utils.GenericTestBase):
     def test_get_user_progress_in_story_chapters_none(self) -> None:
         user_id = self.USER_ID
         user_progress = story_fetchers.get_user_progress_in_story_chapters(
-            user_id, ['invalid_id','invalid_id'])
-        
+            user_id, ['invalid_id', 'invalid_id'])
+
         self.assertEqual(user_progress, [])
-    
+
     def test_get_user_progress_in_story_chapters_no_most_recent(
         self) -> None:
         story_id = self.story_id
@@ -398,8 +398,8 @@ class StoryFetchersUnitTests(test_utils.GenericTestBase):
         story_services.update_story(
             self.USER_ID, self.story_id, change_list,
             'Added node.')
-        
+
         user_progress = story_fetchers.get_user_progress_in_story_chapters(
-            learner_id, [story_id,'invalid_id'])
-        
+            learner_id, [story_id, 'invalid_id'])
+
         self.assertEqual(user_progress[0]['visited_checkpoints_count'], 0)


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #21308.
2. This PR does the following: Added three test cases under StoryFetchersUnitTests in core/domain/story_fetchers_tests.py to provide coverage for core/domain/story_fetchers.py 475->474, 496->495, 518->524

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Coverage before adding tests

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
<img width="639" alt="Screenshot 2024-12-08 at 2 59 20 AM" src="https://github.com/user-attachments/assets/2e351870-c58a-481b-8770-dcd5ebd11705">


#### Coverage after adding tests

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->
<img width="638" alt="Screenshot 2024-12-08 at 2 59 30 AM" src="https://github.com/user-attachments/assets/dc35b876-b2d4-4625-bcd0-de60e1e88f2d">


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
