### PR TITLE
Fix: #21368: Updated X-frame-options to Content-Security-Policy headers

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -687,10 +687,10 @@ class BaseHandler(
         if iframe_restriction is not None:
             if iframe_restriction == 'SAMEORIGIN':
                 self.response.headers['Content-Security-Policy'] = (
-                    "frame-ancestors 'self'")
+                    'frame-ancestors \'self\'')
             elif iframe_restriction == 'DENY':
                 self.response.headers['Content-Security-Policy'] = (
-                    "frame-ancestors 'none'")
+                    'frame-ancestors \'none\'')
             else:
                 raise Exception(
                     'Invalid iframe restriction value: %s' % iframe_restriction)

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -685,9 +685,12 @@ class BaseHandler(
         self.response.headers['X-Content-Type-Options'] = 'nosniff'
         self.response.headers['X-Xss-Protection'] = '1; mode=block'
         if iframe_restriction is not None:
-            if iframe_restriction in ['SAMEORIGIN', 'DENY']:
+            if iframe_restriction == 'SAMEORIGIN':
                 self.response.headers['Content-Security-Policy'] = (
-                    f"frame-ancestors {iframe_restriction.lower()};")
+                    "frame-ancestors 'self'")
+            elif iframe_restriction == 'DENY':
+                self.response.headers['Content-Security-Policy'] = (
+                    "frame-ancestors 'none'")
             else:
                 raise Exception(
                     'Invalid iframe restriction value: %s' % iframe_restriction)

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -673,7 +673,7 @@ class BaseHandler(
                 True when the template is compiled by angular AoT compiler.
 
         Raises:
-            Exception. Invalid X-Frame-Options.
+            Exception. Invalid iframe restriction value.
         """
 
         # The 'no-store' must be used to properly invalidate the cache when we
@@ -686,11 +686,11 @@ class BaseHandler(
         self.response.headers['X-Xss-Protection'] = '1; mode=block'
         if iframe_restriction is not None:
             if iframe_restriction in ['SAMEORIGIN', 'DENY']:
-                self.response.headers['X-Frame-Options'] = (
-                    str(iframe_restriction))
+                self.response.headers['Content-Security-Policy'] = (
+                    f"frame-ancestors {iframe_restriction.lower()};")
             else:
                 raise Exception(
-                    'Invalid X-Frame-Options: %s' % iframe_restriction)
+                    'Invalid iframe restriction value: %s' % iframe_restriction)
 
         self.response.expires = 'Mon, 01 Jan 1990 00:00:00 GMT'
         self.response.pragma = 'no-cache'

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -1337,11 +1337,11 @@ class IframeRestrictionTests(test_utils.GenericTestBase):
 
         response = self.get_html_response(
             '/mock', params={'iframe_restriction': 'DENY'})
-        self.assertEqual(response.headers['Content-Security-Policy'], 'frame-ancestors deny;')
+        self.assertEqual(response.headers['Content-Security-Policy'], "frame-ancestors 'none'")
 
         response = self.get_html_response(
             '/mock', params={'iframe_restriction': 'SAMEORIGIN'})
-        self.assertEqual(response.headers['Content-Security-Policy'], 'frame-ancestors sameorigin;')
+        self.assertEqual(response.headers['Content-Security-Policy'], "frame-ancestors 'self'")
 
         self.logout()
 

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -1337,11 +1337,11 @@ class IframeRestrictionTests(test_utils.GenericTestBase):
 
         response = self.get_html_response(
             '/mock', params={'iframe_restriction': 'DENY'})
-        self.assertEqual(response.headers['Content-Security-Policy'], "frame-ancestors 'none'")
+        self.assertEqual(response.headers['Content-Security-Policy'], 'frame-ancestors \'none\'')
 
         response = self.get_html_response(
             '/mock', params={'iframe_restriction': 'SAMEORIGIN'})
-        self.assertEqual(response.headers['Content-Security-Policy'], "frame-ancestors 'self'")
+        self.assertEqual(response.headers['Content-Security-Policy'], 'frame-ancestors \'self\'')
 
         self.logout()
 

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -1337,11 +1337,11 @@ class IframeRestrictionTests(test_utils.GenericTestBase):
 
         response = self.get_html_response(
             '/mock', params={'iframe_restriction': 'DENY'})
-        self.assertEqual(response.headers['X-Frame-Options'], 'DENY')
+        self.assertEqual(response.headers['Content-Security-Policy'], 'frame-ancestors deny;')
 
         response = self.get_html_response(
             '/mock', params={'iframe_restriction': 'SAMEORIGIN'})
-        self.assertEqual(response.headers['X-Frame-Options'], 'SAMEORIGIN')
+        self.assertEqual(response.headers['Content-Security-Policy'], 'frame-ancestors sameorigin;')
 
         self.logout()
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21368.
2. This PR does the following: Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options, the X-frame-Options is deprecated, so I have updated it with Content-Security-Policy header


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
To test these changes, I created html files and checked the iframe output using `http://localhost:8181/learner-dashboard`, `http://localhost:8181/admin` and `http://localhost:8181/embed/exploration/2xSJ2UwPaYv6`. Only the last one rendered.

<img width="1509" alt="Screenshot 2024-12-28 at 1 13 22 AM" src="https://github.com/user-attachments/assets/63d45dfb-fb21-42a4-adb3-da4e2d4c200d" />
<img width="1511" alt="Screenshot 2024-12-28 at 1 14 54 AM" src="https://github.com/user-attachments/assets/72d9137e-3ed5-4ee8-85c2-219355d463d1" />
<img width="1047" alt="Screenshot 2024-12-28 at 1 14 35 AM" src="https://github.com/user-attachments/assets/9ec88951-7541-4333-9878-34b6d6436382" />


https://github.com/user-attachments/assets/7c4676f5-e018-418e-bfcc-d618e5234080

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
