### PR TITLE
Fix errors in discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
+++ b/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
@@ -7,16 +7,10 @@ body:
   validations:
     required: true
 - type: checkboxes
-  id: sharing
   attributes:
     label: I confirm that I've given edit access to the doc to the dev mailing lists, as described in the instructions at the top of the doc.
     options:
-        - label: "Yes"
-          required: true
-- type: checkboxes
-  id: sharing
-  attributes:
-    label: I confirm that I set the sharing options of the doc to "anyone with the link can comment".
-    options:
-        - label: "Yes"
-          required: true
+      - label: "I confirm that I've given edit access to the doc to the dev mailing lists, as described in the instructions at the top of the doc."
+        required: true
+      - label: "I confirm that I set the sharing options of the doc to 'anyone with the link can comment'."
+        required: true

--- a/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
+++ b/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
@@ -1,16 +1,17 @@
 title: "{{Issue Description}} | {{your GitHub username}}"
 body:
 - type: input
+  id: debugging_doc_link
   attributes:
     label: Link to debugging doc
     description: "Please paste the Google Doc link to the debugging doc here."
   validations:
     required: true
 - type: checkboxes
+  id: sharing
   attributes:
-    label: I confirm that I've given edit access to the doc to the dev mailing lists, as described in the instructions at the top of the doc.
     options:
-      - label: "I confirm that I've given edit access to the doc to the dev mailing lists, as described in the instructions at the top of the doc."
-        required: true
-      - label: "I confirm that I set the sharing options of the doc to 'anyone with the link can comment'."
-        required: true
+    - label: "I confirm that I've given edit access to the doc to the dev mailing lists, as described in the instructions at the top of the doc."
+      required: true
+    - label: "I confirm that I set the sharing options of the doc to 'anyone with the link can comment'."
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
+++ b/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
@@ -1,7 +1,6 @@
 title: "{{Issue Description}} | {{your GitHub username}}"
 body:
 - type: input
-  id: debugging_doc_link
   attributes:
     label: Link to debugging doc
     description: "Please paste the Google Doc link to the debugging doc here."


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Fix errors in the Discussion template for the Debugging Docs category.
3. (For bug-fixing PRs only) The original bug occurred because: Te template in https://github.com/oppia/oppia/pull/22132/files was not formatted correctly. It has errors as shown [here](https://github.com/oppia/oppia/blob/db98e7c763b372e6868e12f3b3e4ef5a4c8d3fec/.github/DISCUSSION_TEMPLATE/debugging-docs.yml). (Sorry I missed this originally.)

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

For some reason GitHub still shows the errors from the old template at https://github.com/oppia/oppia/blob/0cf659ad1bddab9955cf27a0c7f4aff058849214/.github/DISCUSSION_TEMPLATE/debugging-docs.yml. But the updated template doesn't have those errors. So I am not sure how to auto-verify the template -- I think we would just need to merge it and see what happens.

Here are the links shown in the screenshot for reference:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#body-must-have-unique-ids
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#checkboxes-must-have-unique-labels

![Screenshot from 2025-03-21 16-34-29](https://github.com/user-attachments/assets/d1dc7fc3-23dc-4c1c-b148-358b1989aeb3)

#### Proof of changes on desktop with slow/throttled network

N/A, this is not a UI change.

#### Proof of changes on mobile phone

N/A, this is not a UI change.

#### Proof of changes in Arabic language


N/A, this is not a UI change.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
