### PR TITLE
Fix #19746: Console Error "Uncaught in Promise" on signup

### DIFF
--- a/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.spec.ts
@@ -193,7 +193,8 @@ describe('ClassroomNavigationLinksComponent', () => {
   });
 
   it('should not load classroom summaries if currentUrl is signup', fakeAsync(() => {
-    component['windowRef'].nativeWindow.location.pathname = '/signup';
+    const windowRef = TestBed.inject(WindowRef) as WindowRef;
+    windowRef.nativeWindow.location.pathname = '/signup';
 
     component.ngOnInit();
     tick();

--- a/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.spec.ts
@@ -30,6 +30,7 @@ import {ClassroomBackendApiService} from 'domain/classroom/classroom-backend-api
 import {ClassroomNavigationLinksComponent} from './classroom-navigation-links.component';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {WindowRef} from 'services/contextual/window-ref.service';
 
 describe('ClassroomNavigationLinksComponent', () => {
   let component: ClassroomNavigationLinksComponent;
@@ -90,6 +91,15 @@ describe('ClassroomNavigationLinksComponent', () => {
         {
           provide: AssetsBackendApiService,
           useValue: assetsBackendApiServiceSpy,
+        },
+        {
+          provide: WindowRef,
+          useValue: {
+            nativeWindow: {
+              location: {pathname: '/learn'},
+              gtag: jasmine.createSpy('gtag'),
+            },
+          },
         },
       ],
     }).compileComponents();
@@ -181,4 +191,18 @@ describe('ClassroomNavigationLinksComponent', () => {
       siteAnalyticsService.registerClickClassroomCardEvent
     ).toHaveBeenCalled();
   });
+
+  it('should not load classroom summaries if currentUrl is signup', fakeAsync(() => {
+    component['windowRef'].nativeWindow.location.pathname = '/signup';
+
+    component.ngOnInit();
+    tick();
+
+    expect(component.currentUrl).toEqual('signup');
+    expect(
+      classroomBackendApiService.getAllClassroomsSummaryAsync
+    ).not.toHaveBeenCalled();
+    expect(component.classroomSummaries).toEqual([]);
+    expect(component.isLoading).toBeTrue();
+  }));
 });

--- a/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.ts
+++ b/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.ts
@@ -25,6 +25,7 @@ import {
 import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {WindowRef} from 'services/contextual/window-ref.service';
 
 @Component({
   selector: 'oppia-classroom-navigation-links',
@@ -33,12 +34,14 @@ import {SiteAnalyticsService} from 'services/site-analytics.service';
 export class ClassroomNavigationLinksComponent implements OnInit {
   classroomSummaries: ClassroomSummaryDict[] = [];
   isLoading: boolean = true;
+  currentUrl!: string;
 
   constructor(
     private assetsBackendApiService: AssetsBackendApiService,
     private classroomBackendApiService: ClassroomBackendApiService,
     private i18nLanguageCodeService: I18nLanguageCodeService,
-    private siteAnalyticsService: SiteAnalyticsService
+    private siteAnalyticsService: SiteAnalyticsService,
+    private windowRef: WindowRef
   ) {}
 
   getClassroomThumbnail(
@@ -72,19 +75,23 @@ export class ClassroomNavigationLinksComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.classroomBackendApiService
-      .getAllClassroomsSummaryAsync()
-      .then((data: ClassroomSummaryDict[]) => {
-        for (
-          let i = 0;
-          i < data.length && this.classroomSummaries.length < 2;
-          i++
-        ) {
-          if (data[i].is_published) {
-            this.classroomSummaries.push(data[i]);
+    this.currentUrl =
+      this.windowRef.nativeWindow.location.pathname.split('/')[1];
+    if (this.currentUrl !== 'signup') {
+      this.classroomBackendApiService
+        .getAllClassroomsSummaryAsync()
+        .then((data: ClassroomSummaryDict[]) => {
+          for (
+            let i = 0;
+            i < data.length && this.classroomSummaries.length < 2;
+            i++
+          ) {
+            if (data[i].is_published) {
+              this.classroomSummaries.push(data[i]);
+            }
           }
-        }
-        this.isLoading = false;
-      });
+          this.isLoading = false;
+        });
+    }
   }
 }

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
@@ -836,4 +836,19 @@ describe('TopNavigationBarComponent', () => {
       ).toBeTrue();
     }
   );
+
+  it('should not check learner groups feature on signup page', fakeAsync(() => {
+    spyOn(component, 'truncateNavbar').and.stub();
+    const learnerGroupSpy = spyOn(
+      learnerGroupBackendApiService,
+      'isLearnerGroupFeatureEnabledAsync'
+    );
+
+    mockWindowRef.nativeWindow.location.pathname = '/signup';
+    component.ngOnInit();
+    tick();
+
+    expect(learnerGroupSpy).not.toHaveBeenCalled();
+    expect(component.LEARNER_GROUPS_FEATURE_IS_ENABLED).toBeFalse();
+  }));
 });

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -228,11 +228,13 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
       this.navigationService.KEYBOARD_EVENT_TO_KEY_CODES;
     this.windowIsNarrow = this.windowDimensionsService.isWindowNarrow();
 
-    this.learnerGroupBackendApiService
-      .isLearnerGroupFeatureEnabledAsync()
-      .then(featureIsEnabled => {
-        this.LEARNER_GROUPS_FEATURE_IS_ENABLED = featureIsEnabled;
-      });
+    if (this.currentUrl !== 'signup') {
+      this.learnerGroupBackendApiService
+        .isLearnerGroupFeatureEnabledAsync()
+        .then(featureIsEnabled => {
+          this.LEARNER_GROUPS_FEATURE_IS_ENABLED = featureIsEnabled;
+        });
+    }
 
     this.FEEDBACK_UPDATES_IN_PROFILE_PIC_DROP_DOWN_IS_ENABLED =
       this.isShowFeedbackUpdatesInProfilepicDropdownFeatureFlagEnable();


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #19746 .
2. This PR does the following: Prevents the /learner_groups_feature_status_handler and /all_classrooms_summary API requests from being sent on the signup page.
3. The original bug occurred because: The backend redirecting all API requests made when the user is in a partially logged in state and 2 API requests were being sent during that state via the navigation components.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

[screen-capture.webm](https://github.com/user-attachments/assets/725e6073-4474-41d8-b50d-549452d66d14)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
