### PR TITLE
Fix #21492: learner dashboard not refreshing on browser back navigation

### DIFF
--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -53,6 +53,8 @@ import {PageTitleService} from 'services/page-title.service';
 import {LearnerGroupBackendApiService} from 'domain/learner_group/learner-group-backend-api.service';
 import {UrlService} from 'services/contextual/url.service';
 import {PlatformFeatureService} from 'services/platform-feature.service';
+import { WindowRef } from 'services/contextual/window-ref.service';
+
 
 import './learner-dashboard-page.component.css';
 
@@ -195,7 +197,8 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
     private pageTitleService: PageTitleService,
     private learnerGroupBackendApiService: LearnerGroupBackendApiService,
     private urlService: UrlService,
-    private platFeatService: PlatformFeatureService
+    private platFeatService: PlatformFeatureService,
+    private windowRef: WindowRef
   ) {}
 
   ngOnInit(): void {
@@ -343,10 +346,75 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
         this.setPageTitle();
       })
     );
+    this.windowRef.nativeWindow.onpopstate = () => {
+      this.refreshDashboardData();
+    };
+    
   }
+
+  refreshDashboardData(): void {
+    this.loaderService.showLoadingScreen('Loading');
+  
+    const dashboardTopicAndStoriesDataPromise =
+      this.learnerDashboardBackendApiService.fetchLearnerDashboardTopicsAndStoriesDataAsync()
+        .then(responseData => {
+          this.completedStoriesList = responseData.completedStoriesList;
+          this.learntTopicsList = responseData.learntTopicsList;
+          this.partiallyLearntTopicsList = responseData.partiallyLearntTopicsList;
+          this.topicsToLearn = responseData.topicsToLearnList;
+          this.untrackedTopics = responseData.untrackedTopics;
+          this.allTopics = responseData.allTopicsList;
+          this.learntToPartiallyLearntTopics = responseData.learntToPartiallyLearntTopics;
+        });
+  
+    const dashboardCollectionsDataPromise =
+      this.learnerDashboardBackendApiService.fetchLearnerDashboardCollectionsDataAsync()
+        .then(responseData => {
+          this.completedCollectionsList = responseData.completedCollectionsList;
+          this.incompleteCollectionsList = responseData.incompleteCollectionsList;
+          this.completedToIncompleteCollections = responseData.completedToIncompleteCollections;
+          this.collectionPlaylist = responseData.collectionPlaylist;
+        });
+  
+    const dashboardExplorationsDataPromise =
+      this.learnerDashboardBackendApiService.fetchLearnerDashboardExplorationsDataAsync()
+        .then(responseData => {
+          this.completedExplorationsList = responseData.completedExplorationsList;
+          this.incompleteExplorationsList = responseData.incompleteExplorationsList;
+          this.subscriptionsList = responseData.subscriptionList;
+          this.explorationPlaylist = responseData.explorationPlaylist;
+        });
+  
+    Promise.all([
+      dashboardTopicAndStoriesDataPromise,
+      dashboardCollectionsDataPromise,
+      dashboardExplorationsDataPromise
+    ])
+    .then(() => {
+      setTimeout(() => {
+        this.loaderService.hideLoadingScreen();
+        this.communityLessonsDataLoaded = true;
+        this.totalLessonsInPlaylists = [
+          ...this.explorationPlaylist,
+          ...this.collectionPlaylist,
+        ];
+        this.focusManagerService.setFocusWithoutScroll('ourLessonsBtn');
+      }, 0);
+    })
+    .catch(errorResponse => {
+      if (AppConstants.FATAL_ERROR_CODES.indexOf(errorResponse.status) !== -1) {
+        this.alertsService.addWarning('Failed to refresh learner dashboard data.');
+      }
+      this.loaderService.hideLoadingScreen();
+    });
+  }
+  
+  
+  
 
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
+    this.windowRef.nativeWindow.onpopstate = null;
   }
 
   getauthorPicturePngDataUrl(username: string): string {


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of: #21492.
2. This PR does the following: 
- Added a `window.onpopstate` event listener in `ngOnInit()` of `learner-dashboard-page.component.ts`
- Implemented a new method `refreshDashboardData()` to reload backend data on popstate
- Ensured smooth user experience and proper UI refresh after browser navigation
3. (For bug-fixing PRs only) The original bug occurred because: The learner dashboard page did not re-fetch data when a user navigated back using the browser’s Back button. This happened because there was no listener for the popstate event, which is triggered during browser history navigation. As a result, the component’s data remained stale unless the page was fully reloaded. I could not find the original PR that introduced this behavior, but the lack of window.onpopstate handling appears to have been an oversight in earlier implementations of the learner dashboard’s Angular component lifecycle.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.

## Proof that changes are correct

I am currently unable to submit a screen recording or screenshots due to technical limitations with my development environment (Docker running locally without easy screen capture support). I would work on doing this longer, but I need to submit this by a deadline for a class project. I apologize!!! However, I manually tested the dashboard refresh functionality on multiple browsers and verified that the loading screen appears and updated data is fetched upon using the browser’s Back button. 

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


@HardikGoyal2003
