### PR TITLE
Fix #22232: handle cases when checkMarkComponent is not defined

### DIFF
--- a/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.spec.ts
@@ -337,7 +337,7 @@ describe('Tutor card component', () => {
     expect(componentInstance.isOnTerminalCard).toHaveBeenCalled();
   }));
 
-  it('should trigger celebratory animation if on the last card of a chapter', fakeAsync(() => {
+  it('should handle multiple calls when ngOnChanges runs before ngAfterViewInit', fakeAsync(() => {
     spyOn(componentInstance, 'updateDisplayedCard');
     spyOn(componentInstance, 'isOnTerminalCard').and.returnValue(true);
     spyOn(componentInstance, 'triggerCelebratoryAnimation');
@@ -353,9 +353,35 @@ describe('Tutor card component', () => {
     };
 
     componentInstance.ngOnChanges(changes);
-
+    componentInstance.ngAfterViewInit();
     expect(componentInstance.updateDisplayedCard).toHaveBeenCalled();
-    expect(componentInstance.triggerCelebratoryAnimation).toHaveBeenCalled();
+    tick();
+    expect(componentInstance.triggerCelebratoryAnimation).toHaveBeenCalledTimes(
+      1
+    );
+  }));
+
+  it('should trigger celebratory animation once when on last card and ngAfterViewInit runs before ngOnChanges', fakeAsync(() => {
+    spyOn(componentInstance, 'updateDisplayedCard');
+    spyOn(componentInstance, 'isOnTerminalCard').and.returnValue(true);
+    spyOn(componentInstance, 'triggerCelebratoryAnimation');
+    componentInstance.animationHasPlayedOnce = false;
+    componentInstance.inStoryMode = true;
+    const changes: SimpleChanges = {
+      displayedCard: {
+        previousValue: false,
+        currentValue: true,
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+    };
+    componentInstance.ngAfterViewInit();
+    componentInstance.ngOnChanges(changes);
+    expect(componentInstance.updateDisplayedCard).toHaveBeenCalled();
+    tick();
+    expect(componentInstance.triggerCelebratoryAnimation).toHaveBeenCalledTimes(
+      1
+    );
   }));
 
   it('should not trigger celebratory animation if not in story mode', fakeAsync(() => {
@@ -374,8 +400,8 @@ describe('Tutor card component', () => {
     };
 
     componentInstance.ngOnChanges(changes);
-
     expect(componentInstance.updateDisplayedCard).toHaveBeenCalled();
+    tick();
     expect(
       componentInstance.triggerCelebratoryAnimation
     ).not.toHaveBeenCalled();

--- a/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.ts
@@ -158,6 +158,7 @@ export class TutorCardComponent {
   confettiAnimationTimeout!: NodeJS.Timeout;
   skipClickListener: Function | null = null;
   username!: string | null;
+  _viewHasLoadedOnce: boolean = false;
 
   constructor(
     private audioBarStatusService: AudioBarStatusService,
@@ -255,12 +256,25 @@ export class TutorCardComponent {
     ) {
       this.updateDisplayedCard();
     }
+    this.tryTriggerAnimation();
+  }
+
+  ngAfterViewInit(): void {
+    this._viewHasLoadedOnce = true;
+    this.tryTriggerAnimation();
+  }
+
+  tryTriggerAnimation(): void {
     if (
       this.isOnTerminalCard() &&
       !this.animationHasPlayedOnce &&
-      this.inStoryMode
+      this.inStoryMode &&
+      this._viewHasLoadedOnce
     ) {
-      this.triggerCelebratoryAnimation();
+      this._viewHasLoadedOnce = false;
+      setTimeout(() => {
+        this.triggerCelebratoryAnimation();
+      });
     }
   }
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR Fixes #22232 .
2. This PR does the following: In this PR, I made changes to the `tutor-card.component.ts` such that `triggerCelebratoryAnimation`( or `animateCheckMark`) will be executed after it is defined properly. (i.e., when the view is loaded properly).
3. (For bug-fixing PRs only) The original bug occurred because the `checkMarkComponent` gets defined when the view of the component is loaded properly, but the `ngOnChanges` just triggers the `checkMarkComponent` before the view is loaded or `checkMarkComponent` is even defined.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
https://github.com/oppia/oppia/actions/runs/14141745610/job/39624288818?pr=22308

![image](https://github.com/user-attachments/assets/cdf77174-2505-4719-9fbc-3da51133c76d)

## Bug's stacktrace

```
ERROR:root:Frontend error: 
Cannot read properties of undefined (reading 'animateCheckMark')

    at URL: http://localhost:8181/explore/mcoijmgMzJ4A?topic_url_fragment=algebra-i&classroom_url_fragment=math&story_url_fragment=algebra-story&node_id=node_1
  console.log
    LOG: Exploration has completed successfully

      at Object.showMessage (utilities/common/show-message.ts:22:11)
          at runMicrotasks (<anonymous>)

WARNING:root:Invalid URL requested: http://localhost:8181/learn/math/algebra-i/revision/negative-numbers
PASS core/tests/puppeteer-acceptance-tests/specs/logged-out-user/select-and-play-topic-from-classroom-page.spec.ts (234.025 s)
  Logged-out User
    ✓ should be able to select and play a topic from the classroom page (24795 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        235.747 s
Ran all test suites matching /\/home\/runner\/work\/oppia\/oppia\/core\/tests\/puppeteer-acceptance-tests\/specs\/logged-out-user\/select-and-play-topic-from-classroom-page/i.
```

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
