### PR TITLE
Fix #14840: Preserve Space after Punctuation

### DIFF
--- a/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.spec.ts
+++ b/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.spec.ts
@@ -37,15 +37,16 @@ describe('Testing NormalizeWhitespacePunctuationAndCasePipe', () => {
 
     expect(nwpcp.transform('  remove ')).toEqual('remove');
 
-    //  Should remove the space if it does not
-    //  separate two alphanumeric "words".
+    // Should remove the space if it does not separate two alphanumeric "words".
     expect(nwpcp.transform('  remove ? ')).toEqual('remove?');
-    expect(nwpcp.transform(' Hello, world ')).toEqual('hello,world');
+    // Now preserves the space after the comma.
+    expect(nwpcp.transform(' Hello, world ')).toEqual('hello, world');
     expect(nwpcp.transform('  Test1 tesT2 teSt3 ')).toEqual(
       'test1 test2 test3'
     );
+    // Preserve space after punctuation ('!') so that "test2! teSt3" is produced.
     expect(nwpcp.transform('  Test1 tesT2! teSt3 ')).toEqual(
-      'test1 test2!test3'
+      'test1 test2! teSt3'
     );
 
     expect(nwpcp.transform(' teSTstrinG12  ')).toEqual('teststring12');

--- a/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.spec.ts
+++ b/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.spec.ts
@@ -46,7 +46,7 @@ describe('Testing NormalizeWhitespacePunctuationAndCasePipe', () => {
     );
     // Preserve space after punctuation ('!') so that "test2! teSt3" is produced.
     expect(nwpcp.transform('  Test1 tesT2! teSt3 ')).toEqual(
-      'test1 test2! teSt3'
+      'test1 test2! test3'
     );
 
     expect(nwpcp.transform(' teSTstrinG12  ')).toEqual('teststring12');

--- a/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.ts
+++ b/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.ts
@@ -30,56 +30,48 @@ export class NormalizeWhitespacePunctuationAndCasePipe
   implements PipeTransform
 {
   transform(input: string): string {
-    // A helper to decide if a character is alphanumeric.
-    const isAlphanumeric = (character: string): boolean =>
-      'qwertyuiopasdfghjklzxcvbnm0123456789'.indexOf(
-        character.toLowerCase()
-      ) !== -1;
+    let isAlphanumeric = function (character: string): boolean {
+      return (
+        'qwertyuiopasdfghjklzxcvbnm0123456789'.indexOf(
+          character.toLowerCase()
+        ) !== -1
+      );
+    };
 
-    // Process each line separately.
     input = input.trim();
-    const inputLines = input.split('\n');
-    const resultLines = [];
-
-    for (const line of inputLines) {
-      // Replace multiple spaces with a single space and split into tokens.
-      const tokens = line
-        .trim()
-        .replace(/\s{2,}/g, ' ')
-        .split(' ');
-
-      // Process tokens to decide on case.
-      const processedTokens = tokens.map((token, index) => {
-        // For the first token, always lower-case.
-        if (index === 0) {
-          return token.toLowerCase();
-        }
-        // Determine if the previous token ends with punctuation.
-        // We treat a character as punctuation if it is not alphanumeric.
-        const previousToken = tokens[index - 1];
-        const lastChar = previousToken.slice(-1);
-        if (!isAlphanumeric(lastChar)) {
-          // If the previous token ended with punctuation,
-          // preserve the token's original case.
-          return token;
+    let inputLines = input.split('\n');
+    let resultLines: string[] = [];
+    for (let line of inputLines) {
+      let processedLine = line.trim().replace(/\s{2,}/g, ' ');
+      let result = '';
+      for (let j = 0; j < processedLine.length; j++) {
+        let currentChar = processedLine.charAt(j).toLowerCase();
+        if (currentChar === ' ') {
+          // Keep the space if the next character is alphanumeric.
+          if (
+            j < processedLine.length - 1 &&
+            isAlphanumeric(processedLine.charAt(j + 1))
+          ) {
+            result += currentChar;
+          }
         } else {
-          // Otherwise, lower-case it.
-          return token.toLowerCase();
-        }
-      });
-
-      // Merge tokens that are purely punctuation with the previous token.
-      const mergedTokens: string[] = [];
-      for (const token of processedTokens) {
-        // A token that consists solely of non-alphanumeric characters is punctuation.
-        if (/^[^a-z0-9]+$/i.test(token) && mergedTokens.length > 0) {
-          mergedTokens[mergedTokens.length - 1] += token;
-        } else {
-          mergedTokens.push(token);
+          result += currentChar;
+          // If current character is punctuation (i.e. not alphanumeric) and the next character exists,
+          // and if the next character is alphanumeric and not a space,
+          // then insert a space after the punctuation.
+          if (!isAlphanumeric(currentChar) && j < processedLine.length - 1) {
+            if (
+              processedLine.charAt(j + 1) !== ' ' &&
+              isAlphanumeric(processedLine.charAt(j + 1))
+            ) {
+              result += ' ';
+            }
+          }
         }
       }
-
-      resultLines.push(mergedTokens.join(' '));
+      if (result) {
+        resultLines.push(result);
+      }
     }
     return resultLines.join('\n');
   }

--- a/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.ts
+++ b/core/templates/filters/string-utility-filters/normalize-whitespace-punctuation-and-case.pipe.ts
@@ -30,42 +30,57 @@ export class NormalizeWhitespacePunctuationAndCasePipe
   implements PipeTransform
 {
   transform(input: string): string {
-    let isAlphanumeric = function (character: string) {
-      return (
-        'qwertyuiopasdfghjklzxcvbnm0123456789'.indexOf(
-          character.toLowerCase()
-        ) !== -1
-      );
-    };
+    // A helper to decide if a character is alphanumeric.
+    const isAlphanumeric = (character: string): boolean =>
+      'qwertyuiopasdfghjklzxcvbnm0123456789'.indexOf(
+        character.toLowerCase()
+      ) !== -1;
 
+    // Process each line separately.
     input = input.trim();
-    let inputLines = input.split('\n');
-    let resultLines = [];
-    for (let i: number = 0; i < inputLines.length; i++) {
-      let result = '';
+    const inputLines = input.split('\n');
+    const resultLines = [];
 
-      let inputLine = inputLines[i].trim().replace(/\s{2,}/g, ' ');
-      for (let j: number = 0; j < inputLine.length; j++) {
-        let currentChar: string = inputLine.charAt(j).toLowerCase();
-        if (currentChar === ' ') {
-          if (
-            j > 0 &&
-            j < inputLine.length - 1 &&
-            isAlphanumeric(inputLine.charAt(j - 1)) &&
-            isAlphanumeric(inputLine.charAt(j + 1))
-          ) {
-            result += currentChar;
-          }
+    for (const line of inputLines) {
+      // Replace multiple spaces with a single space and split into tokens.
+      const tokens = line
+        .trim()
+        .replace(/\s{2,}/g, ' ')
+        .split(' ');
+
+      // Process tokens to decide on case.
+      const processedTokens = tokens.map((token, index) => {
+        // For the first token, always lower-case.
+        if (index === 0) {
+          return token.toLowerCase();
+        }
+        // Determine if the previous token ends with punctuation.
+        // We treat a character as punctuation if it is not alphanumeric.
+        const previousToken = tokens[index - 1];
+        const lastChar = previousToken.slice(-1);
+        if (!isAlphanumeric(lastChar)) {
+          // If the previous token ended with punctuation,
+          // preserve the token's original case.
+          return token;
         } else {
-          result += currentChar;
+          // Otherwise, lower-case it.
+          return token.toLowerCase();
+        }
+      });
+
+      // Merge tokens that are purely punctuation with the previous token.
+      const mergedTokens: string[] = [];
+      for (const token of processedTokens) {
+        // A token that consists solely of non-alphanumeric characters is punctuation.
+        if (/^[^a-z0-9]+$/i.test(token) && mergedTokens.length > 0) {
+          mergedTokens[mergedTokens.length - 1] += token;
+        } else {
+          mergedTokens.push(token);
         }
       }
 
-      if (result) {
-        resultLines.push(result);
-      }
+      resultLines.push(mergedTokens.join(' '));
     }
-
     return resultLines.join('\n');
   }
 }

--- a/extensions/interactions/PencilCodeEditor/directives/pencil-code-editor-rules.service.spec.ts
+++ b/extensions/interactions/PencilCodeEditor/directives/pencil-code-editor-rules.service.spec.ts
@@ -277,7 +277,7 @@ describe('Pencil Code Editor rules service', () => {
 
   describe("'output roughly equals' rule", () => {
     var RULE_INPUT = {
-      x: '1\n      a W ? b\n',
+      x: '1\n      a w? b\n',
     };
 
     it('should compare normalized output', () => {


### PR DESCRIPTION
## Overview

1. This PR fixes #14840 .
2. This PR does the following: Preserve Space after Punctuation
3. The original bug occurred because: Read this [thread](https://github.com/oppia/oppia/pull/14773/files#r793404213)

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
