### PR TITLE
Move label attribute to the right place in debugging docs discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
+++ b/.github/DISCUSSION_TEMPLATE/debugging-docs.yml
@@ -8,8 +8,8 @@ body:
     required: true
 - type: checkboxes
   id: sharing
-  label: "Please confirm the following:"
   attributes:
+    label: "Please confirm the following:"
     options:
     - label: "I confirm that I've given edit access to the doc to the dev mailing lists, as described in the instructions at the top of the doc."
       required: true


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: Fixing one more error in debugging docs discussion template

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

As noted in #22229, I can't find a way to display the new template -- GitHub still shows the errors from the old template when clicking "View file". So we would just need to merge it and see what happens.

Current version: https://github.com/oppia/oppia/blob/develop/.github/DISCUSSION_TEMPLATE/debugging-docs.yml


#### Proof of changes on desktop with slow/throttled network

N/A

#### Proof of changes on mobile phone

N/A

#### Proof of changes in Arabic language

N/A

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
