### PR TITLE
Fix #22110: Move skill name input to next line below instruction in Skill Editor

### DIFF
--- a/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.component.html
@@ -5,25 +5,41 @@
       <i>This is the name of the skill as visible to learners and other creators.</i>
     </div>
     <br>
-    <p [ngClass]="{'has-error': !(tmpSkillDescription.length > 0)}">
-      <input type="text" aria-label="Skill Description" class="form-control e2e-test-skill-description-field" *ngIf="canEditSkillDescription()"
-             [(ngModel)]="tmpSkillDescription" (change)="resetErrorMsg()" (blur)="saveSkillDescription(tmpSkillDescription)"
-             [attr.maxlength]="MAX_CHARS_IN_SKILL_DESCRIPTION" ng-trim="false">
-      <span class="oppia-input-box-subtitle">
-        <i>
-          Skill description should be at most {{ MAX_CHARS_IN_SKILL_DESCRIPTION }} characters.
-        </i>
-      </span>
+
+    <div class="skill-description-wrapper" [ngClass]="{'has-error': !(tmpSkillDescription.length > 0)}">
+      <label class="oppia-input-box-subtitle">
+        <i>Skill description should be at most {{ MAX_CHARS_IN_SKILL_DESCRIPTION }} characters.</i>
+      </label>
+
+      <input
+        *ngIf="canEditSkillDescription()"
+        type="text"
+        aria-label="Skill Description"
+        class="form-control e2e-test-skill-description-field"
+        [(ngModel)]="tmpSkillDescription"
+        (change)="resetErrorMsg()"
+        (blur)="saveSkillDescription(tmpSkillDescription)"
+        [attr.maxlength]="MAX_CHARS_IN_SKILL_DESCRIPTION"
+        ng-trim="false"
+      />
+
       <span *ngIf="errorMsg" class="skill-description-error-message">
-        <i>
-          {{ errorMsg }}
-        </i>
+        <i>{{ errorMsg }}</i>
       </span>
+
       <span *ngIf="!canEditSkillDescription()">{{ tmpSkillDescription }}</span>
-    </p>
+    </div>
   </div>
 </div>
+
 <style>
+  .skill-description-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 12px;
+  }
+
   span.skill-description-error-message {
     color: #f00;
     display: block;


### PR DESCRIPTION
## Overview

1. This PR fixes [#22110](https://github.com/oppia/oppia/issues/22110).
2. This PR resolves a layout issue in the Skill Editor where the skill name input field appeared inline with the instruction text. The input field has been repositioned to appear on the **next line**, directly below the instruction “Skill description should be at most 100 characters.”
3. The original bug occurred because the instruction and input were placed in the same block-level tag, causing them to render on the same line.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have manually tested the fix in the browser.
- [ ] I have assigned or notified the appropriate reviewers.

## Proof that changes are correct

### Before
The skill name input appeared on the same line as the instructional text, creating a cluttered UI.
![bug before](https://github.com/user-attachments/assets/a160f44a-4569-4534-b11d-1901eeeec95a)


### After
The input field appears **on a new line** below the instruction text, improving readability and maintaining consistent vertical spacing.
<img width="1290" alt="after bug" src="https://github.com/user-attachments/assets/68a3deb3-d748-4e01-9048-0091115f8122" />

> 💡 You can find the change in `skill-description-editor.component.html`.



