### PR TITLE
Fix #20869: Removes downgradeComponent from learner dashboard page

### DIFF
--- a/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.ts
+++ b/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.ts
@@ -16,7 +16,6 @@
  * @fileoverview Component for add goals modal
  */
 import {Component, Inject} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
 import {MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
 @Component({
   selector: 'oppia-add-goals-modal',
@@ -57,10 +56,3 @@ export class AddGoalsModalComponent {
     this.dialogRef.close(this.checkedTopics);
   }
 }
-
-angular
-  .module('oppia')
-  .directive(
-    'addGoalsModalComponent',
-    downgradeComponent({component: AddGoalsModalComponent})
-  );

--- a/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
+++ b/core/templates/pages/learner-dashboard-page/card-display/card-display.component.ts
@@ -24,7 +24,6 @@ import {
   AfterContentInit,
   NgZone,
 } from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 @Component({
   selector: 'oppia-card-display',
@@ -149,10 +148,3 @@ export class CardDisplayComponent implements AfterContentInit {
     );
   }
 }
-
-angular
-  .module('oppia')
-  .directive(
-    'cardDisplayComponent',
-    downgradeComponent({component: CardDisplayComponent})
-  );

--- a/core/templates/pages/learner-dashboard-page/classroom-button/classroom-button.component.ts
+++ b/core/templates/pages/learner-dashboard-page/classroom-button/classroom-button.component.ts
@@ -16,7 +16,6 @@
  * @fileoverview Component for classroom buttons
  */
 import {Component, Input} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 @Component({
   selector: 'oppia-classroom-button',
@@ -39,10 +38,3 @@ export class ClassroomButtonComponent {
     );
   }
 }
-
-angular
-  .module('oppia')
-  .directive(
-    'classroomButtonComponent',
-    downgradeComponent({component: ClassroomButtonComponent})
-  );

--- a/core/templates/pages/learner-dashboard-page/content-toggle-button/content-toggle-button.component.ts
+++ b/core/templates/pages/learner-dashboard-page/content-toggle-button/content-toggle-button.component.ts
@@ -16,7 +16,6 @@
  * @fileoverview Component for content toggle button
  */
 import {Component, EventEmitter, Output} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
 import {TranslateService} from '@ngx-translate/core';
 @Component({
   selector: 'oppia-content-toggle-button',
@@ -45,10 +44,3 @@ export class ContentToggleButtonComponent {
     this.contentToggleEmitter.emit(this.isExpanded);
   }
 }
-
-angular
-  .module('oppia')
-  .directive(
-    'contentToggleButtonComponent',
-    downgradeComponent({component: ContentToggleButtonComponent})
-  );

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
@@ -17,7 +17,6 @@
  */
 
 import {Component, Input, OnInit} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
 import {AppConstants} from 'app.constants';
 import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 import {UrlService} from 'services/contextual/url.service';
@@ -138,10 +137,3 @@ export class GoalListComponent implements OnInit {
     this.displayAllNodes = updateState;
   }
 }
-
-angular
-  .module('oppia')
-  .directive(
-    'goalListComponent',
-    downgradeComponent({component: GoalListComponent})
-  );

--- a/core/templates/pages/learner-dashboard-page/skill-card/skill-card.component.ts
+++ b/core/templates/pages/learner-dashboard-page/skill-card/skill-card.component.ts
@@ -16,7 +16,6 @@
  * @fileoverview Component for skills
  */
 import {Component, Input} from '@angular/core';
-import {downgradeComponent} from '@angular/upgrade/static';
 import {AppConstants} from 'app.constants';
 import {PracticeSessionPageConstants} from 'pages/practice-session-page/practice-session-page.constants';
 import {LearnerTopicSummary} from 'domain/topic/learner-topic-summary.model';
@@ -102,10 +101,3 @@ export class SkillCardComponent {
     }
   }
 }
-
-angular
-  .module('oppia')
-  .directive(
-    'cardDisplayComponent',
-    downgradeComponent({component: SkillCardComponent})
-  );


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #20869 .
2. This PR does the following: Removes downgradeComponent from the learner dashboard page
3. (For bug-fixing PRs only) The original bug occurred because: The [PR](https://github.com/oppia/oppia/pull/19508) which migrated the learner dashboard page didn't remove the downgradeComponent properly and some instances were left.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

- I have tested on my local dev server by running 10 times in mobile mode, and this flake didn't appear once.
- I have tested on my local dev server by running 10 times in desktop mode, and this flake didn't appear once.

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
