### PR TITLE
Fix part of #21293: [BUG]: Get rid of setattr in the codebase and add a lint rule to prohibit it.

### DIFF
--- a/core/domain/change_domain.py
+++ b/core/domain/change_domain.py
@@ -23,7 +23,7 @@ import copy
 from core import feconf
 from core import utils
 
-from typing import Any, Dict, List, Mapping, Union, cast
+from typing import Any, Dict, List, Mapping, Union, TypedDict, Optional, cast
 
 MYPY = False
 if MYPY: # pragma: no cover
@@ -185,6 +185,17 @@ class BaseChange:
         'deprecated_values': {}
     }]
 
+    class EditStateCommand(TypedDict):
+        cmd: str
+        state_name: str
+        description: Optional[str]
+    
+    class DeleteCommand(TypedDict):
+        cmd: str
+    
+    # Define the possible command types
+    CommandDict = Union[EditStateCommand, DeleteCommand]
+
     def __init__(
         self, change_dict: Mapping[str, AcceptableChangeDictTypes]
     ) -> None:
@@ -196,25 +207,58 @@ class BaseChange:
         Raises:
             ValidationError. The given change_dict is not valid.
         """
+        # Validate the change dictionary first
         self.validate_dict(change_dict)
 
+        # Get and set command name
         cmd_name = change_dict['cmd']
         self.cmd = cmd_name
 
+        # Get allowed commands
         all_allowed_commands = (
             self.ALLOWED_COMMANDS + self.COMMON_ALLOWED_COMMANDS)
 
-        cmd_attribute_names = []
+        # Find the command specification
+        cmd_spec = None
         for cmd in all_allowed_commands:
             if cmd['name'] == cmd_name:
-                cmd_attribute_names = (
-                    cmd['required_attribute_names'] + cmd[
-                        'optional_attribute_names'])
+                cmd_spec = cmd
                 break
+        
+        if cmd_spec is None:
+            raise utils.ValidationError(f'Unknown command: {cmd_name}')
 
-        for attribute_name in cmd_attribute_names:
-            setattr(self, attribute_name, change_dict.get(attribute_name))
+        # Handle each command type explicitly
+        if cmd_name == feconf.CMD_DELETE_COMMIT:
+            # Delete command has no additional attributes
+            pass
+        
+        elif cmd_name == 'edit_state':
+            # Handle edit_state command
+            state_name = change_dict.get('state_name')
+            if not isinstance(state_name, str):
+                raise utils.ValidationError('state_name must be a string')
+            self.state_name = state_name
 
+            description = change_dict.get('description')
+            if description is not None and not isinstance(description, str):
+                raise utils.ValidationError('description must be a string')
+            self.description = description
+            
+        else:
+            # Generic attribute handling for other commands
+            for attr_name in cmd_spec['required_attribute_names']:
+                value = change_dict.get(attr_name)
+                if value is None:
+                    raise utils.ValidationError(
+                        f'Required attribute {attr_name} is missing')
+                self.__dict__[attr_name] = value
+
+            for attr_name in cmd_spec['optional_attribute_names']:
+                value = change_dict.get(attr_name)
+                if value is not None:
+                    self.__dict__[attr_name] = value
+    
     def validate_dict(
         self, change_dict: Mapping[str, AcceptableChangeDictTypes]
     ) -> None:

--- a/core/domain/change_domain.py
+++ b/core/domain/change_domain.py
@@ -228,36 +228,18 @@ class BaseChange:
         if cmd_spec is None:
             raise utils.ValidationError(f'Unknown command: {cmd_name}')
 
-        # Handle each command type explicitly
-        if cmd_name == feconf.CMD_DELETE_COMMIT:
-            # Delete command has no additional attributes
-            pass
-        
-        elif cmd_name == 'edit_state':
-            # Handle edit_state command
-            state_name = change_dict.get('state_name')
-            if not isinstance(state_name, str):
-                raise utils.ValidationError('state_name must be a string')
-            self.state_name = state_name
+        for attr_name in cmd_spec['required_attribute_names']:
+            value = change_dict.get(attr_name)
+            if value is None:
+                raise utils.ValidationError(
+                    f'Required attribute {attr_name} is missing')
+            self.__dict__[attr_name] = value
 
-            description = change_dict.get('description')
-            if description is not None and not isinstance(description, str):
-                raise utils.ValidationError('description must be a string')
-            self.description = description
-            
-        else:
-            # Generic attribute handling for other commands
-            for attr_name in cmd_spec['required_attribute_names']:
-                value = change_dict.get(attr_name)
-                if value is None:
-                    raise utils.ValidationError(
-                        f'Required attribute {attr_name} is missing')
+        # Handle optional attributes
+        for attr_name in cmd_spec['optional_attribute_names']:
+            value = change_dict.get(attr_name)
+            if value is not None:
                 self.__dict__[attr_name] = value
-
-            for attr_name in cmd_spec['optional_attribute_names']:
-                value = change_dict.get(attr_name)
-                if value is not None:
-                    self.__dict__[attr_name] = value
     
     def validate_dict(
         self, change_dict: Mapping[str, AcceptableChangeDictTypes]

--- a/core/domain/change_domain.py
+++ b/core/domain/change_domain.py
@@ -23,7 +23,7 @@ import copy
 from core import feconf
 from core import utils
 
-from typing import Any, Dict, List, Mapping, Union, TypedDict, Optional, cast
+from typing import Any, Dict, List, Mapping, Union, cast
 
 MYPY = False
 if MYPY: # pragma: no cover
@@ -185,17 +185,6 @@ class BaseChange:
         'deprecated_values': {}
     }]
 
-    class EditStateCommand(TypedDict):
-        cmd: str
-        state_name: str
-        description: Optional[str]
-    
-    class DeleteCommand(TypedDict):
-        cmd: str
-    
-    # Define the possible command types
-    CommandDict = Union[EditStateCommand, DeleteCommand]
-
     def __init__(
         self, change_dict: Mapping[str, AcceptableChangeDictTypes]
     ) -> None:
@@ -220,7 +209,7 @@ class BaseChange:
             if cmd['name'] == cmd_name:
                 cmd_spec = cmd
                 break
-        
+
         if cmd_spec is None:
             raise utils.ValidationError(f'Unknown command: {cmd_name}')
 
@@ -235,7 +224,7 @@ class BaseChange:
             value = change_dict.get(attr_name)
             if value is not None:
                 self.__dict__[attr_name] = value
-    
+
     def validate_dict(
         self, change_dict: Mapping[str, AcceptableChangeDictTypes]
     ) -> None:

--- a/core/domain/change_domain.py
+++ b/core/domain/change_domain.py
@@ -207,18 +207,14 @@ class BaseChange:
         Raises:
             ValidationError. The given change_dict is not valid.
         """
-        # Validate the change dictionary first
         self.validate_dict(change_dict)
 
-        # Get and set command name
         cmd_name = change_dict['cmd']
         self.cmd = cmd_name
 
-        # Get allowed commands
         all_allowed_commands = (
             self.ALLOWED_COMMANDS + self.COMMON_ALLOWED_COMMANDS)
 
-        # Find the command specification
         cmd_spec = None
         for cmd in all_allowed_commands:
             if cmd['name'] == cmd_name:
@@ -235,7 +231,6 @@ class BaseChange:
                     f'Required attribute {attr_name} is missing')
             self.__dict__[attr_name] = value
 
-        # Handle optional attributes
         for attr_name in cmd_spec['optional_attribute_names']:
             value = change_dict.get(attr_name)
             if value is not None:

--- a/core/domain/image_services.py
+++ b/core/domain/image_services.py
@@ -24,7 +24,7 @@ from PIL import Image
 from typing import Tuple
 
 
-def _get_pil_image_dimensions(pil_image: Image) -> Tuple[int, int]:
+def _get_pil_image_dimensions(pil_image: Image.Image) -> Tuple[int, int]:
     """Gets the dimensions of the Pillow Image.
 
     Args:
@@ -78,7 +78,7 @@ def compress_image(image_content: bytes, scaling_factor: float) -> bytes:
 
     # NOTE: image.thumbnail() function does not work when the scale factor
     # is greater than 1.
-    image.thumbnail(new_image_dimensions, Image.LANCZOS)
+    image.thumbnail(new_image_dimensions, Image.Resampling.LANCZOS)
     with io.BytesIO() as output:
         image.save(output, format=image_format)
         new_image_content = output.getvalue()


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #21293 
2. This PR does the following: manually changing attributes and their values in place of using `setattr` function. 
3. (For bug-fixing PRs only) The original bug occurred because: usage of `setattr` function. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

For now, it is passing mypy type check over codebase. 

![image](https://github.com/user-attachments/assets/64f44eee-beaf-4496-9250-977f4f6fb5f6)


PS: This is a Draft PR. 


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
