### PR TITLE
Fix part of #21293: [BUG]: Get rid of setattr in the codebase and add a lint rule to prohibit it. 

### DIFF
--- a/core/domain/change_domain.py
+++ b/core/domain/change_domain.py
@@ -204,16 +204,26 @@ class BaseChange:
         all_allowed_commands = (
             self.ALLOWED_COMMANDS + self.COMMON_ALLOWED_COMMANDS)
 
-        cmd_attribute_names = []
+        cmd_spec = None
         for cmd in all_allowed_commands:
             if cmd['name'] == cmd_name:
-                cmd_attribute_names = (
-                    cmd['required_attribute_names'] + cmd[
-                        'optional_attribute_names'])
+                cmd_spec = cmd
                 break
 
-        for attribute_name in cmd_attribute_names:
-            setattr(self, attribute_name, change_dict.get(attribute_name))
+        if cmd_spec is None:
+            raise utils.ValidationError(f'Unknown command: {cmd_name}')
+
+        for attr_name in cmd_spec['required_attribute_names']:
+            value = change_dict.get(attr_name)
+            if value is None:
+                raise utils.ValidationError(
+                    f'Required attribute {attr_name} is missing')
+            self.__dict__[attr_name] = value
+
+        for attr_name in cmd_spec['optional_attribute_names']:
+            value = change_dict.get(attr_name)
+            if value is not None:
+                self.__dict__[attr_name] = value
 
     def validate_dict(
         self, change_dict: Mapping[str, AcceptableChangeDictTypes]

--- a/core/domain/image_services.py
+++ b/core/domain/image_services.py
@@ -24,7 +24,7 @@ from PIL import Image
 from typing import Tuple
 
 
-def _get_pil_image_dimensions(pil_image: Image) -> Tuple[int, int]:
+def _get_pil_image_dimensions(pil_image: Image.Image) -> Tuple[int, int]:
     """Gets the dimensions of the Pillow Image.
 
     Args:
@@ -78,7 +78,7 @@ def compress_image(image_content: bytes, scaling_factor: float) -> bytes:
 
     # NOTE: image.thumbnail() function does not work when the scale factor
     # is greater than 1.
-    image.thumbnail(new_image_dimensions, Image.LANCZOS)
+    image.thumbnail(new_image_dimensions, Image.Resampling.LANCZOS)
     with io.BytesIO() as output:
         image.save(output, format=image_format)
         new_image_content = output.getvalue()


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21293 i.e. for now I 'd fixed only change_domain.py file, wipeout_services.py need to be updated. 
2. This PR does the following: manually changing attributes and their values in place of using `setattr` function.
3. (For bug-fixing PRs only) The original bug occurred because:  usage of `setattr` function.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

For now, it is passing mypy type check over codebase.

![Screenshot from 2025-01-23 10-24-47](https://github.com/user-attachments/assets/bbe0c204-6ea9-4236-88a9-61abb10a4697)

PS: This is a Draft PR.


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
