### PR TITLE
Fix #21294: Minor fixes of inactive issue checker over production.

### DIFF
--- a/.github/workflows/inactive_issue_checker.yml
+++ b/.github/workflows/inactive_issue_checker.yml
@@ -1,5 +1,8 @@
 name: Check Inactive Issues
 on:
+  push:
+    branches:
+      - minorFixes#21294
   schedule:
     # Each midnight.
     - cron: '0 0 * * *'

--- a/.github/workflows/inactive_issue_checker.yml
+++ b/.github/workflows/inactive_issue_checker.yml
@@ -1,8 +1,5 @@
 name: Check Inactive Issues
 on:
-  push:
-    branches:
-      - minorFixes#21294
   schedule:
     # Each midnight.
     - cron: '0 0 * * *'

--- a/scripts/inactive_issue_checker.py
+++ b/scripts/inactive_issue_checker.py
@@ -143,8 +143,9 @@ class GitHubService:
             raise AssertionError('Received null res while fetching issues')
         response.raise_for_status()
 
+        response_data = response.json()
         issues_list = []
-        for issue_data in response.get('items', []):
+        for issue_data in response_data.get('items', []):
             assert isinstance(issue_data, dict)
             typed_issue_data: IssueDict = {
                 'number': issue_data['number'],

--- a/scripts/inactive_issue_checker.py
+++ b/scripts/inactive_issue_checker.py
@@ -29,8 +29,8 @@ from typing import Dict, List, Optional, Set, TypedDict
 
 INACTIVE_DAYS_THRESHOLD = 7
 UNASSIGN_DAYS_THRESHOLD = 10
-REPO_OWNER = 'Ashu463'
-REPO_NAME = 'grid6.0'
+REPO_OWNER = 'oppia'
+REPO_NAME = 'oppia'
 
 
 class IssueDict(TypedDict, total=False):

--- a/scripts/inactive_issue_checker.py
+++ b/scripts/inactive_issue_checker.py
@@ -137,14 +137,14 @@ class GitHubService:
             requests.HTTPError. Raised if the request fails.
         """
         search_url = 'https://api.github.com/search/issues'
-        url = f'{search_url}?q=repo:oppia/oppia+is:issue+state:open'
+        url = f'{search_url}?q=repo:{self.repo_owner}/{self.repo_name}+is:issue+state:open'
         response = requests.get(url, headers=self.rest_headers, timeout=10)
         if response is None:
             raise AssertionError('Received null res while fetching issues')
         response.raise_for_status()
 
         issues_list = []
-        for issue_data in response.json():
+        for issue_data in response.get('items', []):
             assert isinstance(issue_data, dict)
             typed_issue_data: IssueDict = {
                 'number': issue_data['number'],

--- a/scripts/inactive_issue_checker.py
+++ b/scripts/inactive_issue_checker.py
@@ -137,16 +137,19 @@ class GitHubService:
             requests.HTTPError. Raised if the request fails.
         """
         search_url = 'https://api.github.com/search/issues'
-        end = 'is:issue+state:open'
-        url = f'{search_url}?q=repo:{self.repo_owner}/{self.repo_name}+{end}'
+
+        url = (
+            f'{search_url}?q=repo:{self.repo_owner}/'
+            f'{self.repo_name}+is:issue+state:open'
+        )
+        print(url, 'is the url')
         response = requests.get(url, headers=self.rest_headers, timeout=10)
         if response is None:
             raise AssertionError('Received null res while fetching issues')
         response.raise_for_status()
 
-        response_data = response.json()
         issues_list = []
-        for issue_data in response_data.get('items', []):
+        for issue_data in response.json().get('items', []):
             assert isinstance(issue_data, dict)
             typed_issue_data: IssueDict = {
                 'number': issue_data['number'],

--- a/scripts/inactive_issue_checker.py
+++ b/scripts/inactive_issue_checker.py
@@ -29,8 +29,8 @@ from typing import Dict, List, Optional, Set, TypedDict
 
 INACTIVE_DAYS_THRESHOLD = 7
 UNASSIGN_DAYS_THRESHOLD = 10
-REPO_OWNER = 'oppia'
-REPO_NAME = 'oppia'
+REPO_OWNER = 'Ashu463'
+REPO_NAME = 'grid6.0'
 
 
 class IssueDict(TypedDict, total=False):

--- a/scripts/inactive_issue_checker.py
+++ b/scripts/inactive_issue_checker.py
@@ -137,7 +137,8 @@ class GitHubService:
             requests.HTTPError. Raised if the request fails.
         """
         search_url = 'https://api.github.com/search/issues'
-        url = f'{search_url}?q=repo:{self.repo_owner}/{self.repo_name}+is:issue+state:open'
+        end = 'is:issue+state:open'
+        url = f'{search_url}?q=repo:{self.repo_owner}/{self.repo_name}+{end}'
         response = requests.get(url, headers=self.rest_headers, timeout=10)
         if response is None:
             raise AssertionError('Received null res while fetching issues')

--- a/scripts/inactive_issue_checker_test.py
+++ b/scripts/inactive_issue_checker_test.py
@@ -107,28 +107,32 @@ class TestGitHubService(unittest.TestCase):
         """Test fetching open issues."""
         mock_response = mock.Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = [
-            {
-                'number': 1,
-                'assignee': {'login': 'user1'},
-                'events_url': f'{self.base_url}/issues/1/events'
-            },
-            {
-                'number': 2,
-                'assignee': None,
-                'events_url': f'{self.base_url}/issues/2/events'
-            }
-        ]
+        mock_response.json.return_value = {
+            'total_count': 2,
+            'items': [
+                {
+                    'number': 1,
+                    'assignee': {'login': 'user1'},
+                    'events_url': f'{self.base_url}/issues/1/events'
+                },
+                {
+                    'number': 2,
+                    'assignee': None,
+                    'events_url': f'{self.base_url}/issues/2/events'
+                }
+            ]
+        }
         mock_get.return_value = mock_response
-
+        
         issues = self.service.get_open_issues()
-
+        
         self.assertEqual(len(issues), 2)
         self.assertEqual(issues[0].number, 1)
         self.assertEqual(issues[0].assignee_username, 'user1')
         self.assertIsNone(issues[1].assignee_username)
+        
         search_url = 'https://api.github.com/search/issues'
-        url = f'{search_url}?q=repo:oppia/oppia+is:issue+state:open'
+        url = f'{search_url}?q=repo:owner/repo+is:issue+state:open'
         mock_get.assert_called_once_with(
             url,
             headers=self.service.rest_headers,
@@ -149,7 +153,7 @@ class TestGitHubService(unittest.TestCase):
             'Received null res while fetching issues'
         )
         search_url = 'https://api.github.com/search/issues'
-        url = f'{search_url}?q=repo:oppia/oppia+is:issue+state:open'
+        url = f'{search_url}?q=repo:owner/repo+is:issue+state:open'
         mock_get.assert_called_once_with(
             url,
             headers=self.service.rest_headers,
@@ -168,7 +172,7 @@ class TestGitHubService(unittest.TestCase):
             'Network error'
         )
         search_url = 'https://api.github.com/search/issues'
-        url = f'{search_url}?q=repo:oppia/oppia+is:issue+state:open'
+        url = f'{search_url}?q=repo:owner/repo+is:issue+state:open'
         mock_get.assert_called_once_with(
             url,
             headers=self.service.rest_headers,
@@ -870,3 +874,6 @@ class TestMainFunction(unittest.TestCase):
             self.assertIn(f'INFO:root:{expected}', log_capture.output)
 
         self.issue_manager.unassign_issues.assert_called_once_with(issues)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/inactive_issue_checker_test.py
+++ b/scripts/inactive_issue_checker_test.py
@@ -123,14 +123,14 @@ class TestGitHubService(unittest.TestCase):
             ]
         }
         mock_get.return_value = mock_response
-        
+
         issues = self.service.get_open_issues()
-        
+
         self.assertEqual(len(issues), 2)
         self.assertEqual(issues[0].number, 1)
         self.assertEqual(issues[0].assignee_username, 'user1')
         self.assertIsNone(issues[1].assignee_username)
-        
+
         search_url = 'https://api.github.com/search/issues'
         url = f'{search_url}?q=repo:owner/repo+is:issue+state:open'
         mock_get.assert_called_once_with(
@@ -874,6 +874,3 @@ class TestMainFunction(unittest.TestCase):
             self.assertIn(f'INFO:root:{expected}', log_capture.output)
 
         self.issue_manager.unassign_issues.assert_called_once_with(issues)
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: I'd updated the way to handle data coming from issue search response while fetching opened issues in `get_open_issues` method.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Everything works fine on my test repo: see this workflow, https://github.com/Ashu463/grid6.0/actions/runs/14535199402/job/40782144598. 
## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
