### PR TITLE
(Draft) Fix part of #21308: Add tests to fully cover user_services and learner_group_fetchers 

### DIFF
--- a/core/domain/learner_group_fetchers_test.py
+++ b/core/domain/learner_group_fetchers_test.py
@@ -160,12 +160,13 @@ class LearnerGroupFetchersUnitTests(test_utils.GenericTestBase):
             self.LEARNER_GROUP_ID, self.LEARNER_ID_2, False)
         learner_groups = (
             learner_group_fetchers.get_learner_group_models_by_ids(
+                # Set strict=False to fail noisily and return list.
                 [self.LEARNER_ID_1, self.LEARNER_ID_2], strict=False
             )
         )
         self.assertEqual(len(learner_groups), 2)
 
-    def test_multi_learners_share_progress_learner_in_mult_groups(self) -> None:
+    def test_can_multi_learners_share_prog_with_multi_learner(self) -> None:
         # Making group 2.
         group2_id = (
             learner_group_fetchers.get_new_learner_group_id()
@@ -186,8 +187,11 @@ class LearnerGroupFetchersUnitTests(test_utils.GenericTestBase):
                 [self.LEARNER_ID_1], self.LEARNER_GROUP_ID
             ), [True])
 
-    def test_can_multi_learners_share_progress_learner_no_group(self) -> None:
-        self.assertEqual(
+    def test_can_multi_learners_share_prog_with_learner_no_group(self) -> None:
+        # Learner is not in a group, returns empty list.
+        learner_groups = (
             learner_group_fetchers.can_multi_learners_share_progress(
                 [self.LEARNER_ID_1], self.LEARNER_GROUP_ID
-            ), [])
+            )
+        )
+        self.assertEqual(len(learner_groups), 0)

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -2385,7 +2385,7 @@ def can_submit_question_suggestions(user_id: str) -> bool:
 
 
 def allow_user_to_review_translation_in_language(
-    user_id: str, language_code: str
+    user_id: str, language_code: Optional[str] = None
 ) -> None:
     """Allows the user with the given user id to review translation in the given
     language_code.


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21308.
2. This PR does the following: Adds tests to fully cover line and branches in user_services and learner_group_fetchers. Slightly modifies original functions for this purpose.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
SUMMARY OF THE FILES WITH INCOMPLETE COVERAGE:
Before modifications-
<img width="1002" alt="Screenshot 2024-12-09 at 5 04 55 PM" src="https://github.com/user-attachments/assets/65fa6ca8-ef25-4851-a8c4-82dcbfe500ce">
<img width="1092" alt="Screenshot 2024-12-09 at 9 51 35 PM" src="https://github.com/user-attachments/assets/5e27b343-806f-4c18-9e20-78d193221b4d">
After modifications-
<img width="993" alt="Screenshot 2024-12-09 at 5 06 34 PM" src="https://github.com/user-attachments/assets/19be4c4f-1ccd-47d2-b05a-8f3ddb3a12df">
<img width="1031" alt="Screenshot 2024-12-09 at 9 57 16 PM" src="https://github.com/user-attachments/assets/a18e864d-3594-46cb-84bc-537b59813a0f">

Changes made to original functions:
-  To test branch (2402->2404) by satisfying language_code is None (line 2402) while passing mypy: Changed parameter language_code of allow_user_to_review_translation_in_language() from str -> Optional[str] = None.
- Removed if statement frc_index > checkpoints_in_current_exp.index(state_name) on line 2840 in the function update_learner_checkpoint_progress(). It does not seem possible for both this statement and exp_user_model.furthest_reached_checkpoint_exp_version < exp_version (line 2805) to both hold true to cover 2840->2845.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
