### PR TITLE
Revert wiki changes from web interface by force-pushing from oppia-web-developer-docs

### DIFF
--- a/.github/workflows/revert-web-wiki-updates.yml
+++ b/.github/workflows/revert-web-wiki-updates.yml
@@ -33,30 +33,15 @@ jobs:
           echo "diff<<$delimiter" >> "$GITHUB_OUTPUT"
           echo $(git log source/develop..origin/master) >> "$GITHUB_OUTPUT"
           echo "$delimiter" >> "$GITHUB_OUTPUT"
-      - name: Revert commits
+      - name: Force-push from source
         if: ${{ steps.check-diff.outputs.diff != '' }}
         run: |
-          git config user.name oppia-wiki-synchronizer[bot]
-          # Email has the form id+name@users.noreply.github.com. The ID
-          # can be retrieved from
-          # https://api.github.com/users/oppia-wiki-synchronizer[bot].
-          git config user.email 102317631+oppia-wiki-synchronizer[bot]@users.noreply.github.com
-          git revert --no-commit source/develop..origin/master
-          msg_file=$(mktemp)
-          echo "Reverting the following changes made through the web interface:\n" > $msg_file
-          git log source/develop..origin/master | while read line; do echo "    ${line}"; done >> $msg_file
-          git commit -F $msg_file
-      - name: Merge in development commits
-        if: ${{ steps.check-diff.outputs.diff != '' }}
-        # If a PR in the source repository was merged around the same time as a
-        # change was made to the wiki through the web interface, its deployment
-        # might fail before this job can revert the change. In that case, we
-        # need to merge in those un-deployed changes to both the source and
-        # deployment repositories.
-        run: git merge source/develop
-      - name: Push to deployment repository
-        if: ${{ steps.check-diff.outputs.diff != '' }}
-        run: git push source master:develop
-      - name: Push to source repository
-        if: ${{ steps.check-diff.outputs.diff != '' }}
-        run: git push
+          # Update our copy of the source repo in case changes have been merged
+          # to it while this workflow was running.
+          git fetch source
+          # Checkout source.
+          git checkout develop
+          # Force-push source commits to deployment repo, over-writing the
+          # changes made via the web interface and bringing the repos back in
+          # sync.
+          git push -f origin develop:master


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: To keep our source (oppia/oppia-web-developer-docs.git) and deployment (oppia/oppia.wiki.git) wiki repositories in sync, all wiki changes need to go through the source repo. To enforce this, we automatically revert any changes made through the wiki web interface (which changes the deployment repository only). Formerly, we reverted by keeping the commit added through the web interface, adding a revert commit to roll back the changes, and pushing the resulting commit history to both source and deployment repos. However, this is incompatible with new branch protection rules on the source repo that require changes to be made by PR. Therefore, this PR simplifies our revert workflow by force-pushing from source to deployment, wiping out changes made through the web interface without keeping a record in the commit history.
3. (For bug-fixing PRs only) The original bug occurred because: n/a

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This PR was tested on the U8NWXD/test-oppia and U8NWXD/test-oppia-docs repos. You can see the successful actions runs here:

* https://github.com/U8NWXD/test-oppia-docs/actions/runs/15761908937/job/44430505452
* https://github.com/U8NWXD/test-oppia/actions/runs/15761980612/job/44430573966

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
