### PR TITLE
Introduce GitHub Discussions template for debugging docs

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
+++ b/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
@@ -1,0 +1,22 @@
+title: "{{Issue Description}} | {{your GitHub username}}"
+body:
+- type: input
+  attributes:
+    label: Link to debugging doc
+    description: "Please paste the Google Doc link to the debugging doc here."
+  validations:
+    required: true
+- type: checkboxes
+  id: sharing
+  attributes:
+    label: I confirm that I've given edit access to the doc to the dev mailing lists, as described in the instructions at the top of the doc.
+    options:
+        - label: "Yes"
+          required: true
+- type: checkboxes
+  id: sharing
+  attributes:
+    label: I confirm that I set the sharing options of the doc to "anyone with the link can comment".
+    options:
+        - label: "Yes"
+          required: true


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Adds a GitHub Discussions template for debugging docs, since this is going to be a standard process in the Oppia-Web dev workflow.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly). 

## Proof that changes are correct

No proof of changes needed because this is a discussion template change.