### PR TITLE
Fix #22134: Normalize URL case for classroom routes

### DIFF
--- a/core/templates/pages/oppia-root/routing/app.routing.module.ts
+++ b/core/templates/pages/oppia-root/routing/app.routing.module.ts
@@ -22,6 +22,7 @@ import {Route, RouterModule} from '@angular/router';
 import {AppConstants} from 'app.constants';
 import {IsLoggedInGuard} from 'pages/lightweight-oppia-root/routing/guards/is-logged-in.guard';
 import {IsNewLessonPlayerGuard} from 'pages/exploration-player-page/new-lesson-player/lesson-player-flag.guard';
+import {NormalizeUrlCaseGuard} from 'pages/oppia-root/routing/normalize-url-case.guard';
 
 // All paths must be defined in constants.ts file.
 // Otherwise pages will have false 404 status code.
@@ -147,6 +148,7 @@ const routes: Route[] = [
       import('pages/classroom-page/classroom-page.module').then(
         m => m.ClassroomPageModule
       ),
+    canActivate: [NormalizeUrlCaseGuard],
   },
   {
     path: AppConstants.PAGES_REGISTERED_WITH_FRONTEND.TOPIC_EDITOR.ROUTE,

--- a/core/templates/pages/oppia-root/routing/normalize-url-case.guard.spec.ts
+++ b/core/templates/pages/oppia-root/routing/normalize-url-case.guard.spec.ts
@@ -1,0 +1,76 @@
+// Copyright 2025 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Normalize URL guard spec.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {NormalizeUrlCaseGuard} from './normalize-url-case.guard';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+
+describe('NormalizeUrlCaseGuard', function () {
+  let guard: NormalizeUrlCaseGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [NormalizeUrlCaseGuard],
+    });
+    guard = TestBed.inject(NormalizeUrlCaseGuard);
+  });
+
+  const mockRouterState = function (url: string): RouterStateSnapshot {
+    return {url} as RouterStateSnapshot;
+  };
+
+  it('should be created', function () {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should allow navigation if URL is already lowercase', function () {
+    const state = mockRouterState('/learn/science');
+    const route = {} as ActivatedRouteSnapshot;
+
+    const result = guard.canActivate(route, state);
+    expect(result).toBe(true);
+  });
+
+  it('should redirect if URL contains uppercase characters', function () {
+    const state = mockRouterState('/learn/SCIENCE');
+    const route = {} as ActivatedRouteSnapshot;
+
+    const result = guard.canActivate(route, state);
+    expect(result instanceof UrlTree).toBeTrue();
+
+    const urlTree = result as UrlTree;
+    expect(urlTree.toString()).toBe('/learn/science');
+  });
+
+  it('should redirect if URL has mixed case', function () {
+    const state = mockRouterState('/learn/ScIeNcE');
+    const route = {} as ActivatedRouteSnapshot;
+
+    const result = guard.canActivate(route, state);
+    expect(result instanceof UrlTree).toBeTrue();
+
+    const urlTree = result as UrlTree;
+    expect(urlTree.toString()).toBe('/learn/science');
+  });
+});

--- a/core/templates/pages/oppia-root/routing/normalize-url-case.guard.ts
+++ b/core/templates/pages/oppia-root/routing/normalize-url-case.guard.ts
@@ -1,0 +1,46 @@
+// Copyright 2025 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Normalize URL guard.
+ */
+import {Injectable} from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NormalizeUrlCaseGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): boolean | UrlTree {
+    const originalUrl = state.url;
+    const lowercasedUrl = originalUrl.toLowerCase();
+
+    if (originalUrl !== lowercasedUrl) {
+      return this.router.parseUrl(lowercasedUrl);
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Overview

1. This PR fixes #22134
2. This PR does the following: Normalizes URL case for `learn/XXX`

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before:

https://github.com/user-attachments/assets/94bfefa7-aae3-45da-8b12-aada96f20364


After: 

https://github.com/user-attachments/assets/d384f907-daed-4964-b84e-eb75f5a89a17

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
