### PR TITLE
Fix #22085: Resolved Media Upload  while Creating a New Skill

### DIFF
--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
@@ -40,6 +40,7 @@ import {TopicsAndSkillsDashboardPageRootComponent} from './topics-and-skills-das
 import {TopicsAndSkillsDashboardAuthGuard} from './topics-and-skills-dashboard-auth.guard';
 import {TopicCreationService} from 'components/entity-creation-services/topic-creation.service';
 import {CreateNewSkillModalService} from 'pages/topic-editor-page/services/create-new-skill-modal.service';
+import {RteHelperService} from 'services/rte-helper.service';
 
 @NgModule({
   imports: [
@@ -84,6 +85,10 @@ import {CreateNewSkillModalService} from 'pages/topic-editor-page/services/creat
     TopicsAndSkillsDashboardPageComponent,
     CreateNewTopicModalComponent,
   ],
-  providers: [TopicCreationService, CreateNewSkillModalService],
+  providers: [
+    TopicCreationService,
+    CreateNewSkillModalService,
+    RteHelperService,
+  ],
 })
 export class TopicsAndSkillsDashboardPageModule {}


### PR DESCRIPTION
## Overview

1. This PR fixes #22085.
2. This PR does the following: Fixes an issue where images could not be inserted while creating skill due to a missing service provider.
3. (For bug-fixing PRs only) The original bug occurred because: The RteHelperService was not included in the providers array of topics-and-skills-dashboard-page.module.ts

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network


https://github.com/user-attachments/assets/cfc50977-9593-4424-ad38-cdfddcedafd1



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


