### PR TITLE
Hides voiceovers tab in exp editor for non-curated exploration

### DIFF
--- a/core/controllers/voice_artist_test.py
+++ b/core/controllers/voice_artist_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 
+from core import feature_flag_list
 from core import feconf
 from core.domain import rights_domain
 from core.domain import rights_manager
@@ -127,6 +128,9 @@ class VoiceArtistTest(BaseVoiceArtistControllerTests):
                     'version': 3
                 }, csrf_token=self.csrf_token)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_voice_artist_can_save_valid_change_list(self) -> None:
         response = self.put_json(
             '/createhandler/data/%s' % self.EXP_ID, {
@@ -227,6 +231,9 @@ class VoiceArtistAutosaveTest(BaseVoiceArtistControllerTests):
         # Generate CSRF token.
         self.csrf_token = self.get_new_csrf_token()
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_draft_updated_version_valid(self) -> None:
         payload = {
             'change_list': self.VALID_DRAFT_CHANGELIST,
@@ -261,6 +268,9 @@ class VoiceArtistAutosaveTest(BaseVoiceArtistControllerTests):
                            ' some changes in the change list.')
                       })
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_draft_updated_version_invalid(self) -> None:
         payload = {
             'change_list': self.VALID_DRAFT_CHANGELIST,

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -23,6 +23,7 @@ import json
 import os
 from unittest import mock
 
+from core import feature_flag_list
 from core import feconf
 from core import utils
 from core.constants import constants
@@ -17140,6 +17141,9 @@ class ExplorationChangesMergeabilityUnitTests(
             self.EXP_0_ID, 4, change_list_5)
         self.assertEqual(changes_are_mergeable_3, False)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_changes_are_mergeable_when_voiceovers_changes_do_not_conflict(
         self
     ) -> None:
@@ -17491,6 +17495,9 @@ class ExplorationChangesMergeabilityUnitTests(
             self.EXP_0_ID, 4, change_list_4)
         self.assertEqual(changes_are_not_mergeable, False)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_changes_are_not_mergeable_when_voiceovers_changes_conflict(
         self
     ) -> None:

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -705,6 +705,14 @@ def apply_change_list(
                         raise Exception(
                             'Expected recorded_voiceovers to be a dict, '
                             'received %s' % change.new_value)
+                    if (
+                        is_voiceover_allowed_for_exploration(exploration_id)
+                        is False
+                    ):
+                        raise Exception(
+                            'Voiceover additions are not allowed for '
+                            'this exploration.')
+
                     # Explicitly convert the duration_secs value from
                     # int to float. Reason for this is the data from
                     # the frontend will be able to match the backend
@@ -2062,6 +2070,13 @@ def compute_models_to_put_when_saving_new_exp_version(
     for change in change_list:
         if change.cmd == exp_domain.CMD_UPDATE_VOICEOVERS:
             voiceover_changes.append(change)
+
+    if (
+        len(voiceover_changes) > 0 and
+        is_voiceover_allowed_for_exploration(exploration_id) is False
+    ):
+        raise utils.ValidationError(
+            'Voiceover additions are not allowed for this exploration.')
 
     new_voiceover_models = voiceover_services.compute_voiceover_related_change(
         updated_exploration,
@@ -3963,3 +3978,22 @@ def rollback_exploration_to_safe_state(exp_id: str) -> int:
         caching_services.delete_multi(
             caching_services.CACHE_NAMESPACE_EXPLORATION, None, [exp_id])
     return last_known_safe_version
+
+
+def is_voiceover_allowed_for_exploration(exploration_id: str) -> bool:
+    """Checks if voiceover is allowed for the given exploration.
+
+    Args:
+        exploration_id: str. The ID of the exploration.
+
+    Returns:
+        bool. Whether voiceover is allowed for the given exploration.
+    """
+    if get_story_id_linked_to_exploration(exploration_id):
+        return True
+    else:
+        return feature_flag_services.is_feature_flag_enabled(
+            feature_flag_list.FeatureNames.
+            SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS.value,
+            None
+        )

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -705,10 +705,8 @@ def apply_change_list(
                         raise Exception(
                             'Expected recorded_voiceovers to be a dict, '
                             'received %s' % change.new_value)
-                    if (
-                        is_voiceover_allowed_for_exploration(exploration_id)
-                        is False
-                    ):
+
+                    if not does_exploration_support_voiceovers(exploration_id):
                         raise Exception(
                             'Voiceover additions are not allowed for '
                             'this exploration.')
@@ -2072,8 +2070,8 @@ def compute_models_to_put_when_saving_new_exp_version(
             voiceover_changes.append(change)
 
     if (
-        len(voiceover_changes) > 0 and
-        is_voiceover_allowed_for_exploration(exploration_id) is False
+        voiceover_changes and
+        not does_exploration_support_voiceovers(exploration_id)
     ):
         raise utils.ValidationError(
             'Voiceover additions are not allowed for this exploration.')
@@ -3980,7 +3978,7 @@ def rollback_exploration_to_safe_state(exp_id: str) -> int:
     return last_known_safe_version
 
 
-def is_voiceover_allowed_for_exploration(exploration_id: str) -> bool:
+def does_exploration_support_voiceovers(exploration_id: str) -> bool:
     """Checks if voiceover is allowed for the given exploration.
 
     Args:

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1040,6 +1040,9 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
         self.assertEqual(retrieved_exp_summary.category, 'A new category')
         self.assertEqual(retrieved_exp_summary.contributor_ids, [self.owner_id])
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_apply_change_list(self) -> None:
         self.save_new_linear_exp_with_state_names_and_interactions(
             self.EXP_0_ID, self.owner_id, ['State 1', 'State 2'],
@@ -1656,6 +1659,129 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
                 exp_fetchers
                 .get_multiple_versioned_exp_interaction_ids_mapping_by_version(
                     'exp_id_1', [1]))
+
+    def test_should_correctly_check_whether_voiceover_addition_is_allowed(
+        self) -> None:
+        self.save_new_valid_exploration(self.EXP_0_ID, self.owner_id)
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_0_ID, [exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
+                'property_name': 'title',
+                'new_value': 'Exploration 1 title'
+            })], 'Changed title.')
+
+        self.assertFalse(
+            exp_services.is_voiceover_allowed_for_exploration(self.EXP_0_ID))
+
+        story_id = story_services.get_new_story_id()
+        topic_id = topic_fetchers.get_new_topic_id()
+        self.save_new_topic(
+            topic_id, self.owner_id, name='Topic',
+            abbreviated_name='topic-one', url_fragment='topic-one',
+            description='A new topic',
+            canonical_story_ids=[], additional_story_ids=[],
+            uncategorized_skill_ids=['skill_4'], subtopics=[],
+            next_subtopic_id=0)
+        self.save_new_story(story_id, self.owner_id, topic_id)
+        topic_services.add_canonical_story(self.owner_id, topic_id, story_id)
+        change_list = [
+            story_domain.StoryChange({
+                'cmd': story_domain.CMD_ADD_STORY_NODE,
+                'node_id': '%s1' % story_domain.NODE_ID_PREFIX,
+                'title': 'Title 1'
+            }),
+            story_domain.StoryChange({
+                'cmd': story_domain.CMD_UPDATE_STORY_NODE_PROPERTY,
+                'property_name': (
+                    story_domain.STORY_NODE_PROPERTY_EXPLORATION_ID),
+                'node_id': '%s1' % story_domain.NODE_ID_PREFIX,
+                'old_value': None,
+                'new_value': self.EXP_0_ID
+            })
+        ]
+        story_services.update_story(
+            self.owner_id, story_id, change_list, 'Added node.')
+
+        self.assertTrue(
+            exp_services.is_voiceover_allowed_for_exploration(self.EXP_0_ID))
+
+    def test_raise_error_when_adding_voiceover_for_non_curated_exploration(
+        self
+    ) -> None:
+        self.save_new_linear_exp_with_state_names_and_interactions(
+            self.EXP_0_ID, self.owner_id, ['State 1', 'State 2'],
+            ['TextInput'], category='Algebra')
+
+        recorded_voiceovers_dict = {
+            'voiceovers_mapping': {
+                'content': {
+                    'en': {
+                        'filename': 'filename3.mp3',
+                        'file_size_bytes': 3000,
+                        'needs_update': False,
+                        'duration_secs': 42.43
+                    }
+                },
+                'default_outcome': {},
+                'ca_placeholder_0': {}
+            }
+        }
+        change_list_voiceover = [exp_domain.ExplorationChange({
+            'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+            'property_name': (
+                exp_domain.STATE_PROPERTY_RECORDED_VOICEOVERS),
+            'state_name': 'State 1',
+            'new_value': recorded_voiceovers_dict
+        })]
+
+        with self.assertRaisesRegex(
+            Exception,
+            'Voiceover additions are not allowed for this exploration.'
+        ):
+            exp_services.apply_change_list(
+                self.EXP_0_ID, change_list_voiceover)
+
+    def test_raise_error_while_adding_voiceover_with_accent(self) -> None:
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'test_exp_id', title='some title', category='Algebra',
+            language_code=constants.DEFAULT_LANGUAGE_CODE
+        )
+        exploration.objective = 'An objective'
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index
+        )
+        self.set_interaction_for_state(
+            exploration.states[exploration.init_state_name], 'NumericInput',
+            content_id_generator
+        )
+        exp_services.save_new_exploration(self.owner_id, exploration)
+
+        manual_voiceover_1: state_domain.VoiceoverDict = {
+            'filename': 'filename1.mp3',
+            'file_size_bytes': 3000,
+            'needs_update': False,
+            'duration_secs': 6.1
+        }
+
+        voiceover_changes = [
+            exp_domain.ExplorationChange({
+                'cmd': 'update_voiceovers',
+                'language_accent_code': 'en-US',
+                'content_id': 'content_0',
+                'voiceovers': {
+                    'manual': manual_voiceover_1
+                }
+            })
+        ]
+
+        with self.assertRaisesRegex(
+            Exception,
+            'Voiceover additions are not allowed for this exploration.'
+        ):
+            exp_services.compute_models_to_put_when_saving_new_exp_version(
+                self.owner_id, 'test_exp_id', voiceover_changes,
+                'Added voiceover', False
+            )
 
 
 class LoadingAndDeletionOfExplorationDemosTests(ExplorationServicesUnitTests):
@@ -8752,6 +8878,9 @@ class UpdateVersionHistoryUnitTests(ExplorationServicesUnitTests):
             new_model.state_version_history.get(
                 feconf.DEFAULT_INIT_STATE_NAME), expected_dict)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_version_history_on_only_translation_commits(self) -> None:
         old_model = self.version_history_model_class.get(
             self.version_history_model_class.get_instance_id(self.EXP_0_ID, 1))
@@ -10307,6 +10436,9 @@ class ComputeVoiceoversModelFromExplorationChangeTest(
 ):
     """Tests entity voiceovers model creation from exploration change dict."""
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_should_be_able_to_create_entity_voiceovers_models(self) -> None:
         exploration = exp_domain.Exploration.create_default_exploration(
             'test_exp_id', title='some title', category='Algebra',

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1671,7 +1671,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
             })], 'Changed title.')
 
         self.assertFalse(
-            exp_services.is_voiceover_allowed_for_exploration(self.EXP_0_ID))
+            exp_services.does_exploration_support_voiceovers(self.EXP_0_ID))
 
         story_id = story_services.get_new_story_id()
         topic_id = topic_fetchers.get_new_topic_id()
@@ -1703,7 +1703,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
             self.owner_id, story_id, change_list, 'Added node.')
 
         self.assertTrue(
-            exp_services.is_voiceover_allowed_for_exploration(self.EXP_0_ID))
+            exp_services.does_exploration_support_voiceovers(self.EXP_0_ID))
 
     def test_raise_error_when_adding_voiceover_for_non_curated_exploration(
         self

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -2214,15 +2214,9 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
             'state_name': 'State 1',
             'new_value': self.old_content,
         })
-        recorded_voiceovers_change = exp_domain.ExplorationChange({
-            'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-            'property_name': exp_domain.STATE_PROPERTY_RECORDED_VOICEOVERS,
-            'state_name': 'State 1',
-            'new_value': recorded_voiceovers_dict,
-        })
         exp_services.update_exploration(
             self.editor_id, exploration.id,
-            [content_change, recorded_voiceovers_change], '')
+            [content_change], '')
 
         rights_manager.publish_exploration(self.editor, self.EXP_ID)
         rights_manager.assign_role_for_exploration(

--- a/core/domain/voiceover_services_test.py
+++ b/core/domain/voiceover_services_test.py
@@ -930,6 +930,10 @@ class ExplorationVoiceArtistLinkTests(test_utils.GenericTestBase):
 
         self.assertEqual(total_files, 1)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS,
+        feature_flag_list.FeatureNames.AUTO_UPDATE_EXP_VOICE_ARTIST_LINK])
     def test_auto_update_exploration_voice_artist_link_model(self) -> None:
         content_id_to_voiceovers_mapping = {
             'content_0': {
@@ -1022,10 +1026,6 @@ class ExplorationVoiceArtistLinkTests(test_utils.GenericTestBase):
         updated_exploration = exp_fetchers.get_exploration_by_id(
             'exploration_id')
 
-        feature_flag_services.update_feature_flag(
-            feature_flag_list.FeatureNames.
-            AUTO_UPDATE_EXP_VOICE_ARTIST_LINK.value, True, 0, [])
-
         voiceover_services.update_exploration_voice_artist_link_model(
             'voice_artist_3', change_list, exploration, updated_exploration
         )
@@ -1107,6 +1107,10 @@ class ExplorationVoiceArtistLinkTests(test_utils.GenericTestBase):
             expected_content_id_to_voiceovers_mapping
         )
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS,
+        feature_flag_list.FeatureNames.AUTO_UPDATE_EXP_VOICE_ARTIST_LINK])
     def test_should_create_exp_link_model(self) -> None:
         expected_content_id_to_voiceovers_mapping = {
             'content_0': {
@@ -1157,10 +1161,6 @@ class ExplorationVoiceArtistLinkTests(test_utils.GenericTestBase):
             'exploration_id', change_list
         )
 
-        feature_flag_services.update_feature_flag(
-            feature_flag_list.FeatureNames.
-            AUTO_UPDATE_EXP_VOICE_ARTIST_LINK.value, True, 0, [])
-
         voiceover_services.update_exploration_voice_artist_link_model(
             'voice_artist_3', change_list, exploration, updated_exploration
         )
@@ -1177,6 +1177,9 @@ class ExplorationVoiceArtistLinkTests(test_utils.GenericTestBase):
             expected_content_id_to_voiceovers_mapping
         )
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_should_not_create_link_model_when_feature_flag_is_false(
         self
     ) -> None:

--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -62,8 +62,8 @@ class FeatureNames(enum.Enum):
     AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP = (
         'automatic_voiceover_regeneration_from_exp')
     LABEL_ACCENT_TO_VOICE_ARTIST = 'label_accent_to_voice_artist'
-    SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATION = (
-        'show_voiceover_tab_for_non_curated_exploration')
+    SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS = (
+        'show_voiceover_tab_for_non_curated_explorations')
 
 
 # Names of feature objects defined in FeatureNames should be added
@@ -90,7 +90,7 @@ DEV_FEATURES_LIST = [
     FeatureNames.NEW_LESSON_PLAYER,
     FeatureNames.REDESIGNED_TOPIC_VIEWER_PAGE,
     FeatureNames.AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP,
-    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATION
+    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -275,7 +275,7 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
             feature_flag_domain.ServerMode.PROD
         )
     ),
-    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATION.value: (
+    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS.value: (
         (
             'The flag enables the voiceover tab for non-curated explorations.',
             feature_flag_domain.ServerMode.DEV

--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -89,8 +89,7 @@ DEV_FEATURES_LIST = [
     FeatureNames.SHOW_TRANSLATION_SIZE,
     FeatureNames.NEW_LESSON_PLAYER,
     FeatureNames.REDESIGNED_TOPIC_VIEWER_PAGE,
-    FeatureNames.AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP,
-    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS
+    FeatureNames.AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -101,7 +100,8 @@ TEST_FEATURES_LIST: List[FeatureNames] = [
     FeatureNames.SERIAL_CHAPTER_LAUNCH_LEARNER_VIEW,
     FeatureNames.CD_ALLOW_UNDOING_TRANSLATION_REVIEW,
     FeatureNames.ENABLE_MULTIPLE_CLASSROOMS,
-    FeatureNames.SHOW_REDESIGNED_LEARNER_DASHBOARD
+    FeatureNames.SHOW_REDESIGNED_LEARNER_DASHBOARD,
+    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS
 ]
 
 # Names of features in prod stage, the corresponding feature flag instances must
@@ -272,7 +272,7 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
     FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS.value: (
         (
             'The flag enables the voiceover tab for non-curated explorations.',
-            feature_flag_domain.ServerMode.DEV
+            feature_flag_domain.ServerMode.TEST
         )
     )
 }

--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -62,6 +62,8 @@ class FeatureNames(enum.Enum):
     AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP = (
         'automatic_voiceover_regeneration_from_exp')
     LABEL_ACCENT_TO_VOICE_ARTIST = 'label_accent_to_voice_artist'
+    SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATION = (
+        'show_voiceover_tab_for_non_curated_exploration')
 
 
 # Names of feature objects defined in FeatureNames should be added
@@ -87,7 +89,8 @@ DEV_FEATURES_LIST = [
     FeatureNames.SHOW_TRANSLATION_SIZE,
     FeatureNames.NEW_LESSON_PLAYER,
     FeatureNames.REDESIGNED_TOPIC_VIEWER_PAGE,
-    FeatureNames.AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP
+    FeatureNames.AUTOMATIC_VOICEOVER_REGENERATION_FROM_EXP,
+    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATION
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -270,6 +273,12 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
             'The flag enables the voice artist accent labeling feature '
             'on the voiceover admin page.',
             feature_flag_domain.ServerMode.PROD
+        )
+    ),
+    FeatureNames.SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATION.value: (
+        (
+            'The flag enables the voiceover tab for non-curated explorations.',
+            feature_flag_domain.ServerMode.DEV
         )
     )
 }

--- a/core/jobs/batch_jobs/manual_voice_artist_name_job_test.py
+++ b/core/jobs/batch_jobs/manual_voice_artist_name_job_test.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from core import feature_flag_list
 from core import feconf
 from core.constants import constants
 from core.domain import exp_domain
@@ -489,6 +490,9 @@ class CreateExplorationVoiceArtistLinkModelsJobTests(
     def test_empty_storage(self) -> None:
         self.assert_job_output_is_empty()
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_version_is_added_after_running_job(self) -> None:
         self._create_curated_explorations()
         self._create_non_curated_exploration()
@@ -568,6 +572,9 @@ class CreateExplorationVoiceArtistLinkModelsJobTests(
 
         self.assertEqual(len(exploration_voice_artist_link_models), 2)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_should_skip_voiceover_if_specific_snapshot_model_is_invalid(
         self
     ) -> None:
@@ -667,6 +674,9 @@ class AuditVoiceArtistMetadataModelsJobTests(
     def test_empty_storage(self) -> None:
         self.assert_job_output_is_empty()
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_version_is_added_after_running_job(self) -> None:
         self._create_curated_explorations()
         self._create_non_curated_exploration()
@@ -708,6 +718,9 @@ class AuditVoiceArtistMetadataModelsJobTests(
         # No models are being saved in the datastore since this is an audit job.
         self.assertEqual(total_exploration_voice_artist_link_models, 0)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_generate_exp_link_model_if_some_commit_log_models_are_missing(
         self
     ) -> None:
@@ -753,6 +766,9 @@ class AuditVoiceArtistMetadataModelsJobTests(
             job_run_result.JobRunResult(stdout=debug_logs_2, stderr='')
         ])
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_generate_exp_link_model_if_some_snapshot_models_are_missing(
         self
     ) -> None:
@@ -798,6 +814,9 @@ class AuditVoiceArtistMetadataModelsJobTests(
             job_run_result.JobRunResult(stdout=debug_logs_2, stderr='')
         ])
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_shoould_raise_error_for_non_existent_user(self) -> None:
         self._create_curated_explorations()
 
@@ -849,6 +868,9 @@ class HelperMethodsForExplorationVoiceArtistLinkJobTest(
 ):
     """Test class to validate helper methods."""
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_should_create_exploration_link_for_voice_artist(self) -> None:
         exploration = self.save_new_valid_exploration(
             self.CURATED_EXPLORATION_ID_1,
@@ -948,6 +970,9 @@ class HelperMethodsForExplorationVoiceArtistLinkJobTest(
         )
         self.assertFalse(is_exploration_curated)
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_should_get_empty_filenames_successfully(self) -> None:
         exploration = self.save_new_valid_exploration(
             self.CURATED_EXPLORATION_ID_1,

--- a/core/jobs/batch_jobs/voiceover_migration_job_test.py
+++ b/core/jobs/batch_jobs/voiceover_migration_job_test.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from core import feature_flag_list
 from core import feconf
 from core.constants import constants
 from core.domain import exp_domain
@@ -506,6 +507,9 @@ class CreateExplorationVoiceArtistLinkModelsJobTests(
     def test_empty_storage(self) -> None:
         self.assert_job_output_is_empty()
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_version_is_added_after_running_job(self) -> None:
         self._create_curated_explorations()
         self._create_exp_voice_artists_link()
@@ -581,6 +585,9 @@ class CreateExplorationVoiceArtistLinkModelsJobTests(
                 model.voiceovers_mapping
             )
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_should_raise_exception_for_empty_accent_code(self) -> None:
         self._create_curated_explorations()
         self._create_exp_voice_artists_link()
@@ -606,6 +613,9 @@ class AuditExplorationVoiceArtistLinkModelsJobTests(
     def test_empty_storage(self) -> None:
         self.assert_job_output_is_empty()
 
+    @test_utils.enable_feature_flags([
+        feature_flag_list.FeatureNames.
+        SHOW_VOICEOVER_TAB_FOR_NON_CURATED_EXPLORATIONS])
     def test_version_is_added_after_running_job(self) -> None:
         self._create_curated_explorations()
         self._create_exp_voice_artists_link()

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -44,6 +44,7 @@ export enum FeatureNames {
   RedesignedTopicViewerPage = 'redesigned_topic_viewer_page',
   AutomaticVoiceoverRegenerationFromExp = 'automatic_voiceover_regeneration_from_exp',
   LabelAccentToVoiceArtist = 'label_accent_to_voice_artist',
+  ShowVoiceoverTabForNonCuratedExploration = 'show_voiceover_tab_for_non_curated_exploration',
 }
 
 export interface FeatureStatusSummaryBackendDict {

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -44,7 +44,7 @@ export enum FeatureNames {
   RedesignedTopicViewerPage = 'redesigned_topic_viewer_page',
   AutomaticVoiceoverRegenerationFromExp = 'automatic_voiceover_regeneration_from_exp',
   LabelAccentToVoiceArtist = 'label_accent_to_voice_artist',
-  ShowVoiceoverTabForNonCuratedExploration = 'show_voiceover_tab_for_non_curated_exploration',
+  ShowVoiceoverTabForNonCuratedExplorations = 'show_voiceover_tab_for_non_curated_explorations',
 }
 
 export interface FeatureStatusSummaryBackendDict {

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
@@ -52,7 +52,7 @@
         </div>
       </li>
 
-      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'translation', 'oppia-disabled-tab': !connectedToInternet || editabilityService.isLockedByAdmin()}" id="tutorialTranslationTab" class="nav-item icon nav-list-item e2e-test-translation-tab"
+      <li *ngIf="isVoiceoverTabEnabled()" [ngClass]="{'navbar-tab-active': getActiveTabName() === 'translation', 'oppia-disabled-tab': !connectedToInternet || editabilityService.isLockedByAdmin()}" id="tutorialTranslationTab" class="nav-item icon nav-list-item e2e-test-translation-tab"
           (click)="!connectedToInternet || editabilityService.isLockedByAdmin() || selectTranslationTab()" [ngbTooltip]="'Translations does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
         <a class="nav-link navbar-tab"
            [ngbTooltip]="'Translations'"

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
@@ -95,6 +95,9 @@ class MockPlatformFeatureService {
     ExplorationEditorCanModifyTranslations: {
       isEnabled: false,
     },
+    ShowVoiceoverTabForNonCuratedExploration: {
+      isEnabled: false,
+    },
   };
 }
 
@@ -123,6 +126,7 @@ describe('Exploration editor page component', () => {
   let userService: UserService;
   let ueps: UserExplorationPermissionsService;
   let ics: InternetConnectivityService;
+  let contextService: ContextService;
   let mockEnterEditorForTheFirstTime: EventEmitter<void>;
   let registerAcceptTutorialModalEventSpy;
   let registerDeclineTutorialModalEventSpy;
@@ -283,6 +287,7 @@ describe('Exploration editor page component', () => {
             },
             setExplorationIsLinkedToStory: () => {},
             setExplorationVersion: expVersion => {},
+            isExplorationLinkedToStory: () => {},
           },
         },
         EditabilityService,
@@ -374,6 +379,7 @@ describe('Exploration editor page component', () => {
     entityBulkTranslationsBackendApiService = TestBed.inject(
       EntityBulkTranslationsBackendApiService
     );
+    contextService = TestBed.inject(ContextService);
 
     isLocationSetToNonStateEditorTabSpy = spyOn(
       rs,
@@ -1227,5 +1233,31 @@ describe('Exploration editor page component', () => {
       flush();
       discardPeriodicTasks();
     }));
+  });
+
+  describe('voiceover tab', () => {
+    it('should be shwon correctly', () => {
+      let isExplorationLinkedToStorySpy = spyOn(
+        contextService,
+        'isExplorationLinkedToStory'
+      );
+
+      // Curated exploration must show voiceover tab.
+      isExplorationLinkedToStorySpy.and.returnValue(true);
+      let voiceoverTabIsEnabled = component.isVoiceoverTabEnabled();
+      expect(voiceoverTabIsEnabled).toBeTrue();
+
+      // Non curated exploration, when feature flag is disabled, must not show voiceover tab.
+      isExplorationLinkedToStorySpy.and.returnValue(false);
+      mockPlatformFeatureService.status.ShowVoiceoverTabForNonCuratedExploration.isEnabled =
+        false;
+      expect(component.isVoiceoverTabEnabled()).toBeFalse();
+
+      // Non curated exploration, when feature flag is enabled, must show voiceover tab.
+      isExplorationLinkedToStorySpy.and.returnValue(false);
+      mockPlatformFeatureService.status.ShowVoiceoverTabForNonCuratedExploration.isEnabled =
+        true;
+      expect(component.isVoiceoverTabEnabled()).toBeTrue();
+    });
   });
 });

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
@@ -95,7 +95,7 @@ class MockPlatformFeatureService {
     ExplorationEditorCanModifyTranslations: {
       isEnabled: false,
     },
-    ShowVoiceoverTabForNonCuratedExploration: {
+    ShowVoiceoverTabForNonCuratedExplorations: {
       isEnabled: false,
     },
   };
@@ -1249,13 +1249,13 @@ describe('Exploration editor page component', () => {
 
       // Non curated exploration, when feature flag is disabled, must not show voiceover tab.
       isExplorationLinkedToStorySpy.and.returnValue(false);
-      mockPlatformFeatureService.status.ShowVoiceoverTabForNonCuratedExploration.isEnabled =
+      mockPlatformFeatureService.status.ShowVoiceoverTabForNonCuratedExplorations.isEnabled =
         false;
       expect(component.isVoiceoverTabEnabled()).toBeFalse();
 
       // Non curated exploration, when feature flag is enabled, must show voiceover tab.
       isExplorationLinkedToStorySpy.and.returnValue(false);
-      mockPlatformFeatureService.status.ShowVoiceoverTabForNonCuratedExploration.isEnabled =
+      mockPlatformFeatureService.status.ShowVoiceoverTabForNonCuratedExplorations.isEnabled =
         true;
       expect(component.isVoiceoverTabEnabled()).toBeTrue();
     });

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
@@ -462,7 +462,7 @@ export class ExplorationEditorPageComponent implements OnInit, OnDestroy {
       return true;
     }
     return this.platformFeatureService.status
-      .ShowVoiceoverTabForNonCuratedExploration.isEnabled;
+      .ShowVoiceoverTabForNonCuratedExplorations.isEnabled;
   }
 
   populateEntityTranslationsWithDraftChanges(

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
@@ -457,6 +457,14 @@ export class ExplorationEditorPageComponent implements OnInit, OnDestroy {
     });
   }
 
+  isVoiceoverTabEnabled(): boolean {
+    if (this.contextService.isExplorationLinkedToStory()) {
+      return true;
+    }
+    return this.platformFeatureService.status
+      .ShowVoiceoverTabForNonCuratedExploration.isEnabled;
+  }
+
   populateEntityTranslationsWithDraftChanges(
     draftChanges: ExplorationChange[] | null,
     version: number

--- a/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/validate-exploration-managers-collaborators-playtesters-access-permissions.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/validate-exploration-managers-collaborators-playtesters-access-permissions.spec.ts
@@ -21,11 +21,13 @@ import {UserFactory} from '../../utilities/common/user-factory';
 import testConstants from '../../utilities/common/test-constants';
 import {ConsoleReporter} from '../../utilities/common/console-reporter';
 import {ExplorationEditor} from '../../utilities/user/exploration-editor';
+import {ReleaseCoordinator} from '../../utilities/user/release-coordinator';
 
 const DEFAULT_SPEC_TIMEOUT_MSECS = testConstants.DEFAULT_SPEC_TIMEOUT_MSECS;
 enum INTERACTION_TYPES {
   END_EXPLORATION = 'End Exploration',
 }
+const ROLES = testConstants.Roles;
 
 ConsoleReporter.setConsoleErrorsToIgnore([/.404.*Not Found./]);
 
@@ -35,6 +37,7 @@ describe('Exploration User Roles', function () {
   let newCollaborator: ExplorationEditor;
   let playtester: ExplorationEditor;
   let explorationCreator: ExplorationEditor;
+  let releaseCoordinator: ReleaseCoordinator;
   let explorationId: string | null;
 
   beforeAll(async function () {
@@ -64,6 +67,17 @@ describe('Exploration User Roles', function () {
     explorationCreator = await UserFactory.createNewUser(
       'explorationCreator',
       'explorationCreator@example.com'
+    );
+
+    releaseCoordinator = await UserFactory.createNewUser(
+      'releaseCoordinator',
+      'release_coordinator@example.com',
+      [ROLES.RELEASE_COORDINATOR]
+    );
+
+    // Enable the feature flag.
+    await releaseCoordinator.enableFeatureFlag(
+      'show_voiceover_tab_for_non_curated_explorations'
     );
 
     // Create exploration with explorationCreator user.


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

The PR hides the voiceover tab from the exploration editor page for **non-curated exploration** (those exploration which are not linked to any story).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

https://github.com/user-attachments/assets/4eb10e6e-572f-46fb-817b-1e31ab3b8422





#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
