### PR TITLE
Fix #20733: TimeoutError: waiting for XPath //a[contains(text(),"Programming with Carla")] failed: timeout 30000ms exceeded

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -778,15 +778,23 @@ export class BaseUser {
     anchorInnerText: string,
     expectedDestinationPageUrl: string
   ): Promise<void> {
-    await this.page.waitForXPath(`//a[contains(text(),"${anchorInnerText}")]`);
+    const escapedText = anchorInnerText.replace(/"/g, '\\"');
+    const xpath = `//a[contains(normalize-space(text()), "${escapedText}")]`;
+    await this.page.waitForXPath(xpath, {visible: true});
+    const [anchorHandle] = await this.page.$x(xpath);
+    if (!anchorHandle) {
+      throw new Error(
+        `Anchor with text "${anchorInnerText}" not found after wait.`
+      );
+    }
     const pageTarget = this.page.target();
-    await this.clickOn(anchorInnerText);
+    await anchorHandle.click();
     const newTarget = await this.browserObject.waitForTarget(
       target => target.opener() === pageTarget
     );
     const newTabPage = await newTarget.page();
     expect(newTabPage).toBeDefined();
-    expect(newTabPage?.url()).toBe(expectedDestinationPageUrl);
+    expect(await newTabPage?.url()).toBe(expectedDestinationPageUrl);
     await newTabPage?.close();
   }
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[ #20733].
2. This PR does the following: The new method is better because it waits for the link to be visible, verifies the element handle, and clicks it directly, making it more reliable and less flaky than relying on a generic clickOn() after waitForXPath()
3. (For bug-fixing PRs only) The original bug occurred because:due to visiblity or text mismatch it is not able to find it

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

![image](https://github.com/user-attachments/assets/9e5c5cbb-5606-4e16-85ab-ac4d12e80e9a)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
