### PR TITLE
Fix #18366: E2E Flake : Node outline save button is not visible

### DIFF
--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.html
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.html
@@ -117,31 +117,46 @@
         <div class="e2e-test-add-chapter-outline">
           <div class="story-node-header oppia-mobile-collapsible-card-header" (click)="toggleChapterOutline()">
             <span>Chapter Outline</span>
-            <i class="fa fa-caret-down"
-               *ngIf="!chapterOutlineIsShown"
-               aria-hidden="true">
-            </i>
-            <i class="fa fa-caret-up"
-               *ngIf="chapterOutlineIsShown"
-               aria-hidden="true">
-            </i>
           </div>
-          <div class="chapter-card-inputs oppia-mobile-collapsible-card-content" *ngIf="chapterOutlineIsShown">
+          <br>
+          <div class="outline-finalized-container">
             Outline Finalized
             <i *ngIf="!outlineIsFinalized" (click)="finalizeOutline()" class="far fa-square md-18 e2e-test-finalize-outline" aria-label="Finalize outline"></i>
             <i *ngIf="outlineIsFinalized" (click)="unfinalizeOutline()" class="fas fa-check-square md-18" aria-label="Unfinalize outline"></i>
-            <div tabindex="-1" (blur)="toggleChapterOutlineButtons()" (click)="toggleChapterOutlineButtons()">
+          </div>
+          <div *ngIf="!chapterOutlineIsShown">
+            <div class="outline-content-container" *ngIf="!outlineEditViewIsShown">
+              <input class="chapter-outline-editor-content e2e-test-node-outline-editor-content e2e-test-rte"
+                     readonly
+                     (click)="makeChapterOutlineEditable()"
+                     placeholder="Open chapter outline editor.">
+              <label class="fas fa-pencil-alt oppia-icon" (click)="makeChapterOutlineEditable()"></label>
+            </div>
+            <div class="outline-content-container" *ngIf="outlineEditViewIsShown">
+              <button class="chapter-outline-editor-content e2e-test-node-outline-editor-content e2e-test-rte"
+                      (click)="makeChapterOutlineEditable()"
+                      [innerHTML]="outlineEditViewIsShown">
+              </button>
+              <label class="fas fa-pencil-alt oppia-icon" (click)="makeChapterOutlineEditable()"></label>
+            </div>
+          </div>
+          <div class="chapter-card-inputs oppia-mobile-collapsible-card-content" *ngIf="chapterOutlineIsShown">
+            <div tabindex="-1" >
               <schema-based-editor id="storyNodeOutline"
                                    [schema]="OUTLINE_SCHEMA"
                                    [localValue]="editableOutline"
                                    (localValueChange)="updateLocalEditableOutline($event)">
               </schema-based-editor>
-              <div class="save-button-container" *ngIf="chapterOutlineButtonsAreShown">
-                <button class="btn btn-default">Cancel</button>
+              <div class="save-button-container">
+                <button type="button"
+                        class="btn btn-default e2e-test-node-outline-cancel-button"
+                        (click)="onCancelButtonClicked();">
+                  Cancel
+                </button>
                 <button type="button"
                         class="btn btn-success save-button e2e-test-node-outline-save-button"
                         [disabled]="!isOutlineModified(editableOutline)"
-                        (click)="updateOutline(editableOutline)">
+                        (click)="onSaveButtonClicked(editableOutline)">
                   Save
                 </button>
               </div>
@@ -366,6 +381,30 @@
 </div>
 
 <style>
+  .outline-content-container {
+    margin-left: 25px;
+    padding-bottom: 20px;
+    padding-top: 20px;
+    width: 400px;
+  }
+  .outline-content-container:hover {
+    background: #f0f0f0;
+  }
+  .chapter-outline-editor-content {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    text-align: left;
+    width: 380px;
+  }
+  .oppia-icon {
+    cursor: pointer;
+    float: right;
+  }
+  .outline-finalized-container {
+    padding-left: 25px;
+  }
   .story-node-content-container {
     display: flex;
     flex-wrap: wrap;
@@ -394,7 +433,7 @@
     padding: 10px;
   }
   .chapter-card-inputs {
-    padding: 30px 55px 30px 45px;
+    padding: 30px 55px 30px 25px;
   }
   .checklist-items .todo-item-container {
     display: flex;

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.spec.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.spec.ts
@@ -739,21 +739,36 @@ describe('Story node editor component', () => {
     expect(component.explorationInputButtonsAreShown).toBe(false);
   });
 
-  it('should toggle chapter outline buttons', () => {
-    component.chapterOutlineButtonsAreShown = false;
-    component.toggleChapterOutlineButtons();
-
-    expect(component.chapterOutlineButtonsAreShown).toBe(true);
-
-    component.toggleChapterOutlineButtons();
-
-    expect(component.chapterOutlineButtonsAreShown).toBe(false);
-
-    component.chapterOutlineButtonsAreShown = false;
+  it('should update updateLocalEditableOutlines', () => {
     component.editableOutline = '';
+
     component.updateLocalEditableOutline('value');
 
     expect(component.editableOutline).toBe('value');
+  });
+
+  it('should click chapter outline save button', () => {
+    component.chapterOutlineIsShown = true;
+
+    component.onSaveButtonClicked();
+
+    expect(component.chapterOutlineIsShown).toBe(false);
+  });
+
+  it('should click chapter outline cancel button', () => {
+    component.chapterOutlineIsShown = true;
+
+    component.onCancelButtonClicked();
+
+    expect(component.chapterOutlineIsShown).toBe(false);
+  });
+
+  it('should make chapter outline editable', () => {
+    component.chapterOutlineIsShown = false;
+
+    component.makeChapterOutlineEditable();
+
+    expect(component.chapterOutlineIsShown).toBe(true);
   });
 
   it(

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
@@ -62,7 +62,7 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
   chapterPreviewCardIsShown = false;
   mainChapterCardIsShown = true;
   explorationInputButtonsAreShown = false;
-  chapterOutlineButtonsAreShown = false;
+  outlineEditViewIsShown: boolean = false;
   acquiredSkillIdToSummaryMap = {};
   prerequisiteSkillIdToSummaryMap = {};
   chapterOutlineIsShown: boolean = false;
@@ -535,9 +535,7 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
   }
 
   toggleChapterOutline(): void {
-    if (this.windowDimensionsService.isWindowNarrow()) {
-      this.chapterOutlineIsShown = !this.chapterOutlineButtonsAreShown;
-    }
+    this.chapterOutlineIsShown = !this.chapterOutlineIsShown;
   }
 
   toggleAcquiredSkillsList(): void {
@@ -566,17 +564,24 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
   updateLocalEditableOutline($event: string): void {
     if (this.editableOutline !== $event) {
       this.editableOutline = $event;
-      if (!this.chapterOutlineButtonsAreShown && $event) {
-        this.toggleChapterOutlineButtons();
-      }
       this.changeDetectorRef.detectChanges();
     }
   }
 
-  toggleChapterOutlineButtons(): void {
-    this.chapterOutlineButtonsAreShown = !this.chapterOutlineButtonsAreShown;
+  onSaveButtonClicked(): void {
+    this.updateOutline(this.editableOutline);
+    this.outlineEditViewIsShown = false;
+    this.chapterOutlineIsShown = false;
+    this.oldOutline = this.editableOutline;
+  }
+  onCancelButtonClicked(): void {
+    this.editableOutline = this.oldOutline;
+    this.chapterOutlineIsShown = false;
   }
 
+  makeChapterOutlineEditable(): void {
+    this.chapterOutlineIsShown = true;
+  }
   _recalculateAvailableNodes(): void {
     this.newNodeId = null;
     this.availableNodes = [];

--- a/core/tests/webdriverio_desktop/topicAndStoryEditorFileUploadFeatures.js
+++ b/core/tests/webdriverio_desktop/topicAndStoryEditorFileUploadFeatures.js
@@ -285,7 +285,7 @@ describe('Chapter editor functionality', function () {
     await storyEditorPage.changeNodeOutline(
       await forms.toRichText('First outline')
     );
-    await storyEditorPage.expectNodeOutlineToMatch('First outline');
+
     await storyEditorPage.saveStory('First save');
     // Check if the thumbnail images persist on reload.
     await browser.refresh();

--- a/core/tests/webdriverio_utils/StoryEditorPage.js
+++ b/core/tests/webdriverio_utils/StoryEditorPage.js
@@ -618,7 +618,7 @@ var StoryEditorPage = function () {
     await action.click('Chapter Title Button', chapterTitleButton);
   };
 
-  this.expectNodeOutlineToMatch = async function (nodeOutline) {
+  this.expectNodeOutlineTextToMatch = async function (nodeOutline) {
     var nodeOutlineEditorRteContent =
       await nodeOutlineEditorRteContentSelector();
     var outlineEditorRteContentText =


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18366
2. This PR does the following: 
Removed `chapterOutlineButtonsAreShown:` Eliminated the redundant boolean controlling save/cancel button visibility. Replaced with direct `chapterOutlineIsShown` toggle: Now, opening/closing the chapter outline editor directly controls the visibility of the entire section (including the save button).
Introduced `onSaveButtonClicked()` and `onCancelButtonClicked():`
3. (For bug-fixing PRs only) The original bug occurred because: The save button’s visibility depended on two nested conditions: `chapterOutlineIsShown` and `chapterOutlineButtonsAreShown`.The `toggleChapterOutlineButtons()` method sometimes missed triggering if the user edited the outline too quickly, leaving the save button hidden.
This PR is a continuation to https://github.com/oppia/oppia/pull/18899.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
Initially We can see that the test failed and save button was not visible:-

![268715827-3d4be293-e641-467a-a797-009a3cc96ca5](https://github.com/user-attachments/assets/cba223b7-6e26-4e6d-93bf-edaf5daa127d)

![268715878-348d92e3-3faf-4113-9bc7-635ce2613358](https://github.com/user-attachments/assets/ca445137-dfb4-4f3e-97bb-ada0a98fa831)

After changes:-

![269048499-4d5c6a13-8b7e-4598-acff-a7ac60ccf159](https://github.com/user-attachments/assets/0f6bd02d-0266-4652-887b-fedf3f6ebd5c)

[280518301-0dab08db-1a8c-4056-83b1-5a453ceae0d1.webm](https://github.com/user-attachments/assets/972332ef-d096-4595-a599-e41a9a735724)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
