### PR TITLE
Fixes the practice page 400 error

### DIFF
--- a/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.spec.ts
+++ b/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.spec.ts
@@ -143,7 +143,7 @@ describe('Access validation backend api service', () => {
   it('should validate access to practice session page', fakeAsync(() => {
     let classroomUrlFragment = 'classroom';
     let topicUrlFragment = 'topic';
-    let selectedSubtopicIds = [1, 2, 3];
+    let selectedSubtopicIds = '[1,2,3]';
 
     spyOn(urlInterpolationService, 'interpolateUrl').and.returnValue(
       '/access_validation_handler/can_access_practice_session_page/' +

--- a/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.ts
+++ b/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.ts
@@ -191,7 +191,7 @@ export class AccessValidationBackendApiService {
   validateAccessToPracticeSessionPage(
     classroomUrlFragment: string,
     topicUrlFragment: string,
-    selectedSubtopicIds: number[]
+    selectedSubtopicIds: string
   ): Promise<void> {
     let url = this.urlInterpolationService.interpolateUrl(
       this.PRACTICE_SESSION_PAGE_ACCESS_VALIDATOR,
@@ -202,7 +202,7 @@ export class AccessValidationBackendApiService {
     );
     const params = new HttpParams().set(
       'selected_subtopic_ids',
-      JSON.stringify(selectedSubtopicIds)
+      selectedSubtopicIds
     );
     return this.http.get<void>(url, {params}).toPromise();
   }

--- a/core/templates/pages/practice-session-page/practice-session-page-auth.guard.ts
+++ b/core/templates/pages/practice-session-page/practice-session-page-auth.guard.ts
@@ -41,7 +41,7 @@ export class PracticeSessionAccessGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Promise<boolean> {
-    const selectedSubtopicIds = route.queryParams.selected_subtopic_ids;
+    const selectedSubtopicIds = route.queryParams.selected_subtopic_ids || '';
     const classroomUrlFragment =
       route.paramMap.get('classroom_url_fragment') || '';
     const topicUrlFragment = route.paramMap.get('topic_url_fragment') || '';


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19435 
2. This PR does the following: Removes the JSON.stringify from frontend access validation
3. (For bug-fixing PRs only) The original bug occurred because: This [PR](https://github.com/oppia/oppia/pull/21520) didn't removed json.stringify() from frontend access validation.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

BEFORE

[Screencast from 2025-02-01 14-06-48.webm](https://github.com/user-attachments/assets/afa65d58-09a3-4938-aa51-cad8c719bb20)

AFTER

[Screencast from 2025-02-01 21-56-38.webm](https://github.com/user-attachments/assets/de3f1c88-bf21-469a-9b11-4170b3cbf5e4)




<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
