### PR TITLE
Fix #22358: Practice session tab page name changed

### DIFF
--- a/core/templates/pages/practice-session-page/practice-session-page.component.ts
+++ b/core/templates/pages/practice-session-page/practice-session-page.component.ts
@@ -61,7 +61,7 @@ export class PracticeSessionPageComponent implements OnInit, OnDestroy {
 
   subscribeToOnLanguageCodeChange(): void {
     this.directiveSubscriptions.add(
-      this.translateService.onLangChange.subscribe(() => {
+      this.i18nLanguageCodeService.onI18nLanguageCodeChange.subscribe(() => {
         this.setPageTitle();
       })
     );

--- a/core/templates/pages/practice-session-page/practice-session-page.component.ts
+++ b/core/templates/pages/practice-session-page/practice-session-page.component.ts
@@ -52,23 +52,16 @@ export class PracticeSessionPageComponent implements OnInit, OnDestroy {
   ) {}
 
   setPageTitle(): void {
-    this.translateService.use(
-      this.i18nLanguageCodeService.getCurrentI18nLanguageCode()
-    );
-
     const translatedTitle = this.translateService.instant(
       'I18N_PRACTICE_SESSION_PAGE_TITLE',
-      {
-        topicName: this.topicName,
-      }
+      {topicName: this.topicName}
     );
-
     this.pageTitleService.setDocumentTitle(translatedTitle);
   }
 
   subscribeToOnLanguageCodeChange(): void {
     this.directiveSubscriptions.add(
-      this.i18nLanguageCodeService.onI18nLanguageCodeChange.subscribe(() => {
+      this.translateService.onLangChange.subscribe(() => {
         this.setPageTitle();
       })
     );


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of [BUG]: Wrong title of the practice session page in incognito mode #22358 
2. This PR does the following: This PR improves the logic for setting the page title on the practice session page. It updates the title only after the translation files are fully loaded, resolving an issue where the title would sometimes appear as the raw translation key (e.g., I18N_PRACTICE_SESSION_PAGE_TITLE)—particularly in incognito mode.
3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because translateService.instant() was called immediately after translateService.use(), without waiting for the language files to finish loading. This led to incorrect or untranslated page titles in cases where translations were not cached.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [yes] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [yes ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ no] I have written tests for my code. (not applicable)
- [yes] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [yes ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

### Proof that changes are correct
Root Cause:
The issue occurred because translateService.instant() was being called immediately after translateService.use(), which initiates an asynchronous language change. As a result, the translation key I18N_PRACTICE_SESSION_PAGE_TITLE was sometimes shown instead of the translated title—particularly in incognito mode, where translation files are not cached and may take longer to load. Since instant() is synchronous, it attempted to fetch the translation before the language resources were fully available.

Fix:
To fix this, I removed the call to translateService.use() and instead subscribed to the translateService.onLangChange event. This ensures the page title is set only after the language has been fully initialized and translation files have loaded. translateService.instant() is still used—but only when we’re certain that translations are ready.

Changes Made:
File Modified: practice-session-page.component.ts
Change Description:
-Removed the call to translateService.use() inside setPageTitle() to prevent premature language switching.
-Subscribed to translateService.onLangChange to update the title after language initialization.
-Ensured the title is correctly rendered on initial load and whenever the language changes dynamically.

#### Proof of changes on desktop with slow/throttled network


https://github.com/user-attachments/assets/65de421e-6a4b-47eb-8a42-3a18c70cb576


#### Proof of changes on mobile phone


https://github.com/user-attachments/assets/2922f95c-1883-48e6-a241-66458f187b26


#### Proof of changes in Arabic language


https://github.com/user-attachments/assets/e37a2092-71a0-42b2-b1a0-b00ec1be903b


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
