### PR TITLE
Updated field name

### DIFF
--- a/core/controllers/access_validators_test.py
+++ b/core/controllers/access_validators_test.py
@@ -177,7 +177,7 @@ class PracticeSessionAccessValidationPageTests(test_utils.GenericTestBase):
                         topic_id_to_prerequisite_topic_ids=(
                             topic_dependency_for_classroom_1),
                         is_published=True,
-                        is_diagnostic_test_enabled=False,
+                        diagnostic_test_is_enabled=False,
                         thumbnail_data=classroom_config_domain.ImageData(
                             'thumbnail.svg', 'transparent', 1000
                         ),

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -1678,7 +1678,7 @@ class AdminHandler(
                             topic_id_to_prerequisite_topic_ids=(
                                 topic_dependency_for_classroom_1),
                             is_published=True,
-                            is_diagnostic_test_enabled=False,
+                            diagnostic_test_is_enabled=False,
                             thumbnail_data=classroom_config_domain.ImageData(
                                 'thumbnail.svg', 'transparent', 1000
                             ),

--- a/core/controllers/classroom.py
+++ b/core/controllers/classroom.py
@@ -131,7 +131,7 @@ class ClassroomDataHandler(
             'url_fragment': classroom.url_fragment,
             'teaser_text': classroom.teaser_text,
             'is_published': classroom.is_published,
-            'is_diagnostic_test_enabled': classroom.is_diagnostic_test_enabled,
+            'diagnostic_test_is_enabled': classroom.diagnostic_test_is_enabled,
             'thumbnail_data': classroom.thumbnail_data.to_dict(),
             'banner_data': classroom.banner_data.to_dict(),
             'public_classrooms_count': public_classrooms_count,
@@ -572,8 +572,8 @@ class AllClassroomsSummaryHandler(
                 'url_fragment': classroom.url_fragment,
                 'teaser_text': classroom.teaser_text,
                 'is_published': classroom.is_published,
-                'is_diagnostic_test_enabled': (
-                    classroom.is_diagnostic_test_enabled),
+                'diagnostic_test_is_enabled': (
+                    classroom.diagnostic_test_is_enabled),
                 'thumbnail_filename': classroom.thumbnail_data.filename,
                 'thumbnail_bg_color': classroom.banner_data.bg_color,
                 'index': 0 if classroom.index is None else classroom.index

--- a/core/controllers/classroom_test.py
+++ b/core/controllers/classroom_test.py
@@ -395,7 +395,7 @@ class ClassroomAdminTests(BaseClassroomControllerTests):
                 self.public_topic_id_3: []
             },
             'is_published': True,
-            'is_diagnostic_test_enabled': False,
+            'diagnostic_test_is_enabled': False,
             'thumbnail_data': dummy_thumbnail_data.to_dict(),
             'banner_data': dummy_banner_data.to_dict(),
             'index': 0
@@ -418,7 +418,7 @@ class ClassroomAdminTests(BaseClassroomControllerTests):
                 self.public_topic_id_2: []
             },
             'is_published': True,
-            'is_diagnostic_test_enabled': False,
+            'diagnostic_test_is_enabled': False,
             'thumbnail_data': dummy_thumbnail_data.to_dict(),
             'banner_data': dummy_banner_data.to_dict(),
             'index': 1
@@ -790,7 +790,7 @@ class UnusedTopicsHandlerTests(test_utils.GenericTestBase):
                 'used_topic_1': []
             },
             'is_published': True,
-            'is_diagnostic_test_enabled': False,
+            'diagnostic_test_is_enabled': False,
             'thumbnail_data': dummy_thumbnail_data.to_dict(),
             'banner_data': dummy_banner_data.to_dict(),
             'index': 0
@@ -924,7 +924,7 @@ class AllClassroomsSummaryHandlerTests(test_utils.GenericTestBase):
                 'url_fragment': 'history',
                 'teaser_text': 'Teaser Text',
                 'is_published': True,
-                'is_diagnostic_test_enabled': False,
+                'diagnostic_test_is_enabled': False,
                 'thumbnail_filename': 'thumbnail.svg',
                 'thumbnail_bg_color': 'transparent', 'index': 0
             },
@@ -934,7 +934,7 @@ class AllClassroomsSummaryHandlerTests(test_utils.GenericTestBase):
                 'url_fragment': 'english',
                 'teaser_text': 'Teaser Text',
                 'is_published': True,
-                'is_diagnostic_test_enabled': False,
+                'diagnostic_test_is_enabled': False,
                 'thumbnail_filename': 'thumbnail.svg',
                 'thumbnail_bg_color': 'transparent', 'index': 1
             }

--- a/core/domain/classroom_config_domain.py
+++ b/core/domain/classroom_config_domain.py
@@ -36,7 +36,7 @@ class ClassroomDict(TypedDict):
     topic_list_intro: str
     topic_id_to_prerequisite_topic_ids: Dict[str, List[str]]
     is_published: bool
-    is_diagnostic_test_enabled: bool
+    diagnostic_test_is_enabled: bool
     thumbnail_data: ImageDataDict
     banner_data: ImageDataDict
     index: int
@@ -61,7 +61,7 @@ class Classroom:
         topic_list_intro: str,
         topic_id_to_prerequisite_topic_ids: Dict[str, List[str]],
         is_published: bool,
-        is_diagnostic_test_enabled: bool,
+        diagnostic_test_is_enabled: bool,
         thumbnail_data: ImageData,
         banner_data: ImageData,
         index: int
@@ -79,7 +79,7 @@ class Classroom:
                 with topic ID as key and a list of prerequisite topic IDs as
                 value.
             is_published: bool. Whether this classroom is published or not.
-            is_diagnostic_test_enabled: bool. Whether this classroom 
+            diagnostic_test_is_enabled: bool. Whether this classroom 
                 is published or not.
             thumbnail_data: ImageData. Image data object for classroom
                 thumbnail.
@@ -95,7 +95,7 @@ class Classroom:
         self.topic_id_to_prerequisite_topic_ids = (
             topic_id_to_prerequisite_topic_ids)
         self.is_published = is_published
-        self.is_diagnostic_test_enabled = is_diagnostic_test_enabled
+        self.diagnostic_test_is_enabled = diagnostic_test_is_enabled
         self.thumbnail_data = thumbnail_data
         self.banner_data = banner_data
         self.index = index
@@ -120,7 +120,7 @@ class Classroom:
             classroom_dict['topic_list_intro'],
             classroom_dict['topic_id_to_prerequisite_topic_ids'],
             classroom_dict['is_published'],
-            classroom_dict['is_diagnostic_test_enabled'],
+            classroom_dict['diagnostic_test_is_enabled'],
             ImageData.from_dict(classroom_dict['thumbnail_data']),
             ImageData.from_dict(classroom_dict['banner_data']),
             classroom_dict['index']
@@ -142,7 +142,7 @@ class Classroom:
             'topic_id_to_prerequisite_topic_ids': (
                 self.topic_id_to_prerequisite_topic_ids),
             'is_published': self.is_published,
-            'is_diagnostic_test_enabled': self.is_diagnostic_test_enabled,
+            'diagnostic_test_is_enabled': self.diagnostic_test_is_enabled,
             'thumbnail_data': self.thumbnail_data.to_dict(),
             'banner_data': self.banner_data.to_dict(),
             'index': self.index
@@ -356,11 +356,11 @@ class Classroom:
                 'Expected is_published of the classroom to be a boolean, '
                 'received: %s.' % self.is_published)
 
-        if not isinstance(self.is_diagnostic_test_enabled, bool):
+        if not isinstance(self.diagnostic_test_is_enabled, bool):
             raise utils.ValidationError(
-                'Expected is_diagnostic_test_enabled of the classroom to '
+                'Expected diagnostic_test_is_enabled of the classroom to '
                 'be a boolean, received: %s.' % (
-                    self.is_diagnostic_test_enabled))
+                    self.diagnostic_test_is_enabled))
 
         if strict:
             if not isinstance(self.index, int):

--- a/core/domain/classroom_config_domain_test.py
+++ b/core/domain/classroom_config_domain_test.py
@@ -65,7 +65,7 @@ class ClassroomDomainTests(test_utils.GenericTestBase):
                 'topic_id_3': []
             },
             'is_published': True,
-            'is_diagnostic_test_enabled': False,
+            'diagnostic_test_is_enabled': False,
             'thumbnail_data': self.dummy_thumbnail_data.to_dict(),
             'banner_data': self.dummy_banner_data.to_dict(),
             'index': 0
@@ -341,11 +341,11 @@ class ClassroomDomainTests(test_utils.GenericTestBase):
     # TODO(#13059): Here we use MyPy ignore because after we fully type
     # the codebase we plan to get rid of the tests that intentionally
     # test wrong inputs that we can normally catch by typing.
-    def test_invalid_is_diagnostic_test_enabled_should_raise_exception(
+    def test_invalid_diagnostic_test_is_enabled_should_raise_exception(
             self) -> None:
-        self.classroom.is_diagnostic_test_enabled = 1 # type: ignore[assignment]
+        self.classroom.diagnostic_test_is_enabled = 1 # type: ignore[assignment]
         error_msg = (
-            'Expected is_diagnostic_test_enabled of the classroom to be'
+            'Expected diagnostic_test_is_enabled of the classroom to be'
             ' a boolean, received: 1.'
         )
         with self.assertRaisesRegex(

--- a/core/domain/classroom_config_services.py
+++ b/core/domain/classroom_config_services.py
@@ -103,7 +103,7 @@ def get_classroom_from_classroom_model(
         classroom_model.topic_list_intro,
         classroom_model.topic_id_to_prerequisite_topic_ids,
         classroom_model.is_published,
-        classroom_model.is_diagnostic_test_enabled,
+        classroom_model.diagnostic_test_is_enabled,
         thumbnail_data, banner_data,
         classroom_model.index
     )
@@ -236,8 +236,8 @@ def update_classroom(
         classroom.topic_id_to_prerequisite_topic_ids)
     classroom_model.teaser_text = classroom.teaser_text
     classroom_model.is_published = classroom.is_published
-    classroom_model.is_diagnostic_test_enabled = (
-        classroom.is_diagnostic_test_enabled)
+    classroom_model.diagnostic_test_is_enabled = (
+        classroom.diagnostic_test_is_enabled)
     classroom_model.thumbnail_filename = (
         classroom.thumbnail_data.filename
     )
@@ -278,7 +278,7 @@ def create_new_classroom(
         classroom.topic_list_intro,
         classroom.topic_id_to_prerequisite_topic_ids,
         classroom.is_published,
-        classroom.is_diagnostic_test_enabled,
+        classroom.diagnostic_test_is_enabled,
         classroom.thumbnail_data.filename,
         classroom.thumbnail_data.bg_color,
         classroom.thumbnail_data.size_in_bytes,
@@ -308,7 +308,7 @@ def create_new_default_classroom(
         teaser_text='', course_details='', topic_list_intro='',
         topic_id_to_prerequisite_topic_ids={},
         is_published=feconf.DEFAULT_CLASSROOM_PUBLICATION_STATUS,
-        is_diagnostic_test_enabled=(
+        diagnostic_test_is_enabled=(
             feconf.DEFAULT_CLASSROOM_DIAGNOSTIC_TEST_STATUS),
         thumbnail_data=classroom_config_domain.ImageData('', '', 0),
         banner_data=classroom_config_domain.ImageData('', '', 0),
@@ -327,7 +327,7 @@ def create_new_default_classroom(
         classroom.topic_list_intro,
         classroom.topic_id_to_prerequisite_topic_ids,
         classroom.is_published,
-        classroom.is_diagnostic_test_enabled,
+        classroom.diagnostic_test_is_enabled,
         classroom.thumbnail_data.filename,
         classroom.thumbnail_data.bg_color,
         classroom.thumbnail_data.size_in_bytes,

--- a/core/domain/classroom_config_services_test.py
+++ b/core/domain/classroom_config_services_test.py
@@ -62,7 +62,7 @@ class ClassroomServicesTests(test_utils.GenericTestBase):
                 'topic_id_3': []
             },
             'is_published': True,
-            'is_diagnostic_test_enabled': False,
+            'diagnostic_test_is_enabled': False,
             'thumbnail_data': self.dummy_thumbnail_data.to_dict(),
             'banner_data': self.dummy_banner_data.to_dict(),
             'index': 0
@@ -78,7 +78,7 @@ class ClassroomServicesTests(test_utils.GenericTestBase):
             self.math_classroom.topic_list_intro,
             self.math_classroom.topic_id_to_prerequisite_topic_ids,
             self.math_classroom.is_published,
-            self.math_classroom.is_diagnostic_test_enabled,
+            self.math_classroom.diagnostic_test_is_enabled,
             self.math_classroom.thumbnail_data.filename,
             self.math_classroom.thumbnail_data.bg_color,
             self.math_classroom.thumbnail_data.size_in_bytes,
@@ -101,7 +101,7 @@ class ClassroomServicesTests(test_utils.GenericTestBase):
                 'topic_id_3': []
             },
             'is_published': True,
-            'is_diagnostic_test_enabled': False,
+            'diagnostic_test_is_enabled': False,
             'thumbnail_data': self.dummy_thumbnail_data.to_dict(),
             'banner_data': self.dummy_banner_data.to_dict(),
             'index': 1
@@ -117,7 +117,7 @@ class ClassroomServicesTests(test_utils.GenericTestBase):
             self.physics_classroom.topic_list_intro,
             self.physics_classroom.topic_id_to_prerequisite_topic_ids,
             self.physics_classroom.is_published,
-            self.physics_classroom.is_diagnostic_test_enabled,
+            self.physics_classroom.diagnostic_test_is_enabled,
             self.physics_classroom.thumbnail_data.filename,
             self.physics_classroom.thumbnail_data.bg_color,
             self.physics_classroom.thumbnail_data.size_in_bytes,
@@ -159,7 +159,7 @@ class ClassroomServicesTests(test_utils.GenericTestBase):
             'topic_list_intro': 'Start from the basics with our first topic.',
             'topic_id_to_prerequisite_topic_ids': {'topic_id_chem': []},
             'is_published': True,
-            'is_diagnostic_test_enabled': False,
+            'diagnostic_test_is_enabled': False,
             'thumbnail_data': self.dummy_thumbnail_data.to_dict(),
             'banner_data': self.dummy_banner_data.to_dict(),
             'index': 2
@@ -175,7 +175,7 @@ class ClassroomServicesTests(test_utils.GenericTestBase):
             chemistry_classroom.topic_list_intro,
             chemistry_classroom.topic_id_to_prerequisite_topic_ids,
             chemistry_classroom.is_published,
-            chemistry_classroom.is_diagnostic_test_enabled,
+            chemistry_classroom.diagnostic_test_is_enabled,
             chemistry_classroom.thumbnail_data.filename,
             chemistry_classroom.thumbnail_data.bg_color,
             chemistry_classroom.thumbnail_data.size_in_bytes,

--- a/core/storage/classroom/gae_models.py
+++ b/core/storage/classroom/gae_models.py
@@ -62,8 +62,10 @@ class ClassroomModel(base_models.BaseModel):
     # False if classroom is hidden, True if published.
     is_published = datastore_services.BooleanProperty(
         indexed=True, required=True, default=False)
-    # Whether this classroom is published or not.
-    # False if classroom is hidden, True if published.
+    # Whether this classroom's diagnostic test
+    #  functionality is enabled or not.
+    # False if diagnostic test functionality
+    #  is hidden, True if enabled.
     diagnostic_test_is_enabled = datastore_services.BooleanProperty(
         indexed=True, required=True, default=False)
     # The thumbnail filename of the classroom.

--- a/core/storage/classroom/gae_models.py
+++ b/core/storage/classroom/gae_models.py
@@ -64,7 +64,7 @@ class ClassroomModel(base_models.BaseModel):
         indexed=True, required=True, default=False)
     # Whether this classroom is published or not.
     # False if classroom is hidden, True if published.
-    is_diagnostic_test_enabled = datastore_services.BooleanProperty(
+    diagnostic_test_is_enabled = datastore_services.BooleanProperty(
         indexed=True, required=True, default=False)
     # The thumbnail filename of the classroom.
     thumbnail_filename = datastore_services.StringProperty(indexed=True)
@@ -104,7 +104,7 @@ class ClassroomModel(base_models.BaseModel):
             'topic_id_to_prerequisite_topic_ids': (
                 base_models.EXPORT_POLICY.NOT_APPLICABLE),
             'is_published': base_models.EXPORT_POLICY.NOT_APPLICABLE,
-            'is_diagnostic_test_enabled': (
+            'diagnostic_test_is_enabled': (
                 base_models.EXPORT_POLICY.NOT_APPLICABLE),
             'thumbnail_filename': base_models.EXPORT_POLICY.NOT_APPLICABLE,
             'thumbnail_bg_color': base_models.EXPORT_POLICY.NOT_APPLICABLE,
@@ -142,7 +142,7 @@ class ClassroomModel(base_models.BaseModel):
         cls, classroom_id: str, name: str, url_fragment: str,
         course_details: str, teaser_text: str, topic_list_intro: str,
         topic_id_to_prerequisite_topic_ids: Dict[str, List[str]],
-        is_published: bool, is_diagnostic_test_enabled: bool,
+        is_published: bool, diagnostic_test_is_enabled: bool,
         thumbnail_filename: str, thumbnail_bg_color: str,
         thumbnail_size_in_bytes: int, banner_filename: str,
         banner_bg_color: str, banner_size_in_bytes: int, index: int
@@ -161,7 +161,7 @@ class ClassroomModel(base_models.BaseModel):
             topic_id_to_prerequisite_topic_ids: dict(str, list(str)). A dict
                 with topic ID as key and list of topic IDs as value.
             is_published: bool. Whether this classroom is published or not.
-            is_diagnostic_test_enabled: bool. Whether diagnostic test 
+            diagnostic_test_is_enabled: bool. Whether diagnostic test 
                 is enabled.
             thumbnail_filename: str. Classroom's thumbnail filename.
             thumbnail_bg_color: str. Classroom's thumbnail background color.
@@ -191,7 +191,7 @@ class ClassroomModel(base_models.BaseModel):
             topic_id_to_prerequisite_topic_ids=(
                 topic_id_to_prerequisite_topic_ids),
             is_published=is_published,
-            is_diagnostic_test_enabled=is_diagnostic_test_enabled,
+            diagnostic_test_is_enabled=diagnostic_test_is_enabled,
             thumbnail_filename=thumbnail_filename,
             thumbnail_bg_color=thumbnail_bg_color,
             thumbnail_size_in_bytes=thumbnail_size_in_bytes,

--- a/core/storage/classroom/gae_models_test.py
+++ b/core/storage/classroom/gae_models_test.py
@@ -106,7 +106,7 @@ class ClassroomModelUnitTest(test_utils.GenericTestBase):
                 'topic_id_to_prerequisite_topic_ids': (
                     base_models.EXPORT_POLICY.NOT_APPLICABLE),
                 'is_published': base_models.EXPORT_POLICY.NOT_APPLICABLE,
-                'is_diagnostic_test_enabled': (
+                'diagnostic_test_is_enabled': (
                     base_models.EXPORT_POLICY.NOT_APPLICABLE),
                 'thumbnail_filename': (
                     base_models.EXPORT_POLICY.NOT_APPLICABLE),

--- a/core/templates/domain/classroom/classroom-backend-api.service.spec.ts
+++ b/core/templates/domain/classroom/classroom-backend-api.service.spec.ts
@@ -87,7 +87,7 @@ describe('Classroom backend API service', function () {
     course_details: 'Course Details',
     topic_list_intro: 'Topics Covered',
     is_published: true,
-    is_diagnostic_test_enabled: false,
+    diagnostic_test_is_enabled: false,
     teaser_text: 'learn math',
     thumbnail_data: {
       filename: 'thumbnail.svg',
@@ -110,7 +110,7 @@ describe('Classroom backend API service', function () {
     topic_id_to_prerequisite_topic_ids: {},
     teaser_text: 'Teaser text of the classroom',
     is_published: true,
-    is_diagnostic_test_enabled: false,
+    diagnostic_test_is_enabled: false,
     thumbnail_data: {
       filename: 'thumbnail.svg',
       bg_color: 'transparent',
@@ -141,7 +141,7 @@ describe('Classroom backend API service', function () {
       responseDictionaries.topic_list_intro,
       responseDictionaries.teaser_text,
       responseDictionaries.is_published,
-      responseDictionaries.is_diagnostic_test_enabled,
+      responseDictionaries.diagnostic_test_is_enabled,
       responseDictionaries.thumbnail_data,
       responseDictionaries.banner_data,
       responseDictionaries.public_classrooms_count
@@ -324,7 +324,7 @@ describe('Classroom backend API service', function () {
       topic_list_intro: 'Start from the basics with our first topic.',
       topic_id_to_prerequisite_topic_ids: {},
       is_published: true,
-      is_diagnostic_test_enabled: false,
+      diagnostic_test_is_enabled: false,
       thumbnail_data: {
         filename: 'thumbnail.svg',
         bg_color: 'transparent',

--- a/core/templates/domain/classroom/classroom-backend-api.service.spec.ts
+++ b/core/templates/domain/classroom/classroom-backend-api.service.spec.ts
@@ -345,7 +345,7 @@ describe('Classroom backend API service', function () {
       topicListIntro: 'Start from the basics with our first topic.',
       topicIdToPrerequisiteTopicIds: {},
       isPublished: true,
-      isDiagnosticTestEnabled: false,
+      diagnosticTestIsEnabled: false,
       thumbnailData: {
         filename: 'thumbnail.svg',
         bg_color: 'transparent',

--- a/core/templates/domain/classroom/classroom-backend-api.service.ts
+++ b/core/templates/domain/classroom/classroom-backend-api.service.ts
@@ -34,7 +34,7 @@ export interface ClassroomDataBackendDict {
   teaser_text: string;
   topic_list_intro: string;
   is_published: boolean;
-  is_diagnostic_test_enabled: boolean;
+  diagnostic_test_is_enabled: boolean;
   thumbnail_data: ImageData;
   banner_data: ImageData;
   public_classrooms_count: number;
@@ -73,7 +73,7 @@ export interface ClassroomBackendDict {
     [topicId: string]: string[];
   };
   is_published: boolean;
-  is_diagnostic_test_enabled: boolean;
+  diagnostic_test_is_enabled: boolean;
   thumbnail_data: ImageData;
   banner_data: ImageData;
 }
@@ -173,7 +173,7 @@ export class ClassroomBackendApiService {
             response.topic_list_intro,
             response.teaser_text,
             response.is_published,
-            response.is_diagnostic_test_enabled,
+            response.diagnostic_test_is_enabled,
             response.thumbnail_data,
             response.banner_data,
             response.public_classrooms_count
@@ -246,7 +246,7 @@ export class ClassroomBackendApiService {
                   response.classroom_dict.topic_id_to_prerequisite_topic_ids,
                 isPublished: response.classroom_dict.is_published,
                 isDiagnosticTestEnabled:
-                  response.classroom_dict.is_diagnostic_test_enabled,
+                  response.classroom_dict.diagnostic_test_is_enabled,
                 thumbnailData: response.classroom_dict.thumbnail_data,
                 bannerData: response.classroom_dict.banner_data,
               },
@@ -284,8 +284,8 @@ export class ClassroomBackendApiService {
               classroomDict.topic_id_to_prerequisite_topic_ids,
             teaser_text: classroomDict.teaser_text,
             is_published: classroomDict.is_published,
-            is_diagnostic_test_enabled:
-              classroomDict.is_diagnostic_test_enabled,
+            diagnostic_test_is_enabled:
+              classroomDict.diagnostic_test_is_enabled,
             thumbnail_data: {
               filename: classroomDict.thumbnail_data.filename,
               bg_color: classroomDict.thumbnail_data.bg_color,

--- a/core/templates/domain/classroom/classroom-backend-api.service.ts
+++ b/core/templates/domain/classroom/classroom-backend-api.service.ts
@@ -89,7 +89,7 @@ export interface ClassroomDict {
     [topicId: string]: string[];
   };
   isPublished: boolean;
-  isDiagnosticTestEnabled: boolean;
+  diagnosticTestIsEnabled: boolean;
   thumbnailData: ImageData;
   bannerData: ImageData;
 }
@@ -245,7 +245,7 @@ export class ClassroomBackendApiService {
                 topicIdToPrerequisiteTopicIds:
                   response.classroom_dict.topic_id_to_prerequisite_topic_ids,
                 isPublished: response.classroom_dict.is_published,
-                isDiagnosticTestEnabled:
+                diagnosticTestIsEnabled:
                   response.classroom_dict.diagnostic_test_is_enabled,
                 thumbnailData: response.classroom_dict.thumbnail_data,
                 bannerData: response.classroom_dict.banner_data,

--- a/core/templates/domain/classroom/classroom-data.model.spec.ts
+++ b/core/templates/domain/classroom/classroom-data.model.spec.ts
@@ -79,7 +79,7 @@ describe('Classroom data model', () => {
     );
     expect(classroomData.getTeaserText()).toEqual('Learn math');
     expect(classroomData.getIsPublished()).toBeTrue();
-    expect(classroomData.getIsDiagnosticTestEnabled()).toBeFalse();
+    expect(classroomData.getDiagnosticTestIsEnabled()).toBeFalse();
     expect(classroomData.getThumbnailData().filename).toEqual('thumbnail.svg');
     expect(classroomData.getThumbnailData().size_in_bytes).toEqual(100);
     expect(classroomData.getThumbnailData().bg_color).toEqual('transparent');

--- a/core/templates/domain/classroom/classroom-data.model.ts
+++ b/core/templates/domain/classroom/classroom-data.model.ts
@@ -31,7 +31,7 @@ export class ClassroomData {
   _topicListIntro: string;
   _teaserText: string;
   _isPublished: boolean;
-  _isDiagnosticTestEnabled: boolean;
+  _diagnosticTestIsEnabled: boolean;
   _thumbnailData: ImageData;
   _bannerData: ImageData;
   _publicClassroomsCount: number;
@@ -45,7 +45,7 @@ export class ClassroomData {
     topicListIntro: string,
     teaserText: string,
     isPublished: boolean,
-    isDiagnosticTestEnabled: boolean,
+    diagnosticTestIsEnabled: boolean,
     thumbnailData: ImageData,
     bannerData: ImageData,
     publicClassroomsCount: number
@@ -58,7 +58,7 @@ export class ClassroomData {
     this._topicListIntro = topicListIntro;
     this._teaserText = teaserText;
     this._isPublished = isPublished;
-    this._isDiagnosticTestEnabled = isDiagnosticTestEnabled;
+    this._diagnosticTestIsEnabled = diagnosticTestIsEnabled;
     this._thumbnailData = thumbnailData;
     this._bannerData = bannerData;
     this._publicClassroomsCount = publicClassroomsCount;
@@ -73,7 +73,7 @@ export class ClassroomData {
     topicListIntro: string,
     teaserText: string,
     isPublished: boolean,
-    isDiagnosticTestEnabled: boolean,
+    diagnosticTestIsEnabled: boolean,
     thumbnailData: ImageData,
     bannerData: ImageData,
     publicClassroomsCount: number
@@ -90,7 +90,7 @@ export class ClassroomData {
       topicListIntro,
       teaserText,
       isPublished,
-      isDiagnosticTestEnabled,
+      diagnosticTestIsEnabled,
       thumbnailData,
       bannerData,
       publicClassroomsCount
@@ -133,8 +133,8 @@ export class ClassroomData {
     return this._isPublished;
   }
 
-  getIsDiagnosticTestEnabled(): boolean {
-    return this._isDiagnosticTestEnabled;
+  getDiagnosticTestIsEnabled(): boolean {
+    return this._diagnosticTestIsEnabled;
   }
 
   getPublicClassroomsCount(): number {

--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.html
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.html
@@ -173,13 +173,13 @@
             </span>
             <div>
               <span *ngIf="classroomViewerMode">
-                {{ tempClassroomData.getIsDiagnosticTestEnabled() ? 'Enabled' : 'Disabled' }}
+                {{ tempClassroomData.getDiagnosticTestIsEnabled() ? 'Enabled' : 'Disabled' }}
               </span>
               <div class="oppia-on-off-switch" *ngIf="!classroomViewerMode">
-                <input *ngIf="tempClassroomData.getIsDiagnosticTestEnabled()" type="checkbox" class="sr-only" aria-label="Toggle diagnostic test status" checked (click)="toggleDiagnosticTestStatus()">
-                <input span *ngIf="tempClassroomData.getIsDiagnosticTestEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox" id="diagnostic-switch" checked (click)="toggleDiagnosticTestStatus()">
-                <input *ngIf="!tempClassroomData.getIsDiagnosticTestEnabled()" type="checkbox" class="sr-only" (click)="toggleDiagnosticTestStatus()" aria-label="Toggle diagnostic test status">
-                <input span *ngIf="!tempClassroomData.getIsDiagnosticTestEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox" id="diagnostic-switch" (click)="toggleDiagnosticTestStatus()">
+                <input *ngIf="tempClassroomData.getDiagnosticTestIsEnabled()" type="checkbox" class="sr-only" aria-label="Toggle diagnostic test status" checked (click)="toggleDiagnosticTestStatus()">
+                <input span *ngIf="tempClassroomData.getDiagnosticTestIsEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox" id="diagnostic-switch" checked (click)="toggleDiagnosticTestStatus()">
+                <input *ngIf="!tempClassroomData.getDiagnosticTestIsEnabled()" type="checkbox" class="sr-only" (click)="toggleDiagnosticTestStatus()" aria-label="Toggle diagnostic test status">
+                <input span *ngIf="!tempClassroomData.getDiagnosticTestIsEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox" id="diagnostic-switch" (click)="toggleDiagnosticTestStatus()">
                 <label class="oppia-on-off-switch-label e2e-test-toggle-diagnostic-test-status-btn" for="diagnostic-switch">
                   <span class="oppia-on-off-switch-inner"></span>
                   <span class="oppia-on-off-switch-main"></span>

--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.spec.ts
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.spec.ts
@@ -492,7 +492,7 @@ describe('Classroom Admin Page component ', () => {
       topic_list_intro: 'Start from the basics with our first topic.',
       topic_id_to_prerequisite_topic_ids: {},
       is_published: true,
-      is_diagnostic_test_enabled: false,
+      diagnostic_test_is_enabled: false,
       thumbnail_data: dummyThumbnailData,
       banner_data: dummyBannerData,
     };

--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.spec.ts
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.spec.ts
@@ -71,7 +71,7 @@ let dummyClassroomDict = {
   topicListIntro: 'Start from the basics with our first topic.',
   topicIdToPrerequisiteTopicIds: {},
   isPublished: true,
-  isDiagnosticTestEnabled: false,
+  diagnosticTestIsEnabled: false,
   thumbnailData: dummyThumbnailData,
   bannerData: dummyBannerData,
 };
@@ -505,7 +505,7 @@ describe('Classroom Admin Page component ', () => {
       topicListIntro: 'Start from the basics with our first topic.',
       topicIdToPrerequisiteTopicIds: {},
       isPublished: true,
-      isDiagnosticTestEnabled: false,
+      diagnosticTestIsEnabled: false,
       thumbnailData: dummyThumbnailData,
       bannerData: dummyBannerData,
     };
@@ -582,7 +582,7 @@ describe('Classroom Admin Page component ', () => {
         topicListIntro: 'Start from the basics with our first topic.',
         topicIdToPrerequisiteTopicIds: {},
         isPublished: true,
-        isDiagnosticTestEnabled: false,
+        diagnosticTestIsEnabled: false,
         thumbnailData: dummyThumbnailData,
         bannerData: dummyBannerData,
       });
@@ -878,7 +878,7 @@ describe('Classroom Admin Page component ', () => {
       topicListIntro: 'Start from the basics with our first topic.',
       topicIdToPrerequisiteTopicIds: {},
       isPublished: true,
-      isDiagnosticTestEnabled: false,
+      diagnosticTestIsEnabled: false,
       thumbnailData: dummyThumbnailData,
       bannerData: dummyBannerData,
     };
@@ -1431,12 +1431,12 @@ describe('Classroom Admin Page component ', () => {
     );
 
     expect(
-      component.tempClassroomData.getIsDiagnosticTestEnabled()
+      component.tempClassroomData.getDiagnosticTestIsEnabled()
     ).toBeFalse();
 
     component.toggleDiagnosticTestStatus();
 
-    expect(component.tempClassroomData.getIsDiagnosticTestEnabled()).toBeTrue();
+    expect(component.tempClassroomData.getDiagnosticTestIsEnabled()).toBeTrue();
     expect(component.classroomDataIsChanged).toBeTrue();
   });
 

--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
@@ -338,8 +338,8 @@ export class ClassroomAdminPageComponent implements OnInit {
       this.tempClassroomData.getIsPublished() !==
       this.classroomData.getIsPublished();
     const classroomDiagnosticTestStatusIsChanged =
-      this.tempClassroomData.getIsDiagnosticTestEnabled() !==
-      this.classroomData.getIsDiagnosticTestEnabled();
+      this.tempClassroomData.getDiagnosticTestIsEnabled() !==
+      this.classroomData.getDiagnosticTestIsEnabled();
 
     this.classroomAdminDataService.validateClassroom(
       this.tempClassroomData,
@@ -386,7 +386,7 @@ export class ClassroomAdminPageComponent implements OnInit {
       topic_id_to_prerequisite_topic_ids:
         classroomDict.topicIdToPrerequisiteTopicIds,
       is_published: classroomDict.isPublished,
-      diagnostic_test_is_enabled: classroomDict.isDiagnosticTestEnabled,
+      diagnostic_test_is_enabled: classroomDict.diagnosticTestIsEnabled,
       thumbnail_data: classroomDict.thumbnailData,
       banner_data: classroomDict.bannerData,
     };
@@ -836,8 +836,8 @@ export class ClassroomAdminPageComponent implements OnInit {
   }
 
   toggleDiagnosticTestStatus(): void {
-    this.tempClassroomData.setIsDiagnosticTestEnabled(
-      !this.tempClassroomData.getIsDiagnosticTestEnabled()
+    this.tempClassroomData.setdiagnosticTestIsEnabled(
+      !this.tempClassroomData.getDiagnosticTestIsEnabled()
     );
     this.updateClassroomField();
   }

--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
@@ -386,7 +386,7 @@ export class ClassroomAdminPageComponent implements OnInit {
       topic_id_to_prerequisite_topic_ids:
         classroomDict.topicIdToPrerequisiteTopicIds,
       is_published: classroomDict.isPublished,
-      is_diagnostic_test_enabled: classroomDict.isDiagnosticTestEnabled,
+      diagnostic_test_is_enabled: classroomDict.isDiagnosticTestEnabled,
       thumbnail_data: classroomDict.thumbnailData,
       banner_data: classroomDict.bannerData,
     };

--- a/core/templates/pages/classroom-admin-page/existing-classroom.model.spec.ts
+++ b/core/templates/pages/classroom-admin-page/existing-classroom.model.spec.ts
@@ -109,7 +109,7 @@ describe('Classroom admin model', () => {
         topic2: ['topic1'],
       },
       isPublished: true,
-      isDiagnosticTestEnabled: false,
+      diagnosticTestIsEnabled: false,
       thumbnailData: dummyThumbnailData,
       bannerData: dummyBannerData,
     };
@@ -130,9 +130,9 @@ describe('Classroom admin model', () => {
     expect(classroom.getIsPublished()).toBeTrue();
     classroom.setIsPublished(false);
     expect(classroom.getIsPublished()).toBeFalse();
-    expect(classroom.getIsDiagnosticTestEnabled()).toBeFalse();
-    classroom.setIsDiagnosticTestEnabled(true);
-    expect(classroom.getIsDiagnosticTestEnabled()).toBeTrue();
+    expect(classroom.getDiagnosticTestIsEnabled()).toBeFalse();
+    classroom.setdiagnosticTestIsEnabled(true);
+    expect(classroom.getDiagnosticTestIsEnabled()).toBeTrue();
   });
 
   it('should be able to get classroom dict from object', () => {
@@ -145,7 +145,7 @@ describe('Classroom admin model', () => {
       topicListIntro: 'Start from the basics with our first topic.',
       topicIdToPrerequisiteTopicIds: {},
       isPublished: true,
-      isDiagnosticTestEnabled: false,
+      diagnosticTestIsEnabled: false,
       thumbnailData: dummyThumbnailData,
       bannerData: dummyBannerData,
     };

--- a/core/templates/pages/classroom-admin-page/existing-classroom.model.ts
+++ b/core/templates/pages/classroom-admin-page/existing-classroom.model.ts
@@ -67,7 +67,7 @@ export class ExistingClassroomData
   _topicsCountInClassroom: number;
   _topicIdToTopicName!: TopicIdToTopicName;
   _isPublished: boolean;
-  _isDiagnosticTestEnabled: boolean;
+  _diagnosticTestIsEnabled: boolean;
   _thumbnail_data: ImageData;
   _banner_data: ImageData;
 
@@ -80,7 +80,7 @@ export class ExistingClassroomData
     topicListIntro: string,
     topicIdToPrerequisiteTopicIds: TopicIdToPrerequisiteTopicIds,
     isPublished: boolean,
-    isDiagnosticTestEnabled: boolean,
+    diagnosticTestIsEnabled: boolean,
     thumbnailData: ImageData,
     bannerData: ImageData
   ) {
@@ -94,7 +94,7 @@ export class ExistingClassroomData
       this._topicIdToPrerequisiteTopicIds
     ).length;
     this._isPublished = isPublished;
-    this._isDiagnosticTestEnabled = isDiagnosticTestEnabled;
+    this._diagnosticTestIsEnabled = diagnosticTestIsEnabled;
     this._thumbnail_data = thumbnailData;
     this._banner_data = bannerData;
   }
@@ -119,8 +119,8 @@ export class ExistingClassroomData
     return this._banner_data;
   }
 
-  getIsDiagnosticTestEnabled(): boolean {
-    return this._isDiagnosticTestEnabled;
+  getDiagnosticTestIsEnabled(): boolean {
+    return this._diagnosticTestIsEnabled;
   }
 
   getTopicIdToPrerequisiteTopicId(): TopicIdToPrerequisiteTopicIds {
@@ -139,8 +139,8 @@ export class ExistingClassroomData
     this._isPublished = isPublished;
   }
 
-  setIsDiagnosticTestEnabled(isDiagnosticTestEnabled: boolean): void {
-    this._isDiagnosticTestEnabled = isDiagnosticTestEnabled;
+  setdiagnosticTestIsEnabled(diagnosticTestIsEnabled: boolean): void {
+    this._diagnosticTestIsEnabled = diagnosticTestIsEnabled;
   }
 
   setTeaserText(teaserText: string): void {
@@ -177,7 +177,7 @@ export class ExistingClassroomData
       classroomDict.topicListIntro,
       classroomDict.topicIdToPrerequisiteTopicIds,
       classroomDict.isPublished,
-      classroomDict.isDiagnosticTestEnabled,
+      classroomDict.diagnosticTestIsEnabled,
       classroomDict.thumbnailData,
       classroomDict.bannerData
     );
@@ -193,7 +193,7 @@ export class ExistingClassroomData
       topicListIntro: this._topicListIntro,
       topicIdToPrerequisiteTopicIds: this._topicIdToPrerequisiteTopicIds,
       isPublished: this._isPublished,
-      isDiagnosticTestEnabled: this._isDiagnosticTestEnabled,
+      diagnosticTestIsEnabled: this._diagnosticTestIsEnabled,
       thumbnailData: this._thumbnail_data,
       bannerData: this._banner_data,
     };

--- a/core/templates/pages/classroom-page/classroom-page.component.html
+++ b/core/templates/pages/classroom-page/classroom-page.component.html
@@ -45,7 +45,7 @@
         <p class="classroom-content-text" *ngIf="!isHackyClassroomTranslationDisplayed('topicListIntro')">{{classroomData.getTopicListIntro()}}</p>
         <p class="classroom-content-text" *ngIf="isHackyClassroomTranslationDisplayed('topicListIntro')">{{ classroomTranslationKeys.topicListIntro | translate }}</p>
       </div>
-      <div *ngIf="isDiagnosticTestFeatureFlagEnabled() && isDiagnosticTestEnabled()" class="content-section diagnostic-test-container">
+      <div *ngIf="isDiagnosticTestFeatureFlagEnabled() && diagnosticTestIsEnabled()" class="content-section diagnostic-test-container">
         <div class="diagnostic-test-box">
           <div class="diagnostic-test-info">
             <h4>{{ 'I18N_CLASSROOM_PAGE_NEW_TO_MATH_HEADING' | translate }}</h4>

--- a/core/templates/pages/classroom-page/classroom-page.component.spec.ts
+++ b/core/templates/pages/classroom-page/classroom-page.component.spec.ts
@@ -374,7 +374,7 @@ describe('Classroom Page Component', () => {
       1
     );
     component.classroomData = classroomData;
-    expect(component.isDiagnosticTestEnabled()).toBeFalse();
+    expect(component.diagnosticTestIsEnabled()).toBeFalse();
   });
 
   it('should show private classroom banner to curriculum admins', fakeAsync(() => {

--- a/core/templates/pages/classroom-page/classroom-page.component.ts
+++ b/core/templates/pages/classroom-page/classroom-page.component.ts
@@ -253,7 +253,7 @@ export class ClassroomPageComponent implements OnDestroy {
     return this.platformFeatureService.status.DiagnosticTest.isEnabled;
   }
 
-  isDiagnosticTestEnabled(): boolean {
-    return this.classroomData.getIsDiagnosticTestEnabled();
+  diagnosticTestIsEnabled(): boolean {
+    return this.classroomData.getDiagnosticTestIsEnabled();
   }
 }

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -4189,7 +4189,7 @@ version: 1
         topic_id_to_prerequisite_topic_ids: Optional[
             Dict[str, List[str]]] = None,
         is_published: bool = True,
-        is_diagnostic_test_enabled: bool = False,
+        diagnostic_test_is_enabled: bool = False,
         thumbnail_data: Optional[
             classroom_config_domain.ImageData
         ] = None,
@@ -4211,7 +4211,7 @@ version: 1
             topic_id_to_prerequisite_topic_ids: Dict[str, List[str]]. A dict
                 with topic ID as key and list of topic IDs as value.
             is_published: bool. Whether this classroom is published or not.
-            is_diagnostic_test_enabled: bool. Whether this classroom
+            diagnostic_test_is_enabled: bool. Whether this classroom
                 is published or not.
             thumbnail_data: Optional[ImageData]. Image data object for
                 thumbnail.
@@ -4239,8 +4239,8 @@ version: 1
                 else {}
             ),
             is_published=is_published,
-            is_diagnostic_test_enabled=(
-                is_diagnostic_test_enabled),
+            diagnostic_test_is_enabled=(
+                diagnostic_test_is_enabled),
             thumbnail_data=(
                 thumbnail_data
                 if thumbnail_data is not None


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR does the following: 
    - Updates the ``is_diagnostic_test_enabled`` to ``diagnostic_test_is_enabled``
    
2. (For bug-fixing PRs only) The original bug occurred because: IThis PR (https://github.com/oppia/oppia/pull/21823) corrects a field name that incorrectly started with a verb, violating our naming conventions. This change is being implemented because currently, no instance of this field exists in the database, as it was introduced in this [PR](https://github.com/oppia/oppia/pull/21823).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
