### PR TITLE
Drop typed-ast from requirements_dev.in

### DIFF
--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -15,6 +15,5 @@ pylint==2.17.2
 pylint-quotes==0.2.3
 pyyaml==6.0
 rcssmin==1.1.1
-typed-ast==1.4.2
 webtest==3.0.0
 xmltodict==0.13.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -351,9 +351,7 @@ typed-ast==1.4.2 \
     --hash=sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3 \
     --hash=sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166 \
     --hash=sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10
-    # via
-    #   -r requirements_dev.in
-    #   mypy
+    # via mypy
 typing-extensions==4.5.0 \
     --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
     --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: Drops typed-ast from requirements_dev.in

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

typed-ast is already imported by mypy so it is superfluous. This can be confirmed by the PR checks passing.