### PR TITLE
Removes Diagnostic Test feature flag

### DIFF
--- a/core/controllers/access_validators.py
+++ b/core/controllers/access_validators.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-from core import feature_flag_list
 from core import feconf
 from core.constants import constants
 from core.controllers import acl_decorators
@@ -25,7 +24,6 @@ from core.controllers import editor
 from core.controllers import reader
 from core.domain import blog_services
 from core.domain import classroom_config_services
-from core.domain import feature_flag_services
 from core.domain import learner_group_services
 from core.domain import skill_domain
 from core.domain import skill_fetchers

--- a/core/controllers/access_validators.py
+++ b/core/controllers/access_validators.py
@@ -322,11 +322,7 @@ class DiagnosticTestPlayerAccessValidationHandler(
     @acl_decorators.open_access
     def get(self) -> None:
         """Handles GET requests."""
-        if not feature_flag_services.is_feature_flag_enabled(
-            feature_flag_list.FeatureNames.DIAGNOSTIC_TEST.value,
-            user_id=self.user_id
-        ):
-            raise self.NotFoundException
+        pass
 
 
 class ReleaseCoordinatorAccessValidationHandler(

--- a/core/controllers/access_validators_test.py
+++ b/core/controllers/access_validators_test.py
@@ -623,8 +623,6 @@ class DiagnosticTestPlayerPageAccessValidationHandlerTests(
                 ACCESS_VALIDATION_HANDLER_PREFIX),
                 expected_status_int=404)
 
-    @test_utils.enable_feature_flags(
-        [feature_flag_list.FeatureNames.DIAGNOSTIC_TEST])
     def test_should_access_diagnostic_test_page_when_feature_is_enabled(
         self) -> None:
         self.get_html_response(

--- a/core/controllers/access_validators_test.py
+++ b/core/controllers/access_validators_test.py
@@ -616,15 +616,7 @@ class DiagnosticTestPlayerPageAccessValidationHandlerTests(
         test_utils.GenericTestBase):
     """Test for diagnostic test player access validation."""
 
-    def test_should_not_access_diagnostic_test_page_when_feature_is_disabled(
-        self) -> None:
-        self.get_json(
-            '%s/can_access_diagnostic_test_player_page' % (
-                ACCESS_VALIDATION_HANDLER_PREFIX),
-                expected_status_int=404)
-
-    def test_should_access_diagnostic_test_page_when_feature_is_enabled(
-        self) -> None:
+    def test_should_access_diagnostic_test(self) -> None:
         self.get_html_response(
            '%s/can_access_diagnostic_test_player_page' % (
                 ACCESS_VALIDATION_HANDLER_PREFIX),

--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -35,6 +35,7 @@ class FeatureNames(enum.Enum):
         'contributor_dashboard_accomplishments')
     ANDROID_BETA_LANDING_PAGE = 'android_beta_landing_page'
     BLOG_PAGES = 'blog_pages'
+    DIAGNOSTIC_TEST = 'diagnostic_test'
     SERIAL_CHAPTER_LAUNCH_CURRICULUM_ADMIN_VIEW = (
         'serial_chapter_launch_curriculum_admin_view')
     SERIAL_CHAPTER_LAUNCH_LEARNER_VIEW = (
@@ -123,6 +124,7 @@ DEPRECATED_FEATURE_NAMES: List[FeatureNames] = [
     FeatureNames.ANDROID_BETA_LANDING_PAGE,
     FeatureNames.BLOG_PAGES,
     FeatureNames.CONTRIBUTOR_DASHBOARD_ACCOMPLISHMENTS,
+    FeatureNames.DIAGNOSTIC_TEST,
 ]
 
 FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {

--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -35,7 +35,6 @@ class FeatureNames(enum.Enum):
         'contributor_dashboard_accomplishments')
     ANDROID_BETA_LANDING_PAGE = 'android_beta_landing_page'
     BLOG_PAGES = 'blog_pages'
-    DIAGNOSTIC_TEST = 'diagnostic_test'
     SERIAL_CHAPTER_LAUNCH_CURRICULUM_ADMIN_VIEW = (
         'serial_chapter_launch_curriculum_admin_view')
     SERIAL_CHAPTER_LAUNCH_LEARNER_VIEW = (
@@ -112,7 +111,6 @@ PROD_FEATURES_LIST: List[FeatureNames] = [
     FeatureNames.ENABLE_VOICEOVER_CONTRIBUTION,
     FeatureNames.AUTO_UPDATE_EXP_VOICE_ARTIST_LINK,
     FeatureNames.ADD_VOICEOVER_WITH_ACCENT,
-    FeatureNames.DIAGNOSTIC_TEST,
     FeatureNames.EXPLORATION_EDITOR_CAN_MODIFY_TRANSLATIONS,
     FeatureNames.EXPLORATION_EDITOR_CAN_TAG_MISCONCEPTIONS,
     FeatureNames.LABEL_ACCENT_TO_VOICE_ARTIST
@@ -143,12 +141,6 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
     FeatureNames.CHECKPOINT_CELEBRATION.value: (
         (
             'This flag is for the checkpoint celebration feature.',
-            feature_flag_domain.ServerMode.PROD
-        )
-    ),
-    FeatureNames.DIAGNOSTIC_TEST.value: (
-        (
-            'This flag is for the diagnostic test functionality.',
             feature_flag_domain.ServerMode.PROD
         )
     ),

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -26,7 +26,6 @@ export enum FeatureNames {
   DummyFeatureFlagForE2ETests = 'dummy_feature_flag_for_e2e_tests',
   EndChapterCelebration = 'end_chapter_celebration',
   CheckpointCelebration = 'checkpoint_celebration',
-  DiagnosticTest = 'diagnostic_test',
   SerialChapterLaunchCurriculumAdminView = 'serial_chapter_launch_curriculum_admin_view',
   SerialChapterLaunchLearnerView = 'serial_chapter_launch_learner_view',
   ShowTranslationSize = 'show_translation_size',

--- a/core/templates/pages/classroom-page/classroom-page.component.html
+++ b/core/templates/pages/classroom-page/classroom-page.component.html
@@ -45,7 +45,7 @@
         <p class="classroom-content-text" *ngIf="!isHackyClassroomTranslationDisplayed('topicListIntro')">{{classroomData.getTopicListIntro()}}</p>
         <p class="classroom-content-text" *ngIf="isHackyClassroomTranslationDisplayed('topicListIntro')">{{ classroomTranslationKeys.topicListIntro | translate }}</p>
       </div>
-      <div *ngIf="isDiagnosticTestFeatureFlagEnabled() && diagnosticTestIsEnabled()" class="content-section diagnostic-test-container">
+      <div *ngIf="diagnosticTestIsEnabled()" class="content-section diagnostic-test-container">
         <div class="diagnostic-test-box">
           <div class="diagnostic-test-info">
             <h4>{{ 'I18N_CLASSROOM_PAGE_NEW_TO_MATH_HEADING' | translate }}</h4>

--- a/core/templates/pages/classroom-page/classroom-page.component.spec.ts
+++ b/core/templates/pages/classroom-page/classroom-page.component.spec.ts
@@ -350,14 +350,6 @@ describe('Classroom Page Component', () => {
     expect(component.directiveSubscriptions.closed).toBe(true);
   });
 
-  it('should return correct value for diagnostic test feature flag', () => {
-    expect(component.isDiagnosticTestFeatureFlagEnabled()).toBeFalse();
-
-    mockPlatformFeatureService.status.DiagnosticTest.isEnabled = true;
-
-    expect(component.isDiagnosticTestFeatureFlagEnabled()).toBeTrue();
-  });
-
   it('should return false if diagnostic test is not enabled for the classroom', () => {
     let classroomData = ClassroomData.createFromBackendData(
       'mathid',

--- a/core/templates/pages/classroom-page/classroom-page.component.ts
+++ b/core/templates/pages/classroom-page/classroom-page.component.ts
@@ -124,7 +124,6 @@ export class ClassroomPageComponent implements OnDestroy {
       this.urlInterpolationService.getStaticImageUrl('/splash/books.svg');
 
     this.loaderService.showLoadingScreen('Loading');
-    this.isDiagnosticTestFeatureFlagEnabled();
 
     this.accessValidationBackendApiService
       .validateAccessToClassroomPage(this.classroomUrlFragment)
@@ -247,10 +246,6 @@ export class ClassroomPageComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
-  }
-
-  isDiagnosticTestFeatureFlagEnabled(): boolean {
-    return this.platformFeatureService.status.DiagnosticTest.isEnabled;
   }
 
   diagnosticTestIsEnabled(): boolean {

--- a/core/tests/test_utils_test.py
+++ b/core/tests/test_utils_test.py
@@ -53,14 +53,14 @@ class EnableFeatureFlagTests(test_utils.GenericTestBase):
 
     @test_utils.enable_feature_flags([
         feature_flag_list.FeatureNames.DUMMY_FEATURE_FLAG_FOR_E2E_TESTS,
-        feature_flag_list.FeatureNames.DIAGNOSTIC_TEST
+        feature_flag_list.FeatureNames.BLOG_PAGES
     ])
     def test_enable_multiple_feature_flags_decorator(self) -> None:
         """Tests if multiple feature flags are enabled."""
         self.assertTrue(feature_flag_services.is_feature_flag_enabled(
             'dummy_feature_flag_for_e2e_tests', None))
         self.assertTrue(feature_flag_services.is_feature_flag_enabled(
-            'diagnostic_test', None))
+            'blog_pages', None))
 
 
 class SetPlatformParametersTests(test_utils.GenericTestBase):


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

The PR removes the diagnostic test feature flag from the codebase, as now the functionality is live in the PROD. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
