### PR TITLE
Fix: Normalize URL case to lowercase to prevent 404 errors.

### DIFF
--- a/core/templates/pages/oppia-root/routing/app.routing.module.ts
+++ b/core/templates/pages/oppia-root/routing/app.routing.module.ts
@@ -18,7 +18,7 @@
 
 import {APP_BASE_HREF} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {Route, RouterModule} from '@angular/router';
+import {Route, RouterModule, Router, Event, NavigationStart} from '@angular/router';
 import {AppConstants} from 'app.constants';
 import {IsLoggedInGuard} from 'pages/lightweight-oppia-root/routing/guards/is-logged-in.guard';
 import {IsNewLessonPlayerGuard} from 'pages/exploration-player-page/new-lesson-player/lesson-player-flag.guard';
@@ -587,4 +587,23 @@ routes.push(
     },
   ],
 })
-export class AppRoutingModule {}
+
+export class AppRoutingModule {
+  constructor(private router: Router) {
+    this.router.events.subscribe((event: Event) => {
+      if (event instanceof NavigationStart) {
+        const currentUrl =
+          window.location.pathname +
+          window.location.search +
+          window.location.hash;
+        const lowercaseUrl = currentUrl.toLowerCase();
+        const loginPath = AppConstants.PAGES_REGISTERED_WITH_FRONTEND.LOGIN.ROUTE;
+        if (currentUrl !== lowercaseUrl && !currentUrl.startsWith(loginPath)) {
+          setTimeout(() => {
+            this.router.navigateByUrl(lowercaseUrl, { replaceUrl: true });
+          }, 0);
+        }
+      }
+    });
+  }  
+}

--- a/core/templates/pages/oppia-root/routing/app.routing.module.ts
+++ b/core/templates/pages/oppia-root/routing/app.routing.module.ts
@@ -18,7 +18,13 @@
 
 import {APP_BASE_HREF} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {Route, RouterModule, Router, Event, NavigationStart} from '@angular/router';
+import {
+  Route,
+  RouterModule,
+  Router,
+  Event,
+  NavigationStart,
+} from '@angular/router';
 import {AppConstants} from 'app.constants';
 import {IsLoggedInGuard} from 'pages/lightweight-oppia-root/routing/guards/is-logged-in.guard';
 import {IsNewLessonPlayerGuard} from 'pages/exploration-player-page/new-lesson-player/lesson-player-flag.guard';
@@ -587,7 +593,6 @@ routes.push(
     },
   ],
 })
-
 export class AppRoutingModule {
   constructor(private router: Router) {
     this.router.events.subscribe((event: Event) => {
@@ -597,13 +602,14 @@ export class AppRoutingModule {
           window.location.search +
           window.location.hash;
         const lowercaseUrl = currentUrl.toLowerCase();
-        const loginPath = AppConstants.PAGES_REGISTERED_WITH_FRONTEND.LOGIN.ROUTE;
+        const loginPath =
+          AppConstants.PAGES_REGISTERED_WITH_FRONTEND.LOGIN.ROUTE;
         if (currentUrl !== lowercaseUrl && !currentUrl.startsWith(loginPath)) {
           setTimeout(() => {
-            this.router.navigateByUrl(lowercaseUrl, { replaceUrl: true });
+            this.router.navigateByUrl(lowercaseUrl, {replaceUrl: true});
           }, 0);
         }
       }
     });
-  }  
+  }
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

This PR fixes or fixes part of #22134

The issue occurs because Oppia's routing system is case-sensitive. If a user manually enters a URL like **`https://www.oppia.org/learn/Math`**, it does not match the expected lowercase route (`learn/math`) and results in a ``404 error``.  

Even though the frontend **`url-fragment-editor`** component already converts user input to lowercase when generating URLs, it does not handle cases where users manually enter a URL with uppercase letters in the browser’s address bar.  

I initially tried to resolve this issue by examining several files:  

- **`url-fragment-editor.component.ts`** – Handles form input, but not manual URLs.  
- **`access-validation-backend-api.service.ts`** – Validates access, but doesn’t control routing. 
- **`app.constants.ts`** – Defines routes, but doesn’t enforce case conversion.  

After several iterations, I realized that **`app.routing.module.ts`** is where Angular first processes navigation requests, making it the correct place to normalize URLs(**`oppia/core/templates/pages/oppia-root/routing/app.routing.module.ts`**). This file defines Oppia’s core routing logic and is the ideal place to enforce lowercase URLs. 

The Angular router does not automatically normalize URLs. If a user enters `/learn/Math` or `/learn/matH`, it won’t match `/learn/math`, leading to a `404 error`. Oppia defines routes in **`AppConstants.PAGES_REGISTERED_WITH_FRONTEND`**, but these routes do not automatically convert URLs to lowercase.  

Thus, the fix needed to be applied where navigation events are processed. I modified **`app.routing.module.ts`** to listen for URL changes and force lowercase before Angular processes the route.  

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

User-facing interface **before**: <img width="1280" alt="image" src="https://github.com/user-attachments/assets/92700783-e6aa-4694-936c-f4e67e99315c" /> <img width="1280" alt="image" src="https://github.com/user-attachments/assets/2f21fcdc-591c-4d34-892f-ff02ddf0f23c" />

User-facing interface **after**: https://github.com/user-attachments/assets/352279c7-3f16-4f74-9fea-2940287edb8b

Command line push check passed: <img width="663" alt="Command_Line_Push_Check_Pass" src="https://github.com/user-attachments/assets/1fdbca14-13b6-4627-8067-bdf4f4760ddb" />


