### PR TITLE
Fix part of #22448: Card name Revision Card not found in the graph.

### DIFF
--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -181,7 +181,7 @@ jobs:
         id: check_skip
         # TODO(#22448): Remove once all suites are fixed.
         run: |
-          broken_suites=("exploration-editor/manage-exploration-misconceptions" "exploration-editor/modify-translations-through-modal" "exploration-editor/publish-the-exploration-with-an-interaction" "logged-out-user/play-through-lesson-while-getting-feedback-and-hints" "practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties")
+          broken_suites=("exploration-editor/manage-exploration-misconceptions" "exploration-editor/modify-translations-through-modal" "exploration-editor/publish-the-exploration-with-an-interaction" "practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties")
           for suite in "${broken_suites[@]}"; do
             if [[ "${{ matrix.suite.name }}" == "$suite" ]]; then
               echo "Suite '${{ matrix.suite.name }}' is marked to be skipped."

--- a/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts
@@ -117,7 +117,9 @@ describe('Exploration Editor', function () {
       '',
       false
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong.');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong.'
+    );
     await explorationEditor.addHintToState(
       'It is closer to zero but not a positive number.'
     );

--- a/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/modify-translations-through-modal.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/modify-translations-through-modal.spec.ts
@@ -109,7 +109,9 @@ describe('Exploration Editor', function () {
       CARD_NAME.TEXT_QUESTION,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong.');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong.'
+    );
     await explorationEditor.addHintToState(
       'It is closer to zero but not a positive number.'
     );
@@ -128,7 +130,9 @@ describe('Exploration Editor', function () {
       CARD_NAME.FINAL_CARD,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong.');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong.'
+    );
     await explorationEditor.addSolutionToState(
       'minus',
       'Minus is the opposite of plus.',
@@ -359,7 +363,9 @@ describe('Exploration Editor', function () {
         1
       );
       await explorationEditor.navigateToEditorTab();
-      await explorationEditor.editDefaultResponseFeedback('Feedback content.');
+      await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+        'Feedback content.'
+      );
       await explorationEditor.openModifyExistingTranslationsModal();
       await explorationEditor.verifyTranslationInModifyTranslationsModal(
         'de',

--- a/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/publish-the-exploration-with-an-interaction.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/publish-the-exploration-with-an-interaction.spec.ts
@@ -58,7 +58,9 @@ describe('Exploration Creator', function () {
       await explorationEditor.dismissWelcomeModal();
       await explorationEditor.updateCardContent(INTRODUCTION_CARD_CONTENT);
       await explorationEditor.addImageInteraction();
-      await explorationEditor.editDefaultResponseFeedback('Wrong.');
+      await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+        'Wrong.'
+      );
       await explorationEditor.addHintToState('Initial coordinate');
       await explorationEditor.saveExplorationDraft();
 

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/give-feedback-rate-and-report-an-exploration.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/give-feedback-rate-and-report-an-exploration.spec.ts
@@ -89,7 +89,9 @@ describe('Logged-out User', function () {
       CARD_NAME.FINAL_CARD,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong, try again!');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong, try again!'
+    );
 
     await explorationEditor.saveExplorationDraft();
 

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/restart-or-continue-exploration-on-revisit.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/restart-or-continue-exploration-on-revisit.spec.ts
@@ -73,7 +73,9 @@ describe('Logged-in User', function () {
       CARD_NAME.REVISION_CARD,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong, try again!');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong, try again!'
+    );
     await explorationEditor.saveExplorationDraft();
 
     // Navigate to the new card and Revision content.

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/play-through-lesson-while-getting-feedback-and-hints.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/play-through-lesson-while-getting-feedback-and-hints.spec.ts
@@ -86,7 +86,9 @@ describe('Logged-out User', function () {
       CARD_NAME.FRACTION_CONVERSION,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong, try again!');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong, try again!'
+    );
     await explorationEditor.addHintToState(
       'Remember that negative numbers are less than 0.'
     );
@@ -111,7 +113,7 @@ describe('Logged-out User', function () {
       true
     );
 
-    await explorationEditor.editDefaultResponseFeedback(
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
       'Incorrect, try again!',
       undefined,
       CARD_NAME.REVISION_CARD

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/share-and-give-feedback-for-exploration-but-not-report-and-rate-it.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/share-and-give-feedback-for-exploration-but-not-report-and-rate-it.spec.ts
@@ -88,7 +88,9 @@ describe('Logged-out User', function () {
       CARD_NAME.FINAL_CARD,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong, try again!');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong, try again!'
+    );
 
     await explorationEditor.saveExplorationDraft();
 

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/sign-in-and-save-exploration-progress.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/sign-in-and-save-exploration-progress.spec.ts
@@ -79,7 +79,9 @@ describe('Logged-out User', function () {
       CARD_NAME.REVISION_CARD,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong, try again!');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong, try again!'
+    );
     await explorationEditor.saveExplorationDraft();
 
     // Navigate to the new card and Revision content.

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/track-and-resume-exploration-progress-via-url.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-out-user/track-and-resume-exploration-progress-via-url.spec.ts
@@ -76,7 +76,9 @@ describe('Logged-out User', function () {
       CARD_NAME.REVISION_CARD,
       true
     );
-    await explorationEditor.editDefaultResponseFeedback('Wrong, try again!');
+    await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong, try again!'
+    );
     await explorationEditor.saveExplorationDraft();
 
     // Navigate to the new card and Revision content.

--- a/core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts
@@ -96,7 +96,7 @@ describe('Question Submitter', function () {
       await questionSubmitter.addImageInteraction();
 
       await questionSubmitter.addHintToState('Test Hint 1');
-      await questionSubmitter.editDefaultResponseFeedback();
+      await questionSubmitter.editDefaultResponseFeedback('Wrong Answer');
       await questionSubmitter.submitQuestionSuggestion();
 
       await questionSubmitter.expectQuestionSuggestionInContributorDashboard(
@@ -127,7 +127,7 @@ describe('Question Submitter', function () {
         'Option 4',
       ]);
 
-      await questionSubmitter.editDefaultResponseFeedback();
+      await questionSubmitter.editDefaultResponseFeedback('Wrong Answer');
       await questionSubmitter.addHintToState('Test Hint 2');
       await questionSubmitter.submitQuestionSuggestion();
 
@@ -154,7 +154,7 @@ describe('Question Submitter', function () {
 
       await questionSubmitter.addTextInputInteraction('Answer');
 
-      await questionSubmitter.editDefaultResponseFeedback();
+      await questionSubmitter.editDefaultResponseFeedback('Wrong Answer');
       await questionSubmitter.addHintToState('Test Hint 3');
       await questionSubmitter.addSolutionToState(
         'Answer',

--- a/core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts
@@ -96,7 +96,7 @@ describe('Question Submitter', function () {
       await questionSubmitter.addImageInteraction();
 
       await questionSubmitter.addHintToState('Test Hint 1');
-      await questionSubmitter.editDefaultResponseFeedbackInQuestionSubmitter(
+      await questionSubmitter.editDefaultResponseFeedbackInQuestionEditorPage(
         'Wrong Answer'
       );
       await questionSubmitter.submitQuestionSuggestion();
@@ -129,7 +129,7 @@ describe('Question Submitter', function () {
         'Option 4',
       ]);
 
-      await questionSubmitter.editDefaultResponseFeedbackInQuestionSubmitter(
+      await questionSubmitter.editDefaultResponseFeedbackInQuestionEditorPage(
         'Wrong Answer'
       );
       await questionSubmitter.addHintToState('Test Hint 2');
@@ -158,7 +158,7 @@ describe('Question Submitter', function () {
 
       await questionSubmitter.addTextInputInteraction('Answer');
 
-      await questionSubmitter.editDefaultResponseFeedbackInQuestionSubmitter(
+      await questionSubmitter.editDefaultResponseFeedbackInQuestionEditorPage(
         'Wrong Answer'
       );
       await questionSubmitter.addHintToState('Test Hint 3');

--- a/core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts
@@ -96,7 +96,9 @@ describe('Question Submitter', function () {
       await questionSubmitter.addImageInteraction();
 
       await questionSubmitter.addHintToState('Test Hint 1');
-      await questionSubmitter.editDefaultResponseFeedback('Wrong Answer');
+      await questionSubmitter.editDefaultResponseFeedbackInQuestionSubmitter(
+        'Wrong Answer'
+      );
       await questionSubmitter.submitQuestionSuggestion();
 
       await questionSubmitter.expectQuestionSuggestionInContributorDashboard(
@@ -127,7 +129,9 @@ describe('Question Submitter', function () {
         'Option 4',
       ]);
 
-      await questionSubmitter.editDefaultResponseFeedback('Wrong Answer');
+      await questionSubmitter.editDefaultResponseFeedbackInQuestionSubmitter(
+        'Wrong Answer'
+      );
       await questionSubmitter.addHintToState('Test Hint 2');
       await questionSubmitter.submitQuestionSuggestion();
 
@@ -154,7 +158,9 @@ describe('Question Submitter', function () {
 
       await questionSubmitter.addTextInputInteraction('Answer');
 
-      await questionSubmitter.editDefaultResponseFeedback('Wrong Answer');
+      await questionSubmitter.editDefaultResponseFeedbackInQuestionSubmitter(
+        'Wrong Answer'
+      );
       await questionSubmitter.addHintToState('Test Hint 3');
       await questionSubmitter.addSolutionToState(
         'Answer',

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -1248,14 +1248,14 @@ export class ExplorationEditor extends BaseUser {
 
   // TODO (#22539): This function has a duplicate in exploration-editor.ts.
   // To avoid unexpected behavior, ensure that any modifications here are also
-  // made in editDefaultResponseFeedbackInQuestionSubmitter() in question-submitter.ts.
+  // made in editDefaultResponseFeedbackInQuestionEditorPage() in question-submitter.ts.
   /**
    * Function to add feedback for default responses of a state interaction.
    * @param {string} defaultResponseFeedback - The feedback for the default responses.
    * @param {string} [directToCard] - The card to direct to (optional).
    * @param {string} [directToCardWhenStuck] - The card to direct to when the learner is stuck (optional).
    */
-  async editDefaultResponseFeedback(
+  async editDefaultResponseFeedbackInExplorationEditorPage(
     defaultResponseFeedback: string,
     directToCard?: string,
     directToCardWhenStuck?: string
@@ -1970,7 +1970,9 @@ export class ExplorationEditor extends BaseUser {
     await this.clickOn(addNewResponseButton);
     await this.clickOn(correctAnswerInTheGroupSelector);
 
-    await this.editDefaultResponseFeedback('Wrong Answer. Please try again');
+    await this.editDefaultResponseFeedbackInExplorationEditorPage(
+      'Wrong Answer. Please try again'
+    );
     await this.navigateToCard(lastInteraction);
     await this.createMinimalExploration(
       'This is last card',

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -1246,6 +1246,9 @@ export class ExplorationEditor extends BaseUser {
     }
   }
 
+  // TODO (#22539): This function has a duplicate in exploration-editor.ts.
+  // To avoid unexpected behavior, ensure that any modifications here are also
+  // made in editDefaultResponseFeedbackInQuestionSubmitter() in question-submitter.ts.
   /**
    * Function to add feedback for default responses of a state interaction.
    * @param {string} defaultResponseFeedback - The feedback for the default responses.
@@ -1257,10 +1260,6 @@ export class ExplorationEditor extends BaseUser {
     directToCard?: string,
     directToCardWhenStuck?: string
   ): Promise<void> {
-    // TODO (#22539): This function has a duplicate in exploration-editor.ts.
-    // To avoid unexpected behavior, ensure that any modifications here are also
-    // made in editDefaultResponseFeedbackInQuestionSubmitter() in question-submitter.ts.
-
     await this.clickOn(defaultFeedbackTab);
 
     if (defaultResponseFeedback) {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -1259,7 +1259,7 @@ export class ExplorationEditor extends BaseUser {
   ): Promise<void> {
     // TODO (#22539): This function has a duplicate in exploration-editor.ts.
     // To avoid unexpected behavior, ensure that any modifications here are also
-    // made in editDefaultResponseFeedback() in question-submitter.ts.
+    // made in editDefaultResponseFeedbackInQuestionSubmitter() in question-submitter.ts.
 
     await this.clickOn(defaultFeedbackTab);
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -1257,6 +1257,10 @@ export class ExplorationEditor extends BaseUser {
     directToCard?: string,
     directToCardWhenStuck?: string
   ): Promise<void> {
+    // TODO (#22539): This function has a duplicate in exploration-editor.ts.
+    // To avoid unexpected behavior, ensure that any modifications here are also
+    // made in editDefaultResponseFeedback() in question-submitter.ts.
+
     await this.clickOn(defaultFeedbackTab);
 
     if (defaultResponseFeedback) {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -2677,7 +2677,7 @@ export class LoggedOutUser extends BaseUser {
    */
   async continueToNextCard(): Promise<void> {
     try {
-      await this.page.waitForSelector(nextCardButton, {timeout: 10000});
+      await this.page.waitForSelector(nextCardButton, {timeout: 7000});
       await this.clickOn(nextCardButton);
     } catch (error) {
       if (error instanceof puppeteer.errors.TimeoutError) {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -2677,11 +2677,8 @@ export class LoggedOutUser extends BaseUser {
    */
   async continueToNextCard(): Promise<void> {
     try {
-      showMessage('Hello 1');
       await this.page.waitForSelector(nextCardButton, {timeout: 10000});
-      showMessage('Hello 2');
       await this.clickOn(nextCardButton);
-      showMessage('Hello 3');
     } catch (error) {
       if (error instanceof puppeteer.errors.TimeoutError) {
         await this.clickOn(nextCardArrowButton);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -2677,8 +2677,11 @@ export class LoggedOutUser extends BaseUser {
    */
   async continueToNextCard(): Promise<void> {
     try {
-      await this.page.waitForSelector(nextCardButton, {timeout: 7000});
+      showMessage('Hello 1');
+      await this.page.waitForSelector(nextCardButton, {timeout: 10000});
+      showMessage('Hello 2');
       await this.clickOn(nextCardButton);
+      showMessage('Hello 3');
     } catch (error) {
       if (error instanceof puppeteer.errors.TimeoutError) {
         await this.clickOn(nextCardArrowButton);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
@@ -71,10 +71,6 @@ const solutionInputTextArea =
 const submitQuestionButon = '.e2e-test-save-question-button';
 const feedbackEditorButton =
   'div.oppia-edit-feedback .oppia-click-to-start-editing';
-const defaultResponseTab = '.e2e-test-default-response-tab';
-const saveOutcomeFeedbackButton = '.e2e-test-save-outcome-feedback';
-const openOutcomeFeedBackEditorSelector =
-  'div.e2e-test-open-outcome-feedback-editor';
 const addElementToTextInputInteraction = 'button.e2e-test-add-list-entry';
 const skillDifficultyEasy = '.e2e-test-skill-difficulty-easy';
 const skillDifficultyMedium = '.e2e-test-skill-difficulty-medium';

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
@@ -37,6 +37,17 @@ const addInteractionButton = 'button.e2e-test-open-add-interaction-modal';
 const saveInteractionButton = 'button.e2e-test-save-interaction';
 const mathInteractionsTab = '.e2e-test-interaction-tab-math';
 
+const defaultFeedbackTab = 'a.e2e-test-default-response-tab';
+const openOutcomeFeedBackEditor = 'div.e2e-test-open-outcome-feedback-editor';
+const saveOutcomeFeedbackButton = 'button.e2e-test-save-outcome-feedback';
+const openOutcomeDestButton = '.e2e-test-open-outcome-dest-editor';
+const destinationSelectorDropdown = '.e2e-test-destination-selector-dropdown';
+const destinationWhenStuckSelectorDropdown =
+  '.e2e-test-destination-when-stuck-selector-dropdown';
+const addDestinationStateWhenStuckInput = '.protractor-test-add-state-input';
+const outcomeDestWhenStuckSelector =
+  '.protractor-test-open-outcome-dest-if-stuck-editor';
+
 const addInteractionModalSelector = 'customize-interaction-body-container';
 const multipleChoiceInteractionButton =
   'div.e2e-test-interaction-tile-MultipleChoiceInput';
@@ -78,6 +89,8 @@ const skillDifficultyHard = '.e2e-test-skill-difficulty-hard';
 const viewQuestionSudggestionModalHeader =
   '.e2e-test-question-suggestion-review-modal-header';
 const questionSuggestionModalDifficultySelector = '.oppia-difficulty-title';
+
+const LABEL_FOR_SAVE_DESTINATION_BUTTON = ' Save Destination ';
 
 export class QuestionSubmitter extends BaseUser {
   /**
@@ -131,6 +144,40 @@ export class QuestionSubmitter extends BaseUser {
     throw new Error(
       `No opportunity found for topic "${topicName}" and skill "${skillName}"`
     );
+  }
+  /**
+   * Function to add feedback for default responses of a state interaction.
+   * @param {string} defaultResponseFeedback - The feedback for the default responses.
+   * @param {string} [directToCard] - The card to direct to (optional).
+   * @param {string} [directToCardWhenStuck] - The card to direct to when the learner is stuck (optional).
+   */
+  async editDefaultResponseFeedback(
+    defaultResponseFeedback: string,
+    directToCard?: string,
+    directToCardWhenStuck?: string
+  ): Promise<void> {
+    await this.clickOn(defaultFeedbackTab);
+
+    if (defaultResponseFeedback) {
+      await this.clickOn(openOutcomeFeedBackEditor);
+      await this.clickOn(stateContentInputField);
+      await this.type(stateContentInputField, `${defaultResponseFeedback}`);
+      await this.clickOn(saveOutcomeFeedbackButton);
+    }
+
+    if (directToCard) {
+      await this.clickOn(openOutcomeDestButton);
+      await this.page.select(destinationSelectorDropdown, directToCard);
+      await this.clickOn(LABEL_FOR_SAVE_DESTINATION_BUTTON);
+    }
+
+    if (directToCardWhenStuck) {
+      await this.clickOn(outcomeDestWhenStuckSelector);
+      // The '4: /' value is used to select the 'a new card called' option in the dropdown.
+      await this.select(destinationWhenStuckSelectorDropdown, '4: /');
+      await this.type(addDestinationStateWhenStuckInput, directToCardWhenStuck);
+      await this.clickOn(LABEL_FOR_SAVE_DESTINATION_BUTTON);
+    }
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
@@ -511,6 +511,10 @@ export class QuestionSubmitter extends BaseUser {
     directToCard?: string,
     directToCardWhenStuck?: string
   ): Promise<void> {
+    // TODO (#22539): This function has a duplicate in exploration-editor.ts.
+    // To avoid unexpected behavior, ensure that any modifications here are also
+    // made in editDefaultResponseFeedback() in exploration-editor.ts.
+
     await this.clickOn(defaultFeedbackTab);
 
     if (defaultResponseFeedback) {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
@@ -145,40 +145,6 @@ export class QuestionSubmitter extends BaseUser {
       `No opportunity found for topic "${topicName}" and skill "${skillName}"`
     );
   }
-  /**
-   * Function to add feedback for default responses of a state interaction.
-   * @param {string} defaultResponseFeedback - The feedback for the default responses.
-   * @param {string} [directToCard] - The card to direct to (optional).
-   * @param {string} [directToCardWhenStuck] - The card to direct to when the learner is stuck (optional).
-   */
-  async editDefaultResponseFeedback(
-    defaultResponseFeedback: string,
-    directToCard?: string,
-    directToCardWhenStuck?: string
-  ): Promise<void> {
-    await this.clickOn(defaultFeedbackTab);
-
-    if (defaultResponseFeedback) {
-      await this.clickOn(openOutcomeFeedBackEditor);
-      await this.clickOn(stateContentInputField);
-      await this.type(stateContentInputField, `${defaultResponseFeedback}`);
-      await this.clickOn(saveOutcomeFeedbackButton);
-    }
-
-    if (directToCard) {
-      await this.clickOn(openOutcomeDestButton);
-      await this.page.select(destinationSelectorDropdown, directToCard);
-      await this.clickOn(LABEL_FOR_SAVE_DESTINATION_BUTTON);
-    }
-
-    if (directToCardWhenStuck) {
-      await this.clickOn(outcomeDestWhenStuckSelector);
-      // The '4: /' value is used to select the 'a new card called' option in the dropdown.
-      await this.select(destinationWhenStuckSelectorDropdown, '4: /');
-      await this.type(addDestinationStateWhenStuckInput, directToCardWhenStuck);
-      await this.clickOn(LABEL_FOR_SAVE_DESTINATION_BUTTON);
-    }
-  }
 
   /**
    * Function to select the difficulty level of the question to be suggested.
@@ -532,6 +498,41 @@ export class QuestionSubmitter extends BaseUser {
     await this.clickOn(addNewResponseButton);
 
     showMessage('Image interaction has been added successfully.');
+  }
+
+  /**
+   * Function to add feedback for default responses of a state interaction.
+   * @param {string} defaultResponseFeedback - The feedback for the default responses.
+   * @param {string} [directToCard] - The card to direct to (optional).
+   * @param {string} [directToCardWhenStuck] - The card to direct to when the learner is stuck (optional).
+   */
+  async editDefaultResponseFeedback(
+    defaultResponseFeedback: string,
+    directToCard?: string,
+    directToCardWhenStuck?: string
+  ): Promise<void> {
+    await this.clickOn(defaultFeedbackTab);
+
+    if (defaultResponseFeedback) {
+      await this.clickOn(openOutcomeFeedBackEditor);
+      await this.clickOn(stateContentInputField);
+      await this.type(stateContentInputField, `${defaultResponseFeedback}`);
+      await this.clickOn(saveOutcomeFeedbackButton);
+    }
+
+    if (directToCard) {
+      await this.clickOn(openOutcomeDestButton);
+      await this.page.select(destinationSelectorDropdown, directToCard);
+      await this.clickOn(LABEL_FOR_SAVE_DESTINATION_BUTTON);
+    }
+
+    if (directToCardWhenStuck) {
+      await this.clickOn(outcomeDestWhenStuckSelector);
+      // The '4: /' value is used to select the 'a new card called' option in the dropdown.
+      await this.select(destinationWhenStuckSelectorDropdown, '4: /');
+      await this.type(addDestinationStateWhenStuckInput, directToCardWhenStuck);
+      await this.clickOn(LABEL_FOR_SAVE_DESTINATION_BUTTON);
+    }
   }
 }
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
@@ -490,17 +490,6 @@ export class QuestionSubmitter extends BaseUser {
 
     showMessage('Image interaction has been added successfully.');
   }
-
-  /**
-   * Function to edit the default response feedback.
-   */
-  async editDefaultResponseFeedback(): Promise<void> {
-    await this.clickOn(defaultResponseTab);
-    await this.clickOn(openOutcomeFeedBackEditorSelector);
-    await this.page.waitForSelector(stateContentInputField, {visible: true});
-    await this.type(stateContentInputField, 'Wrong Answer');
-    await this.clickOn(saveOutcomeFeedbackButton);
-  }
 }
 
 export let QuestionSubmitterFactory = (): QuestionSubmitter =>

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
@@ -500,21 +500,20 @@ export class QuestionSubmitter extends BaseUser {
     showMessage('Image interaction has been added successfully.');
   }
 
+  // TODO (#22539): This function has a duplicate in exploration-editor.ts.
+  // To avoid unexpected behavior, ensure that any modifications here are also
+  // made in editDefaultResponseFeedback() in exploration-editor.ts.
   /**
    * Function to add feedback for default responses of a state interaction.
    * @param {string} defaultResponseFeedback - The feedback for the default responses.
    * @param {string} [directToCard] - The card to direct to (optional).
    * @param {string} [directToCardWhenStuck] - The card to direct to when the learner is stuck (optional).
    */
-  async editDefaultResponseFeedback(
+  async editDefaultResponseFeedbackInQuestionSubmitter(
     defaultResponseFeedback: string,
     directToCard?: string,
     directToCardWhenStuck?: string
   ): Promise<void> {
-    // TODO (#22539): This function has a duplicate in exploration-editor.ts.
-    // To avoid unexpected behavior, ensure that any modifications here are also
-    // made in editDefaultResponseFeedback() in exploration-editor.ts.
-
     await this.clickOn(defaultFeedbackTab);
 
     if (defaultResponseFeedback) {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/question-submitter.ts
@@ -502,14 +502,14 @@ export class QuestionSubmitter extends BaseUser {
 
   // TODO (#22539): This function has a duplicate in exploration-editor.ts.
   // To avoid unexpected behavior, ensure that any modifications here are also
-  // made in editDefaultResponseFeedback() in exploration-editor.ts.
+  // made in editDefaultResponseFeedbackInExplorationEditorPage() in exploration-editor.ts.
   /**
    * Function to add feedback for default responses of a state interaction.
    * @param {string} defaultResponseFeedback - The feedback for the default responses.
    * @param {string} [directToCard] - The card to direct to (optional).
    * @param {string} [directToCardWhenStuck] - The card to direct to when the learner is stuck (optional).
    */
-  async editDefaultResponseFeedbackInQuestionSubmitter(
+  async editDefaultResponseFeedbackInQuestionEditorPage(
     defaultResponseFeedback: string,
     directToCard?: string,
     directToCardWhenStuck?: string


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of https://github.com/oppia/oppia/issues/22448#issuecomment-2816083091.
2. This PR does the following: 
    - Copies a function from exploration-editor.ts to question-submitter.ts as it was being overwritten by different function.
4. The original bug occurred because: https://github.com/oppia/oppia/issues/22448#issuecomment-2816083091 introduced a function to addResponeFeedback for QuestionSubmitter, but it started overwritting same function in ExplorationEditor as UserFactory tries to add all methods (functions) in one user when creating a user.
    Filed https://github.com/oppia/oppia/issues/22539 for the same

[**Debugging Doc**](https://docs.google.com/document/d/1mjUhkNKewoCte9Xbl4gfvmnVcyBlcsVd899xPIb27CQ/edit?tab=t.0)
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Passing logged-out-user/play-through-lesson-while-getting-feedback-and-hints in CI proves the test suite is fixed. As it was bug and not a flake, we don't need proof by running multiple times.

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->



<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->



<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
