### PR TITLE
Fix part of #21980:  Add validation to require commit message for public exploration updates

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -36,6 +36,7 @@ from core.domain import feature_flag_services
 from core.domain import fs_services
 from core.domain import image_validation_services
 from core.domain import question_services
+from core.domain import rights_domain
 from core.domain import rights_manager
 from core.domain import search_services
 from core.domain import state_domain
@@ -238,10 +239,16 @@ class ExplorationHandler(
         commit_message = self.normalized_payload.get('commit_message')
         change_list = self.normalized_payload['change_list']
 
+        # Validate commit message for public explorations
+        exploration_rights = rights_manager.get_exploration_rights(exploration_id)
+        if exploration_rights.status == rights_domain.ACTIVITY_STATUS_PUBLIC:
+            if not commit_message:
+                raise self.InvalidInputException(
+                    'Exploration is public so expected a commit message but received none.'
+                )
+
         changes_are_mergeable = exp_services.are_changes_mergeable(
             exploration_id, version, change_list)
-        exploration_rights = rights_manager.get_exploration_rights(
-            exploration_id)
         can_edit = rights_manager.check_can_edit_activity(
             self.user, exploration_rights)
         can_voiceover = rights_manager.check_can_voiceover_activity(

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -239,12 +239,15 @@ class ExplorationHandler(
         commit_message = self.normalized_payload.get('commit_message')
         change_list = self.normalized_payload['change_list']
 
-        # Validate commit message for public explorations
-        exploration_rights = rights_manager.get_exploration_rights(exploration_id)
+        # Validate commit message for public explorations.
+        exploration_rights = rights_manager.get_exploration_rights(
+            exploration_id
+        )
         if exploration_rights.status == rights_domain.ACTIVITY_STATUS_PUBLIC:
             if not commit_message:
                 raise self.InvalidInputException(
-                    'Exploration is public so expected a commit message but received none.'
+                    'Exploration is public so expected a commit '
+                    'message but received none.'
                 )
 
         changes_are_mergeable = exp_services.are_changes_mergeable(

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -358,7 +358,9 @@ class EditorTests(BaseEditorControllerTests):
         self.logout()
 
     def test_public_exploration_requires_commit_message(self) -> None:
-        """Test that public explorations require a commit message when updated."""
+        """Test that public explorations require a commit message
+        when updated.
+        """
         self.login(self.OWNER_EMAIL)
 
         csrf_token = self.get_new_csrf_token()
@@ -389,7 +391,8 @@ class EditorTests(BaseEditorControllerTests):
 
         self.assertEqual(
             response['error'],
-            'Exploration is public so expected a commit message but received none.'
+            'Exploration is public so expected a commit message but received '
+            'none.'
         )
 
         response = self.put_json(

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -358,6 +358,57 @@ class EditorTests(BaseEditorControllerTests):
         self.logout()
 
 
+    def test_public_exploration_requires_commit_message(self) -> None:
+        """Test that public explorations require a commit message when updated."""
+        self.login(self.OWNER_EMAIL)
+        
+        csrf_token = self.get_new_csrf_token()
+        
+        exp_id = 'eid'
+        self.save_new_valid_exploration(
+            exp_id, self.owner_id, end_state_name='End State')
+        
+        rights_manager.publish_exploration(self.owner, exp_id)
+        
+        change_list = [{
+            'cmd': 'edit_exploration_property',
+            'property_name': 'title',
+            'old_value': 'A title',
+            'new_value': 'Updated Title'
+        }]
+        
+        response = self.put_json(
+            '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
+            {
+                'version': 1,
+                'commit_message': None,
+                'change_list': change_list
+            },
+            csrf_token=csrf_token,
+            expected_status_int=400
+        )
+        
+        self.assertEqual(
+            response['error'],
+            'Exploration is public so expected a commit message but received none.'
+        )
+        
+        response = self.put_json(
+            '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
+            {
+                'version': 1,
+                'commit_message': 'Updated the title',
+                'change_list': change_list
+            },
+            csrf_token=csrf_token
+        )
+        
+        updated_exploration = exp_fetchers.get_exploration_by_id(exp_id)
+        self.assertEqual(updated_exploration.title, 'Updated Title')
+        
+        self.logout()
+
+
 class DownloadIntegrationTest(BaseEditorControllerTests):
     """Test handler for exploration and state download."""
 

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -378,6 +378,7 @@ class EditorTests(BaseEditorControllerTests):
             'new_value': 'Updated Title'
         }]
 
+        # Test with commit_message set to None
         response = self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
@@ -388,13 +389,29 @@ class EditorTests(BaseEditorControllerTests):
             csrf_token=csrf_token,
             expected_status_int=400
         )
-
         self.assertEqual(
             response['error'],
             'Exploration is public so expected a commit message but received '
             'none.'
         )
 
+        # Test without commit_message field
+        response = self.put_json(
+            '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
+            {
+                'version': 1,
+                'change_list': change_list
+            },
+            csrf_token=csrf_token,
+            expected_status_int=400
+        )
+        self.assertEqual(
+            response['error'],
+            'Exploration is public so expected a commit message but received '
+            'none.'
+        )
+
+        # Test with a valid commit_message
         response = self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
@@ -404,9 +421,44 @@ class EditorTests(BaseEditorControllerTests):
             },
             csrf_token=csrf_token
         )
-
         updated_exploration = exp_fetchers.get_exploration_by_id(exp_id)
         self.assertEqual(updated_exploration.title, 'Updated Title')
+
+        self.logout()
+
+    def test_private_exploration_does_not_require_commit_message(
+        self
+    ) -> None:
+        """Test that private explorations do not require a commit message
+        when updated.
+        """
+        self.login(self.OWNER_EMAIL)
+
+        csrf_token = self.get_new_csrf_token()
+
+        exp_id = 'eid'
+        self.save_new_valid_exploration(
+            exp_id, self.owner_id, end_state_name='End State')
+
+        change_list = [{
+            'cmd': 'edit_exploration_property',
+            'property_name': 'title',
+            'old_value': 'A title',
+            'new_value': 'Updated Title'
+        }]
+
+        # Test updating a private exploration without a commit message.
+        response = self.put_json(
+            '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
+            {
+                'version': 1,
+                'change_list': change_list
+            },
+            csrf_token=csrf_token
+        )
+        updated_exploration = exp_fetchers.get_exploration_by_id(exp_id)
+        self.assertEqual(updated_exploration.title, 'Updated Title')
+
         self.logout()
 
 

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -357,26 +357,25 @@ class EditorTests(BaseEditorControllerTests):
             'This exploration cannot be edited. Please contact the admin.')
         self.logout()
 
-
     def test_public_exploration_requires_commit_message(self) -> None:
         """Test that public explorations require a commit message when updated."""
         self.login(self.OWNER_EMAIL)
-        
+
         csrf_token = self.get_new_csrf_token()
-        
+
         exp_id = 'eid'
         self.save_new_valid_exploration(
             exp_id, self.owner_id, end_state_name='End State')
-        
+
         rights_manager.publish_exploration(self.owner, exp_id)
-        
+
         change_list = [{
             'cmd': 'edit_exploration_property',
             'property_name': 'title',
             'old_value': 'A title',
             'new_value': 'Updated Title'
         }]
-        
+
         response = self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
@@ -387,12 +386,12 @@ class EditorTests(BaseEditorControllerTests):
             csrf_token=csrf_token,
             expected_status_int=400
         )
-        
+
         self.assertEqual(
             response['error'],
             'Exploration is public so expected a commit message but received none.'
         )
-        
+
         response = self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
@@ -402,10 +401,9 @@ class EditorTests(BaseEditorControllerTests):
             },
             csrf_token=csrf_token
         )
-        
+
         updated_exploration = exp_fetchers.get_exploration_by_id(exp_id)
         self.assertEqual(updated_exploration.title, 'Updated Title')
-        
         self.logout()
 
 

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -378,7 +378,7 @@ class EditorTests(BaseEditorControllerTests):
             'new_value': 'Updated Title'
         }]
 
-        # Test with commit_message set to None
+        # Test with commit_message set to None.
         response = self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
@@ -395,7 +395,7 @@ class EditorTests(BaseEditorControllerTests):
             'none.'
         )
 
-        # Test without commit_message field
+        # Test without commit_message field.
         response = self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
@@ -411,7 +411,7 @@ class EditorTests(BaseEditorControllerTests):
             'none.'
         )
 
-        # Test with a valid commit_message
+        # Test with a valid commit_message.
         response = self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
@@ -448,7 +448,7 @@ class EditorTests(BaseEditorControllerTests):
         }]
 
         # Test updating a private exploration without a commit message.
-        response = self.put_json(
+        self.put_json(
             '%s/%s' % (feconf.EXPLORATION_DATA_PREFIX, exp_id),
             {
                 'version': 1,


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21980 .
2. This PR does the following:
- Adds validation in the ExplorationHandler to check if an exploration is public before allowing updates
- If the exploration is public, requires a commit message to be provided with the update
- Raises a 400 error (InvalidInputException) if a public exploration is updated without a commit message
- This ensures better documentation and tracking of changes to public explorations

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


- [x] A testing doc has been written: ... [DOC](https://docs.google.com/document/d/1GNpMaVQMZsQO7p8WKSzJfDVmOYL8l6BUHedPOnmPbaA/edit?usp=sharing) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

https://github.com/user-attachments/assets/3d5b2eca-a19f-42ea-a2d9-46793d38d8b8


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
