### PR TITLE
[GSoC 2025] M1.1 - Fix part of #19217: Make visitedNameStates consistent in the current files

### DIFF
--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.spec.ts
@@ -1463,11 +1463,15 @@ describe('Conversation skin component', () => {
       spyOn(explorationEngineService, 'getShortestPathToState').and.returnValue(
         ['Start', 'Mid']
       );
-
       spyOn(explorationEngineService, 'getStateCardByName').and.returnValues(
         stateCards[0],
         stateCards[1],
         stateCards[2]
+      );
+      spyOn(explorationEngineService, 'getStateFromStateName').and.returnValues(
+        expResponse.exploration.states.Start,
+        expResponse.exploration.states.Mid,
+        expResponse.exploration.states.End
       );
 
       spyOn(playerPositionService, 'getDisplayedCardIndex').and.returnValue(1);

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.spec.ts
@@ -1460,7 +1460,6 @@ describe('Conversation skin component', () => {
         'loadLatestExplorationAsync'
       ).and.returnValue(Promise.resolve(expResponse));
       componentInstance.prevSessionStatesProgress = ['Start', 'Mid'];
-      componentInstance.visitedCheckpointStateNames = ['Start'];
       spyOn(explorationEngineService, 'getShortestPathToState').and.returnValue(
         ['Start', 'Mid']
       );
@@ -1514,6 +1513,11 @@ describe('Conversation skin component', () => {
       expect(componentInstance.visitedCheckpointStateNames).toContain('Mid');
       expect(componentInstance.prevSessionStatesProgress).toEqual(['Start']);
       expect(componentInstance.mostRecentlyReachedCheckpoint).toBe('Mid');
+
+      componentInstance.prevSessionStatesProgress = [];
+      componentInstance.visitedCheckpointStateNames = [];
+      componentInstance.initializePage();
+      tick(100);
     })
   );
 

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.spec.ts
@@ -1448,7 +1448,6 @@ describe('Conversation skin component', () => {
       ).and.returnValue(false);
       spyOn(componentInstance, 'adjustPageHeight');
       spyOn(playerPositionService.onNewCardOpened, 'emit');
-      componentInstance.isIframed = true;
       spyOn(playerPositionService, 'setDisplayedCardIndex');
       spyOn(playerPositionService, 'getCurrentStateName').and.returnValues(
         'Start',
@@ -1460,6 +1459,8 @@ describe('Conversation skin component', () => {
         readOnlyExplorationBackendApiService,
         'loadLatestExplorationAsync'
       ).and.returnValue(Promise.resolve(expResponse));
+      componentInstance.prevSessionStatesProgress = ['Start', 'Mid'];
+      componentInstance.visitedCheckpointStateNames = ['Start'];
       spyOn(explorationEngineService, 'getShortestPathToState').and.returnValue(
         ['Start', 'Mid']
       );
@@ -1468,10 +1469,26 @@ describe('Conversation skin component', () => {
         stateCards[1],
         stateCards[2]
       );
-      spyOn(explorationEngineService, 'getStateFromStateName').and.returnValues(
-        expResponse.exploration.states.Start,
-        expResponse.exploration.states.Mid,
-        expResponse.exploration.states.End
+
+      spyOn(explorationEngineService, 'getStateFromStateName').and.callFake(
+        stateName => {
+          if (stateName === 'Mid') {
+            return {
+              cardIsCheckpoint: true,
+              ...expResponse.exploration.states.Mid,
+            };
+          } else if (stateName === 'Start') {
+            return {
+              cardIsCheckpoint: true,
+              ...expResponse.exploration.states.Start,
+            };
+          } else if (stateName === 'End') {
+            return {
+              cardIsCheckpoint: false,
+              ...expResponse.exploration.states.End,
+            };
+          }
+        }
       );
 
       spyOn(playerPositionService, 'getDisplayedCardIndex').and.returnValue(1);
@@ -1494,6 +1511,7 @@ describe('Conversation skin component', () => {
       componentInstance.initializePage();
       tick(100);
 
+      expect(componentInstance.visitedCheckpointStateNames).toContain('Mid');
       expect(componentInstance.prevSessionStatesProgress).toEqual(['Start']);
       expect(componentInstance.mostRecentlyReachedCheckpoint).toBe('Mid');
     })

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.ts
@@ -785,12 +785,12 @@ export class ConversationSkinComponent {
           );
 
         let indexToRedirectTo = 0;
-        
 
         for (let i = 0; i < this.prevSessionStatesProgress.length; i++) {
           // Set state name of a previously completed state.
           let stateName = this.prevSessionStatesProgress[i];
-          let stateData = this.explorationEngineService.getStateFromStateName(stateName);
+          let stateData =
+            this.explorationEngineService.getStateFromStateName(stateName);
 
           // Skip the card if it has already been added to transcript.
           if (
@@ -801,7 +801,10 @@ export class ConversationSkinComponent {
             this._addNewCard(stateCard);
           }
 
-          if (!this.visitedCheckpointStateNames.includes(stateName) && stateData.cardIsCheckpoint) {
+          if (
+            !this.visitedCheckpointStateNames.includes(stateName) &&
+            stateData.cardIsCheckpoint
+          ) {
             this.visitedCheckpointStateNames.push(stateName);
           }
 

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.ts
@@ -152,7 +152,7 @@ export class ConversationSkinComponent {
   questionSessionCompleted: boolean;
   moveToExploration: boolean;
   upcomingInteractionInstructions;
-  visitedStateNames: string[] = [];
+  visitedCheckpointStateNames: string[] = [];
   completedStateNames: string[] = [];
   prevSessionStatesProgress: string[] = [];
   mostRecentlyReachedCheckpoint: string;
@@ -481,8 +481,8 @@ export class ConversationSkinComponent {
             this.explorationPlayerStateService.setLastCompletedCheckpoint(
               firstStateName
             );
+            this.visitedCheckpointStateNames.push(firstStateName);
           });
-        this.visitedStateNames.push(firstStateName);
       }
     });
   }
@@ -785,10 +785,13 @@ export class ConversationSkinComponent {
           );
 
         let indexToRedirectTo = 0;
+        
 
         for (let i = 0; i < this.prevSessionStatesProgress.length; i++) {
           // Set state name of a previously completed state.
           let stateName = this.prevSessionStatesProgress[i];
+          let stateData = this.explorationEngineService.getStateFromStateName(stateName);
+
           // Skip the card if it has already been added to transcript.
           if (
             !this.playerTranscriptService.hasEncounteredStateBefore(stateName)
@@ -798,11 +801,14 @@ export class ConversationSkinComponent {
             this._addNewCard(stateCard);
           }
 
+          if (!this.visitedCheckpointStateNames.includes(stateName) && stateData.cardIsCheckpoint) {
+            this.visitedCheckpointStateNames.push(stateName);
+          }
+
           if (this.mostRecentlyReachedCheckpoint === stateName) {
             break;
           }
 
-          this.visitedStateNames.push(stateName);
           indexToRedirectTo += 1;
         }
 
@@ -846,7 +852,7 @@ export class ConversationSkinComponent {
       let currentStateName = currentState.name;
       if (
         currentState.cardIsCheckpoint &&
-        !this.visitedStateNames.includes(currentStateName) &&
+        !this.visitedCheckpointStateNames.includes(currentStateName) &&
         !this.prevSessionStatesProgress.includes(currentStateName)
       ) {
         this.readOnlyExplorationBackendApiService
@@ -863,7 +869,7 @@ export class ConversationSkinComponent {
               this.explorationPlayerStateService.getUniqueProgressUrlId()
             );
           });
-        this.visitedStateNames.push(currentStateName);
+        this.visitedCheckpointStateNames.push(currentStateName);
       }
     }
 

--- a/core/templates/pages/exploration-player-page/services/player-transcript.service.ts
+++ b/core/templates/pages/exploration-player-page/services/player-transcript.service.ts
@@ -60,6 +60,7 @@ export class PlayerTranscriptService {
   }
 
   hasEncounteredStateBefore(stateName: string): boolean {
+    console.log(this.transcript);
     return this.transcript.some(transcriptItem => {
       return transcriptItem.getStateName() === stateName;
     });

--- a/core/templates/pages/exploration-player-page/services/player-transcript.service.ts
+++ b/core/templates/pages/exploration-player-page/services/player-transcript.service.ts
@@ -60,7 +60,6 @@ export class PlayerTranscriptService {
   }
 
   hasEncounteredStateBefore(stateName: string): boolean {
-    console.log(this.transcript);
     return this.transcript.some(transcriptItem => {
       return transcriptItem.getStateName() === stateName;
     });


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #19217.
2. This PR does the following: 
    - Fixes the undefined state in the VisitedStateNames array by moving it inside the promise.
    - Fixes the duplicate state names when a user starts the lesson from a checkpoint.
    - Changes the name of `visitedStateNames` to `visitedCheckpointStateNames`, as it was only meant to store the visited checkpoint states.
3. (For bug-fixing PRs only) The original bug occurred because: This [PR](https://github.com/oppia/oppia/pull/15294/files#diff-b0dca490eb8d14df081b1e28543aad6e1ea3011f1215bd1c348e6fe70b77b338) `visitedStateNames` was placed outside the promise, due to which `firstStateName` was always left undefined.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

Initially
![Screenshot from 2025-06-12 00-16-26](https://github.com/user-attachments/assets/bd0cb0a8-6a61-4bcf-b05c-2725867d5bba)

After Fix
![image](https://github.com/user-attachments/assets/32c311e4-784a-40d9-9886-862c5b4685a0)


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
