### PR TITLE
Disables and removes max line length from pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -119,7 +119,7 @@ disable=abstract-method,
         consider-using-f-string,
         duplicate-code,
         import-outside-toplevel,
-        line-too-long
+        line-too-long,
         logging-not-lazy,
         no-else-return,
         no-member,

--- a/.pylintrc
+++ b/.pylintrc
@@ -60,7 +60,6 @@ bad-functions=apply
 
 [FORMAT]
 
-max-line-length=80
 ignore-long-lines=^.*#\stype:\signore.*$|^\s*(# )?<?https?://\S+>?$
 
 indent-string='    '
@@ -120,6 +119,7 @@ disable=abstract-method,
         consider-using-f-string,
         duplicate-code,
         import-outside-toplevel,
+        line-too-long
         logging-not-lazy,
         no-else-return,
         no-member,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[N/A].
2. This PR does the following: This pr disables and removes max line length in pylint. This is due to eliminate
errors due to formatting by Black #21909

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
