### PR TITLE
Fix #20957 Make concept card hint popup responsive

### DIFF
--- a/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.css
+++ b/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.css
@@ -15,6 +15,10 @@
   width: 100%;
 }
 
+.oppia-exploration-footer .row {
+  flex-wrap: nowrap;
+}
+
 .oppia-exploration-footer .exploration-footer-img {
   height: 60px;
   margin: -31px 5px 0 10px;
@@ -319,6 +323,14 @@
     height: auto;
     margin-right: 10px;
     padding: 16px 8px 16px 8px;
+  }
+
+  .oppia-footer-info-icon {
+    display: none;
+  }
+
+  .oppia-lesson-info-header {
+    display: none;
   }
 }
 

--- a/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.html
@@ -120,7 +120,7 @@
     font-size: 17px;
     height: 40px;
     margin-right: 10px;
-    min-width: 395px;
+    min-width: 350px;
     padding: 20px 10px 20px 10px;
     position: relative;
     text-align: center;
@@ -181,4 +181,19 @@
       -webkit-transform: translateY(0);
     }
   }
+
+  @media (max-width: 475px) {
+
+    .hint-box-add-ons::after {
+    margin-left: 141px;
+  }
+  .hint-box-add-ons::before {
+    margin-left: 139px;
+  }
+
+  .hint-box {
+    font-size: 14px;
+  }
+  
+}
 </style>

--- a/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.html
@@ -194,6 +194,5 @@
   .hint-box {
     font-size: 14px;
   }
-  
 }
 </style>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #20957.
2. This PR does the following: Since, the error arises due to the flexbox "col-sm-5" and "col-sm-7" vertically stacking in case of small screens, which is the default behavior in case of flex-wrap set to wrap. This PR essentially fixes the wrapping of the footer component so that the columns are one beside the another instead of stacking vertically, along with some minor CSS changes.
3. (For bug-fixing PRs only) The original bug occurred because: the flexbox "col-sm-5" and "col-sm-7" vertically stacking in case of small screens, which is the default behavior in case of flex-wrap set to wrap.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

After:

https://github.com/user-attachments/assets/4c280493-c58c-4bba-b6ae-e51e336577cb



#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
![Demo laptop](https://github.com/user-attachments/assets/c6840b2f-1814-4b2a-afa6-5b68412ecd05)


#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->
![Demo mobile](https://github.com/user-attachments/assets/2ba81fc5-465f-467f-a79e-35b412b0a955)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
