### PR TITLE
Fix part of #21308 : Improve branch test coverage in learner_progress_services_test.py and recommendations_services_test.py to 100%.

### DIFF
--- a/core/domain/learner_progress_services_test.py
+++ b/core/domain/learner_progress_services_test.py
@@ -1015,7 +1015,9 @@ class LearnerProgressTests(test_utils.GenericTestBase):
         # Removing a collection with an invalid user id has no effect.
         self.user_id = 'invalid user id'
         learner_progress_services.remove_collection_from_completed_list(
-                self.user_id, self.COL_ID_0)
+                self.user_id, self.COL_ID_1)
+        self.assertEqual(self._get_all_completed_collection_ids(
+            self.user_id), [])
 
     def test_remove_story_from_completed_list(self) -> None:
         self.assertEqual(self._get_all_completed_story_ids(
@@ -1051,6 +1053,8 @@ class LearnerProgressTests(test_utils.GenericTestBase):
         self.user_id = 'invalid user id'
         learner_progress_services.remove_story_from_completed_list(
                 self.user_id, self.STORY_ID_0)
+        self.assertEqual(self._get_all_completed_story_ids(
+            self.user_id), [])
 
     def test_remove_topic_from_learnt_list(self) -> None:
         self.assertEqual(self._get_all_learnt_topic_ids(
@@ -1086,6 +1090,8 @@ class LearnerProgressTests(test_utils.GenericTestBase):
         self.user_id = 'invalid user id'
         learner_progress_services.remove_topic_from_learnt_list(
                 self.user_id, self.TOPIC_ID_0)
+        self.assertEqual(self._get_all_completed_story_ids(
+            self.user_id), [])
 
     def test_get_all_completed_exp_ids(self) -> None:
         self.assertEqual(learner_progress_services.get_all_completed_exp_ids(

--- a/core/domain/recommendations_services_test.py
+++ b/core/domain/recommendations_services_test.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+import datetime
+
 from core import feconf
 from core.domain import exp_services
 from core.domain import recommendations_services
@@ -296,6 +298,41 @@ class RecommendationsServicesUnitTests(test_utils.GenericTestBase):
             recommendations_services.get_item_similarity(
                 exp_summaries['exp_id_1'], exp_summaries['exp_id_2']),
             0.0
+        )
+
+    def test_get_item_similarity_when_language_code_differs(self) -> None:
+        exp_summaries = exp_services.get_all_exploration_summaries()
+        exp_summaries['exp_id_1'].language_code = 'en'
+        exp_summaries['exp_id_2'].language_code = 'es'
+        self.assertEqual(
+            recommendations_services.get_item_similarity(
+                exp_summaries['exp_id_1'],
+                exp_summaries['exp_id_2']),
+                2.5
+        )
+
+    def test_get_item_similarity_when_owner_ids_differs(self) -> None:
+        exp_summaries = exp_services.get_all_exploration_summaries()
+        exp_summaries['exp_id_1'].owner_ids = ['owner_id_1']
+        exp_summaries['exp_id_2'].owner_ids = ['owner_id_2']
+        self.assertEqual(
+            recommendations_services.get_item_similarity(
+                exp_summaries['exp_id_1'],
+                exp_summaries['exp_id_2']),
+                3.5
+        )
+
+    def test_get_item_similarity_when_time_delta_is_greater_than_7_days(
+        self) -> None:
+        exp_summaries = exp_services.get_all_exploration_summaries()
+        # Test case where time_delta_days > 7.
+        time_in_past = datetime.datetime.utcnow() - datetime.timedelta(days=10)
+        exp_summaries['exp_id_2'].exploration_model_last_updated = time_in_past
+        self.assertEqual(
+            recommendations_services.get_item_similarity(
+                exp_summaries['exp_id_1'],
+                exp_summaries['exp_id_2']),
+                3.5
         )
 
     def test_get_and_set_exploration_recommendations(self) -> None:


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR  fixes part of #21308 .
2. This PR does the following:This PR improves the branch test coverage for learner_progress_services_test.py and recommendations_services_test.py to 100%. as part of resolving issue https://github.com/oppia/oppia/issues/21308. The changes focus on ensuring all logical branches in the following sections are tested:

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

![Screenshot from 2025-01-17 19-34-24](https://github.com/user-attachments/assets/a7194cb8-f1c1-48c2-8338-f19b453cadc5)


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->



<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
