### PR TITLE
Fix #21456: Make convert_millisecs_to_datetime_object and its test not fail because they are in different timezones

### DIFF
--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -717,7 +717,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
 
     def test_story_node_update_planned_publication_date(self) -> None:
         self.story.story_contents.nodes[0].planned_publication_date = None
-        current_time = datetime.datetime.now()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         current_time_msecs = utils.get_time_in_millisecs(current_time)
         self.story.update_node_planned_publication_date(
             'node_1', current_time_msecs)
@@ -727,7 +727,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
 
     def test_story_node_update_last_modified(self) -> None:
         self.story.story_contents.nodes[0].last_modified = None
-        current_time = datetime.datetime.now()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         current_time_msecs = utils.get_time_in_millisecs(current_time)
         self.story.update_node_last_modified('node_1', current_time_msecs)
         self.assertEqual(
@@ -735,7 +735,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
 
     def test_story_node_update_first_publication_date(self) -> None:
         self.story.story_contents.nodes[0].first_publication_date = None
-        current_time = datetime.datetime.now()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         current_time_msecs = utils.get_time_in_millisecs(current_time)
         self.story.update_node_first_publication_date(
             'node_1', current_time_msecs)

--- a/core/domain/story_services_test.py
+++ b/core/domain/story_services_test.py
@@ -363,16 +363,17 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             story.story_contents.nodes[1].status,
             constants.STORY_NODE_STATUS_PUBLISHED)
         self.assertEqual(
-            story.story_contents.nodes[1].
-            planned_publication_date, datetime.datetime(2023, 1, 2, 0, 0),
+            story.story_contents.nodes[1].planned_publication_date,
+            datetime.datetime(2023, 1, 2, 0, 0, tzinfo=datetime.timezone.utc),
             msg='Incorrect planned publication date received.')
         self.assertEqual(
-            story.story_contents.nodes[1].
-            first_publication_date, datetime.datetime(2023, 1, 1, 0, 0),
+            story.story_contents.nodes[1].first_publication_date,
+            datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
             msg='Incorrect first publication date received.')
         self.assertEqual(
             story.story_contents.nodes[1].
-            last_modified, datetime.datetime(2023, 1, 1, 0, 0),
+            last_modified, datetime.datetime(
+                2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
             msg='Incorrect last modified date received.')
 
         story_summary = story_fetchers.get_story_summary_by_id(self.STORY_ID)

--- a/core/utils.py
+++ b/core/utils.py
@@ -632,7 +632,11 @@ def convert_millisecs_time_to_datetime_object(
         datetime. An object of type datetime.datetime corresponding to
         the given milliseconds.
     """
-    return datetime.datetime.fromtimestamp(date_time_msecs / 1000.0)
+    return (
+        datetime.datetime.fromtimestamp(
+            date_time_msecs / 1000.0, tz=datetime.timezone.utc
+        )
+    )
 
 
 def convert_naive_datetime_to_string(datetime_obj: datetime.datetime) -> str:

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -780,9 +780,8 @@ class UtilsTests(test_utils.GenericTestBase):
 
     def test_convert_millisecs_time_to_datetime_object(self) -> None:
         msecs = 1690761600000
-        dt = utils.convert_millisecs_time_to_datetime_object(
-            msecs + 1000.0 * time.timezone)
-        dt2 = datetime.datetime(2023, 7, 31)
+        dt = utils.convert_millisecs_time_to_datetime_object(msecs)
+        dt2 = datetime.datetime(2023, 7, 31, 0, 0, tzinfo=datetime.timezone.utc)
         self.assertEqual(dt, dt2)
 
     def test_grouper(self) -> None:


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of https://github.com/oppia/oppia/issues/21456.
2. This PR does the following: makes the functions convert_millisecs_to_datetime_object and test_convert_millisecs_to_datetime_object to be both based in the UTC time zone. Before the test was failing, I assume because of daylight savings time.
3. (For bug-fixing PRs only) The original bug occurred because: https://github.com/oppia/oppia/commit/2400c5d0a7d5db7d259594212cb5a86bf90f2577

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x ] I have written tests for my code.
- [x ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
All that I did was add a specification in the code that the timezones in both functions were to be the same. I will happily provide more reasoning or screenshots if needed but the code is very straightforward




