### PR TITLE
fix part of #21214, add TODO to instances of tarfile.extractall 

### DIFF
--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -115,8 +115,8 @@ def download_and_install_package(url_to_retrieve: str, filename: str) -> None:
     """
     common.url_retrieve(url_to_retrieve, filename)
     tar = tarfile.open(name=filename)
-    # TODO(#21906): add parameter filter = 'data'
-    # after updating to Python 3.12
+    # TODO(#21906): Add parameter filter = 'data'
+    # after updating to Python 3.12.
     tar.extractall(path=common.OPPIA_TOOLS_DIR)
     tar.close()
     rename_yarn_folder(filename, common.OPPIA_TOOLS_DIR)
@@ -206,8 +206,8 @@ def install_gcloud_sdk() -> None:
 
         print('Download complete. Installing Google Cloud SDK...')
         tar = tarfile.open(name='gcloud-sdk.tar.gz')
-        # TODO(#21906): add parameter filter = 'data'
-        # after updating to Python 3.12
+        # TODO(#21906): Add parameter filter = 'data'
+        # after updating to Python 3.12.
         tar.extractall(path=os.path.join(
             common.OPPIA_TOOLS_DIR, 'google-cloud-sdk-500.0.0/'))
         tar.close()
@@ -292,8 +292,8 @@ def download_and_untar_files(
         common.url_retrieve(source_url, TMP_UNZIP_PATH)
         with contextlib.closing(tarfile.open(
             name=TMP_UNZIP_PATH, mode='r:gz')) as tfile:
-            # TODO(#21906): add parameter filter = 'data'
-            # after updating to Python 3.12
+            # TODO(#21906): Add parameter filter = 'data'
+            # after updating to Python 3.12.
             tfile.extractall(target_parent_dir)
         os.remove(TMP_UNZIP_PATH)
 

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -115,6 +115,8 @@ def download_and_install_package(url_to_retrieve: str, filename: str) -> None:
     """
     common.url_retrieve(url_to_retrieve, filename)
     tar = tarfile.open(name=filename)
+    # TODO: (#21906) add parameter filter = 'data'
+    #  after updating to Python 3.12
     tar.extractall(path=common.OPPIA_TOOLS_DIR)
     tar.close()
     rename_yarn_folder(filename, common.OPPIA_TOOLS_DIR)
@@ -204,6 +206,8 @@ def install_gcloud_sdk() -> None:
 
         print('Download complete. Installing Google Cloud SDK...')
         tar = tarfile.open(name='gcloud-sdk.tar.gz')
+        # TODO: (21906) add parameter filter = 'data'
+        # after updating to Python 3.12
         tar.extractall(path=os.path.join(
             common.OPPIA_TOOLS_DIR, 'google-cloud-sdk-500.0.0/'))
         tar.close()
@@ -288,6 +292,8 @@ def download_and_untar_files(
         common.url_retrieve(source_url, TMP_UNZIP_PATH)
         with contextlib.closing(tarfile.open(
             name=TMP_UNZIP_PATH, mode='r:gz')) as tfile:
+            # TODO: (#21906) add parameter filter = 'data'
+            #  after updating to Python 3.12
             tfile.extractall(target_parent_dir)
         os.remove(TMP_UNZIP_PATH)
 

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -115,8 +115,8 @@ def download_and_install_package(url_to_retrieve: str, filename: str) -> None:
     """
     common.url_retrieve(url_to_retrieve, filename)
     tar = tarfile.open(name=filename)
-    # TODO: (#21906) add parameter filter = 'data'
-    #  after updating to Python 3.12
+    # TODO(#21906): add parameter filter = 'data'
+    # after updating to Python 3.12
     tar.extractall(path=common.OPPIA_TOOLS_DIR)
     tar.close()
     rename_yarn_folder(filename, common.OPPIA_TOOLS_DIR)
@@ -206,7 +206,7 @@ def install_gcloud_sdk() -> None:
 
         print('Download complete. Installing Google Cloud SDK...')
         tar = tarfile.open(name='gcloud-sdk.tar.gz')
-        # TODO: (21906) add parameter filter = 'data'
+        # TODO(#21906): add parameter filter = 'data'
         # after updating to Python 3.12
         tar.extractall(path=os.path.join(
             common.OPPIA_TOOLS_DIR, 'google-cloud-sdk-500.0.0/'))
@@ -292,8 +292,8 @@ def download_and_untar_files(
         common.url_retrieve(source_url, TMP_UNZIP_PATH)
         with contextlib.closing(tarfile.open(
             name=TMP_UNZIP_PATH, mode='r:gz')) as tfile:
-            # TODO: (#21906) add parameter filter = 'data'
-            #  after updating to Python 3.12
+            # TODO(#21906): add parameter filter = 'data'
+            # after updating to Python 3.12
             tfile.extractall(target_parent_dir)
         os.remove(TMP_UNZIP_PATH)
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[21214].
2. This PR does the following: [Add TODO to instances of tarfile.extractall() which has the directive of adding a data filter to the parameters once upgraded to 3.12. It is not necessary to upgrade this method before  3.12 because in oppias usage, the 'data' filter has the same affect as the 'fully-trusted' filter]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
If you have more questions my process is in this google Doc: https://docs.google.com/document/d/1xd0Iu9-pK5fHuB9R_JWCFuDdyU1Fzjc-RggrfJ7Hq6c/edit?usp=sharing 

I figured out that my Python 3.9.20 was backported so it was unnecessary to change environments for this test. 
You can see that this tests installing third party libs with and without the data filter attribute in tarfile. The functionality does not change. We only use extractall() in install_third_party_libs and it's test file. The functionality is likely the same because we trust the dependencies we download aren't trying to do malicious things while extracting tarfiles from them. If we add more extractall() calls between implementing Python 3.12 and 3.14 we need to be mindful about how the mandatory data filtering in 3.14 will affect the codebase.
![image](https://github.com/user-attachments/assets/431aecb0-ec71-4ba4-8c82-2d22702c97c3)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
