### PR TITLE
Fix #22080: CI breakage related to save button clickability in exploration editor.

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.html
@@ -312,5 +312,7 @@
   .publish-button {
     background-color: #419889;
     color: #fff;
+    position: relative;
+    z-index: 1041;
   }
 </style>

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -974,6 +974,7 @@ export class ExplorationEditor extends BaseUser {
       if (!element) {
         await this.clickOn(mobileOptionsButton);
       }
+
       await this.page.waitForSelector(
         `${mobileSaveChangesButton}:not([disabled])`,
         {visible: true}

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -974,6 +974,10 @@ export class ExplorationEditor extends BaseUser {
       if (!element) {
         await this.clickOn(mobileOptionsButton);
       }
+      await this.page.waitForSelector(
+        `${mobileSaveChangesButton}:not([disabled])`,
+        {visible: true}
+      );
       await this.clickOn(mobileSaveChangesButton);
     } else {
       await this.clickOn(saveChangesButton);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
@@ -1638,6 +1638,10 @@ export class LoggedInUser extends BaseUser {
       if (!element) {
         await this.clickOn(mobileOptionsButton);
       }
+      await this.page.waitForSelector(
+        `${mobileSaveChangesButton}:not([disabled])`,
+        {visible: true}
+      );
       await this.clickOn(mobileSaveChangesButton);
     } else {
       await this.clickOn(saveChangesButton);


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #22080.
2. This PR does the following: This PR fixes the issue where the "Save draft" button is sometimes unclickable by adjusting its z-index and positioning.
3. (For bug-fixing PRs only) The original bug occurred because: 

While inspecting the page using dev tools, it appears that the "Save draft" button is trapped within its parent container's stacking context, created by the parent’s `position: fixed` and `z-index: 1040`. Also, it's z-index is currently auto. During compositing, the parent container may sometimes overlap the button, making it unclickable even though it appears visible. This problem is due to slight timing differences in the rendering process.

<img src="https://github.com/user-attachments/assets/73f18016-7cd7-497d-b612-337a9e0bedbd" width="460">

**Solution:**
To resolve this, the button needs to escape the parent stacking context. This can be achieved by setting its `z-index` to 1041 (greater than the parent's 1040) and adding `position: relative`. Additionally, I've added an extra wait for the selector before clicking on them to ensure they're fully loaded.

<img src="https://github.com/user-attachments/assets/cf7f547e-1af2-4a48-86bb-2d588e94e54d" width="500">

**Alternative considered:**
- Moving the button outside the navbar container was considered but rejected as it would disrupt the layout.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

There are no changes to the overall UI.

Before and after:

<img src="https://github.com/user-attachments/assets/a8e85b26-4bfe-499d-b9d2-d24cd865551e" width="400" />

<img src="https://github.com/user-attachments/assets/886a975c-e2a5-455e-92dc-b20fd63ee3aa" width="400" />

The button is clickable.

[Screencast from 2025-04-14 07-40-29.webm](https://github.com/user-attachments/assets/06ff50b1-0ed3-4380-8ee4-a5d6555ed9a4)

The test is running successfully. 
![image](https://github.com/user-attachments/assets/c61f942b-b060-4792-9e3f-95df017509cb)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
