### PR TITLE
Fix #16484 flakey backend tests datetime mismatch

### DIFF
--- a/core/jobs/batch_jobs/suggestion_stats_computation_jobs_test.py
+++ b/core/jobs/batch_jobs/suggestion_stats_computation_jobs_test.py
@@ -1187,7 +1187,7 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
                 target_id=self.EXP_1_ID,
                 target_version_at_submission=0,
                 language_code=self.LANG_1,
-                created_on=datetime.datetime.utcnow()
+                created_on=mocked_now
             )
             suggestion_1_model.update_timestamps()
             suggestion_2_model = self.create_model(
@@ -1209,7 +1209,7 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
                 target_id=self.EXP_1_ID,
                 target_version_at_submission=0,
                 language_code=self.LANG_1,
-                created_on=datetime.datetime.utcnow() - datetime.timedelta(days=2)
+                created_on=mocked_now - datetime.timedelta(days=2)
             )
             suggestion_2_model.update_timestamps()
             suggestion_3_model = self.create_model(
@@ -1231,7 +1231,7 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
                 target_id=self.EXP_1_ID,
                 target_version_at_submission=0,
                 language_code=self.LANG_1,
-                created_on=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                created_on=mocked_now - datetime.timedelta(days=1)
             )
             suggestion_3_model.update_timestamps()
             suggestion_models.GeneralSuggestionModel.put_multi([

--- a/core/jobs/batch_jobs/suggestion_stats_computation_jobs_test.py
+++ b/core/jobs/batch_jobs/suggestion_stats_computation_jobs_test.py
@@ -77,40 +77,42 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
         self.assert_job_output_is_empty()
 
     def test_creates_stats_model_from_one_in_review_suggestion(self) -> None:
-        suggestion_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': '111 222 333',
-                'translation_html': '111 222 333',
-                'data_format': 'html'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_IN_REVIEW,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1
-        )
-        suggestion_model.update_timestamps()
-        suggestion_model.put()
-        opportunity_model = self.create_model(
-            opportunity_models.ExplorationOpportunitySummaryModel,
-            id=self.EXP_1_ID,
-            topic_id=self.TOPIC_1_ID,
-            chapter_title='irelevant',
-            content_count=1,
-            story_id='irelevant',
-            story_title='irelevant',
-            topic_name='irelevant'
-        )
-        opportunity_model.update_timestamps()
-        opportunity_model.put()
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            suggestion_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': '111 222 333',
+                    'translation_html': '111 222 333',
+                    'data_format': 'html'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_IN_REVIEW,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1
+            )
+            suggestion_model.update_timestamps()
+            suggestion_model.put()
+            opportunity_model = self.create_model(
+                opportunity_models.ExplorationOpportunitySummaryModel,
+                id=self.EXP_1_ID,
+                topic_id=self.TOPIC_1_ID,
+                chapter_title='irelevant',
+                content_count=1,
+                story_id='irelevant',
+                story_title='irelevant',
+                topic_name='irelevant'
+            )
+            opportunity_model.update_timestamps()
+            opportunity_model.put()
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(
@@ -198,39 +200,41 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
     def test_creates_stats_model_from_one_suggestion_in_legacy_format(
         self
     ) -> None:
-        suggestion_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.DEPRECATED_CMD_ADD_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': '111 a',
-                'translation_html': '111 a'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_IN_REVIEW,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1
-        )
-        suggestion_model.update_timestamps()
-        suggestion_model.put()
-        opportunity_model = self.create_model(
-            opportunity_models.ExplorationOpportunitySummaryModel,
-            id=self.EXP_1_ID,
-            topic_id=self.TOPIC_1_ID,
-            chapter_title='irelevant',
-            content_count=1,
-            story_id='irelevant',
-            story_title='irelevant',
-            topic_name='irelevant'
-        )
-        opportunity_model.update_timestamps()
-        opportunity_model.put()
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            suggestion_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.DEPRECATED_CMD_ADD_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': '111 a',
+                    'translation_html': '111 a'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_IN_REVIEW,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1
+            )
+            suggestion_model.update_timestamps()
+            suggestion_model.put()
+            opportunity_model = self.create_model(
+                opportunity_models.ExplorationOpportunitySummaryModel,
+                id=self.EXP_1_ID,
+                topic_id=self.TOPIC_1_ID,
+                chapter_title='irelevant',
+                content_count=1,
+                story_id='irelevant',
+                story_title='irelevant',
+                topic_name='irelevant'
+            )
+            opportunity_model.update_timestamps()
+            opportunity_model.put()
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(
@@ -272,40 +276,43 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
     def test_creates_stats_model_from_one_suggestion_in_set_format(
         self
     ) -> None:
-        suggestion_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': ['111 a', '222 b', '333 c'],
-                'translation_html': ['111 a', '222 b', '333 c'],
-                'data_format': 'set_of_normalized_string'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_IN_REVIEW,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1
-        )
-        suggestion_model.update_timestamps()
-        suggestion_model.put()
-        opportunity_model = self.create_model(
-            opportunity_models.ExplorationOpportunitySummaryModel,
-            id=self.EXP_1_ID,
-            topic_id=self.TOPIC_1_ID,
-            chapter_title='irelevant',
-            content_count=1,
-            story_id='irelevant',
-            story_title='irelevant',
-            topic_name='irelevant'
-        )
-        opportunity_model.update_timestamps()
-        opportunity_model.put()
+         # Define a fixed datetime.
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            suggestion_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': ['111 a', '222 b', '333 c'],
+                    'translation_html': ['111 a', '222 b', '333 c'],
+                    'data_format': 'set_of_normalized_string'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_IN_REVIEW,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1
+            )
+            suggestion_model.update_timestamps()
+            suggestion_model.put()
+            opportunity_model = self.create_model(
+                opportunity_models.ExplorationOpportunitySummaryModel,
+                id=self.EXP_1_ID,
+                topic_id=self.TOPIC_1_ID,
+                chapter_title='irelevant',
+                content_count=1,
+                story_id='irelevant',
+                story_title='irelevant',
+                topic_name='irelevant'
+            )
+            opportunity_model.update_timestamps()
+            opportunity_model.put()
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(
@@ -347,40 +354,42 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
     def test_creates_stats_model_from_one_in_review_suggestion_with_opportunity(
         self
     ) -> None:
-        suggestion_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': '111 222 333',
-                'translation_html': '111 222 333',
-                'data_format': 'html'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_IN_REVIEW,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1
-        )
-        suggestion_model.update_timestamps()
-        suggestion_model.put()
-        opportunity_model = self.create_model(
-            opportunity_models.ExplorationOpportunitySummaryModel,
-            id=self.EXP_1_ID,
-            topic_id=self.TOPIC_1_ID,
-            chapter_title='irelevant',
-            content_count=1,
-            story_id='irelevant',
-            story_title='irelevant',
-            topic_name='irelevant'
-        )
-        opportunity_model.update_timestamps()
-        opportunity_model.put()
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            suggestion_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': '111 222 333',
+                    'translation_html': '111 222 333',
+                    'data_format': 'html'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_IN_REVIEW,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1
+            )
+            suggestion_model.update_timestamps()
+            suggestion_model.put()
+            opportunity_model = self.create_model(
+                opportunity_models.ExplorationOpportunitySummaryModel,
+                id=self.EXP_1_ID,
+                topic_id=self.TOPIC_1_ID,
+                chapter_title='irelevant',
+                content_count=1,
+                story_id='irelevant',
+                story_title='irelevant',
+                topic_name='irelevant'
+            )
+            opportunity_model.update_timestamps()
+            opportunity_model.put()
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(
@@ -422,41 +431,43 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
     def test_creates_translation_stats_models_from_one_accepted_suggestion(
         self
     ) -> None:
-        suggestion_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': '111 222 333',
-                'translation_html': '111 222 333',
-                'data_format': 'unicode'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_ACCEPTED,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1,
-            final_reviewer_id='reviewer1'
-        )
-        suggestion_model.update_timestamps()
-        suggestion_model.put()
-        opportunity_model = self.create_model(
-            opportunity_models.ExplorationOpportunitySummaryModel,
-            id=self.EXP_1_ID,
-            topic_id=self.TOPIC_1_ID,
-            chapter_title='irelevant',
-            content_count=1,
-            story_id='irelevant',
-            story_title='irelevant',
-            topic_name='irelevant'
-        )
-        opportunity_model.update_timestamps()
-        opportunity_model.put()
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            suggestion_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': '111 222 333',
+                    'translation_html': '111 222 333',
+                    'data_format': 'unicode'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_ACCEPTED,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1,
+                final_reviewer_id='reviewer1'
+            )
+            suggestion_model.update_timestamps()
+            suggestion_model.put()
+            opportunity_model = self.create_model(
+                opportunity_models.ExplorationOpportunitySummaryModel,
+                id=self.EXP_1_ID,
+                topic_id=self.TOPIC_1_ID,
+                chapter_title='irelevant',
+                content_count=1,
+                story_id='irelevant',
+                story_title='irelevant',
+                topic_name='irelevant'
+            )
+            opportunity_model.update_timestamps()
+            opportunity_model.put()
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(
@@ -525,11 +536,11 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
             translation_review_stats_model.accepted_translation_word_count, 3)
         self.assertEqual(
             translation_review_stats_model.first_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
         self.assertEqual(
             translation_review_stats_model.last_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
 
     def test_escapes_stats_without_opportunity(
@@ -574,65 +585,67 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
     def test_creates_translation_stats_models_from_two_accepted_suggestions(
         self
     ) -> None:
-        first_suggestion_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': '111 222 333',
-                'translation_html': '111 222 333',
-                'data_format': 'unicode'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_ACCEPTED,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1,
-            final_reviewer_id=None
-        )
-        first_suggestion_model.update_timestamps()
-        first_suggestion_model.put()
-        opportunity_model = self.create_model(
-            opportunity_models.ExplorationOpportunitySummaryModel,
-            id=self.EXP_1_ID,
-            topic_id=self.TOPIC_1_ID,
-            chapter_title='irelevant',
-            content_count=1,
-            story_id='irelevant',
-            story_title='irelevant',
-            topic_name='irelevant'
-        )
-        opportunity_model.update_timestamps()
-        opportunity_model.put()
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            first_suggestion_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': '111 222 333',
+                    'translation_html': '111 222 333',
+                    'data_format': 'unicode'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_ACCEPTED,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1,
+                final_reviewer_id=None
+            )
+            first_suggestion_model.update_timestamps()
+            first_suggestion_model.put()
+            opportunity_model = self.create_model(
+                opportunity_models.ExplorationOpportunitySummaryModel,
+                id=self.EXP_1_ID,
+                topic_id=self.TOPIC_1_ID,
+                chapter_title='irelevant',
+                content_count=1,
+                story_id='irelevant',
+                story_title='irelevant',
+                topic_name='irelevant'
+            )
+            opportunity_model.update_timestamps()
+            opportunity_model.put()
 
-        second_suggestion_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': '111 222 333',
-                'translation_html': '111 222 333',
-                'data_format': 'unicode'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_ACCEPTED,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1,
-            final_reviewer_id=None
-        )
-        second_suggestion_model.update_timestamps()
-        second_suggestion_model.put()
+            second_suggestion_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': '111 222 333',
+                    'translation_html': '111 222 333',
+                    'data_format': 'unicode'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_ACCEPTED,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1,
+                final_reviewer_id=None
+            )
+            second_suggestion_model.update_timestamps()
+            second_suggestion_model.put()
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(
@@ -702,11 +715,11 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
             translation_review_stats_model.accepted_translation_word_count, 6)
         self.assertEqual(
             translation_review_stats_model.first_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
         self.assertEqual(
             translation_review_stats_model.last_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
 
     def test_creates_multiple_stats_models_from_multiple_users(
@@ -1061,7 +1074,9 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
     def test_creates_question_stats_models_from_one_accepted_suggestion(
         self
     ) -> None:
-        topic_id = self._create_question()
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            topic_id = self._create_question()
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(
@@ -1108,11 +1123,11 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
         )
         self.assertEqual(
             question_stats_model.first_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
         self.assertEqual(
             question_stats_model.last_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
 
         self.assertEqual(
@@ -1131,94 +1146,96 @@ class GenerateContributionStatsJobTests(job_test_utils.JobTestBase):
         )
         self.assertEqual(
             question_review_stats_model.first_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
         self.assertEqual(
             question_review_stats_model.last_contribution_date,
-            datetime.datetime.utcnow().date()
+            mocked_now.date()
         )
 
     def test_creates_stats_model_from_multiple_suggestions(self) -> None:
-        opportunity_model = self.create_model(
-            opportunity_models.ExplorationOpportunitySummaryModel,
-            id=self.EXP_1_ID,
-            topic_id=self.TOPIC_1_ID,
-            chapter_title='irelevant',
-            content_count=1,
-            story_id='irelevant',
-            story_title='irelevant',
-            topic_name='irelevant'
-        )
-        opportunity_model.update_timestamps()
-        opportunity_model.put()
-        suggestion_1_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': '111 222 333',
-                'translation_html': '111 222 333',
-                'data_format': 'html'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_IN_REVIEW,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1,
-            created_on=datetime.datetime.utcnow()
-        )
-        suggestion_1_model.update_timestamps()
-        suggestion_2_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': ['111', '222', '333', '444', '555'],
-                'translation_html': ['111', '222', '333', '444', '555'],
-                'data_format': 'set_of_unicode_string'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_IN_REVIEW,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1,
-            created_on=datetime.datetime.utcnow() - datetime.timedelta(days=2)
-        )
-        suggestion_2_model.update_timestamps()
-        suggestion_3_model = self.create_model(
-            suggestion_models.GeneralSuggestionModel,
-            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            author_id=self.VALID_USER_ID_1,
-            change_cmd={
-                'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
-                'state_name': 'state',
-                'content_id': 'content_id',
-                'language_code': 'lang',
-                'content_html': ['111', '222', '333', '444', '555'],
-                'translation_html': ['111', '222', '333', '444', '555'],
-                'data_format': 'set_of_unicode_string'
-            },
-            score_category='irelevant',
-            status=suggestion_models.STATUS_IN_REVIEW,
-            target_type='exploration',
-            target_id=self.EXP_1_ID,
-            target_version_at_submission=0,
-            language_code=self.LANG_1,
-            created_on=datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        )
-        suggestion_3_model.update_timestamps()
-        suggestion_models.GeneralSuggestionModel.put_multi([
-            suggestion_1_model, suggestion_2_model, suggestion_3_model])
+        mocked_now = datetime.datetime(2025, 1, 7)
+        with self.mock_datetime_utcnow(mocked_now):
+            opportunity_model = self.create_model(
+                opportunity_models.ExplorationOpportunitySummaryModel,
+                id=self.EXP_1_ID,
+                topic_id=self.TOPIC_1_ID,
+                chapter_title='irelevant',
+                content_count=1,
+                story_id='irelevant',
+                story_title='irelevant',
+                topic_name='irelevant'
+            )
+            opportunity_model.update_timestamps()
+            opportunity_model.put()
+            suggestion_1_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': '111 222 333',
+                    'translation_html': '111 222 333',
+                    'data_format': 'html'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_IN_REVIEW,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1,
+                created_on=datetime.datetime.utcnow()
+            )
+            suggestion_1_model.update_timestamps()
+            suggestion_2_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': ['111', '222', '333', '444', '555'],
+                    'translation_html': ['111', '222', '333', '444', '555'],
+                    'data_format': 'set_of_unicode_string'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_IN_REVIEW,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1,
+                created_on=datetime.datetime.utcnow() - datetime.timedelta(days=2)
+            )
+            suggestion_2_model.update_timestamps()
+            suggestion_3_model = self.create_model(
+                suggestion_models.GeneralSuggestionModel,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                author_id=self.VALID_USER_ID_1,
+                change_cmd={
+                    'cmd': exp_domain.CMD_ADD_WRITTEN_TRANSLATION,
+                    'state_name': 'state',
+                    'content_id': 'content_id',
+                    'language_code': 'lang',
+                    'content_html': ['111', '222', '333', '444', '555'],
+                    'translation_html': ['111', '222', '333', '444', '555'],
+                    'data_format': 'set_of_unicode_string'
+                },
+                score_category='irelevant',
+                status=suggestion_models.STATUS_IN_REVIEW,
+                target_type='exploration',
+                target_id=self.EXP_1_ID,
+                target_version_at_submission=0,
+                language_code=self.LANG_1,
+                created_on=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            )
+            suggestion_3_model.update_timestamps()
+            suggestion_models.GeneralSuggestionModel.put_multi([
+                suggestion_1_model, suggestion_2_model, suggestion_3_model])
 
         self.assert_job_output_is([
             job_run_result.JobRunResult(


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16484.
2. This PR does the following: Introduces `with self.mock_datetime_utcnow(mocked_now)` statements before model creation to mock out utc now calls with a static value. This helps decouple tests from testing with server times if the models get created between time boundaries 
3. (For bug-fixing PRs only) The original bug occurred because: The continuous integration pipeline had tested between a day boundary and found mismatched dates for utc_now.

@seanlip PTAL

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

<img width="842" alt="Screenshot 2025-01-13 at 10 02 02 PM" src="https://github.com/user-attachments/assets/0fd21304-b3cb-4dbd-beb3-b0009bf22467" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
