### PR TITLE
FIX #21403 Added Hover Shadow to Play Store Button in Footer

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -677,6 +677,7 @@ Tuguldur Baigalmaa <philoniare@gmail.com>
 Tushar Mohan <tushar.mohan2001@gmail.com>
 Tyler Ishikawa <tyi3@cornell.edu>
 Uday Kiran <udaykiran001.work@gmail.com>
+Udit Jain <uditjainstjis@gmail.com>
 Ujjwal Gulecha <ujjwal.gulecha@gmail.com>
 Umesh Singla <umeshksingla@gmail.com>
 Utkarsh Dixit <downloadplaza97@gmail.com>

--- a/core/templates/components/button-directives/social-buttons.component.css
+++ b/core/templates/components/button-directives/social-buttons.component.css
@@ -106,6 +106,11 @@
   box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, .4);
 }
 
+.oppia-footer-social img:hover{
+  box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, .4);
+  border-radius:7px;
+}
+
 .oppia-footer-social a .oppia-android-app-button {
   display: block;
   margin-top: 20px;


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #21403  
2. This PR does the following: This PR adds hover shadow effect to play store button where shadow effect was present on other socials but not on play store button in footer and adds my name to contributors list.
3. The original bug occured because css class was not added to play store button which i added to fix the issue.


## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [N/A] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before on hovering on play store button-
![image](https://github.com/user-attachments/assets/85ee6ac2-a327-4556-8131-19f31e9689d0)
After on hovering on play store button-
![image](https://github.com/user-attachments/assets/dd01f185-21ab-43a3-9a0c-a1aaa6e8deb6)

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
