### PR TITLE
Fix #20640: Resolve flakiness in language selection acceptance test.

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -233,6 +233,8 @@ const editRolesButtonSelector = '.oppia-edit-roles-btn-container';
 const stateContentEditorSelector =
   '.e2e-test-edit-content.oppia-editable-section';
 const tagFilterDropdownSelector = '.e2e-test-tag-filter-selection-dropdown';
+const languageDropdownValueSelector =
+  'mat-select.e2e-test-exploration-language-select .mat-select-value';
 
 const historyTableIndex = '.history-table-index';
 const historyListOptions = '.e2e-test-history-list-options';
@@ -755,37 +757,31 @@ export class ExplorationEditor extends BaseUser {
 
     await this.clickOn(languageUpdateDropdown);
     await this.clickOn(language);
+    await this.page.waitForNetworkIdle();
   }
 
   /**
    *  Verifies that the selected language matches the expected language.
    */
   async expectSelectedLanguageToBe(expectedLanguage: string): Promise<void> {
-    await this.page.waitForSelector(languageUpdateDropdown);
-    const languageDropdown = await this.page.$(languageUpdateDropdown);
-    if (!languageDropdown) {
-      throw new Error('Category dropdown not found.');
-    }
-    await languageDropdown.click();
-
-    const selectedLanguage = await this.page.evaluate(() => {
-      const matOption = document.querySelector(
-        '.mat-option.mat-selected'
-      ) as HTMLElement;
-      if (!matOption) {
-        throw new Error('Selected language option not found.');
-      }
-      return matOption.innerText.trim();
+    await this.page.waitForSelector(languageDropdownValueSelector, {
+      visible: true,
     });
+
+    const selectedLanguage = await this.page.evaluate(selector => {
+      const element = document.querySelector(selector) as HTMLElement;
+      return element?.innerText.trim() ?? '';
+    }, languageDropdownValueSelector);
 
     if (selectedLanguage.includes(expectedLanguage)) {
       showMessage(
         `The language ${selectedLanguage} contains the expected language.`
       );
     } else {
-      throw new Error('Language is not correct.');
+      throw new Error(
+        `Expected language: ${expectedLanguage}, but found: "${selectedLanguage}".`
+      );
     }
-    await this.page.keyboard.press('Enter');
   }
 
   async addTags(tagNames: string[]): Promise<void> {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #20640.
2. This PR does the following: This PR fixes the flaky behavior in the test for verifying the selected language in the exploration editor by eliminating the race condition
3. (For bug-fixing PRs only) The original bug occurred because: The test used to check the selected language by reopening the dropdown and looking for the `.mat-option.mat-selected` element. But this wasn’t always reliable because DOM is updated asynchronously. Right after selecting a new language, the `.mat-selected` class wasn’t always applied quickly enough, so the test sometimes picked up an old value "English" instead of "Arabic." This led to random failures.

**Changes**: Now, the test directly queries `.mat-select-value`, which always reflects the selected language. Additionally, `await this.page.waitForNetworkIdle` ensures updates are complete. These changes eliminate timing issues.

**Why this fix works:**

- Directly queries the displayed value instead.
- Avoids reopening the dropdown, reducing unnecessary interference with the DOM.
- Uses a scoped selector to ensure the correct element is queried (`mat-select.e2e-test-exploration-language-select .mat-select-value`)
- Eliminates timing issues by waiting for network and DOM to stabilize.

**Alternative considered:**

At first, I suspected the issue might be due to Arabic being a RLT language, since RTL text can sometimes affect how it's rendered. To check, I tested with Hebrew and saw no issues. I also confirmed that the `includes` method works fine with RTL text, as it checks the raw content. This ruled out RTL as the cause. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.