### PR TITLE
Fix #21072- Warning popup added when user wants to skip or goes back to a translation without saving

### DIFF
--- a/core/templates/components/shared-component.module.ts
+++ b/core/templates/components/shared-component.module.ts
@@ -194,6 +194,7 @@ import {DonationBoxComponent} from 'pages/donate-page/donation-box/donation-box.
 import {DonationBoxModalComponent} from 'pages/donate-page/donation-box/donation-box-modal.component';
 import {RteHelperModalComponent} from 'services/rte-helper-modal.controller';
 import {DirectivesModule} from 'directives/directives.module';
+import {ConfirmationModalComponent} from 'pages/contributor-dashboard-page/modal-templates/confirmation-modal.component';
 
 @NgModule({
   imports: [
@@ -373,6 +374,7 @@ import {DirectivesModule} from 'directives/directives.module';
     RteHelperModalComponent,
     UndoSnackbarComponent,
     TranslationModalComponent,
+    ConfirmationModalComponent,
     FullExpandAccordionComponent,
   ],
 
@@ -511,6 +513,7 @@ import {DirectivesModule} from 'directives/directives.module';
     RteHelperModalComponent,
     UndoSnackbarComponent,
     TranslationModalComponent,
+    ConfirmationModalComponent,
     FullExpandAccordionComponent,
   ],
 
@@ -659,6 +662,7 @@ import {DirectivesModule} from 'directives/directives.module';
     RteHelperModalComponent,
     UndoSnackbarComponent,
     TranslationModalComponent,
+    ConfirmationModalComponent,
     FullExpandAccordionComponent,
   ],
 })

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/confirmation-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/confirmation-modal.component.spec.ts
@@ -1,0 +1,88 @@
+// Copyright 2021 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for ConfirmationModalComponent.
+ */
+
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
+import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
+import {ConfirmationModalComponent} from './confirmation-modal.component';
+
+describe('Confirmation Modal Component', () => {
+  let component: ConfirmationModalComponent;
+  let fixture: ComponentFixture<ConfirmationModalComponent>;
+  let modalService: NgbModal;
+  let modalRef: NgbModalRef;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfirmationModalComponent],
+      providers: [NgbModal],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmationModalComponent);
+    component = fixture.componentInstance;
+    modalService = TestBed.inject(NgbModal);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have default content values', () => {
+    expect(component.content).toEqual({
+      title: '',
+      message: '',
+      confirmText: '',
+      cancelText: '',
+    });
+  });
+
+  it('should update content when input is provided', () => {
+    const testContent = {
+      title: 'Test Title',
+      message: 'Test Message',
+      confirmText: 'Confirm',
+      cancelText: 'Cancel',
+    };
+    component.content = testContent;
+    fixture.detectChanges();
+
+    expect(component.content).toEqual(testContent);
+  });
+
+  it('should emit confirm when confirm button is clicked', fakeAsync(() => {
+    spyOn(component.activeModal, 'close');
+    component.confirm();
+    tick();
+    expect(component.activeModal.close).toHaveBeenCalledWith('confirm');
+  }));
+
+  it('should emit cancel when cancel button is clicked', fakeAsync(() => {
+    spyOn(component.activeModal, 'dismiss');
+    component.cancel();
+    tick();
+    expect(component.activeModal.dismiss).toHaveBeenCalledWith('cancel');
+  }));
+});

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/confirmation-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/confirmation-modal.component.ts
@@ -1,0 +1,62 @@
+// Copyright 2021 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Component for the translation modal.
+ */
+
+import {Component, Input} from '@angular/core';
+import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'app-confirmation-modal',
+  template: `
+    <div class="modal-header">
+      <h4 class="modal-title">{{ content.title }}</h4>
+      <button
+        type="button"
+        class="close"
+        aria-label="Close"
+        (click)="modal.dismiss()"
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="modal-body">
+      <p>{{ content.message }}</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-secondary" (click)="modal.dismiss()">
+        {{ content.cancelText }}
+      </button>
+      <button
+        type="button"
+        class="btn btn-success"
+        (click)="modal.close('confirm')"
+      >
+        {{ content.confirmText }}
+      </button>
+    </div>
+  `,
+})
+export class ConfirmationModalComponent {
+  @Input() content!: {
+    title: string;
+    message: string;
+    confirmText: string;
+    cancelText: string;
+  };
+
+  constructor(public modal: NgbActiveModal) {}
+}

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.spec.ts
@@ -30,7 +30,12 @@ import {
   tick,
   waitForAsync,
 } from '@angular/core/testing';
-import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import {
+  NgbActiveModal,
+  NgbModal,
+  NgbModalRef,
+} from '@ng-bootstrap/ng-bootstrap';
+import {ConfirmationModalComponent} from './confirmation-modal.component';
 import {AppConstants} from 'app.constants';
 import {CkEditorCopyContentService} from 'components/ck-editor-helpers/ck-editor-copy-content.service';
 import {OppiaAngularRootComponent} from 'components/oppia-angular-root.component';
@@ -919,5 +924,141 @@ describe('Translation Modal Component', () => {
     component.updateTranslatedText();
 
     expect(activeModal.close).not.toHaveBeenCalled();
+  });
+
+  describe('returnToPreviousTranslation', () => {
+    let modalService: NgbModal;
+    let modalRef: NgbModalRef;
+
+    beforeEach(() => {
+      modalService = TestBed.inject(NgbModal);
+      modalRef = jasmine.createSpyObj('NgbModalRef', [
+        'componentInstance',
+        'result',
+      ]);
+      spyOn(modalService, 'open').and.returnValue(modalRef);
+    });
+
+    it('should return to previous translation without confirmation if no unsaved changes', () => {
+      component.hasUnsavedChanges = false;
+      component.activeWrittenTranslation = '';
+      spyOn(translateTextService, 'getPreviousTextToTranslate').and.returnValue(
+        {
+          text: 'previous text',
+          more: true,
+          status: 'draft',
+          translation: '',
+          dataFormat: 'html',
+          contentType: 'content',
+        }
+      );
+
+      component.returnToPreviousTranslation();
+
+      expect(modalService.open).not.toHaveBeenCalled();
+      expect(
+        translateTextService.getPreviousTextToTranslate
+      ).toHaveBeenCalled();
+      expect(component.textToTranslate).toBe('previous text');
+      expect(component.moreAvailable).toBeTrue();
+    });
+
+    it('should show confirmation modal when there are unsaved changes', fakeAsync(() => {
+      component.hasUnsavedChanges = true;
+      component.activeWrittenTranslation = 'new translation';
+      component.textToTranslate = 'original text';
+
+      modalRef.componentInstance = {content: {}};
+      modalRef.result = Promise.resolve('confirm');
+
+      component.returnToPreviousTranslation();
+
+      expect(modalService.open).toHaveBeenCalledWith(
+        ConfirmationModalComponent,
+        {
+          centered: true,
+          backdrop: 'static',
+        }
+      );
+
+      expect(modalRef.componentInstance.content).toEqual({
+        title: 'Unsaved Changes',
+        message:
+          'You have unsaved changes. Are you sure you want to go back? Your changes will be lost.',
+        confirmText: 'Discard Changes',
+        cancelText: 'Continue Editing',
+      });
+    }));
+
+    it('should discard changes and return to previous translation when confirmed', fakeAsync(() => {
+      component.hasUnsavedChanges = true;
+      component.activeWrittenTranslation = 'new translation';
+      component.textToTranslate = 'original text';
+
+      modalRef.componentInstance = {content: {}};
+      modalRef.result = Promise.resolve('confirm');
+
+      spyOn(translateTextService, 'getPreviousTextToTranslate').and.returnValue(
+        {
+          text: 'previous text',
+          more: true,
+          status: 'draft',
+          translation: '',
+          dataFormat: 'html',
+          contentType: 'content',
+        }
+      );
+
+      component.returnToPreviousTranslation();
+      tick();
+
+      expect(component.hasUnsavedChanges).toBeFalse();
+      expect(component.activeWrittenTranslation).toBe('');
+      expect(
+        translateTextService.getPreviousTextToTranslate
+      ).toHaveBeenCalled();
+      expect(component.textToTranslate).toBe('previous text');
+      expect(component.moreAvailable).toBeTrue();
+    }));
+
+    it('should keep current translation when modal is cancelled', fakeAsync(() => {
+      component.hasUnsavedChanges = true;
+      component.activeWrittenTranslation = 'new translation';
+      component.textToTranslate = 'original text';
+
+      modalRef.componentInstance = {content: {}};
+      modalRef.result = Promise.reject();
+
+      spyOn(translateTextService, 'getPreviousTextToTranslate');
+
+      component.returnToPreviousTranslation();
+      tick();
+
+      expect(component.hasUnsavedChanges).toBeTrue();
+      expect(component.activeWrittenTranslation).toBe('new translation');
+      expect(
+        translateTextService.getPreviousTextToTranslate
+      ).not.toHaveBeenCalled();
+    }));
+
+    it('should not show confirmation modal for empty changes', () => {
+      component.hasUnsavedChanges = true;
+      component.activeWrittenTranslation = '';
+      component.textToTranslate = 'original text';
+
+      component.returnToPreviousTranslation();
+
+      expect(modalService.open).not.toHaveBeenCalled();
+    });
+
+    it('should not show confirmation modal when translation matches original', () => {
+      component.hasUnsavedChanges = true;
+      component.activeWrittenTranslation = 'original text';
+      component.textToTranslate = 'original text';
+
+      component.returnToPreviousTranslation();
+
+      expect(modalService.open).not.toHaveBeenCalled();
+    });
   });
 });

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.ts
@@ -25,7 +25,7 @@ import {
   Input,
   ViewChild,
 } from '@angular/core';
-import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import {NgbActiveModal, NgbModal} from '@ng-bootstrap/ng-bootstrap';
 
 import {AlertsService} from 'services/alerts.service';
 import {CkEditorCopyContentService} from 'components/ck-editor-helpers/ck-editor-copy-content.service';
@@ -51,6 +51,7 @@ import {
 import {RteOutputDisplayComponent} from 'rich_text_components/rte-output-display.component';
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
 import {TranslatedContent} from 'domain/exploration/TranslatedContentObjectFactory';
+import {ConfirmationModalComponent} from './confirmation-modal.component';
 
 const INTERACTION_SPECS = require('interactions/interaction_specs.json');
 
@@ -136,6 +137,7 @@ export class TranslationModalComponent {
   textToTranslate: string | string[] = '';
   activeStatus!: Status;
   activeLanguageCode!: string;
+  hasUnsavedChanges: boolean = false;
   HTML_SCHEMA!: {
     type: string;
     ui_config: UiConfig;
@@ -182,8 +184,14 @@ export class TranslationModalComponent {
   @ViewChild('translationContainer')
   translationContainer!: ElementRef;
 
+  private resetUnsavedChanges(): void {
+    this.hasUnsavedChanges = false;
+    this.activeWrittenTranslation = '';
+  }
+
   constructor(
     public readonly activeModal: NgbActiveModal,
+    private readonly modalService: NgbModal,
     private readonly alertsService: AlertsService,
     private readonly ckEditorCopyContentService: CkEditorCopyContentService,
     private readonly contextService: ContextService,
@@ -388,6 +396,7 @@ export class TranslationModalComponent {
 
   updateHtml($event: string): void {
     if ($event !== this.activeWrittenTranslation) {
+      this.hasUnsavedChanges = true;
       this.activeWrittenTranslation = $event;
       this.changeDetectorRef.detectChanges();
     }
@@ -409,11 +418,45 @@ export class TranslationModalComponent {
   }
 
   returnToPreviousTranslation(): void {
-    const translatableItem =
-      this.translateTextService.getPreviousTextToTranslate();
-    this.updateActiveState(translatableItem);
-    this.moreAvailable = true;
-    this.resetEditor();
+    const hasActualChanges =
+      this.hasUnsavedChanges &&
+      this.activeWrittenTranslation !== '' &&
+      this.activeWrittenTranslation !== this.textToTranslate;
+
+    if (hasActualChanges) {
+      const modalRef = this.modalService.open(ConfirmationModalComponent, {
+        centered: true,
+        backdrop: 'static',
+      });
+
+      modalRef.componentInstance.content = {
+        title: 'Unsaved Changes',
+        message:
+          'You have unsaved changes. Are you sure you want to go back? Your changes will be lost.',
+        confirmText: 'Discard Changes',
+        cancelText: 'Continue Editing',
+      };
+
+      modalRef.result.then(
+        result => {
+          if (result === 'confirm') {
+            this.resetUnsavedChanges();
+            const translatableItem =
+              this.translateTextService.getPreviousTextToTranslate();
+            this.updateActiveState(translatableItem);
+            this.moreAvailable = true;
+            this.resetEditor();
+          }
+        },
+        () => {}
+      );
+    } else {
+      const translatableItem =
+        this.translateTextService.getPreviousTextToTranslate();
+      this.updateActiveState(translatableItem);
+      this.moreAvailable = true;
+      this.resetEditor();
+    }
   }
 
   isSetOfStringDataFormat(): boolean {
@@ -632,6 +675,7 @@ export class TranslationModalComponent {
             'Submitted translation for review.'
           );
           this.uploadingTranslation = false;
+          this.resetUnsavedChanges();
           if (this.moreAvailable) {
             this.skipActiveTranslation();
             this.resetEditor();
@@ -656,6 +700,7 @@ export class TranslationModalComponent {
     if (!this.translatedTextCanBeSubmitted()) {
       return;
     }
+    this.hasUnsavedChanges = false;
     this.activeModal.close(this.activeWrittenTranslation);
   }
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21072 .
2. This PR does the following: 
 
- Created a **confirmation-modal-component** that shows up whenever a user tries to go back when he has not saved his changes.
- Introduced ``hasUnsavedChanges`` and ``resetUnsavedChanges`` property that tracks whether there are unsaved modifications in the component's state.
- Imported ``NgbModal`` modal services from **@ng-bootstrap/ng-bootstrap**
- Updated ``returnToPreviousTranslation`` method which introduces handling for unsaved changes, displays a confirmation modal and fallback for No Unsaved Changes

P.S.- This handles all the edge case scenarios also when user tries to
1. save translation.
2. skip translation with/without translation text.
3. skip translation to a saved translation.
4. clicks on go back button with/without translation text.

3. The original bug occurred because:
There was no warning message when user skips or goes back in a translation without saving.
 
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


https://github.com/user-attachments/assets/cd2805b2-9d6c-46ab-8158-3c7347230234


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
