### PR TITLE
Fix #19132: Resolve drag-and-drop console error when switching interaction rules

### DIFF
--- a/core/templates/components/state-directives/rule-editor/rule-editor.component.ts
+++ b/core/templates/components/state-directives/rule-editor/rule-editor.component.ts
@@ -25,6 +25,7 @@ import {
   OnInit,
   Output,
   AfterViewChecked,
+  NgZone,
 } from '@angular/core';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
@@ -80,7 +81,8 @@ export class RuleEditorComponent
     private stateInteractionIdService: StateInteractionIdService,
     private responsesService: ResponsesService,
     private populateRuleContentIdsService: PopulateRuleContentIdsService,
-    private readonly changeDetectorRef: ChangeDetectorRef
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone
   ) {
     this.eventBusGroup = new EventBusGroup(this.eventBusService);
   }
@@ -196,7 +198,7 @@ export class RuleEditorComponent
     // interaction, where the rule inputs can sometimes be integers and
     // sometimes be lists of music notes.
     this.ruleDescriptionFragments = [];
-    setTimeout(() => {
+    this.ngZone.run(() => {
       this.ruleDescriptionFragments = result;
     }, 10);
 


### PR DESCRIPTION
## Overview

1. This PR fixes #19132.
2. This PR does the following: fixes drag-and-drop console error (ExpressionChangedAfterItHasBeenCheckedError) that occurred when switching interaction rules by using ngZone.run(), ensuring that updates to ruleDescriptionFragments are executed within Angular's zone, making it aware of the changes, without introducing timing issues.
3. (For bug-fixing PRs only) The original bug occurred because: the use of setTimeout introduced an asynchronous update to ruleDescriptionFragments, causing a mismatch between Angular’s state and the change detection cycle. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before the fix, the following error appeared in the console, when switching between interaction rules:
![console_error](https://github.com/user-attachments/assets/e9aee4c4-fcc9-40d9-8f2c-bf1a7eba703e)

After the fix, as demonstrated in this video, I created a new Exploration and switching between different interaction rules no longer caused the issue:
[bug_fix_reproduction.webm](https://github.com/user-attachments/assets/7999f685-05d4-42bc-93df-218135190b10)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
