### PR TITLE
Revert "Fix part of #18973: Enable solution tab for multiple choice input interaction"

### DIFF
--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.py
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.py
@@ -39,7 +39,9 @@ class MultipleChoiceInput(base.BaseInteraction):
     instructions: Optional[str] = None
     narrow_instructions: Optional[str] = None
     needs_summary: bool = False
-    can_have_solution: bool = True
+    # Radio buttons get unselected when specifying a solution. This needs to be
+    # fixed before solution feature can support this interaction.
+    can_have_solution: bool = False
     # MultipleChoiceInput interaction must contain a generic submit button.
     show_generic_submit_button: bool = True
 

--- a/extensions/interactions/interaction_specs.json
+++ b/extensions/interactions/interaction_specs.json
@@ -625,7 +625,7 @@
     }
   },
   "MultipleChoiceInput": {
-    "can_have_solution": true,
+    "can_have_solution": false,
     "show_generic_submit_button": true,
     "instructions": null,
     "is_trainable": false,


### PR DESCRIPTION
Reverts oppia/oppia#22150

The Question models, which have multiple choice interactions, do not have solutions (in the prod servers), but this PR enables the option to add a solution, the result of which all the existing Questions (with multiple choice interaction) are now invalid. 

Issue because of the changes: https://github.com/oppia/oppia/issues/22613

Testing doc: https://docs.google.com/document/d/1vEz_OnIZZV9ubhwrAajfiFT6Nv2P__qkDvgnWrac6Zc/edit?tab=t.0
