### PR TITLE
Add helpful message for developers to CI logs on test failure

### DIFF
--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -363,6 +363,10 @@ jobs:
       - name: Fail if workflow status is failure
         if: ${{ steps.check_workflow_status.outputs.WORKFLOW_STATUS == 'failure' }}
         run: |
+          echo "Note to developers: This CI check is failing because another e2e/acceptance/lighthouse full-stack test workflow has failed."
+          echo "Please see that other workflow for the relevant logs to investigate."
+          echo "When all full-stack workflows pass, this CI check will automatically pass."
+          echo "If all other full-stack workflows have passed and this is the only failure, please file an issue on our issue tracker and link to this log. Thanks!"
           exit 1
         shell: bash
     permissions:


### PR DESCRIPTION

Fixes #21103

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21103.
2. This PR modifies the "Fail if workflow status is failure" step in the full_stack_tests.yml workflow to include a helpful message in the CI logs. The message informs developers that the failure is due to another workflow failure (e2e/acceptance/lighthouse test) and provides guidance on investigating and resolving the issue. This change aims to reduce confusion during CI failures and direct developers to the relevant logs. This change will make it easier for developers to locate the actual failing test and resolve issues quickly.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ]  I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ]  I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ]  I have written tests for my code.
- [ ]  The PR title starts with "Fix #21103: " followed by a clear summary of the changes.
- [ ]  I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing Steps:

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

1. Trigger a failing workflow that runs the full-stack tests.
2. Verify that the CI logs show the new message, directing developers to investigate the relevant failing workflow (e.g., e2e, acceptance, or lighthouse test) for the error.

## Proof that changes are correct

No proof of UI changes needed as this is a change related to CI logs.


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
