### PR TITLE
Add missing translations for exploration editor

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1891,5 +1891,9 @@
     "I18N_WARNING_MODAL_DESCRIPTION": "This will show the full solution. Are you sure?",
     "I18N_WARNING_MODAL_TITLE": "Warning!",
     "I18N_WORKED_EXAMPLE": "Worked Example",
-    "I18N_YES": "Yes"
-}
+    "I18N_YES": "Yes",
+    "I18N_EXPLORATION_EDITOR_SAVE_CHANGES": "Save Changes",
+    "I18N_EXPLORATION_EDITOR_CANCEL_BUTTON": "Cancel",
+    "I18N_EXPLORATION_EDITOR_PUBLISH_BUTTON": "Publish"
+  }
+     


### PR DESCRIPTION
This PR adds missing translations for some text in the exploration editor,
 as mentioned in issue #19000.

