### PR TITLE
Fix #18529 : Duplicate CI runs avoided when multiple pushes are made to a PR in quick succession

### DIFF
--- a/.github/workflows/all_lint_checks.yml
+++ b/.github/workflows/all_lint_checks.yml
@@ -11,7 +11,9 @@ on:
     branches:
       - develop
       - release-*
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   backend_lint:
     name: Backend

--- a/.github/workflows/all_lint_checks.yml
+++ b/.github/workflows/all_lint_checks.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
       - release-*
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/all_type_checks.yml
+++ b/.github/workflows/all_type_checks.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
       - release-*
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/all_type_checks.yml
+++ b/.github/workflows/all_type_checks.yml
@@ -11,7 +11,9 @@ on:
     branches:
       - develop
       - release-*
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   backend_type_checks:
     name: Backend

--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
       - release-*
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -11,7 +11,9 @@ on:
     branches:
       - develop
       - release-*
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   run_backend_associated_test_file_checks:
     name: Verify associated test files

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -11,7 +11,9 @@ on:
     branches:
       - develop
       - release-*
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   generate-job-strategy-matrix:
     name: Generate job strategy matrix

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
       - release-*
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -11,7 +11,9 @@ on:
     branches:
       - develop
       - release-*
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   e2e_and_acceptance_coverage:
     name: Verify all e2e/acceptance tests are included

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - develop
       - release-*
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR addresses issue #18529.

2. This PR does the following: This PR introduces the use of `Concurrency groups` to optimize CI runs. When a new commit triggers a workflow, if there is an existing workflow run still in progress or pending for the same PR (even for an earlier commit), the previous run will be canceled. This ensures that only the most recent commit is built and tested, speeding up the CI process.

3. (For bug-fixing PRs only) The original issue occurred because, when multiple commits were pushed to a PR, tests were run for each commit, resulting in longer CI times and higher memory consumption.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have tested  my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

As demonstrated in [[this PR](https://github.com/Fgrdxgu/oppia/pull/12)](https://github.com/Fgrdxgu/oppia/pull/12), two commits were made in quick succession. However, the first commit was canceled, as shown in the image below:  
![image](https://github.com/user-attachments/assets/18851b69-bda2-4867-b049-42200c0e3394).

The logs indicate this cancellation:  
![oppia aa](https://github.com/user-attachments/assets/a6d80253-b1e6-43c0-abdb-44880204bd68).

Meanwhile, the second and most recent commit proceeded smoothly:  
![image](https://github.com/user-attachments/assets/0a030d1f-7bad-4a5c-a831-2f5712d426a6).

This shows the effectiveness of the concurrency group feature in preventing redundant CI runs and ensuring that only the latest commit is processed.


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
