### PR TITLE
Fix #21596: Fix flake in contributor admin dashboard date selector

### DIFF
--- a/core/tests/webdriverio_utils/ContributorDashboardAdminPage.js
+++ b/core/tests/webdriverio_utils/ContributorDashboardAdminPage.js
@@ -311,19 +311,11 @@ var ContributorDashboardAdminPage = function () {
     var month = selectedDate.getMonth() + 1;
     var year = selectedDate.getFullYear();
 
-    if (year) {
-      var yearsToNavigate =
-        year - new Date(initialValueOfDatePicker).getFullYear();
-
-      await this.navigateThroughMonths(yearsToNavigate * 12);
-    }
-
-    if (month) {
-      var currentMonth = new Date(initialValueOfDatePicker).getMonth() + 1;
-      var monthsToNavigate = month - currentMonth;
-
-      await this.navigateThroughMonths(monthsToNavigate);
-    }
+    var yearsToNavigate =
+      year - new Date(initialValueOfDatePicker).getFullYear();
+    var currentMonth = new Date(initialValueOfDatePicker).getMonth() + 1;
+    var monthsToNavigate = month - currentMonth;
+    await this.navigateThroughMonths(yearsToNavigate * 12 + monthsToNavigate);
 
     if (day) {
       /**


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #21596
2. This PR does the following: Fixes flake in contributor admin dashboard selector.
3. (For bug-fixing PRs only) The original bug occurred because: The original logic for selecting a date was wrong, and failed in the month of January 2025 because, starting at Oct 2024, it would calculate the year difference as +1 and the month difference as -9, and try to advance a year (going past today's date) and then backwards by 9 months. This PR fixes that bug by collapsing the logic to calculate the number of months to move and only then does the advancing.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

The contributor admin dashboard acceptance test should pass on this PR.