### PR TITLE
Fixes part of #20961: Storing data for auditing translation_counts  and contetn_count

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1569,6 +1569,12 @@ def delete_explorations(
         taskqueue_services.FUNCTION_ID_DELETE_EXPS_FROM_ACTIVITIES,
         taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS, exploration_ids)
 
+    for exp_id in exploration_ids:
+        opportunity_services.store_opportunity_debug_data(
+            exp_id,
+            None,
+            opportunity_services.EXPLORATION_DELETED)
+
 
 def delete_explorations_from_user_models(exploration_ids: List[str]) -> None:
     """Remove explorations from all subscribers' exploration_ids.
@@ -1978,6 +1984,16 @@ def update_exploration(
         caching_services.CACHE_NAMESPACE_EXPLORATION, None,
         [exploration_id]
     )
+
+    # OPPORTUNITY DEBUG INFO
+    if opportunity_services.is_exploration_available_for_contribution(
+        exploration_id
+    ):
+        opportunity_services.store_opportunity_debug_data(
+            exploration_id,
+            None,
+            opportunity_services.EXPLORATION_UPDATED
+        )
 
 
 def compute_models_to_put_when_saving_new_exp_version(
@@ -2575,6 +2591,16 @@ def revert_exploration(
     )
     datastore_services.put_multi(exp_issues_models_to_put)
     datastore_services.put_multi(translation_and_opportunity_models_to_put)
+
+    # OPPORTUNITY DEBUG INFO
+    if opportunity_services.is_exploration_available_for_contribution(
+        exploration_id
+    ):
+        opportunity_services.store_opportunity_debug_data(
+            exploration_id,
+            None,
+            opportunity_services.EXPLORATION_REVERTED
+        )
 
 
 # Creation and deletion methods.

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1985,7 +1985,7 @@ def update_exploration(
         [exploration_id]
     )
 
-    # OPPORTUNITY DEBUG INFO
+    # OPPORTUNITY DEBUG INFO.
     if opportunity_services.is_exploration_available_for_contribution(
         exploration_id
     ):
@@ -2592,7 +2592,7 @@ def revert_exploration(
     datastore_services.put_multi(exp_issues_models_to_put)
     datastore_services.put_multi(translation_and_opportunity_models_to_put)
 
-    # OPPORTUNITY DEBUG INFO
+    # OPPORTUNITY DEBUG INFO.
     if opportunity_services.is_exploration_available_for_contribution(
         exploration_id
     ):

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -22,6 +22,7 @@ import collections
 import logging
 
 from core import feconf
+from datetime import datetime
 
 from core.constants import constants
 from core.domain import exp_domain
@@ -41,11 +42,17 @@ from typing import Dict, List, Optional, Sequence, Tuple
 MYPY = False
 if MYPY: # pragma: no cover
     from mypy_imports import opportunity_models
+    from mypy_imports import opportunity_debug_modelss
     from mypy_imports import user_models
+    from mypy_imports import datastore_services
 
-(opportunity_models, user_models) = models.Registry.import_models([
-    models.Names.OPPORTUNITY, models.Names.USER
+(
+    opportunity_models,
+    opportunity_debug_modelss,
+    user_models) = models.Registry.import_models([
+    models.Names.OPPORTUNITY,  models.Names.OPPORTUNITY_DEBUG, models.Names.USER
 ])
+datastore_services = models.Registry.import_datastore_services()
 
 # NOTE TO DEVELOPERS: The functions:
 #   - delete_all_exploration_opportunity_summary_models()
@@ -53,6 +60,125 @@ if MYPY: # pragma: no cover
 # were removed in #13021 as part of the migration to Apache Beam. Please refer
 # to that PR if you need to reinstate them.
 
+STORY_PUBLISED = 'story_published'
+EXPLORATION_UPDATED = 'exploration_updated'
+EXPLORATION_REVERTED = 'exploration_reverted'
+EXPLORATION_DELETED = 'exploration_deleted'
+STORY_DELETED = 'story_deleted'
+STORY_UNPUBLISHED = 'story_unpublished'
+TOPIC_DELETED = 'topic_deleted'
+TRANSLATION_ACCEPTED = 'translation_accepted'
+
+def store_opportunity_debug_data(
+    exp_id: str,
+    language_code: Optional[str],
+    event_type: str
+) -> None:
+    """Saves the debug information for the opportunity model.
+
+    Args:
+        exp_id: str. The exploration id.
+        language_code: str. The language code of the translation.
+        event_type: str. The type of event that occurred.
+    """
+    debug_models = []
+    if language_code:
+        debug_model = opportunity_debug_models.OpportunityDebugModel
+            .get_by_exp_id_and_langauge_code(exp_id, language_code)
+        if not debug_model:
+            debug_model = opportunity_models.OpportunityDebugModel(
+                id=f'{exp_id}.{language_code}',
+                exp_id=exp_id,
+                language_code=language_code,
+                events=[]
+            )
+
+        opp_summary_model = opportunity_models
+            .ExplorationOpportunitySummaryModel.get(
+            exp_id, strict=False)
+        if opp_summary_model is not None:
+            opp_summary = (
+                get_exploration_opportunity_summary_from_model(
+                    opp_summary_model))
+            exp = exp_fetchers.get_exploration_by_id(exp_id, strict=False)
+            entity_translation = translation_fetchers.get_entity_translation(
+                feconf.TranslatableEntityType.EXPLORATION,
+                exp_id,
+                exp.version,
+                language_code) if exp else None
+
+            actual_content_count = exp.get_content_count() if exp else 0
+            stored_content_count = opp_summary.content_count
+            actual_translation_count = exp.get_translation_count(
+                entity_translation) if exp else 0
+            stored_translation_count = opp_summary.translation_counts.get(
+                language_code, 0)
+
+            debug_model = opportunity_debug_models.OpportunityDebugModel
+                .get_by_exp_id_and_langauge_code(exp_id, language_code)
+            if not debug_model:
+                debug_model = opportunity_models.OpportunityDebugModel(
+                    id=f'{exp_id}.{language_code}',
+                    exp_id=exp_id,
+                    language_code=language_code,
+                    events=[]
+                )
+
+            event = {
+                'event_type': event_type,
+                'timestamp': datetime.utcnow()
+            }
+            event['actual_content_count'] = actual_content_count
+            event['stored_content_count'] = stored_content_count
+            event['actual_translation_count'] = actual_translation_count
+            event['stored_translation_count'] = stored_trans_count
+            debug_model.events.append(event)
+            debug_models.append(debug_model)
+    else:
+        opp_summary_model = opportunity_models
+            .ExplorationOpportunitySummaryModel.get(
+            exp_id, strict=False)
+        if opp_summary_model is not None:
+            opp_summary = (
+                get_exploration_opportunity_summary_from_model(
+                    opp_summary_model))
+            exp = exp_fetchers.get_exploration_by_id(exp_id, strict=False)
+            actual_transalaion_count_mapping = (
+                translation_services.get_transalation_counts(
+                    feconf.TranslatableEntityType.EXPLORATION,
+                    exp)) if exp else {}
+
+            actual_content_count = exp.get_content_count() if exp else 0
+            stored_content_count = opp_summary.content_count
+            for lang_code in actual_transalaion_count_mapping.keys():
+                actual_translation_count = actual_translation_count_mapping.get(
+                    lang_code, 0)
+                stored_translation_count = opp_summary.translation_counts.get(
+                    lang_code, 0)
+                
+                debug_model = opportunity_debug_models.OpportunityDebugModel
+                    .get_by_exp_id_and_langauge_code(exp_id, language_code)
+                if not debug_model:
+                    debug_model = opportunity_models.OpportunityDebugModel(
+                        id=f'{exp_id}.{lang_code}',
+                        exp_id=exp_id,
+                        language_code=lang_code,
+                        events=[]
+                    )
+
+                event = {
+                    'event_type': event_type,
+                    'timestamp': datetime.utcnow()
+                }
+                event['actual_content_count'] = actual_content_count
+                event['stored_content_count'] = stored_content_count
+                event['actual_translation_count'] = actual_translation_count
+                event['stored_translation_count'] = stored_trans_count
+                debug_model.events.append(event)
+                debug_models.append(debug_model)
+        
+    datastore_services.update_timestamps_multi(debug_models)
+    datastore_services.put_multi(debug_models)
 
 def is_exploration_available_for_contribution(exp_id: str) -> bool:
     """Checks whether a given exploration id belongs to a curated list of
@@ -471,6 +597,11 @@ def delete_exploration_opportunities_corresponding_to_topic(
     opportunity_models.ExplorationOpportunitySummaryModel.delete_multi(
         list(exp_opportunity_models))
 
+    # OPPORTUINTY DEBUG INFO
+    for exp_opportunity_model in exp_opportunity_models:
+        store_opportunity_debug_data(
+            exp_opportunity_model.id, None, TOPIC_DELETED)
+
 
 def update_exploration_opportunities(
     old_story: story_domain.Story,
@@ -523,6 +654,11 @@ def delete_exp_opportunities_corresponding_to_story(story_id: str) -> None:
         exp_opprtunity_model_class.story_id == story_id
     ).fetch()
     exp_opprtunity_model_class.delete_multi(list(exp_opportunity_models))
+
+    # OPPORTUINTY DEBUG INFO
+    for exp_opportunity_model in exp_opportunity_models:
+        store_opportunity_debug_data(
+            exp_opportunity_model.id, None, STORY_DELETED)
 
 
 def get_translation_opportunities(

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -19,11 +19,10 @@
 from __future__ import annotations
 
 import collections
+import datetime
 import logging
 
 from core import feconf
-from datetime import datetime
-
 from core.constants import constants
 from core.domain import exp_domain
 from core.domain import exp_fetchers
@@ -34,23 +33,24 @@ from core.domain import story_fetchers
 from core.domain import suggestion_services
 from core.domain import topic_domain
 from core.domain import topic_fetchers
+from core.domain import translation_fetchers
 from core.domain import translation_services
 from core.platform import models
 
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 MYPY = False
 if MYPY: # pragma: no cover
-    from mypy_imports import opportunity_models
-    from mypy_imports import opportunity_debug_modelss
-    from mypy_imports import user_models
     from mypy_imports import datastore_services
+    from mypy_imports import opportunity_debug_models
+    from mypy_imports import opportunity_models
+    from mypy_imports import user_models
 
 (
+    opportunity_debug_models,
     opportunity_models,
-    opportunity_debug_modelss,
     user_models) = models.Registry.import_models([
-    models.Names.OPPORTUNITY,  models.Names.OPPORTUNITY_DEBUG, models.Names.USER
+    models.Names.OPPORTUNITY_DEBUG, models.Names.OPPORTUNITY, models.Names.USER
 ])
 datastore_services = models.Registry.import_datastore_services()
 
@@ -60,7 +60,7 @@ datastore_services = models.Registry.import_datastore_services()
 # were removed in #13021 as part of the migration to Apache Beam. Please refer
 # to that PR if you need to reinstate them.
 
-STORY_PUBLISED = 'story_published'
+STORY_PUBLISHED = 'story_published'
 EXPLORATION_UPDATED = 'exploration_updated'
 EXPLORATION_REVERTED = 'exploration_reverted'
 EXPLORATION_DELETED = 'exploration_deleted'
@@ -68,6 +68,7 @@ STORY_DELETED = 'story_deleted'
 STORY_UNPUBLISHED = 'story_unpublished'
 TOPIC_DELETED = 'topic_deleted'
 TRANSLATION_ACCEPTED = 'translation_accepted'
+
 
 def store_opportunity_debug_data(
     exp_id: str,
@@ -83,19 +84,21 @@ def store_opportunity_debug_data(
     """
     debug_models = []
     if language_code:
-        debug_model = opportunity_debug_models.OpportunityDebugModel
-            .get_by_exp_id_and_langauge_code(exp_id, language_code)
+        debug_model = (
+            opportunity_debug_models.OpportunityDebugModel
+                .get_by_exp_id_and_langauge_code(
+                    exp_id, language_code))
         if not debug_model:
-            debug_model = opportunity_models.OpportunityDebugModel(
+            debug_model = opportunity_debug_models.OpportunityDebugModel(
                 id=f'{exp_id}.{language_code}',
                 exp_id=exp_id,
                 language_code=language_code,
                 events=[]
             )
 
-        opp_summary_model = opportunity_models
-            .ExplorationOpportunitySummaryModel.get(
-            exp_id, strict=False)
+        opp_summary_model = (
+            opportunity_models.ExplorationOpportunitySummaryModel.get(
+                exp_id, strict=False))
         if opp_summary_model is not None:
             opp_summary = (
                 get_exploration_opportunity_summary_from_model(
@@ -109,76 +112,81 @@ def store_opportunity_debug_data(
 
             actual_content_count = exp.get_content_count() if exp else 0
             stored_content_count = opp_summary.content_count
-            actual_translation_count = exp.get_translation_count(
-                entity_translation) if exp else 0
+            actual_translation_count = (
+                exp.get_translation_count(entity_translation)
+                if exp and entity_translation else 0)
             stored_translation_count = opp_summary.translation_counts.get(
                 language_code, 0)
 
-            debug_model = opportunity_debug_models.OpportunityDebugModel
-                .get_by_exp_id_and_langauge_code(exp_id, language_code)
+            debug_model = (
+                opportunity_debug_models.OpportunityDebugModel
+                    .get_by_exp_id_and_langauge_code(exp_id, language_code))
             if not debug_model:
-                debug_model = opportunity_models.OpportunityDebugModel(
+                debug_model = opportunity_debug_models.OpportunityDebugModel(
                     id=f'{exp_id}.{language_code}',
                     exp_id=exp_id,
                     language_code=language_code,
                     events=[]
                 )
 
-            event = {
+            event: Dict[str, Union[str, int]] = {
                 'event_type': event_type,
-                'timestamp': datetime.utcnow()
+                'timestamp': datetime.datetime.utcnow().isoformat()
             }
             event['actual_content_count'] = actual_content_count
             event['stored_content_count'] = stored_content_count
             event['actual_translation_count'] = actual_translation_count
-            event['stored_translation_count'] = stored_trans_count
+            event['stored_translation_count'] = stored_translation_count
             debug_model.events.append(event)
             debug_models.append(debug_model)
     else:
-        opp_summary_model = opportunity_models
-            .ExplorationOpportunitySummaryModel.get(
-            exp_id, strict=False)
+        opp_summary_model = (
+            opportunity_models.ExplorationOpportunitySummaryModel.get(
+            exp_id, strict=False))
         if opp_summary_model is not None:
             opp_summary = (
                 get_exploration_opportunity_summary_from_model(
                     opp_summary_model))
             exp = exp_fetchers.get_exploration_by_id(exp_id, strict=False)
-            actual_transalaion_count_mapping = (
-                translation_services.get_transalation_counts(
+            actual_translation_count_mapping = (
+                translation_services.get_translation_counts(
                     feconf.TranslatableEntityType.EXPLORATION,
                     exp)) if exp else {}
 
             actual_content_count = exp.get_content_count() if exp else 0
             stored_content_count = opp_summary.content_count
-            for lang_code in actual_transalaion_count_mapping.keys():
+            for lang_code in actual_translation_count_mapping:
                 actual_translation_count = actual_translation_count_mapping.get(
                     lang_code, 0)
                 stored_translation_count = opp_summary.translation_counts.get(
                     lang_code, 0)
-                
-                debug_model = opportunity_debug_models.OpportunityDebugModel
-                    .get_by_exp_id_and_langauge_code(exp_id, language_code)
+
+                debug_model = (
+                    opportunity_debug_models.OpportunityDebugModel
+                        .get_by_exp_id_and_langauge_code(
+                            exp_id, lang_code))
                 if not debug_model:
-                    debug_model = opportunity_models.OpportunityDebugModel(
+                    debug_model = (
+                        opportunity_debug_models.OpportunityDebugModel(
                         id=f'{exp_id}.{lang_code}',
                         exp_id=exp_id,
                         language_code=lang_code,
-                        events=[]
-                    )
+                        events=[]))
 
                 event = {
                     'event_type': event_type,
-                    'timestamp': datetime.utcnow()
+                    'timestamp': datetime.datetime.utcnow().isoformat()
                 }
                 event['actual_content_count'] = actual_content_count
                 event['stored_content_count'] = stored_content_count
                 event['actual_translation_count'] = actual_translation_count
-                event['stored_translation_count'] = stored_trans_count
+                event['stored_translation_count'] = stored_translation_count
                 debug_model.events.append(event)
                 debug_models.append(debug_model)
-        
+
     datastore_services.update_timestamps_multi(debug_models)
     datastore_services.put_multi(debug_models)
+
 
 def is_exploration_available_for_contribution(exp_id: str) -> bool:
     """Checks whether a given exploration id belongs to a curated list of
@@ -527,6 +535,10 @@ def update_translation_opportunity_with_accepted_suggestion(
     exp_opportunity_summary.validate()
     _save_multi_exploration_opportunity_summary([exp_opportunity_summary])
 
+    # OPPORTUINTY DEBUG INFO.
+    store_opportunity_debug_data(
+        exploration_id, language_code, TRANSLATION_ACCEPTED)
+
 
 def update_exploration_opportunities_with_story_changes(
     story: story_domain.Story, exp_ids: List[str]
@@ -597,7 +609,7 @@ def delete_exploration_opportunities_corresponding_to_topic(
     opportunity_models.ExplorationOpportunitySummaryModel.delete_multi(
         list(exp_opportunity_models))
 
-    # OPPORTUINTY DEBUG INFO
+    # OPPORTUINTY DEBUG INFO.
     for exp_opportunity_model in exp_opportunity_models:
         store_opportunity_debug_data(
             exp_opportunity_model.id, None, TOPIC_DELETED)
@@ -655,7 +667,7 @@ def delete_exp_opportunities_corresponding_to_story(story_id: str) -> None:
     ).fetch()
     exp_opprtunity_model_class.delete_multi(list(exp_opportunity_models))
 
-    # OPPORTUINTY DEBUG INFO
+    # OPPORTUINTY DEBUG INFO.
     for exp_opportunity_model in exp_opportunity_models:
         store_opportunity_debug_data(
             exp_opportunity_model.id, None, STORY_DELETED)

--- a/core/domain/opportunity_services_test.py
+++ b/core/domain/opportunity_services_test.py
@@ -49,20 +49,26 @@ from typing import Dict, List, Union
 MYPY = False
 if MYPY: # pragma: no cover
     from mypy_imports import feedback_models
+    from mypy_imports import opportunity_debug_models
     from mypy_imports import opportunity_models
     from mypy_imports import story_models
     from mypy_imports import suggestion_models
+    from mypy_imports import translation_models
 
 (
     feedback_models,
+    opportunity_debug_models,
     opportunity_models,
     story_models,
-    suggestion_models
+    suggestion_models,
+    translation_models
 ) = models.Registry.import_models([
     models.Names.FEEDBACK,
+    models.Names.OPPORTUNITY_DEBUG,
     models.Names.OPPORTUNITY,
     models.Names.STORY,
-    models.Names.SUGGESTION
+    models.Names.SUGGESTION,
+    models.Names.TRANSLATION
 ])
 
 
@@ -1209,3 +1215,163 @@ class OpportunityUpdateOnAcceeptingSuggestionUnitTest(
 
         self.assertFalse(
             'hi' in opportunity.incomplete_translation_language_codes)
+
+
+class OpportunityServicesDebugDataTest(test_utils.GenericTestBase):
+    """Tests for the store_opportunity_debug_data method."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
+        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+        self.signup(self.CURRICULUM_ADMIN_EMAIL, self.CURRICULUM_ADMIN_USERNAME)
+        self.admin_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
+        self.set_curriculum_admins([self.CURRICULUM_ADMIN_USERNAME])
+        self.exploration_id = 'exp1'
+        self.subtopic_id = 'subtopic1'
+        self.topic_id = 'topic1'
+        self.story_id = 'story1'
+
+        exp1 = self.save_new_valid_exploration(
+            self.exploration_id, self.owner_id)
+        self.publish_exploration(self.owner_id, exp1.id)
+
+        self.save_new_topic(
+            self.topic_id, self.owner_id)
+
+        self.create_story_for_translation_opportunity(
+            self.owner_id,
+            self.admin_id,
+            self.story_id,
+            self.topic_id,
+            self.exploration_id)
+
+        opportunity_services.add_new_exploration_opportunities(
+            self.story_id, [self.exploration_id])
+
+        self.language_code = 'hi'
+
+        model = translation_models.EntityTranslationsModel.create_new(
+            'exploration',
+            exp1.id,
+            exp1.version,
+            self.language_code,
+            {
+                'content_0': {
+                    'content_value': '<p>hi</p>',
+                    'content_format': 'html',
+                    'needs_update': False
+                }
+            }
+        )
+        model.update_timestamps()
+        model.put()
+
+    def test_store_opportunity_debug_data_for_nonexistent_exploration(
+        self) -> None:
+        nonexistent_exp_id = 'nonexistent_exp'
+        opportunity_services.store_opportunity_debug_data(
+            nonexistent_exp_id, self.language_code,
+            opportunity_services.EXPLORATION_DELETED)
+
+        debug_model = (
+            opportunity_debug_models.OpportunityDebugModel
+            .get_by_exp_id_and_langauge_code(
+                self.exploration_id, self.language_code))
+        self.assertIsNone(debug_model)
+
+    def test_store_opportunity_debug_data_for_nonexistent_exploration_and_none_language(self) -> None: # pylint: disable=line-too-long
+        nonexistent_exp_id = 'nonexistent_exp'
+        opportunity_services.store_opportunity_debug_data(
+            nonexistent_exp_id, None,
+            opportunity_services.EXPLORATION_DELETED)
+
+        debug_models = (
+            opportunity_debug_models.OpportunityDebugModel
+            .get_multi_by_exp_id(self.exploration_id))
+        self.assertEqual(len(debug_models), 0)
+
+    def test_store_opportunity_debug_data_with_none_language(self) -> None:
+        opportunity_services.store_opportunity_debug_data(
+            self.exploration_id, None, opportunity_services.STORY_DELETED)
+
+        debug_models = (
+            opportunity_debug_models.OpportunityDebugModel
+            .get_multi_by_exp_id(self.exploration_id))
+        self.assertIsNotNone(debug_models)
+        self.assertEqual(len(debug_models), 1)
+        self.assertEqual(debug_models[0].exp_id, self.exploration_id)
+        self.assertEqual(debug_models[0].language_code, self.language_code)
+        self.assertEqual(len(debug_models[0].events), 1)
+        self.assertEqual(
+            debug_models[0].events[0]['event_type'],
+            opportunity_services.STORY_DELETED)
+
+    def test_store_opportunity_debug_data_with_language_code(self) -> None:
+        opportunity_services.store_opportunity_debug_data(
+            self.exploration_id, self.language_code,
+            opportunity_services.TRANSLATION_ACCEPTED)
+
+        debug_model = (
+            opportunity_debug_models.OpportunityDebugModel
+            .get_by_exp_id_and_langauge_code(
+                self.exploration_id, self.language_code))
+        self.assertIsNotNone(debug_model)
+
+        assert debug_model is not None
+        self.assertEqual(debug_model.exp_id, self.exploration_id)
+        self.assertEqual(debug_model.language_code, self.language_code)
+        self.assertEqual(len(debug_model.events), 1)
+        self.assertEqual(
+            debug_model.events[0]['event_type'],
+            opportunity_services.TRANSLATION_ACCEPTED)
+
+    def test_store_opportunity_debug_data_multiple_events(self) -> None:
+        opportunity_services.store_opportunity_debug_data(
+            self.exploration_id, self.language_code,
+            opportunity_services.EXPLORATION_UPDATED)
+
+        opportunity_services.store_opportunity_debug_data(
+            self.exploration_id, self.language_code,
+            opportunity_services.TRANSLATION_ACCEPTED)
+
+        debug_model = (
+            opportunity_debug_models.OpportunityDebugModel
+            .get_by_exp_id_and_langauge_code(
+                self.exploration_id, self.language_code))
+        assert debug_model is not None
+        self.assertEqual(len(debug_model.events), 2)
+        self.assertEqual(
+            debug_model.events[0]['event_type'],
+            opportunity_services.EXPLORATION_UPDATED)
+        self.assertEqual(
+            debug_model.events[1]['event_type'],
+            opportunity_services.TRANSLATION_ACCEPTED)
+
+    def test_store_opportunity_debug_data_with_different_event_types(
+        self) -> None:
+        event_types = [
+            opportunity_services.STORY_PUBLISHED,
+            opportunity_services.EXPLORATION_UPDATED,
+            opportunity_services.EXPLORATION_REVERTED,
+            opportunity_services.EXPLORATION_DELETED,
+            opportunity_services.STORY_DELETED,
+            opportunity_services.STORY_UNPUBLISHED,
+            opportunity_services.TOPIC_DELETED,
+            opportunity_services.TRANSLATION_ACCEPTED
+        ]
+
+        event_index = 0
+        for event_type in event_types:
+            opportunity_services.store_opportunity_debug_data(
+                self.exploration_id, self.language_code, event_type)
+
+            debug_model = (
+                opportunity_debug_models.OpportunityDebugModel
+                .get_by_exp_id_and_langauge_code(
+                    self.exploration_id, self.language_code))
+            assert debug_model is not None
+            self.assertEqual(
+                debug_model.events[event_index]['event_type'],
+                event_type)
+            event_index += 1

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -866,6 +866,11 @@ def publish_story(
     opportunity_services.add_new_exploration_opportunities(
         story_id, linked_exp_ids)
 
+    # OPPORTUNITY DEBUG INFO.
+    for exp_id in linked_exp_ids:
+        opportunity_services.store_opportunity_debug_data(
+            exp_id, None, opportunity_services.STORY_PUBLISHED)
+
 
 def unpublish_story(
     topic_id: str, story_id: str, committer_id: str
@@ -932,10 +937,10 @@ def unpublish_story(
     opportunity_services.delete_exploration_opportunities(exp_ids)
     suggestion_services.auto_reject_translation_suggestions_for_exp_ids(exp_ids)
 
-    # OPPORTUNITY DEBUG INFO
+    # OPPORTUNITY DEBUG INFO.
     for exp_id in exp_ids:
         opportunity_services.store_opportunity_debug_data(
-            exp_id, None, opportunity_services.STORY_DELETED)
+            exp_id, None, opportunity_services.STORY_UNPUBLISHED)
 
 
 def delete_canonical_story(

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -932,6 +932,11 @@ def unpublish_story(
     opportunity_services.delete_exploration_opportunities(exp_ids)
     suggestion_services.auto_reject_translation_suggestions_for_exp_ids(exp_ids)
 
+    # OPPORTUNITY DEBUG INFO
+    for exp_id in exp_ids:
+        opportunity_services.store_opportunity_debug_data(
+            exp_id, None, opportunity_services.STORY_DELETED)
+
 
 def delete_canonical_story(
     user_id: str, topic_id: str, story_id: str

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -60,6 +60,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
     """Tests for topic services."""
 
     user_id: str = 'user_id'
+    exp_id_1: str = 'exp_id_1'
     story_id_1: str = 'story_1'
     story_id_2: str = 'story_2'
     story_id_3: str = 'story_3'
@@ -1606,6 +1607,29 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
             },
             'change'
         )
+        self.save_new_valid_exploration(
+            self.exp_id_1, self.owner_id)
+        self.publish_exploration(self.owner_id, self.exp_id_1)
+        story_services.update_story(
+            self.user_id, self.story_id_1, [story_domain.StoryChange({
+                'cmd': story_domain.CMD_ADD_STORY_NODE,
+                'node_id': 'node_1',
+                'title': 'Node1',
+            }), story_domain.StoryChange({
+                'cmd': story_domain.CMD_UPDATE_STORY_NODE_PROPERTY,
+                'property_name': (
+                    story_domain.STORY_NODE_PROPERTY_EXPLORATION_ID),
+                'node_id': 'node_1',
+                'old_value': None,
+                'new_value': self.exp_id_1
+            }), story_domain.StoryChange({
+                'cmd': story_domain.CMD_UPDATE_STORY_NODE_PROPERTY,
+                'property_name': (
+                    story_domain.STORY_NODE_PROPERTY_STATUS),
+                'node_id': 'node_1',
+                'old_value': constants.STORY_NODE_STATUS_DRAFT,
+                'new_value': constants.STORY_NODE_STATUS_PUBLISHED
+            })], 'Changes.')
 
         self.assertIsNotNone(
             suggestion_services.get_suggestion_by_id(suggestion.suggestion_id))

--- a/core/feconf.py
+++ b/core/feconf.py
@@ -167,7 +167,7 @@ class ValidModelNames(enum.Enum):
     SUGGESTION = 'suggestion'
     TOPIC = 'topic'
     TRANSLATION = 'translation'
-    TRANSLATION_COUNT_DEBUG_TRACKER = 'translation_count_debug_tracker'
+    OPPORTUNITY_DEBUG = 'opportunity_debug'
     USER = 'user'
     VOICEOVER = 'voiceover'
 

--- a/core/feconf.py
+++ b/core/feconf.py
@@ -167,6 +167,7 @@ class ValidModelNames(enum.Enum):
     SUGGESTION = 'suggestion'
     TOPIC = 'topic'
     TRANSLATION = 'translation'
+    TRANSLATION_COUNT_DEBUG_TRACKER = 'translation_count_debug_tracker'
     USER = 'user'
     VOICEOVER = 'voiceover'
 

--- a/core/platform/models.py
+++ b/core/platform/models.py
@@ -184,10 +184,10 @@ class _Gae(Platform):
                 from core.storage.translation import (
                     gae_models as translation_models)
                 returned_models.append(translation_models)
-            elif name == Names.TRANSLATION_COUNT_DEBUG_TRACKER:
-                from core.storage.translation_count_debug_tracker import (
-                    gae_models as translation_count_debug_tracker_models)
-                returned_models.append(translation_count_debug_tracker_models)
+            elif name == Names.OPPORTUNITY_DEBUG:
+                from core.storage.opportunity_debug import (
+                    gae_models as opportunity_debug_models)
+                returned_models.append(opportunity_debug_models)
             elif name == Names.USER:
                 from core.storage.user import gae_models as user_models
                 returned_models.append(user_models)

--- a/core/platform/models.py
+++ b/core/platform/models.py
@@ -184,6 +184,10 @@ class _Gae(Platform):
                 from core.storage.translation import (
                     gae_models as translation_models)
                 returned_models.append(translation_models)
+            elif name == Names.TRANSLATION_COUNT_DEBUG_TRACKER:
+                from core.storage.translation_count_debug_tracker import (
+                    gae_models as translation_count_debug_tracker_models)
+                returned_models.append(translation_count_debug_tracker_models)
             elif name == Names.USER:
                 from core.storage.user import gae_models as user_models
                 returned_models.append(user_models)

--- a/core/storage/opportunity_debug/gae_models.py
+++ b/core/storage/opportunity_debug/gae_models.py
@@ -32,8 +32,8 @@ if MYPY: # pragma: no cover
 datastore_services = models.Registry.import_datastore_services()
 
 
-class TranslationCountDebugTrackerModel(base_models.BaseModel):
-    """Storage model for recording changes to translation counts.
+class OpportunityDebugModel(base_models.BaseModel):
+    """Storage model for recording changes made to opportunity model.
 
     The ID of each instance is <exploration_id>.<language_code>.
     """
@@ -66,7 +66,7 @@ class TranslationCountDebugTrackerModel(base_models.BaseModel):
     @classmethod
     def get_by_exp_id_and_langauge_code(
         cls, exp_id: str, language_code: str
-    ) -> Optional[TranslationCountDebugTrackerModel]:
+    ) -> Optional[OpportunityDebugModel]:
         """Gets the model instance for the given exploration and language code.
 
         Args:
@@ -74,7 +74,7 @@ class TranslationCountDebugTrackerModel(base_models.BaseModel):
             language_code: str. The language code.
 
         Returns:
-            TranslationCountDebugTrackerModel|None. The model instance, if it
+            OpportunityDebugModel|None. The model instance, if it
             exists, else None.
         """
         return cls.get_by_id(f'{exp_id}.{language_code}')
@@ -82,33 +82,33 @@ class TranslationCountDebugTrackerModel(base_models.BaseModel):
     @classmethod
     def get_multi_by_exp_id(
         cls, exp_id: str
-    ) -> Sequence[TranslationCountDebugTrackerModel]:
+    ) -> Sequence[OpportunityDebugModel]:
         """Gets all the model instances for the given exploration ID.
 
         Args:
             exp_id: str. The exploration ID.
 
         Returns:
-            list(TranslationCountDebugTrackerModel). The model instances.
+            list(OpportunityDebugModel). The model instances.
         """
         debug_models: Sequence[
-            TranslationCountDebugTrackerModel] = cls.get_all().filter(
+            OpportunityDebugModel] = cls.get_all().filter(
                 cls.exp_id == exp_id).fetch()
         return debug_models
 
     @classmethod
     def get_multi_by_language_code(
         cls, language_code: str
-    ) -> Sequence[TranslationCountDebugTrackerModel]:
+    ) -> Sequence[OpportunityDebugModel]:
         """Gets all the model instances for the given language code.
 
         Args:
             language_code: str. The language code.
 
         Returns:
-            list(TranslationCountDebugTrackerModel). The model instances.
+            list(OpportunityDebugModel). The model instances.
         """
         debug_models: Sequence[
-            TranslationCountDebugTrackerModel] = cls.get_all().filter(
+            OpportunityDebugModel] = cls.get_all().filter(
                 cls.language_code == language_code).fetch()
         return debug_models

--- a/core/storage/opportunity_debug/gae_models_test.py
+++ b/core/storage/opportunity_debug/gae_models_test.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for core.storage.translation_count_debug_tracker.gae_models."""
+"""Tests for core.storage.opportunity_debug.gae_models."""
 
 from __future__ import annotations
 import datetime
@@ -25,24 +25,24 @@ from core.tests import test_utils
 MYPY = False
 if MYPY: # pragma: no cover
     from mypy_imports import base_models
-    from mypy_imports import translation_count_debug_tracker_models
+    from mypy_imports import opportunity_debug_models
 
 (
     base_models,
-    translation_count_debug_tracker_models) = models.Registry.import_models([
-    models.Names.BASE_MODEL, models.Names.TRANSLATION_COUNT_DEBUG_TRACKER
+    opportunity_debug_models) = models.Registry.import_models([
+    models.Names.BASE_MODEL, models.Names.OPPORTUNITY_DEBUG
 ])
 
 
-class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
-    """Test the TranslationCountDebugTrackerModel class."""
+class OpportunityDebugModelUnitTest(test_utils.GenericTestBase):
+    """Test the OpportunityDebugModel class."""
 
     dt = datetime.datetime.utcnow()
 
     def setUp(self) -> None:
         super().setUp()
         # Create first model.
-        translation_count_debug_tracker_models.TranslationCountDebugTrackerModel( # pylint: disable=line-too-long
+        opportunity_debug_models.OpportunityDebugModel( # pylint: disable=line-too-long
             id='exp_id1.hi',
             exp_id='exp_id1',
             language_code='hi',
@@ -66,7 +66,7 @@ class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
             ]
         ).put()
         # Create second model.
-        translation_count_debug_tracker_models.TranslationCountDebugTrackerModel( # pylint: disable=line-too-long
+        opportunity_debug_models.OpportunityDebugModel( # pylint: disable=line-too-long
             id='exp_id1.es',
             exp_id='exp_id1',
             language_code='es',
@@ -82,7 +82,7 @@ class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
             ]
         ).put()
         # Create third model.
-        translation_count_debug_tracker_models.TranslationCountDebugTrackerModel( # pylint: disable=line-too-long
+        opportunity_debug_models.OpportunityDebugModel( # pylint: disable=line-too-long
             id='exp_id2.hi',
             exp_id='exp_id2',
             language_code='hi',
@@ -100,15 +100,15 @@ class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
 
     def test_get_deletion_policy(self) -> None:
         self.assertEqual(
-            translation_count_debug_tracker_models
-                .TranslationCountDebugTrackerModel
+            opportunity_debug_models
+                .OpportunityDebugModel
                     .get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
 
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
-            translation_count_debug_tracker_models
-                .TranslationCountDebugTrackerModel
+            opportunity_debug_models
+                .OpportunityDebugModel
                     .get_model_association_to_user(),
             base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
         )
@@ -123,8 +123,8 @@ class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
             'events': base_models.EXPORT_POLICY.NOT_APPLICABLE
         }
         self.assertEqual(
-            translation_count_debug_tracker_models
-                .TranslationCountDebugTrackerModel
+            opportunity_debug_models
+                .OpportunityDebugModel
                     .get_export_policy(),
             expected_export_policy_dict
         )
@@ -132,8 +132,8 @@ class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
     def test_get_by_exploration_id_and_langauge_code(
         self) -> None:
         model1 = (
-            translation_count_debug_tracker_models
-                .TranslationCountDebugTrackerModel
+            opportunity_debug_models
+                .OpportunityDebugModel
                     .get_by_exp_id_and_langauge_code(
                     'exp_id1', 'hi'))
 
@@ -165,8 +165,8 @@ class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
 
     def test_get_multi_by_exp_id(self) -> None:
         models_list = (
-            translation_count_debug_tracker_models
-                .TranslationCountDebugTrackerModel
+            opportunity_debug_models
+                .OpportunityDebugModel
                     .get_multi_by_exp_id('exp_id1'))
         self.assertEqual(len(models_list), 2)
 
@@ -214,8 +214,8 @@ class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
 
     def test_get_multi_by_language_code(self) -> None:
         models_list = (
-            translation_count_debug_tracker_models
-                .TranslationCountDebugTrackerModel
+            opportunity_debug_models
+                .OpportunityDebugModel
                     .get_multi_by_language_code('hi'))
         self.assertEqual(len(models_list), 2)
 

--- a/core/storage/translation_count_debug_tracker/gae_models.py
+++ b/core/storage/translation_count_debug_tracker/gae_models.py
@@ -1,0 +1,114 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Models for translation count debug information."""
+
+from __future__ import annotations
+
+from core.platform import models
+
+from typing import Dict, Optional, Sequence
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import base_models
+    from mypy_imports import datastore_services
+
+(base_models,) = models.Registry.import_models([models.Names.BASE_MODEL])
+
+datastore_services = models.Registry.import_datastore_services()
+
+
+class TranslationCountDebugTrackerModel(base_models.BaseModel):
+    """Storage model for recording changes to translation counts.
+
+    The ID of each instance is <exploration_id>.<language_code>.
+    """
+
+    exp_id = datastore_services.StringProperty(required=True, indexed=True)
+    language_code = datastore_services.StringProperty(
+        required=True, indexed=True)
+    events = datastore_services.JsonProperty(default={}, indexed=False)
+
+    @staticmethod
+    def get_deletion_policy() -> base_models.DELETION_POLICY:
+        """Model doesn't contain any data directly corresponding to a user."""
+        return base_models.DELETION_POLICY.NOT_APPLICABLE
+
+    @staticmethod
+    def get_model_association_to_user(
+    ) -> base_models.MODEL_ASSOCIATION_TO_USER:
+        """Model does not contain user data."""
+        return base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+
+    @classmethod
+    def get_export_policy(cls) -> Dict[str, base_models.EXPORT_POLICY]:
+        """Model doesn't contain any data directly corresponding to a user."""
+        return dict(super(cls, cls).get_export_policy(), **{
+            'exp_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'language_code': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'events': base_models.EXPORT_POLICY.NOT_APPLICABLE
+        })
+
+    @classmethod
+    def get_by_exp_id_and_langauge_code(
+        cls, exp_id: str, language_code: str
+    ) -> Optional[TranslationCountDebugTrackerModel]:
+        """Gets the model instance for the given exploration and language code.
+
+        Args:
+            exp_id: str. The exploration ID.
+            language_code: str. The language code.
+
+        Returns:
+            TranslationCountDebugTrackerModel|None. The model instance, if it
+            exists, else None.
+        """
+        return cls.get_by_id(f'{exp_id}.{language_code}')
+
+    @classmethod
+    def get_multi_by_exp_id(
+        cls, exp_id: str
+    ) -> Sequence[TranslationCountDebugTrackerModel]:
+        """Gets all the model instances for the given exploration ID.
+
+        Args:
+            exp_id: str. The exploration ID.
+
+        Returns:
+            list(TranslationCountDebugTrackerModel). The model instances.
+        """
+        debug_models: Sequence[
+            TranslationCountDebugTrackerModel] = cls.get_all().filter(
+                cls.exp_id == exp_id).fetch()
+        return debug_models
+
+    @classmethod
+    def get_multi_by_language_code(
+        cls, language_code: str
+    ) -> Sequence[TranslationCountDebugTrackerModel]:
+        """Gets all the model instances for the given language code.
+
+        Args:
+            language_code: str. The language code.
+
+        Returns:
+            list(TranslationCountDebugTrackerModel). The model instances.
+        """
+        debug_models: Sequence[
+            TranslationCountDebugTrackerModel] = cls.get_all().filter(
+                cls.language_code == language_code).fetch()
+        return debug_models

--- a/core/storage/translation_count_debug_tracker/gae_models_test.py
+++ b/core/storage/translation_count_debug_tracker/gae_models_test.py
@@ -1,0 +1,262 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for core.storage.translation_count_debug_tracker.gae_models."""
+
+from __future__ import annotations
+import datetime
+
+from core.platform import models
+from core.tests import test_utils
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import base_models
+    from mypy_imports import translation_count_debug_tracker_models
+
+(
+    base_models,
+    translation_count_debug_tracker_models) = models.Registry.import_models([
+    models.Names.BASE_MODEL, models.Names.TRANSLATION_COUNT_DEBUG_TRACKER
+])
+
+
+class TranslationCountDebugTrackerModelUnitTest(test_utils.GenericTestBase):
+    """Test the TranslationCountDebugTrackerModel class."""
+
+    dt = datetime.datetime.utcnow()
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Create first model.
+        translation_count_debug_tracker_models.TranslationCountDebugTrackerModel( # pylint: disable=line-too-long
+            id='exp_id1.hi',
+            exp_id='exp_id1',
+            language_code='hi',
+            events=[
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 120,
+                    'stored_content_count': 120,
+                    'actual_translation_count': 80,
+                    'stored_translation_count': 80,
+                    'timestamp': self.dt.isoformat()
+                },
+                {
+                    'type': 'exploration_update',
+                    'actual_content_count': 122,
+                    'stored_content_count': 122,
+                    'actual_translation_count': 81,
+                    'stored_translation_count': 81,
+                    'timestamp': self.dt.isoformat()
+                }
+            ]
+        ).put()
+        # Create second model.
+        translation_count_debug_tracker_models.TranslationCountDebugTrackerModel( # pylint: disable=line-too-long
+            id='exp_id1.es',
+            exp_id='exp_id1',
+            language_code='es',
+            events=[
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 92,
+                    'stored_content_count': 92,
+                    'actual_translation_count': 12,
+                    'stored_translation_count': 12,
+                    'timestamp': self.dt.isoformat()
+                }
+            ]
+        ).put()
+        # Create third model.
+        translation_count_debug_tracker_models.TranslationCountDebugTrackerModel( # pylint: disable=line-too-long
+            id='exp_id2.hi',
+            exp_id='exp_id2',
+            language_code='hi',
+            events=[
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 62,
+                    'stored_content_count': 62,
+                    'actual_translation_count': 57,
+                    'stored_translation_count': 52,
+                    'timestamp': self.dt.isoformat()
+                }
+            ]
+        ).put()
+
+    def test_get_deletion_policy(self) -> None:
+        self.assertEqual(
+            translation_count_debug_tracker_models
+                .TranslationCountDebugTrackerModel
+                    .get_deletion_policy(),
+            base_models.DELETION_POLICY.NOT_APPLICABLE)
+
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            translation_count_debug_tracker_models
+                .TranslationCountDebugTrackerModel
+                    .get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
+
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'exp_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'language_code': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'events': base_models.EXPORT_POLICY.NOT_APPLICABLE
+        }
+        self.assertEqual(
+            translation_count_debug_tracker_models
+                .TranslationCountDebugTrackerModel
+                    .get_export_policy(),
+            expected_export_policy_dict
+        )
+
+    def test_get_by_exploration_id_and_langauge_code(
+        self) -> None:
+        model1 = (
+            translation_count_debug_tracker_models
+                .TranslationCountDebugTrackerModel
+                    .get_by_exp_id_and_langauge_code(
+                    'exp_id1', 'hi'))
+
+        self.assertIsNotNone(model1)
+        if model1 is None:
+            raise AssertionError('model1 should not be None')
+        self.assertEqual(model1.exp_id, 'exp_id1')
+        self.assertEqual(model1.language_code, 'hi')
+        self.assertEqual(len(model1.events), 2)
+        expected_events_model1 = [
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 120,
+                    'stored_content_count': 120,
+                    'actual_translation_count': 80,
+                    'stored_translation_count': 80,
+                    'timestamp': self.dt.isoformat()
+                },
+                {
+                    'type': 'exploration_update',
+                    'actual_content_count': 122,
+                    'stored_content_count': 122,
+                    'actual_translation_count': 81,
+                    'stored_translation_count': 81,
+                    'timestamp': self.dt.isoformat()
+                }
+        ]
+        self.assertEqual(model1.events, expected_events_model1)
+
+    def test_get_multi_by_exp_id(self) -> None:
+        models_list = (
+            translation_count_debug_tracker_models
+                .TranslationCountDebugTrackerModel
+                    .get_multi_by_exp_id('exp_id1'))
+        self.assertEqual(len(models_list), 2)
+
+        models_list = sorted(models_list, key=lambda x: str(x.language_code))
+
+        model1 = models_list[0]
+        self.assertEqual(model1.exp_id, 'exp_id1')
+        self.assertEqual(model1.language_code, 'es')
+        self.assertEqual(len(model1.events), 1)
+        expected_events_model1 = [
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 92,
+                    'stored_content_count': 92,
+                    'actual_translation_count': 12,
+                    'stored_translation_count': 12,
+                    'timestamp': self.dt.isoformat()
+                }
+        ]
+        self.assertEqual(model1.events, expected_events_model1)
+
+        model2 = models_list[1]
+        self.assertEqual(model2.exp_id, 'exp_id1')
+        self.assertEqual(model2.language_code, 'hi')
+        self.assertEqual(len(model2.events), 2)
+        expected_events_model2 = [
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 120,
+                    'stored_content_count': 120,
+                    'actual_translation_count': 80,
+                    'stored_translation_count': 80,
+                    'timestamp': self.dt.isoformat()
+                },
+                {
+                    'type': 'exploration_update',
+                    'actual_content_count': 122,
+                    'stored_content_count': 122,
+                    'actual_translation_count': 81,
+                    'stored_translation_count': 81,
+                    'timestamp': self.dt.isoformat()
+                }
+        ]
+        self.assertEqual(model2.events, expected_events_model2)
+
+    def test_get_multi_by_language_code(self) -> None:
+        models_list = (
+            translation_count_debug_tracker_models
+                .TranslationCountDebugTrackerModel
+                    .get_multi_by_language_code('hi'))
+        self.assertEqual(len(models_list), 2)
+
+        models_list = sorted(models_list, key=lambda x: str(x.exp_id))
+
+        model1 = models_list[0]
+        self.assertEqual(model1.exp_id, 'exp_id1')
+        self.assertEqual(model1.language_code, 'hi')
+        self.assertEqual(len(model1.events), 2)
+        expected_events_model1 = [
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 120,
+                    'stored_content_count': 120,
+                    'actual_translation_count': 80,
+                    'stored_translation_count': 80,
+                    'timestamp': self.dt.isoformat()
+                },
+                {
+                    'type': 'exploration_update',
+                    'actual_content_count': 122,
+                    'stored_content_count': 122,
+                    'actual_translation_count': 81,
+                    'stored_translation_count': 81,
+                    'timestamp': self.dt.isoformat()
+                }
+        ]
+        self.assertEqual(model1.events, expected_events_model1)
+
+        model2 = models_list[1]
+        self.assertEqual(model2.exp_id, 'exp_id2')
+        self.assertEqual(model2.language_code, 'hi')
+        self.assertEqual(len(model2.events), 1)
+        expected_events_model2 = [
+                {
+                    'type': 'translation_review',
+                    'actual_content_count': 62,
+                    'stored_content_count': 62,
+                    'actual_translation_count': 57,
+                    'stored_translation_count': 52,
+                    'timestamp': self.dt.isoformat()
+                }
+        ]
+        self.assertEqual(model2.events, expected_events_model2)

--- a/mypy_imports.py
+++ b/mypy_imports.py
@@ -71,6 +71,8 @@ from core.storage.subtopic import gae_models as subtopic_models
 from core.storage.suggestion import gae_models as suggestion_models
 from core.storage.topic import gae_models as topic_models
 from core.storage.translation import gae_models as translation_models
+from core.storage.translation_count_debug_tracker import (
+    gae_models as translation_count_debug_tracker_models)
 from core.storage.user import gae_models as user_models
 from core.storage.voiceover import gae_models as voiceover_models
 
@@ -113,6 +115,7 @@ __all__ = [
     'suggestion_models',
     'topic_models',
     'translation_models',
+    'translation_count_debug_tracker_models',
     'translate_services',
     'transaction_services',
     'user_models',

--- a/mypy_imports.py
+++ b/mypy_imports.py
@@ -62,6 +62,8 @@ from core.storage.improvements import gae_models as improvements_models
 from core.storage.job import gae_models as job_models
 from core.storage.learner_group import gae_models as learner_group_models
 from core.storage.opportunity import gae_models as opportunity_models
+from core.storage.opportunity_debug import (
+    gae_models as opportunity_debug_models)
 from core.storage.question import gae_models as question_models
 from core.storage.recommendations import gae_models as recommendations_models
 from core.storage.skill import gae_models as skill_models
@@ -71,8 +73,6 @@ from core.storage.subtopic import gae_models as subtopic_models
 from core.storage.suggestion import gae_models as suggestion_models
 from core.storage.topic import gae_models as topic_models
 from core.storage.translation import gae_models as translation_models
-from core.storage.translation_count_debug_tracker import (
-    gae_models as translation_count_debug_tracker_models)
 from core.storage.user import gae_models as user_models
 from core.storage.voiceover import gae_models as voiceover_models
 
@@ -115,7 +115,7 @@ __all__ = [
     'suggestion_models',
     'topic_models',
     'translation_models',
-    'translation_count_debug_tracker_models',
+    'opportunity_debug_models',
     'translate_services',
     'transaction_services',
     'user_models',

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -293,6 +293,7 @@
         "core.storage.subtopic.gae_models_test",
         "core.domain.user_domain_test",
         "core.storage.opportunity.gae_models_test",
+        "core.storage.opportunity_debug.gae_models_test",
         "scripts.build_test",
         "scripts.install_third_party_libs_test",
         "core.storage.statistics.gae_models_test",


### PR DESCRIPTION
## Overview

1. This PR fixes part of #20961.
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
