### PR TITLE
Fix #20856: Fix commonly-occurring "node is not clickable" flake in the classroom admin page.

### DIFF
--- a/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader-modal.component.html
@@ -1,4 +1,4 @@
-<div class="oppia-image-uploader-modal-container">
+<div class="oppia-image-uploader-modal-container e2e-test-image-uploader-modal">
   <div class="modal-header">
     <h3>{{ 'I18N_IMAGE_UPLOADER_MODAL_UPLOAD_HEADING' | translate:{ imageName: imageUploaderParameters.imageName } }}</h3>
   </div>

--- a/core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-edit-and-delete-classroom.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-edit-and-delete-classroom.spec.ts
@@ -61,7 +61,9 @@ describe('Curriculum Admin', function () {
     );
 
     await curriculumAdmin.publishDraftTopic('Test Topic 1');
-  }, DEFAULT_SPEC_TIMEOUT_MSECS);
+
+    // Setup taking longer than 300000 ms.
+  }, 480000);
 
   it(
     'should create, publish and delete a classroom.',

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -170,7 +170,7 @@ const editClassroomTopicListIntroInputField =
   '.e2e-test-update-classroom-topic-list-intro';
 const classroomThumbnailContainer = '.e2e-test-classroom-thumbnail-container';
 const classroomBannerContainer = '.e2e-test-classroom-banner-container';
-const imageUploaderModal = '.e2e-test-thumbnail-editor';
+const imageUploaderModal = '.e2e-test-image-uploader-modal';
 const openTopicDropdownButton = '.e2e-test-add-topic-to-classroom-button';
 const topicDropDownFormField = '.e2e-test-classroom-category-dropdown';
 const topicSelector = '.e2e-test-classroom-topic-selector-choice';
@@ -1385,7 +1385,7 @@ export class CurriculumAdmin extends BaseUser {
     await this.uploadFile(curriculumAdminThumbnailImage);
     await this.page.waitForSelector(`${uploadPhotoButton}:not([disabled])`);
     await this.clickOn(uploadPhotoButton);
-    await this.page.waitForSelector(photoUploadModal, {hidden: true});
+    await this.page.waitForSelector(uploadPhotoButton, {hidden: true});
 
     await this.clickOn(classroomBannerContainer);
     await this.page.waitForSelector(imageUploaderModal, {visible: true});

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -170,7 +170,6 @@ const editClassroomTopicListIntroInputField =
   '.e2e-test-update-classroom-topic-list-intro';
 const classroomThumbnailContainer = '.e2e-test-classroom-thumbnail-container';
 const classroomBannerContainer = '.e2e-test-classroom-banner-container';
-const uploadClassroomImageButton = '.e2e-test-photo-upload-submit';
 const imageUploaderModal = '.e2e-test-thumbnail-editor';
 const openTopicDropdownButton = '.e2e-test-add-topic-to-classroom-button';
 const topicDropDownFormField = '.e2e-test-classroom-category-dropdown';
@@ -500,7 +499,10 @@ export class CurriculumAdmin extends BaseUser {
       await this.clickOn(saveTopicButton);
 
       await this.page.waitForSelector(modalDiv, {visible: true});
-      await this.page.waitForSelector(closeSaveModalButton, {visible: true});
+      await this.page.waitForSelector(
+        `${closeSaveModalButton}:not([disabled])`,
+        {visible: true}
+      );
       await this.clickOn(closeSaveModalButton);
       await this.page.waitForSelector(modalDiv, {hidden: true});
     }
@@ -1379,17 +1381,19 @@ export class CurriculumAdmin extends BaseUser {
     await this.page.type(editClassroomTopicListIntroInputField, topicListIntro);
     await this.page.type(editClassroomCourseDetailsInputField, courseDetails);
     await this.clickOn(classroomThumbnailContainer);
+
     await this.uploadFile(curriculumAdminThumbnailImage);
     await this.page.waitForSelector(`${uploadPhotoButton}:not([disabled])`);
     await this.clickOn(uploadPhotoButton);
-    await this.clickOn(uploadClassroomImageButton);
     await this.page.waitForSelector(photoUploadModal, {hidden: true});
 
     await this.clickOn(classroomBannerContainer);
     await this.page.waitForSelector(imageUploaderModal, {visible: true});
     await this.uploadFile(classroomBannerImage);
     await this.page.waitForSelector(`${uploadPhotoButton}:not([disabled])`);
-    await this.clickOn(uploadClassroomImageButton);
+    await this.clickOn(uploadPhotoButton);
+    await this.page.waitForSelector(imageUploaderModal, {hidden: true});
+
     await this.clickOn(saveClassroomButton);
 
     showMessage(`Updated ${classroomName} classroom.`);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
@@ -450,6 +450,9 @@ export class TopicManager extends BaseUser {
     } else {
       await this.clickOn(saveTopicButton);
       await this.page.waitForSelector(modalDiv, {visible: true});
+      await this.page.waitForSelector(
+        `${closeSaveModalButton}:not([disabled])`
+      );
       await this.clickOn(closeSaveModalButton);
       await this.page.waitForSelector(modalDiv, {hidden: true});
     }


### PR DESCRIPTION
## Overview

1. This PR fixes #20856, and attempts to address #20988 (but might not be successful in the latter).
2. This PR does the following: 
    - #20856 has been occurring frequently. On further investigation I believe this is because we are clicking a button in a modal, and then clicking the same button again. If the re-click happens after the modal is closed, then the element is not present on the page, resulting in a test failure. This PR drops the duplicate click.
    - Increases the time limit for the set-up part of the curriculum-admin tests since they timed out once on my machine.
    - Adds a "not disabled" check to some buttons before they are clicked, to hopefully reduce the occurrence of other flakes like #20988.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

This depends on the CI checks for this PR.