### PR TITLE
Fix part of #22315: Align spacing between topic preview and practice tab views

### DIFF
--- a/assets/i18n/pcm.json
+++ b/assets/i18n/pcm.json
@@ -1397,7 +1397,7 @@
 	"I18N_TOPIC_VIEWER_STORIES_HEAD": "Tori wen you fit play",
 	"I18N_TOPIC_VIEWER_STORY": "Tori",
 	"I18N_TOPIC_VIEWER_STUDY_SKILLS": "Study Skills for <[topicName]>",
-	"I18N_TOPIC_VIEWER_STUDY_SKILLS_SUBTITLE": "Use the following Review Cards to help you  about <[topicName]>.",
+	"I18N_TOPIC_VIEWER_STUDY_SKILLS_SUBTITLE": "Use the following Review Cards to help you study skills about <[topicName]>.",
 	"I18N_TOPIC_VIEWER_VIEW_ALL": "Look all",
 	"I18N_TOPIC_VIEWER_VIEW_LESS": "Look small",
 	"I18N_TOPIC_VjCpR1DB2MVN_DESCRIPTION": "You know sey place values dey wey small pass 1? If you no wan use fractions, you go fit use d place values system wey you know to handle nombas wey dey stand as parts. Make we see how",

--- a/assets/i18n/pcm.json
+++ b/assets/i18n/pcm.json
@@ -1397,7 +1397,7 @@
 	"I18N_TOPIC_VIEWER_STORIES_HEAD": "Tori wen you fit play",
 	"I18N_TOPIC_VIEWER_STORY": "Tori",
 	"I18N_TOPIC_VIEWER_STUDY_SKILLS": "Study Skills for <[topicName]>",
-	"I18N_TOPIC_VIEWER_STUDY_SKILLS_SUBTITLE": "Use the following Review Cards to help you study skills about <[topicName]>.",
+	"I18N_TOPIC_VIEWER_STUDY_SKILLS_SUBTITLE": "Use the following Review Cards to help you  about <[topicName]>.",
 	"I18N_TOPIC_VIEWER_VIEW_ALL": "Look all",
 	"I18N_TOPIC_VIEWER_VIEW_LESS": "Look small",
 	"I18N_TOPIC_VjCpR1DB2MVN_DESCRIPTION": "You know sey place values dey wey small pass 1? If you no wan use fractions, you go fit use d place values system wey you know to handle nombas wey dey stand as parts. Make we see how",

--- a/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
+++ b/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
@@ -67,7 +67,7 @@
     position: relative;
     top: 36px;
     width: 45%;
-    max-width: 700px;
+    max-width: 710px;
     box-sizing: border-box;
   }
   .topic-preview-parent {

--- a/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
+++ b/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
@@ -12,9 +12,7 @@
             <img alt="" class="tab-icon"
                  [src]="getStaticImageUrl('/icons/play_icon_24px.svg')">
           </div>
-          <div class="topic-preview-text">
-            Lessons
-          </div>
+          <div class="topic-preview-text">Lessons</div>
         </div>
         <div class="topic-preview-navbar-tab"
              [ngClass]="{'topic-preview-nav-active': activeTab === 'practice'}"
@@ -22,9 +20,7 @@
           <div class="topic-preview-icon">
             <img alt="" class="tab-icon" [src]="getStaticImageUrl('/icons/train_icon_24px.svg')">
           </div>
-          <div class="topic-preview-text">
-            Practice
-          </div>
+          <div class="topic-preview-text">Practice</div>
         </div>
         <div class="topic-preview-navbar-tab"
              [ngClass]="{'topic-preview-nav-active': activeTab === 'subtopic'}"
@@ -33,9 +29,7 @@
             <img alt="" class="tab-icon"
                  [src]="getStaticImageUrl('/icons/review_icon_24px.svg')">
           </div>
-          <div class="topic-preview-text">
-            Revision
-          </div>
+          <div class="topic-preview-text">Revision</div>
         </div>
       </div>
     </div>
@@ -71,16 +65,18 @@
     background-color: #fff;
     margin: 0 auto;
     position: relative;
-    top: 50px;
-    width: 50%;
+    top: 36px;
+    width: 45%;
+    max-width: 700px;
+    box-sizing: border-box;
   }
   .topic-preview-parent {
-    margin-top: -40px;
+    margin-top: -30px;
   }
   .topic-preview-nav {
     background-color: #00645c;
-    box-shadow: 0 2px 8px #000000cf;
-    margin-bottom: 12px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+    margin-bottom: 0;
   }
   .topic-preview-navbar-tabs {
     display: flex;
@@ -94,44 +90,69 @@
     cursor: pointer;
     display: inline-block;
     height: 100%;
-    padding: 20px 0;
+    padding: 12px 0;
     text-align: center;
     width: 25%;
   }
   .topic-preview-icon img {
-    height: 40px;
+    height: 32px;
   }
   .topic-preview-text {
     color: #fff;
     font-family: Capriola, Roboto, Arial, sans-serif;
-    font-size: 20px;
+    font-size: 16px;
     margin-top: 4px;
     text-transform: uppercase;
   }
   .topic-preview-container md-card {
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 0 rgba(0,0,0,0.24);
     margin-top: 0;
+    padding: 0;
   }
   .topic-preview-parent .topic-preview-container md-card {
     box-shadow: none;
+    padding: 0;
+  }
+  /* Ensure practice-tab and subtopics-list fill width */
+  .topic-preview-container practice-tab,
+  .topic-preview-container subtopics-list {
+    display: block;
+    width: 100%;
+    /* keep overflow visible */
+    overflow: hidden;
+  }
+  /* Style overrides for practice & story to remove padding */
+  .topic-preview-container :host ::ng-deep .practice-tab-container,
+  .topic-preview-container :host ::ng-deep .story-container {
+    padding: 0;
+    margin: 0;
+  }
+  /* Restore original padding for revision cards */
+  .topic-preview-container :host ::ng-deep .subtopics-list-container {
+    padding: 12px;
+    margin: 0;
+  }
+  .topic-preview-container :host ::ng-deep subtopics-list md-card {
+    margin: 0;
+    padding: 12px;
   }
   @media screen and (max-width: 1000px) {
     .topic-preview-container {
-      width: 70%;
+      width: 60%;
    }
   }
   @media screen and (max-width: 800px) {
     .topic-preview-container {
-      width: 80%;
+      width: 70%;
     }
     .topic-preview-parent .background-banner-position {
-      top: 30px;
+      top: 24px;
     }
   }
   @media screen and (max-width: 650px) {
     .topic-preview-container {
-      margin-top: 80px;
-      width: 100%;
+      margin-top: 60px;
+      width: 90%;
     }
   }
 </style>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #22315.
2. This PR does the following: This PR resolves a UI inconsistency between the topic preview and learner-facing practice tab. Specifically, it aligns the layout spacing (top margin/padding) to ensure both pages display consistent content structure. This improves the experience for topic editors and ensures visual consistency across learning interfaces.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

Before: 
<img width="1783" alt="Screenshot 2025-04-19 at 1 54 58 PM" src="https://github.com/user-attachments/assets/17f0d7ee-d373-447f-918a-5c4827aafb44" />
<img width="1783" alt="Screenshot 2025-04-19 at 1 55 03 PM" src="https://github.com/user-attachments/assets/bf4919e3-792a-4991-8a8e-75bf54c072cf" />

After: 
<img width="1792" alt="Screenshot 2025-04-19 at 3 18 07 PM" src="https://github.com/user-attachments/assets/e22b123a-3f7f-4668-8bb5-fb52c966b3c0" />
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/a056acbb-f057-4610-84ee-e6f4ddcf4d3f" />



#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
