### PR TITLE
Fix #22061: Can Upload Media in Skill Editor

### DIFF
--- a/core/templates/pages/skill-editor-page/skill-editor-page.module.ts
+++ b/core/templates/pages/skill-editor-page/skill-editor-page.module.ts
@@ -45,6 +45,7 @@ import {toastrConfig} from 'pages/lightweight-oppia-root/app.module';
 import {SkillEditorAccessGuard} from './skill-editor-access.guard';
 import {SkillEditorPageRootComponent} from './skill-editor-page-root.component';
 import {SkillEditorStalenessDetectionService} from './services/skill-editor-staleness-detection.service';
+import {RteHelperService} from 'services/rte-helper.service';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -104,6 +105,6 @@ import {SkillEditorStalenessDetectionService} from './services/skill-editor-stal
     SkillEditorMainTabComponent,
     SkillEditorPageComponent,
   ],
-  providers: [SkillEditorStalenessDetectionService],
+  providers: [SkillEditorStalenessDetectionService, RteHelperService],
 })
 export class SkillEditorPageModule {}


### PR DESCRIPTION
## Overview



1. This PR fixes #22061 .
2. This PR does the following: Fixes an issue where images could not be inserted in the Skill Editor due to a missing service provider.
3. (For bug-fixing PRs only) The original bug occurred because: The RteHelperService was not included in the providers array of skill-editor-page.module.ts.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
https://github.com/user-attachments/assets/61d73d2a-cfe8-4aea-8cf9-92a4362ddf41

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->






## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
