### PR TITLE
Fix #21445: Fix caching and make building a reusable action

### DIFF
--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -36,12 +36,14 @@ runs:
       run: |
         echo "Failed to download build files. Regenerating."
         python -m scripts.build --prod_env
+      shell: bash
     - name: (Artifact re-build) Zip build files
       # We avoid using ../ or absolute paths because unzip treats these as
       # security issues and will refuse to follow them.
       run: |
         zip -rqy build_files.zip oppia/build oppia/webpack_bundles oppia/app.yaml oppia/assets/hashes.json oppia/backend_prod_files oppia/dist
       working-directory: /home/runner/work/oppia
+      shell: bash
     - name: Upload build files artifact
       if: steps.download_artifact.outcome == 'failure'
       uses: actions/upload-artifact@v4

--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -1,0 +1,51 @@
+name: Generate build files
+description: 'Generate build files'
+runs:
+  using: composite
+  steps:
+    - name: Attempt to download build files
+      id: download_artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build_files
+        path: /home/runner/work/oppia
+    - name: Unzip build files
+      if: steps.download_artifact.outcome != 'failure'
+      run: |
+        echo "Successfully downloaded build files"
+        pwd
+        ls -la
+        unzip build_files.zip
+        rm build_files.zip
+        echo "Files in ./:"
+        ls -la .
+        echo "Files in oppia_tools:"
+        ls -la oppia_tools
+        echo "Files in oppia:"
+        ls -la oppia
+        echo "Files in build:"
+        ls -la oppia/build
+        echo "Files in third_party:"
+        ls -la oppia/third_party
+      working-directory: /home/runner/work/oppia
+      shell: bash
+    - name: (Artifact re-build) Build Webpack
+      if: steps.download_artifact.outcome == 'failure'
+      # Note: this and the following steps should be kept in sync with the
+      # build step in full_stack_tests.yml.
+      run: |
+        echo "Failed to download build files. Regenerating."
+        python -m scripts.build --prod_env
+    - name: (Artifact re-build) Zip build files
+      # We avoid using ../ or absolute paths because unzip treats these as
+      # security issues and will refuse to follow them.
+      run: |
+        zip -rqy build_files.zip oppia/build oppia/webpack_bundles oppia/app.yaml oppia/assets/hashes.json oppia/backend_prod_files oppia/dist
+      working-directory: /home/runner/work/oppia
+    - name: Upload build files artifact
+      if: steps.download_artifact.outcome == 'failure'
+      uses: actions/upload-artifact@v4
+      with:
+        name: build_files
+        path: /home/runner/work/oppia/build_files.zip
+        retention-days: 7

--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -52,3 +52,4 @@ runs:
         name: build_files
         path: /home/runner/work/oppia/build_files.zip
         retention-days: 7
+        overwrite: true

--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -6,6 +6,7 @@ runs:
     - name: Attempt to download build files
       id: download_artifact
       uses: actions/download-artifact@v4
+      continue-on-error: true
       with:
         name: build_files
         path: /home/runner/work/oppia

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -343,8 +343,6 @@ jobs:
       #       ${{ runner.os }}-
       - name: Install Oppia dependencies
         uses: ./.github/actions/install-oppia-dependencies
-      - name: Generate build files
-        uses: ./.github/actions/generate-build-files
       - name: Increase lighthouse timeout
         run: |
           # Replace the 1.5 second timeout in lighthouse for retrieving

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -73,35 +73,34 @@ jobs:
         uses: ./.github/actions/merge-develop-and-setup-python
         with:
           use_cache: true
-      - name: Cache node modules and third_party/static
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+      - name: Cache dependencies
+        uses: actions/cache@v4
         with:
           path: |
+            /home/runner/work/oppia/oppia_tools
             /home/runner/work/oppia/yarn_cache
-            /home/runner/work/oppia/oppia/third_party/static
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('yarn.lock', 'dependencies.json') }}
+            /home/runner/work/oppia/oppia/third_party
+          key: ${{ runner.os }}-oppiadeps-${{ hashFiles('yarn.lock', 'dependencies.json', 'requirements.txt', 'requirements_dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-oppiadeps-
             ${{ runner.os }}-
       - name: Install Oppia dependencies
         uses: ./.github/actions/install-oppia-dependencies
       - name: Build Webpack
+        # Note: this and the following steps should be kept in sync with generate-build-files/action.yml.
         run: python -m scripts.build --prod_env
       - name: Zip build files
         # We avoid using ../ or absolute paths because unzip treats these as
         # security issues and will refuse to follow them.
         run: |
-          zip -rqy build_files.zip oppia/third_party oppia_tools oppia/build oppia/webpack_bundles oppia/app.yaml oppia/assets/hashes.json oppia/backend_prod_files oppia/dist
+          zip -rqy build_files.zip oppia/build oppia/webpack_bundles oppia/app.yaml oppia/assets/hashes.json oppia/backend_prod_files oppia/dist
         working-directory: /home/runner/work/oppia
       - name: Upload build files artifact
         uses: actions/upload-artifact@v4
         with:
           name: build_files
           path: /home/runner/work/oppia/build_files.zip
-          retention-days: 1
+          retention-days: 7
   e2e_test:
     needs: [check_test_suites_to_run, build]
     runs-on: ubuntu-22.04
@@ -118,42 +117,21 @@ jobs:
         uses: ./.github/actions/merge-develop-and-setup-python
         with:
           use_cache: true
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+      - name: Cache dependencies
+        uses: actions/cache@v4
         with:
-          path: /home/runner/work/oppia/yarn_cache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+          path: |
+            /home/runner/work/oppia/oppia_tools
+            /home/runner/work/oppia/yarn_cache
+            /home/runner/work/oppia/oppia/third_party
+          key: ${{ runner.os }}-oppiadeps-${{ hashFiles('yarn.lock', 'dependencies.json', 'requirements.txt', 'requirements_dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-oppiadeps-
             ${{ runner.os }}-
-      - name: Download build files artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build_files
-          path: /home/runner/work/oppia
-      - name: Unzip build files
-        run: |
-          pwd
-          ls -la
-          unzip build_files.zip
-          rm build_files.zip
-          echo "Files in ./:"
-          ls -la .
-          echo "Files in oppia_tools:"
-          ls -la oppia_tools
-          echo "Files in oppia:"
-          ls -la oppia
-          echo "Files in build:"
-          ls -la oppia/build
-          echo "Files in third_party:"
-          ls -la oppia/third_party
-        working-directory: /home/runner/work/oppia
-        shell: bash
       - name: Install Oppia dependencies
         uses: ./.github/actions/install-oppia-dependencies
+      - name: Generate build files
+        uses: ./.github/actions/generate-build-files
       - name: Install Chrome
         uses: ./.github/actions/install-chrome
       - name: Install ffmpeg for wdio videos
@@ -216,42 +194,21 @@ jobs:
         uses: ./.github/actions/merge-develop-and-setup-python
         with:
           use_cache: true
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+      - name: Cache dependencies
+        uses: actions/cache@v4
         with:
-          path: /home/runner/work/oppia/yarn_cache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+          path: |
+            /home/runner/work/oppia/oppia_tools
+            /home/runner/work/oppia/yarn_cache
+            /home/runner/work/oppia/oppia/third_party
+          key: ${{ runner.os }}-oppiadeps-${{ hashFiles('yarn.lock', 'dependencies.json', 'requirements.txt', 'requirements_dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-oppiadeps-
             ${{ runner.os }}-
-      - name: Download build files artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build_files
-          path: /home/runner/work/oppia
-      - name: Unzip build files
-        run: |
-          pwd
-          ls -la
-          unzip build_files.zip
-          rm build_files.zip
-          echo "Files in ./:"
-          ls -la .
-          echo "Files in oppia_tools:"
-          ls -la oppia_tools
-          echo "Files in oppia:"
-          ls -la oppia
-          echo "Files in build:"
-          ls -la oppia/build
-          echo "Files in third_party:"
-          ls -la oppia/third_party
-        working-directory: /home/runner/work/oppia
-        shell: bash
       - name: Install Oppia dependencies
         uses: ./.github/actions/install-oppia-dependencies
+      - name: Generate build files
+        uses: ./.github/actions/generate-build-files
       - name: Run Desktop Acceptance Test ${{ matrix.suite.name }}
         run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_acceptance_tests --skip-build --suite=${{ matrix.suite.name }} --prod_env
       - name: Generate modified suite name for artifacts
@@ -320,7 +277,7 @@ jobs:
         run: |
           make build
           docker compose up angular-build -d
-          # This is required as lighthouse tests are run on the host machine and not in the docker container.
+          # This is required as acceptance tests are run on the host machine and not in the docker container.
           sudo docker cp oppia-angular-build:/app/oppia/node_modules .
       - name: Run Desktop Acceptance Test ${{ matrix.suite.name }}
         run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" make run_tests.acceptance suite=${{ matrix.suite.name }}
@@ -373,19 +330,21 @@ jobs:
       # Caching is disabled to avoid poisoning our cache with the
       # changed lighthouse file (see later).
       #
-      # - name: Cache node modules
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-node-modules
+      # - name: Cache dependencies
+      #   uses: actions/cache@v4
       #   with:
-      #     path: /home/runner/work/oppia/yarn_cache
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+      #     path: |
+      #       /home/runner/work/oppia/oppia_tools
+      #       /home/runner/work/oppia/yarn_cache
+      #       /home/runner/work/oppia/oppia/third_party
+      #     key: ${{ runner.os }}-oppiadeps-${{ hashFiles('yarn.lock', 'dependencies.json', 'requirements.txt', 'requirements_dev.txt') }}
       #     restore-keys: |
-      #       ${{ runner.os }}-build-${{ env.cache-name }}-
-      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-oppiadeps-
       #       ${{ runner.os }}-
       - name: Install Oppia dependencies
         uses: ./.github/actions/install-oppia-dependencies
+      - name: Generate build files
+        uses: ./.github/actions/generate-build-files
       - name: Increase lighthouse timeout
         run: |
           # Replace the 1.5 second timeout in lighthouse for retrieving
@@ -433,42 +392,21 @@ jobs:
         uses: ./.github/actions/merge-develop-and-setup-python
         with:
           use_cache: true
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+      - name: Cache dependencies
+        uses: actions/cache@v4
         with:
-          path: /home/runner/work/oppia/yarn_cache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
+          path: |
+            /home/runner/work/oppia/oppia_tools
+            /home/runner/work/oppia/yarn_cache
+            /home/runner/work/oppia/oppia/third_party
+          key: ${{ runner.os }}-oppiadeps-${{ hashFiles('yarn.lock', 'dependencies.json', 'requirements.txt', 'requirements_dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-oppiadeps-
             ${{ runner.os }}-
-      - name: Download build files artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build_files
-          path: /home/runner/work/oppia
-      - name: Unzip build files
-        run: |
-          pwd
-          ls -la
-          unzip build_files.zip
-          rm build_files.zip
-          echo "Files in ./:"
-          ls -la .
-          echo "Files in oppia_tools:"
-          ls -la oppia_tools
-          echo "Files in oppia:"
-          ls -la oppia
-          echo "Files in build:"
-          ls -la oppia/build
-          echo "Files in third_party:"
-          ls -la oppia/third_party
-        working-directory: /home/runner/work/oppia
-        shell: bash
       - name: Install Oppia dependencies
         uses: ./.github/actions/install-oppia-dependencies
+      - name: Generate build files
+        uses: ./.github/actions/generate-build-files
       - name: Install Chrome
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
         uses: ./.github/actions/install-chrome


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #21445.
2. This PR does the following: Extend artifact cache time to 7 days and include a rebuild step. Make build action a reusable action.
3. (For bug-fixing PRs only) The original bug occurred because: In #21363 the regeneration of build files if the artifact was not present was deleted. This resulted in the full set of full-stack tests needing to be re-run in order to execute the "generate build files" step. With this PR, the build files are regenerated and stored as an artifact for future runs if the original artifact  is not present.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Will be observed in the CI checks.