### PR TITLE
Fix #21566: fix flake in topics and skills dashboard

### DIFF
--- a/core/tests/webdriverio_desktop/topicsAndSkillsDashboard.js
+++ b/core/tests/webdriverio_desktop/topicsAndSkillsDashboard.js
@@ -152,33 +152,32 @@ describe('Topics and skills dashboard functionality', function () {
     );
 
     await topicsAndSkillsDashboardPage.get();
-    let topicsCount = await topicsAndSkillsDashboardPage.getTopicsCount();
     await topicsAndSkillsDashboardPage.filterTopicsByKeyword(
       TOPIC_ALPHA + '\n' + TOPIC_BETA
     );
     await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(2);
     await topicsAndSkillsDashboardPage.resetTopicFilters();
-    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(topicsCount);
+    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(2);
 
     await topicsAndSkillsDashboardPage.filterTopicsByKeyword('alp');
     await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(1);
     await topicsAndSkillsDashboardPage.resetTopicFilters();
-    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(topicsCount);
+    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(2);
 
     await topicsAndSkillsDashboardPage.filterTopicsByKeyword('be');
     await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(1);
     await topicsAndSkillsDashboardPage.resetTopicFilters();
-    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(topicsCount);
+    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(2);
 
     await topicsAndSkillsDashboardPage.filterTopicsByClassroom('math');
     await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(0);
     await topicsAndSkillsDashboardPage.resetTopicFilters();
-    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(topicsCount);
+    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(2);
 
     await topicsAndSkillsDashboardPage.filterTopicsByKeyword('gamma');
     await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(0);
     await topicsAndSkillsDashboardPage.resetTopicFilters();
-    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(topicsCount);
+    await topicsAndSkillsDashboardPage.expectNumberOfTopicsToBe(2);
   });
 
   it('should move skill to a topic', async function () {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #21566.l
2. This PR does the following: Fixes flake in topics and skills dashboard. The expectations for the "reset" state were all failing. On closer investigation, the test was using logic to compute the expected value and that logic was faulty, so this PR replaces it with hardcoded expectations instead.
3. (For bug-fixing PRs only) The original bug occurred because: The cause is [this line](https://github.com/oppia/oppia/blob/cf027e1ab64bae561d935ecc3e0b9bdfb7344aa0/core/tests/webdriverio_desktop/topicsAndSkillsDashboard.js#L155) which is returning 0, perhaps because the page isn't being given enough time to load (it should return 2). This causes all the expectations below that (after each filter is reset) to fail.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

CI checks should validate this.