### PR TITLE
Gae models test time fix

### DIFF
--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -208,7 +208,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.STATUS_ACCEPTED, 'test_author',
             'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_6', 'hi')
-        to_date = datetime.datetime.now()
+        to_date = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         from_date = to_date - datetime.timedelta(days=1)
 
         suggestions = (
@@ -228,7 +228,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.STATUS_ACCEPTED, 'test_author',
             'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_6', 'hi')
-        to_date = datetime.datetime.now()
+        to_date = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         from_date = to_date - datetime.timedelta(days=1)
 
         suggestions = (

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -208,7 +208,8 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.STATUS_ACCEPTED, 'test_author',
             'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_6', 'hi')
-        to_date = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        to_date = datetime.datetime.now(
+            datetime.timezone.utc).replace(tzinfo=None)
         from_date = to_date - datetime.timedelta(days=1)
 
         suggestions = (
@@ -228,7 +229,8 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.STATUS_ACCEPTED, 'test_author',
             'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_6', 'hi')
-        to_date = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        to_date = datetime.datetime.now(
+            datetime.timezone.utc).replace(tzinfo=None)
         from_date = to_date - datetime.timedelta(days=1)
 
         suggestions = (


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes a bug in core/storage/suggestion/gae_models_test.py
2. This PR does the following: Fixes the Assertion error by making the variable to_date naive UTC time
3. (For bug-fixing PRs only) The test failed because timezone mismatch between test dates 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
## Proof that changes are correct
![Screenshot 2025-04-30 183358](https://github.com/user-attachments/assets/0899de17-8d59-49a4-b4d6-871069ae2568)
![Screenshot 2025-04-30 183846](https://github.com/user-attachments/assets/2e2d9956-6441-437c-bbb8-913b3d7a6e62)

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

