### PR TITLE
Update version of stale-review-request-notifier

### DIFF
--- a/.github/workflows/notify_if_pending_reviews.yml
+++ b/.github/workflows/notify_if_pending_reviews.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/merge-develop-and-set-up-dependencies
       - name: Notify reviewers
         # SHA1 hash of the develop commit.
-        uses: oppia/stale-review-request-notifier@48e428b1f531a0b1dc24beb361cd4352af0a084d
+        uses: oppia/stale-review-request-notifier@265e48e829a0513ab68a17167e21ecbe84f1542a
         with:
           category-name: Notify\ Reviewers
           repo-token: ${{ secrets.DISCUSSION_NOTIFICATION_TOKEN }}


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #N/A
2. This PR does the following: Update version of stale-review-request-notifier to handle deleted users correctly (see https://github.com/oppia/stale-review-request-notifier/pull/7 )

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

@kevintab95 has tested the commit on stale-review-request-notifier (the issue came up because the release build was failing due to the notifier action being associated with the most recent commit on develop).