### PR TITLE
Fix #9531 preventDeafult inside passive event listener by removing unnecessary preventDefault calls

### DIFF
--- a/extensions/objects/templates/image-editor.component.spec.ts
+++ b/extensions/objects/templates/image-editor.component.spec.ts
@@ -1598,14 +1598,12 @@ describe('ImageEditor', () => {
       ' the crop area',
     () => {
       let dummyMouseEvent = new MouseEvent('Mouseover');
-      spyOn(MouseEvent.prototype, 'preventDefault');
 
       component.userIsDraggingCropArea = true;
       component.userIsResizingCropArea = true;
 
       component.onMouseUpOnCropArea(dummyMouseEvent);
 
-      expect(dummyMouseEvent.preventDefault).toHaveBeenCalled();
       expect(component.userIsDraggingCropArea).toBe(false);
       expect(component.userIsResizingCropArea).toBe(false);
     }

--- a/extensions/objects/templates/image-editor.component.ts
+++ b/extensions/objects/templates/image-editor.component.ts
@@ -646,8 +646,6 @@ export class ImageEditorComponent implements OnInit, OnChanges {
   }
 
   onMouseMoveOnImageArea(e: MouseEvent): void {
-    e.preventDefault();
-
     const coords = this.getEventCoorindatesRelativeToImageContainer(e);
 
     if (this.userIsDraggingCropArea) {
@@ -662,7 +660,6 @@ export class ImageEditorComponent implements OnInit, OnChanges {
   }
 
   onMouseDownOnCropArea(e: MouseEvent): void {
-    e.preventDefault();
     const coords = this.getEventCoorindatesRelativeToImageContainer(e);
     const position = this.mousePositionWithinCropArea;
 
@@ -679,7 +676,6 @@ export class ImageEditorComponent implements OnInit, OnChanges {
   }
 
   onMouseUpOnCropArea(e: MouseEvent): void {
-    e.preventDefault();
     this.userIsDraggingCropArea = false;
     this.userIsResizingCropArea = false;
   }

--- a/extensions/objects/templates/image-with-regions-editor.component.spec.ts
+++ b/extensions/objects/templates/image-with-regions-editor.component.spec.ts
@@ -772,7 +772,6 @@ describe('ImageWithRegionsEditorComponent', () => {
       0,
       null
     );
-    spyOn(Event.prototype, 'preventDefault');
     component.mouseX = 500;
     component.mouseY = 400;
     component.hoveredRegion = null;
@@ -784,7 +783,6 @@ describe('ImageWithRegionsEditorComponent', () => {
 
     component.onSvgMouseDown(evt);
 
-    expect(Event.prototype.preventDefault).toHaveBeenCalled();
     expect(component.rectWidth).toBe(0);
     expect(component.rectHeight).toBe(0);
     expect(component.originalMouseX).toBe(500);

--- a/extensions/objects/templates/image-with-regions-editor.component.ts
+++ b/extensions/objects/templates/image-with-regions-editor.component.ts
@@ -510,7 +510,6 @@ export class ImageWithRegionsEditorComponent implements OnInit {
   }
 
   onSvgMouseDown(evt: MouseEvent): void {
-    evt.preventDefault();
     this.originalMouseX = this.mouseX;
     this.originalMouseY = this.mouseY;
     if (this.hoveredRegion === null) {


### PR DESCRIPTION
## Overview

1. This PR fixes #9531 .
2. This PR does the following:  The PR fixes the console error "Unable to preventDefault inside passive event listener invocation. image-editor.component.ts:515" by removing the preventDefault call. It fixes this error since the preventDefault function can't be called inside a passive listener and therefore shouldn't be called in this case. I explored the possibility of turning the event listener to active (passive = false) but this invoked some other console errors when the image was uploaded. In my first comment on the issue I addressed the possibility of only calling preventDefault when on a mobile device but I realized that the TouchEvent isn't handled by this event handler and therefore was redundant to implement.
3. The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it] The bug message occured when hovering over an image during the stage of uploading, cropping and selecting region when submitting a question within the contributer dashboard. Was caused by calling preventDefault within a passive listener.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

Before:
https://github.com/user-attachments/assets/3ddb2af8-5cca-48f3-bc6f-9cd16a92f4c6

After:

https://github.com/user-attachments/assets/2f32a777-3357-4dc0-b5cd-1ee8c5f9c5e1


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
