### PR TITLE
Fix part of #21970: Implemented validate() function for TranslationCoordinatorsModel

### DIFF
--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -3677,3 +3677,22 @@ class TranslationCoordinatorsModel(base_models.BaseModel):
             coordinator.
         """
         return cls.query(cls.coordinator_ids == user_id).fetch()
+    
+    def validate(self) -> None:
+        """ Validates TranslationCoordinatorsModel"""
+
+        for curr_id in self.coordinator_ids:
+            if not isinstance(curr_id, str):
+                raise utils.ValidationError(
+                    'All translation coordinators expected to be strings but invalid instance exists: %s' % curr_id
+                )
+
+        if not isinstance(self.coordinators_count, int):
+            raise utils.ValidationError('Translation coordinator count is expected to be an integer.')
+        else:
+            total_coordinator_ids = len(self.coordinator_ids)
+            if self.coordinators_count != self.coordinators_count:
+                raise utils.ValidationError(
+                    'Coordinator count does not match length of coordinator_ids. '
+                    'Expected coordinator count: %d   Actual: %d' % (self.coordinators_count, total_coordinator_ids)
+                )


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21970.
2. This PR does the following: This PR implements a validate() function for TranslationCoordinatorsModel by ensuring that coordinators_id and coordinators_count have correct properties.
3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
