### PR TITLE
Fix #22088-22091, part of #18384: Fixed QA bugs for learner dashboard redesign 

### DIFF
--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -116,11 +116,11 @@
   }
 
   .lesson-card-desc {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     display: -webkit-box;
     font-size: 11px;
     overflow: hidden;
     text-overflow: ellipsis;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
   }
 </style>

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -116,11 +116,11 @@
   }
 
   .lesson-card-desc {
-    display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    display: -webkit-box;
     font-size: 11px;
     overflow: hidden;
+    -webkit-line-clamp: 2;
     text-overflow: ellipsis;
   }
 </style>

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -116,7 +116,11 @@
   }
 
   .lesson-card-desc {
+    display: -webkit-box;
     font-size: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
   }
 </style>

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -116,9 +116,9 @@
   }
 
   .lesson-card-desc {
+    display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
-    display: -webkit-box;
     font-size: 11px;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -109,7 +109,7 @@
   .lesson-card-title-container {
     height: 50px;
   }
-
+s
   .lesson-card-topic {
     font-size: 12px;
     font-weight: 600;
@@ -119,8 +119,8 @@
     -webkit-box-orient: vertical;
     display: -webkit-box;
     font-size: 11px;
-    overflow: hidden;
     -webkit-line-clamp: 2;
+    overflow: hidden;
     text-overflow: ellipsis;
   }
 </style>

--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -109,7 +109,7 @@
   .lesson-card-title-container {
     height: 50px;
   }
-s
+
   .lesson-card-topic {
     font-size: 12px;
     font-weight: 600;

--- a/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
+++ b/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
@@ -37,9 +37,9 @@
   }
 
   .oppia-learner-dash-goals-checkbox-text {
+    display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
-    display: -webkit-box;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: normal;

--- a/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
+++ b/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
@@ -37,8 +37,8 @@
   }
 
   .oppia-learner-dash-goals-checkbox-text {
-    display: -webkit-box;
     -webkit-box-orient: vertical;
+    display: -webkit-box;
     -webkit-line-clamp: 2;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
+++ b/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
@@ -10,7 +10,7 @@
                     (change)="onChange(topic.key)"
                     [checked]="checkedTopics.has(topic.key) || completedTopics.has(topic.key)"
                     [disabled]="checkedTopics.size === 5 && !checkedTopics.has(topic.key) || completedTopics.has(topic.key)">
-                   <span class="oppia-learner-dash-goals-checkbox-text"> {{ topic.value }} </span> 
+        <span class="oppia-learner-dash-goals-checkbox-text"> {{ topic.value }} </span>
       </mat-checkbox>
     </ng-container>
   </div>
@@ -37,11 +37,11 @@
   }
 
   .oppia-learner-dash-goals-checkbox-text {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     display: -webkit-box;
     overflow: hidden;
     text-overflow: ellipsis;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
     white-space: normal;
     word-break: break-all;
   }

--- a/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
+++ b/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
@@ -9,8 +9,8 @@
                     class="oppia-learner-dash-goals-checkbox"
                     (change)="onChange(topic.key)"
                     [checked]="checkedTopics.has(topic.key) || completedTopics.has(topic.key)"
-                    [disabled]="checkedTopics.length === 5 && !checkedTopics.has(topic.key) || completedTopics.has(topic.key)">
-                    {{ topic.value }}
+                    [disabled]="checkedTopics.size === 5 && !checkedTopics.has(topic.key) || completedTopics.has(topic.key)">
+                   <span class="oppia-learner-dash-goals-checkbox-text"> {{ topic.value }} </span> 
       </mat-checkbox>
     </ng-container>
   </div>
@@ -33,6 +33,17 @@
   .oppia-learner-dash-goals-checkbox {
     font-size: 16px;
     gap: 0 12px;
+    overflow: hidden;
+  }
+
+  .oppia-learner-dash-goals-checkbox-text {
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    white-space: normal;
+    word-break: break-all;
   }
 
   .oppia-learner-dash-goals-modal-content {

--- a/core/templates/pages/learner-dashboard-page/home-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.html
@@ -105,7 +105,7 @@
           </ng-container>
         </oppia-card-display>
         <!--TODO(#18384): Styling: https://shorturl.at/oAUY5 (links to Figma frame) -->
-        <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION'" [numCards]="storySummariesWithAvailableNodes.size" [displayMaxWidth]="'fit-content'">
+        <oppia-card-display *ngIf="storySummariesWithAvailableNodes.size !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_HOME_RECOMMEND_SECTION'" [numCards]="storySummariesWithAvailableNodes.size" [displayMaxWidth]="'fit-content'">
           <ng-container *ngFor="let topicSummaryTile of continueWhereYouLeftOffList">
             <ng-container *ngFor="let storySummaryTile of topicSummaryTile.canonicalStorySummaryDicts">
               <lesson-card *ngIf="storySummariesWithAvailableNodes.has(storySummaryTile.getId())" [story]="storySummaryTile" [topic]="topicSummaryTile.name" [isGoal]="currentGoalIds.has(topicSummaryTile.id)" [isRecommendation]="true"> </lesson-card>

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -294,7 +294,7 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
       responseData => {
         this.completedExplorationsList = responseData.completedExplorationsList;
         this.incompleteExplorationsList =
-          responseData.incompleteExplorationsList;
+          responseData.incompleteExplorationsList || [];
         this.subscriptionsList = responseData.subscriptionList;
         this.explorationPlaylist = responseData.explorationPlaylist;
       },


### PR DESCRIPTION
## Overview

This PR fixes #22088, #22089, #22090, #22091, which are all associated with #18384. 

- 88  - Added overflow: hidden and line-clamped at 2. 
- 89 - Expected behavior. I corrected an edge case where an empty recommended section was displayed when a classroom only had one lesson. 
- 90 - Accidentally wrote .length instead of .size for set. .length returns undefined which is always false. 
- 91 - Added overflow: hidden and line-clamped at 2. The library checkbox is stylized to automatically centered with text.

EDIT (March 24): Handled edge case when incompleteExplorationsList returned data is undefined, causing .length error.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)



## Proof that changes are correct

### 22088, 22089 (overflow card text and edge case with one classroom lesson left) 

<img width="750" alt="Screenshot 2025-03-11 at 4 48 08 PM" src="https://github.com/user-attachments/assets/ae35df33-69a2-4af9-b29a-b7611d58bf7d" />


### 22090 & 22091 (overflow text and selecting 5 goals) 

https://github.com/user-attachments/assets/6cdcfa97-95f1-405d-a11c-290b7ddbd6be


https://github.com/user-attachments/assets/d9512fd0-aba1-4804-a941-3746767397fb



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
