### PR TITLE
Fix #20338: Changes $timeout to async function using Promise

### DIFF
--- a/core/templates/pages/exploration-editor-page/modal-templates/exploration-metadata-modal.component.ts
+++ b/core/templates/pages/exploration-editor-page/modal-templates/exploration-metadata-modal.component.ts
@@ -143,7 +143,7 @@ export class ExplorationMetadataModalComponent
     this.explorationTagsService.displayed = this.explorationTags;
   }
 
-  save(): void {
+  async save(): Promise<void> {
     if (!this.areRequiredFieldsFilled()) {
       return;
     }
@@ -166,22 +166,23 @@ export class ExplorationMetadataModalComponent
       metadataList.push('tags');
     }
 
-    // Save all the displayed values.
-    this.explorationTitleService.saveDisplayedValue();
-    this.explorationObjectiveService.saveDisplayedValue();
-    this.explorationCategoryService.saveDisplayedValue();
-    this.explorationLanguageCodeService.saveDisplayedValue();
-    this.explorationTagsService.saveDisplayedValue();
-
-    // TODO(#20338): Get rid of the $timeout here.
-    // It's currently used because there is a race condition: the
-    // saveDisplayedValue() calls above result in autosave calls.
-    // These race with the discardDraft() call that
-    // will be called when the draft changes entered here
-    // are properly saved to the backend.
-    setTimeout(() => {
+    try {
+      // Save all the displayed values.
+      await Promise.all([
+        this.explorationTitleService.saveDisplayedValue();
+        this.explorationObjectiveService.saveDisplayedValue();
+        this.explorationCategoryService.saveDisplayedValue();
+        this.explorationLanguageCodeService.saveDisplayedValue();
+        this.explorationTagsService.saveDisplayedValue();
+      ]);
+      //Close modal after all saves are complete
       this.ngbActiveModal.close(metadataList);
-    }, 500);
+    } catch (error) {
+      this.alertService.addWarning(
+        'An error occurred while saving changes.'
+      );
+      this.ngbActiveModal.close(metadataList);
+    }
   }
 
   areRequiredFieldsFilled(): boolean {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #20338.
2. This PR does the following: I have changed the file core/templates/pages/exploration-editor-page/modal-templates/exploration-metadata-modal.component.ts to use Promise from the Angular library. My change replaces the setTimeout in the exploration metadata modal's save method with a Promise to handle asynchronous operations.
Changes made:
Converted save() method to be async
Used Promise.all() to properly wait for all save operations to complete
Added proper error handling with AlertsService
Removed setTimeout that was causing race conditions
The new implementation:
Waits for all save operations to complete before closing the modal
Properly handles any errors during save operations
Eliminates the race condition between save operations and draft discard

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

https://github.com/user-attachments/assets/fd83f1c9-a1f6-4fc6-8a1a-69f6fbc209c2

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
