### PR TITLE
Update build files artifact name to reduce confusion between the artifact name and the zip file name.

### DIFF
--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: actions/download-artifact@v4
       continue-on-error: true
       with:
-        name: build_files
+        name: cached_build_files
         path: /home/runner/work/oppia
     - name: Unzip build files
       if: steps.download_artifact.outcome != 'failure'
@@ -47,7 +47,7 @@ runs:
       if: steps.download_artifact.outcome == 'failure'
       uses: actions/upload-artifact@v4
       with:
-        name: build_files
+        name: cached_build_files
         path: /home/runner/work/oppia/build_files.zip
         retention-days: 7
         overwrite: true


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #N/A.
2. This PR does the following: Changes the build files artifact name to be unique so we can distinguish it from the actual file that is being uploaded.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

GitHub CI checks (full_stack_tests in particular) will use this artifact and should fail if there are errors in the workflow.