### PR TITLE
Fix #16656 : Fully cover question difficulty modals

### DIFF
--- a/core/templates/pages/topic-editor-page/modal-templates/questions-list-select-skill-and-difficulty-modal.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/questions-list-select-skill-and-difficulty-modal.component.spec.ts
@@ -182,6 +182,25 @@ describe('Questions List Select Skill And Difficulty Modal Component', () => {
     component.selectOrDeselectSkill(summary);
   });
 
+  it('should change the skill difficulty', () => {
+    let summary = allSkillSummaries[0];
+    component.selectOrDeselectSkill(summary);
+
+    let newSummary = allSkillSummaries[1];
+    let newSkilldifficulty = SkillDifficulty.create(
+      newSummary.id,
+      newSummary.description,
+      0.6
+    );
+
+    component.changeSkillWithDifficulty(newSkilldifficulty, 0);
+
+    expect(component.linkedSkillsWithDifficulty.length).toBe(1);
+    expect(component.linkedSkillsWithDifficulty).toEqual([newSkilldifficulty]);
+
+    component.selectOrDeselectSkill(newSummary);
+  });
+
   it('should filter the skills', () => {
     component.filterSkills('Skill 1 description');
 

--- a/core/templates/pages/topic-editor-page/modal-templates/questions-list-select-skill-and-difficulty-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/questions-list-select-skill-and-difficulty-modal.component.ts
@@ -123,6 +123,12 @@ export class QuestionsListSelectSkillAndDifficultyModalComponent
     newSkillWithDifficulty: SkillDifficulty,
     index: number
   ): void {
+    let oldSkillId = this.linkedSkillsWithDifficulty[index].getId();
+    if (this.isSkillSelected(oldSkillId)) {
+      let indexOfOldSelectedSkill = this.selectedSkills.indexOf(oldSkillId);
+      this.selectedSkills[indexOfOldSelectedSkill] =
+        newSkillWithDifficulty.getId();
+    }
     this.linkedSkillsWithDifficulty[index] = newSkillWithDifficulty;
   }
 

--- a/core/templates/pages/topic-editor-page/modal-templates/questions-opportunities-select-difficulty-modal.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/questions-opportunities-select-difficulty-modal.component.spec.ts
@@ -31,7 +31,7 @@ import {ConceptCardBackendDict} from 'domain/skill/concept-card.model';
 import {MisconceptionBackendDict} from 'domain/skill/MisconceptionObjectFactory';
 import {RubricBackendDict} from 'domain/skill/rubric.model';
 import {SkillBackendApiService} from 'domain/skill/skill-backend-api.service';
-import {SkillDifficultyBackendDict} from 'domain/skill/skill-difficulty.model';
+import {SkillDifficulty} from 'domain/skill/skill-difficulty.model';
 import {Skill, SkillObjectFactory} from 'domain/skill/SkillObjectFactory';
 import {ImageFile} from 'domain/utilities/image-file.model';
 import {ExtractImageFilenamesFromModelService} from 'pages/exploration-player-page/services/extract-image-filenames-from-model.service';
@@ -198,39 +198,7 @@ describe('Questions Opportunities Select Difficulty Modal Component', () => {
           })
         );
         component.linkedSkillsWithDifficulty = [
-          {
-            _id: '1',
-            _description: 'desc',
-            _difficulty: 0.6,
-
-            toBackendDict(): SkillDifficultyBackendDict {
-              return {
-                id: '1',
-                description: 'desc',
-                difficulty: 0.6,
-              };
-            },
-
-            getDescription(): string {
-              return 'desc';
-            },
-
-            getDifficulty(): number {
-              return 0.6;
-            },
-
-            setDifficulty(): void {
-              return;
-            },
-
-            setDescription(): void {
-              return;
-            },
-
-            getId(): string {
-              return '1';
-            },
-          },
+          SkillDifficulty.create('1', 'desc', 0.6),
         ];
 
         component.ngOnInit();

--- a/core/templates/pages/topic-editor-page/modal-templates/questions-opportunities-select-difficulty-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/questions-opportunities-select-difficulty-modal.component.ts
@@ -110,13 +110,6 @@ export class QuestionsOpportunitiesSelectDifficultyModalComponent
     );
   }
 
-  changeSkillWithDifficulty(
-    newSkillWithDifficulty: SkillDifficulty,
-    idx: number
-  ): void {
-    this.linkedSkillsWithDifficulty[idx] = newSkillWithDifficulty;
-  }
-
   startQuestionCreation(): void {
     const result = {
       skill: this.skill,

--- a/scripts/check_frontend_test_coverage.py
+++ b/scripts/check_frontend_test_coverage.py
@@ -73,12 +73,6 @@ NOT_FULLY_COVERED_FILENAMES = [
         'services/voiceover-recording.service.ts',
     'core/templates/pages/exploration-player-page/services/'
         'learner-answer-info.service.ts',
-    'core/templates/pages/topic-editor-page/modal-templates/'
-        'questions-list-select-skill-and-difficulty-modal.component.ts',
-    # TODO(#16656): This file will be covered by angular migration team.
-    'core/templates/pages/topic-editor-page/modal-templates/'
-        'questions-opportunities-select-difficulty-modal.component.ts',
-    # TODO(#16656): This file will be covered by angular migration team.
     'core/templates/services/rte-helper-modal.component.ts',
     # TODO(#18390): Completely cover "rte-helper-modal.component.ts".
     'core/templates/services/'


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16656 
2. This PR does the following: Adds additional tests to fully cover 'questions-list-select-skill-and-difficulty-modal.component.ts' and 'questions-opportunities-select-difficulty-modal.component.ts', along with removing/refactoring some redundant code.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
