### PR TITLE
Fix part of #18470 - Add Topic in Classroom Admin Page 

### DIFF
--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.html
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.html
@@ -296,7 +296,8 @@
                         <ngx-mat-select-search
                           ngModel
                           (ngModelChange)="filterTopicsByName($event)"
-                          placeholderLabel="Search topic name here...">
+                          placeholderLabel="Search topic name"
+                          noEntriesFoundLabel="No available topics">
                         </ngx-mat-select-search>
                       </mat-option>
                       <mat-option *ngFor="let option of filteredTopicsToClassroomRelation"

--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
@@ -258,11 +258,14 @@ export class ClassroomAdminPageComponent implements OnInit {
   }
 
   getAvailableTopics(): TopicClassroomRelationDict[] {
-    return this.topicsToClassroomRelation.filter(
-      value =>
-        value.classroom_name === null &&
-        !this.topicNames.includes(value.topic_name)
-    );
+    const seen = new Set();
+    return this.topicsToClassroomRelation.filter(value => {
+      if (value.classroom_name !== null) return false;
+      if (this.topicNames.includes(value.topic_name)) return false;
+      if (seen.has(value.topic_name)) return false;
+      seen.add(value.topic_name);
+      return true;
+    });
   }
 
   filterTopicsByName(searchTerm: string): void {

--- a/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
+++ b/core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
@@ -260,9 +260,15 @@ export class ClassroomAdminPageComponent implements OnInit {
   getAvailableTopics(): TopicClassroomRelationDict[] {
     const seen = new Set();
     return this.topicsToClassroomRelation.filter(value => {
-      if (value.classroom_name !== null) return false;
-      if (this.topicNames.includes(value.topic_name)) return false;
-      if (seen.has(value.topic_name)) return false;
+      if (value.classroom_name !== null) {
+        return false;
+      }
+      if (this.topicNames.includes(value.topic_name)) {
+        return false;
+      }
+      if (seen.has(value.topic_name)) {
+        return false;
+      }
       seen.add(value.topic_name);
       return true;
     });


### PR DESCRIPTION
## Overview

1. This PR fixes issues of #18470 
2. This PR does the following: This PR adds a user-friendly message (noEntriesFoundLabel) to the select-search component used when adding topics, improving the UX by clearly indicating when no topics are available. Additionally, it introduces a uniqueness check in the getAvailableTopics() method to prevent duplicate topics from appearing in the list. Previously, users would see the default fallback message (which is in the German language) when no topics were found, potentially leading to frustration. Also, duplicate topics could appear, cluttering the selection and causing ambiguity. 

## Essential Checklist

- [ yes] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [yes ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [not applicable ] I have written tests for my code.
- [yes ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ n/a] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct


https://github.com/user-attachments/assets/8f56883c-a0e8-4549-9607-388564df4523


#### Proof of changes on desktop with slow/throttled network


https://github.com/user-attachments/assets/08004127-4cb5-4095-962f-2219f7c3e4bd


#### Proof of changes on mobile phone


https://github.com/user-attachments/assets/ddfe994c-4d1c-4136-b67d-6b6d78e3fb3b


#### Proof of changes in Arabic language

The classroom admin page does not support language changing. 
