### PR TITLE
Fix #21448  Colorize errors feature

### DIFF
--- a/scripts/run_acceptance_tests.py
+++ b/scripts/run_acceptance_tests.py
@@ -7,7 +7,7 @@
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-#distributed under the License is distributed on an 'AS-IS' BASIS,
+# distributed under the License is distributed on an 'AS-IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/scripts/run_acceptance_tests.py
+++ b/scripts/run_acceptance_tests.py
@@ -7,7 +7,7 @@
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS-IS' BASIS,
+#distributed under the License is distributed on an 'AS-IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -164,8 +164,21 @@ def run_tests(args: argparse.Namespace) -> Tuple[List[bytes], int]:
                     # non-unicode strings.
                     line = line.encode('utf-8')  # pragma: no cover
                 output_lines.append(line.rstrip())
-                # Replaces non-ASCII characters with '?'.
-                common.write_stdout_safe(line.decode('ascii', errors='replace'))
+
+                # Decode the line for processing
+                decoded_line = line.decode('ascii', errors='replace')
+
+                # Check if the line contains an error
+                if "ERROR" in decoded_line or "FAIL" in decoded_line:
+                    # Apply red color for errors
+                    decoded_line = f"\033[91m{decoded_line}\033[0m"  # Red color
+                elif "SUCCESS" in decoded_line or "PASS" in decoded_line:
+                    # Apply green color for success messages
+                    decoded_line = f"\033[92m{decoded_line}\033[0m"  # Green color
+
+                # Write the processed line to the console
+                common.write_stdout_safe(decoded_line)
+
             # The poll() method returns None while the process is running,
             # otherwise it returns the return code of the process (an int).
             if proc.poll() is not None:


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[21448].
2. This PR does the following: [This PR adds a feature required in 21448, which adds color to errors in CI for acceptance tests by adding ANSI escape codes to change the text color]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
