### PR TITLE
Update error logging in base.py to include HTTP method, URL, and cont…

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -581,7 +581,9 @@ class BaseHandler(
         return (
             self.current_user_is_super_admin or
             feconf.ROLE_ID_RELEASE_COORDINATOR in self.roles)
-
+        
+    # Here we use type Any because the sub-classes of 'Basehandler' can have
+    # 'get' method with different number of arguments and types.
     def get(self, *args: Any, **kwargs: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle GET requests."""
         request_method = self.request.environ.get('REQUEST_METHOD', 'UNKNOWN')
@@ -599,6 +601,8 @@ class BaseHandler(
         }
         self._render_exception(values)
 
+    # Here we use type Any because the sub-classes of 'Basehandler' can have
+    # 'post' method with different number of arguments and types.
     def post(self, *args: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle POST requests.
 
@@ -607,6 +611,8 @@ class BaseHandler(
         """
         raise self.NotFoundException
 
+    # Here we use type Any because the sub-classes of 'Basehandler' can have
+    # 'put' method with different number of arguments and types.
     def put(self, *args: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle PUT requests.
 
@@ -615,6 +621,8 @@ class BaseHandler(
         """
         raise self.NotFoundException
 
+    # Here we use type Any because the sub-classes of 'Basehandler' can have
+    # 'delete' method with different number of arguments and types.
     def delete(self, *args: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle DELETE requests.
 
@@ -623,12 +631,19 @@ class BaseHandler(
         """
         raise self.NotFoundException
 
+    # Here we use type Any because the sub-classes of 'Basehandler' can have
+    # 'head' method with different number of arguments and types.
     def head(self, *args: Any, **kwargs: Any) -> None:
         """Method to handle HEAD requests. The webapp library automatically
         makes sure that HEAD only returns the headers of GET request.
         """
         return self.get(*args, **kwargs)
 
+    # TODO(#16539): Once all the places are fixed with the type of value
+    # that is rendered to JSON, then please remove Sequence[Mapping[str, Any]]
+    # from render_json's argument type.
+    # Here we use type Any because the argument 'values' can accept various
+    # kinds of dictionaries that needs to be sent as a JSON response.
     def render_json(
         self, values: Union[str, Sequence[Mapping[str, Any]], Mapping[str, Any]]
     ) -> None:
@@ -647,6 +662,7 @@ class BaseHandler(
         self.response.headers['X-Xss-Protection'] = '1; mode=block'
 
         json_output = json.dumps(values, cls=utils.JSONEncoderForHTML)
+        # Write expects bytes, thus we need to encode the JSON output.
         self.response.write(
             b'%s%s' % (feconf.XSSI_PREFIX, json_output.encode('utf-8')))
 
@@ -664,6 +680,14 @@ class BaseHandler(
         self.response.headers['Content-Disposition'] = (
             'attachment; filename=%s' % filename)
         self.response.charset = 'utf-8'
+                # Here we use MyPy ignore because according to MyPy super can
+        # accept 'super class and self' as arguments but here we are passing
+        # 'webapp2.Response, and self.response' which confuses MyPy about the
+        # typing of super, and due to this MyPy is unable to recognize the
+        # 'write' method and throws an error. This change in arguments is
+        # done because we use 'super' method in order to bypass the write
+        # method in webapp2.Response, since webapp2.Response doesn't support
+        # writing bytes.
         super(webapp2.Response, self.response).write(file.getvalue())  # type: ignore[misc] # pylint: disable=bad-super-call
 
     def render_template(
@@ -690,6 +714,8 @@ class BaseHandler(
             Exception. Invalid iframe restriction value.
         """
 
+        # The 'no-store' must be used to properly invalidate the cache when we
+        # deploy a new version, using only 'no-cache' doesn't work properly.
         self.response.cache_control.no_store = True
         self.response.cache_control.must_revalidate = True
         self.response.headers['Strict-Transport-Security'] = (
@@ -728,6 +754,9 @@ class BaseHandler(
         if return_type == feconf.HANDLER_TYPE_HTML and method == 'GET':
             self.values.update(values)
             if values['status_code'] == 404:
+                # Only 404 routes can be handled with angular router as it only
+                # has access to the path, not to the status code.
+                # That's why 404 status code is treated differently.
                 self.render_template('oppia-root.mainpage.html')
         else:
             if return_type not in (
@@ -744,6 +773,8 @@ class BaseHandler(
         Args:
             values: dict. The key-value pairs to include in the response.
         """
+        # The error codes here should be in sync with the error pages
+        # generated via webpack.common.config.ts.
         assert values['status_code'] in [400, 401, 404, 405, 500]
         method = self.request.environ['REQUEST_METHOD']
 
@@ -778,6 +809,15 @@ class BaseHandler(
         handler_class_name = self.__class__.__name__
         request_method = self.request.environ['REQUEST_METHOD']
         if isinstance(exception, self.NotLoggedInException):
+            # This checks if the response should be JSON or HTML.
+            # For GET requests, there is no payload, so we check against
+            # GET_HANDLER_ERROR_RETURN_TYPE.
+            # Otherwise, we check whether self.payload exists.
+
+            # This check is to avoid throwing of 401 when payload doesn't
+            # exists and self.payload is replaced by RaiseErrorOnGet object.
+            # TODO(#13155): Change this to self.normalized_payload
+            #  once schema is implemented for all handlers.
             self._log_exception_message(
                 401,
                 "NotLoggedInException: Request to %s with method %s" %
@@ -904,6 +944,8 @@ class RaiseErrorOnGet:
 
     def __init__(self, message: str) -> None:
         self.error_message = message
+    # Here we use type Any because the 'get' method can accept arbitrary number
+    # of arguments with different types.
 
     def get(self, *args: Any, **kwargs: Any) -> None:
         """Raises an error when invoked."""
@@ -913,7 +955,9 @@ class RaiseErrorOnGet:
 class CsrfTokenManager:
     """Manages page/user tokens in memcache to protect against CSRF."""
 
+    # Max age of the token (48 hours).
     _CSRF_TOKEN_AGE_SECS: Final = 60 * 60 * 48
+    # Default user id for non-logged-in users.
     _USER_ID_DEFAULT: Final = 'non_logged_in_user'
 
     @classmethod
@@ -933,11 +977,21 @@ class CsrfTokenManager:
         Returns:
             str. The generated CSRF token.
         """
+        # The token has 4 parts: hash of the actor user id, hash of the page
+        # name, hash of the time issued and plain text of the time issued.
+
         if user_id is None:
             user_id = cls._USER_ID_DEFAULT
 
+        # Round time to seconds.
         issued_on_str = str(int(issued_on))
 
+        # Generate a nonce (number used once) to ensure that even two
+        # consecutive calls to the same endpoint in the same second generate
+        # different tokens. Note that this nonce is just for anti-collision
+        # purposes, so it's okay that the nonce is stored in the CSRF token and
+        # therefore can be controlled by an attacker. See OWASP guidance here:
+        # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#signed-double-submit-cookie.
         if nonce is None:
             nonce = base64.urlsafe_b64encode(os.urandom(20)).decode('utf-8')
 
@@ -952,6 +1006,8 @@ class CsrfTokenManager:
         digester.update(nonce.encode('utf-8'))
 
         digest = digester.digest()
+        # The b64encode returns bytes, so we first need to decode the returned
+        # bytes to string.
         token = '%s/%s/%s' % (
             issued_on_str, nonce,
             base64.urlsafe_b64encode(digest).decode('utf-8'))
@@ -1021,6 +1077,8 @@ class CsrfTokenHandler(BaseHandler[Dict[str, str], Dict[str, str]]):
     URL_PATH_ARGS_SCHEMAS: Dict[str, str] = {}
     HANDLER_ARGS_SCHEMAS: Dict[str, Dict[str, str]] = {'GET': {}}
 
+    # Here we use MyPy ignore because the signature of 'get' method is not
+    # compatible with super class's (BaseHandler) 'get' method.
     def get(self) -> None:  # type: ignore[override]
         csrf_token = CsrfTokenManager.create_csrf_token(
             self.user_id)

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -289,6 +289,44 @@ class BaseHandler(
 
         self.values['is_super_admin'] = self.current_user_is_super_admin
 
+    def _is_requested_path_currently_accessible_to_user(self) -> bool:
+        """Checks whether the requested path is currently accessible to user.
+
+        Returns:
+            bool. Whether the requested path is currently accessible to user.
+        """
+        return (
+            self.request.path in AUTH_HANDLER_PATHS or
+            not feconf.ENABLE_MAINTENANCE_MODE or
+            self.current_user_is_site_maintainer)
+
+    def _log_exception_message(self, status_code: int, error_message: str, log_level: str = 'error') -> None:
+        """Logs detailed error information with context.
+
+        Args:
+            status_code: The HTTP status code.
+            error_message: The error message to log.
+            log_level: The log level to use ('error', 'warning', 'exception', or 'info').
+        """
+        request_method = self.request.environ.get('REQUEST_METHOD', 'UNKNOWN')
+        url = self.request.uri
+        controller = self.__class__.__name__
+        msg = (
+            "Error message: %s\n"
+            "Request method: %s\n"
+            "Status code: %s\n"
+            "URL: %s\n"
+            "Controller: %s" % (error_message, request_method, status_code, url, controller)
+        )
+        if log_level == 'error':
+            logging.error(msg)
+        elif log_level == 'warning':
+            logging.warning(msg)
+        elif log_level == 'exception':
+            logging.exception(msg)
+        else:
+            logging.info(msg)
+
     def dispatch(self) -> None:
         """Overrides dispatch method in webapp2 superclass.
 
@@ -544,22 +582,16 @@ class BaseHandler(
             self.current_user_is_super_admin or
             feconf.ROLE_ID_RELEASE_COORDINATOR in self.roles)
 
-    def _is_requested_path_currently_accessible_to_user(self) -> bool:
-        """Checks whether the requested path is currently accessible to user.
-
-        Returns:
-            bool. Whether the requested path is currently accessible to user.
-        """
-        return (
-            self.request.path in AUTH_HANDLER_PATHS or
-            not feconf.ENABLE_MAINTENANCE_MODE or
-            self.current_user_is_site_maintainer)
-
-    # Here we use type Any because the sub-classes of 'Basehandler' can have
-    # 'get' method with different number of arguments and types.
     def get(self, *args: Any, **kwargs: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle GET requests."""
-        logging.warning('Invalid URL requested: %s', self.request.uri)
+        request_method = self.request.environ.get('REQUEST_METHOD', 'UNKNOWN')
+        request_url = self.request.uri
+        request_params = json.dumps(self.request.GET, default=str) if self.request.GET else "{}"
+        error_message = (
+            "NotFoundException: Invalid URL requested with method %s, URL %s, Params %s" %
+            (request_method, request_url, request_params)
+        )
+        self._log_exception_message(404, error_message, log_level='warning')
         self.error(404)
         values: ResponseValueDict = {
             'error': 'Could not find the resource %s.' % self.request.uri,
@@ -567,8 +599,6 @@ class BaseHandler(
         }
         self._render_exception(values)
 
-    # Here we use type Any because the sub-classes of 'Basehandler' can have
-    # 'post' method with different number of arguments and types.
     def post(self, *args: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle POST requests.
 
@@ -577,8 +607,6 @@ class BaseHandler(
         """
         raise self.NotFoundException
 
-    # Here we use type Any because the sub-classes of 'Basehandler' can have
-    # 'put' method with different number of arguments and types.
     def put(self, *args: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle PUT requests.
 
@@ -587,8 +615,6 @@ class BaseHandler(
         """
         raise self.NotFoundException
 
-    # Here we use type Any because the sub-classes of 'Basehandler' can have
-    # 'delete' method with different number of arguments and types.
     def delete(self, *args: Any) -> None:  # pylint: disable=unused-argument
         """Base method to handle DELETE requests.
 
@@ -597,19 +623,12 @@ class BaseHandler(
         """
         raise self.NotFoundException
 
-    # Here we use type Any because the sub-classes of 'Basehandler' can have
-    # 'head' method with different number of arguments and types.
     def head(self, *args: Any, **kwargs: Any) -> None:
         """Method to handle HEAD requests. The webapp library automatically
         makes sure that HEAD only returns the headers of GET request.
         """
         return self.get(*args, **kwargs)
 
-    # TODO(#16539): Once all the places are fixed with the type of value
-    # that is rendered to JSON, then please remove Sequence[Mapping[str, Any]]
-    # from render_json's argument type.
-    # Here we use type Any because the argument 'values' can accept various
-    # kinds of dictionaries that needs to be sent as a JSON response.
     def render_json(
         self, values: Union[str, Sequence[Mapping[str, Any]], Mapping[str, Any]]
     ) -> None:
@@ -628,7 +647,6 @@ class BaseHandler(
         self.response.headers['X-Xss-Protection'] = '1; mode=block'
 
         json_output = json.dumps(values, cls=utils.JSONEncoderForHTML)
-        # Write expects bytes, thus we need to encode the JSON output.
         self.response.write(
             b'%s%s' % (feconf.XSSI_PREFIX, json_output.encode('utf-8')))
 
@@ -646,14 +664,6 @@ class BaseHandler(
         self.response.headers['Content-Disposition'] = (
             'attachment; filename=%s' % filename)
         self.response.charset = 'utf-8'
-        # Here we use MyPy ignore because according to MyPy super can
-        # accept 'super class and self' as arguments but here we are passing
-        # 'webapp2.Response, and self.response' which confuses MyPy about the
-        # typing of super, and due to this MyPy is unable to recognize the
-        # 'write' method and throws an error. This change in arguments is
-        # done because we use 'super' method in order to bypass the write
-        # method in webapp2.Response, since webapp2.Response doesn't support
-        # writing bytes.
         super(webapp2.Response, self.response).write(file.getvalue())  # type: ignore[misc] # pylint: disable=bad-super-call
 
     def render_template(
@@ -680,8 +690,6 @@ class BaseHandler(
             Exception. Invalid iframe restriction value.
         """
 
-        # The 'no-store' must be used to properly invalidate the cache when we
-        # deploy a new version, using only 'no-cache' doesn't work properly.
         self.response.cache_control.no_store = True
         self.response.cache_control.must_revalidate = True
         self.response.headers['Strict-Transport-Security'] = (
@@ -720,9 +728,6 @@ class BaseHandler(
         if return_type == feconf.HANDLER_TYPE_HTML and method == 'GET':
             self.values.update(values)
             if values['status_code'] == 404:
-                # Only 404 routes can be handled with angular router as it only
-                # has access to the path, not to the status code.
-                # That's why 404 status code is treated differently.
                 self.render_template('oppia-root.mainpage.html')
         else:
             if return_type not in (
@@ -739,8 +744,6 @@ class BaseHandler(
         Args:
             values: dict. The key-value pairs to include in the response.
         """
-        # The error codes here should be in sync with the error pages
-        # generated via webpack.common.config.ts.
         assert values['status_code'] in [400, 401, 404, 405, 500]
         method = self.request.environ['REQUEST_METHOD']
 
@@ -775,15 +778,12 @@ class BaseHandler(
         handler_class_name = self.__class__.__name__
         request_method = self.request.environ['REQUEST_METHOD']
         if isinstance(exception, self.NotLoggedInException):
-            # This checks if the response should be JSON or HTML.
-            # For GET requests, there is no payload, so we check against
-            # GET_HANDLER_ERROR_RETURN_TYPE.
-            # Otherwise, we check whether self.payload exists.
-
-            # This check is to avoid throwing of 401 when payload doesn't
-            # exists and self.payload is replaced by RaiseErrorOnGet object.
-            # TODO(#13155): Change this to self.normalized_payload
-            #  once schema is implemented for all handlers.
+            self._log_exception_message(
+                401,
+                "NotLoggedInException: Request to %s with method %s" %
+                (self.request.uri, request_method),
+                log_level='warning'
+            )
             payload_exists = (
                 self.payload is not None and
                 not isinstance(self.payload, RaiseErrorOnGet)
@@ -804,7 +804,12 @@ class BaseHandler(
             return
 
         if isinstance(exception, self.NotFoundException):
-            logging.warning('Invalid URL requested: %s', self.request.uri)
+            self._log_exception_message(
+                404,
+                "NotFoundException: Invalid URL requested %s with method %s" %
+                (self.request.uri, request_method),
+                log_level='warning'
+            )
             self.error(404)
             values = {
                 'error': 'Could not find the resource %s.' % self.request.uri,
@@ -813,10 +818,12 @@ class BaseHandler(
             self._render_exception(values)
             return
 
-        logging.exception(
-            'Exception raised at %s: %s', self.request.uri, exception)
-
         if isinstance(exception, self.UnauthorizedUserException):
+            self._log_exception_message(
+                401,
+                "UnauthorizedUserException: %s" % str(exception),
+                log_level='exception'
+            )
             self.error(401)
             values = {
                 'error': str(exception),
@@ -826,6 +833,11 @@ class BaseHandler(
             return
 
         if isinstance(exception, self.InvalidInputException):
+            self._log_exception_message(
+                400,
+                "InvalidInputException: %s" % str(exception),
+                log_level='exception'
+            )
             self.error(400)
             values = {
                 'error': str(exception),
@@ -835,6 +847,11 @@ class BaseHandler(
             return
 
         if isinstance(exception, self.InternalErrorException):
+            self._log_exception_message(
+                500,
+                "InternalErrorException: %s" % str(exception),
+                log_level='exception'
+            )
             self.error(500)
             values = {
                 'error': str(exception),
@@ -844,15 +861,24 @@ class BaseHandler(
             return
 
         if isinstance(exception, TypeError):
+            self._log_exception_message(
+                405,
+                "TypeError: Invalid method %s for %s" % (request_method, handler_class_name),
+                log_level='exception'
+            )
             self.error(405)
             values = {
-                'error': 'Invalid method %s for %s' % (
-                    request_method, handler_class_name),
+                'error': 'Invalid method %s for %s' % (request_method, handler_class_name),
                 'status_code': 405
             }
             self._render_exception(values)
             return
 
+        self._log_exception_message(
+            500,
+            "Unexpected exception: %s" % str(exception),
+            log_level='exception'
+        )
         self.error(500)
         values = {
             'error': str(exception),
@@ -879,8 +905,6 @@ class RaiseErrorOnGet:
     def __init__(self, message: str) -> None:
         self.error_message = message
 
-    # Here we use type Any because the 'get' method can accept arbitrary number
-    # of arguments with different types.
     def get(self, *args: Any, **kwargs: Any) -> None:
         """Raises an error when invoked."""
         raise ValueError(self.error_message)
@@ -889,9 +913,7 @@ class RaiseErrorOnGet:
 class CsrfTokenManager:
     """Manages page/user tokens in memcache to protect against CSRF."""
 
-    # Max age of the token (48 hours).
     _CSRF_TOKEN_AGE_SECS: Final = 60 * 60 * 48
-    # Default user id for non-logged-in users.
     _USER_ID_DEFAULT: Final = 'non_logged_in_user'
 
     @classmethod
@@ -911,21 +933,11 @@ class CsrfTokenManager:
         Returns:
             str. The generated CSRF token.
         """
-        # The token has 4 parts: hash of the actor user id, hash of the page
-        # name, hash of the time issued and plain text of the time issued.
-
         if user_id is None:
             user_id = cls._USER_ID_DEFAULT
 
-        # Round time to seconds.
         issued_on_str = str(int(issued_on))
 
-        # Generate a nonce (number used once) to ensure that even two
-        # consecutive calls to the same endpoint in the same second generate
-        # different tokens. Note that this nonce is just for anti-collision
-        # purposes, so it's okay that the nonce is stored in the CSRF token and
-        # therefore can be controlled by an attacker. See OWASP guidance here:
-        # https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#signed-double-submit-cookie.
         if nonce is None:
             nonce = base64.urlsafe_b64encode(os.urandom(20)).decode('utf-8')
 
@@ -940,8 +952,6 @@ class CsrfTokenManager:
         digester.update(nonce.encode('utf-8'))
 
         digest = digester.digest()
-        # The b64encode returns bytes, so we first need to decode the returned
-        # bytes to string.
         token = '%s/%s/%s' % (
             issued_on_str, nonce,
             base64.urlsafe_b64encode(digest).decode('utf-8'))
@@ -1011,8 +1021,6 @@ class CsrfTokenHandler(BaseHandler[Dict[str, str], Dict[str, str]]):
     URL_PATH_ARGS_SCHEMAS: Dict[str, str] = {}
     HANDLER_ARGS_SCHEMAS: Dict[str, Dict[str, str]] = {'GET': {}}
 
-    # Here we use MyPy ignore because the signature of 'get' method is not
-    # compatible with super class's (BaseHandler) 'get' method.
     def get(self) -> None:  # type: ignore[override]
         csrf_token = CsrfTokenManager.create_csrf_token(
             self.user_id)


### PR DESCRIPTION
## Overview

1. This PR fixes Update error logging in base.py to include HTTP method, URL, and cont… #22045
2. **What this PR does and why:**  
   I enhanced the backend error logging in Oppia to provide complete context for every error. Previously, errors were logged with minimal details, making it time-consuming for developers to trace what led to an error. My changes now ensure that each log entry includes the HTTP method, full request URL, any query parameters, the HTTP status code, and the name of the controller (handler) that raised the error. This consolidated information helps developers diagnose issues quickly.

   The improvements are implemented in the `BaseHandler` class in `core/controllers/base.py` and include:
   
   - **Centralized Logging Helper:**  
     I introduced a new helper function within the BaseHandler class to centralize error logging. This function gathers key details from the current request (HTTP method, complete URL, and controller name) and constructs a comprehensive log entry that includes a custom error message along with the HTTP status code. It logs this detailed message at different levels (warning, exception, etc.) based on the type of error, ensuring consistency across all error logs in the codebase.
   
   - **Enhanced GET Handler for 404 Errors:**  
     The default GET method (which handles cases where an invalid URL is requested) was updated to capture additional context. Instead of simply logging that an invalid URL was requested, the updated GET handler now retrieves the HTTP method, full URL, and any query parameters from the request. It constructs a detailed error message explaining that a NotFoundException occurred (including the method, URL, and parameters) and logs this message using the centralized logging helper before returning a 404 error response. This ensures that whenever a 404 error is encountered, the log clearly indicates the request details that led to it.
   
   - **Improved Exception Handling:**  
     I updated the centralized exception handler (`handle_exception()`) to use the new logging helper across all exception branches. For each type of exception—such as NotLoggedInException, NotFoundException, UnauthorizedUserException, InvalidInputException, InternalErrorException, and even TypeError—the exception handler now logs a detailed error message before processing the error. For unexpected exceptions (those not explicitly handled), the fallback branch now logs the error with complete context using the logging helper before returning a 500 error. This ensures that every error log entry provides a complete snapshot of the error context, which is invaluable for debugging.

3. (For bug-fixing PRs only) The original bug occurred because error logs lacked critical context—there was no direct correlation between the logged exception and the specific user action or endpoint that caused it. This PR addresses that by including all relevant request details in each log entry.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@reviewer_username PTAL" if I can't assign them directly).

## Proof that changes are correct

To test these changes:
- I created temporary endpoints that deliberately throw different exceptions (e.g., NotLoggedInException, NotFoundException, UnauthorizedUserException, InvalidInputException, InternalErrorException, and even TypeError).  
- I then used command-line tools (like `curl`) to trigger each endpoint. 

In the logs, I observed detailed error messages that include the HTTP method, URL, status code, and controller name, confirming that the centralized logging mechanism is working as expected.
- I also tested the default GET handler by requesting a non-existent URL and confirmed that the log now shows a detailed 404 error entry.

![image](https://github.com/user-attachments/assets/a47f449d-d2e9-447d-aea3-be764817b356)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow the instructions in the [Oppia PR guidelines](https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve).
- Some e2e tests are flaky and might fail for reasons unrelated to this PR. If you need to restart tests, refer to the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for additional expectations.


