### PR TITLE
fix part of 21731: Update a couple of incorrect types

### DIFF
--- a/core/domain/image_services.py
+++ b/core/domain/image_services.py
@@ -24,7 +24,7 @@ from PIL import Image
 from typing import Tuple
 
 
-def _get_pil_image_dimensions(pil_image: Image) -> Tuple[int, int]:
+def _get_pil_image_dimensions(pil_image: Image.Image) -> Tuple[int, int]:
     """Gets the dimensions of the Pillow Image.
 
     Args:
@@ -78,7 +78,7 @@ def compress_image(image_content: bytes, scaling_factor: float) -> bytes:
 
     # NOTE: image.thumbnail() function does not work when the scale factor
     # is greater than 1.
-    image.thumbnail(new_image_dimensions, Image.LANCZOS)
+    image.thumbnail(new_image_dimensions, Image.Resampling.LANCZOS)
     with io.BytesIO() as output:
         image.save(output, format=image_format)
         new_image_content = output.getvalue()


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21731 
2. This PR does the following: Temporarily fixes mypy problem occured while pushing. I opened this PR on seanlip [recommendation](https://github.com/oppia/oppia/pull/21568#discussion_r1966678289) for fixing it temporarily, thus can't get root cause of why this occured. But one thing I could tell is `Pillow version` isn't responsible for this issue, i.e. Pillow version should be `10.1.0` and it is verified on my own which you can see in this [discussion](https://github.com/oppia/oppia/discussions/21615). Now how did I got solution: I got a article over [stackoverflow](https://stackoverflow.com/questions/58236138/pil-and-python-static-typing), where it is explained as the `Image` we're tyring to access (`from PIL import Image` used in image_service.py file) isn't object either it is module, so now we have to access it as `Image.Image`. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code. ~Not needed. 
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
No proof of changes needed because I'm able to push without `no-verify` flag with above discussed changes. 

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
