### PR TITLE
Exp services test time fix

### DIFF
--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4536,7 +4536,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
 
     def test_get_last_updated_by_human_ms(self) -> None:
         original_timestamp = datetime.datetime.now(
-        datetime.timezone.utc).replace(tzinfo=None).timestamp() * 1000
+            datetime.timezone.utc).replace(tzinfo=None).timestamp() * 1000
 
         self.save_new_valid_exploration(
             self.EXP_0_ID, self.owner_id, end_state_name='End')

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4535,12 +4535,14 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
     SECOND_EMAIL: Final = 'abc123@gmail.com'
 
     def test_get_last_updated_by_human_ms(self) -> None:
-        original_timestamp = utils.get_current_time_in_millisecs()
+        original_timestamp = datetime.datetime.now(
+        datetime.timezone.utc).replace(tzinfo=None).timestamp() * 100
 
         self.save_new_valid_exploration(
             self.EXP_0_ID, self.owner_id, end_state_name='End')
 
-        timestamp_after_first_edit = utils.get_current_time_in_millisecs()
+        timestamp_after_first_edit = datetime.datetime.now(
+            datetime.timezone.utc).replace(tzinfo=None).timestamp() * 1000
 
         exp_services.update_exploration(
             feconf.MIGRATION_BOT_USER_ID, self.EXP_0_ID, [

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4536,7 +4536,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
 
     def test_get_last_updated_by_human_ms(self) -> None:
         original_timestamp = datetime.datetime.now(
-        datetime.timezone.utc).replace(tzinfo=None).timestamp() * 100
+        datetime.timezone.utc).replace(tzinfo=None).timestamp() * 1000
 
         self.save_new_valid_exploration(
             self.EXP_0_ID, self.owner_id, end_state_name='End')

--- a/package.json
+++ b/package.json
@@ -226,6 +226,8 @@
     "wdio-intercept-service": "^4.2.2"
   },
   "resolutions": {
-    "@types/babel__traverse": "7.20.6"
+    "@types/babel__traverse": "7.20.6",
+    "pretty-format": "28.1.3",
+    "expect": "28.1.3"
   }
 }


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #22785
2.This PR fixes a timezone bug in the that caused inconsistent behavior when running tests on systems not set to UTC
3. The bug occurred because utils.get_time_in_millisecs(dt) called .timestamp() on naive datetime objects. Python interpreted these as local time, leading to incorrect millisecond values on non-UTC systems. This caused time-based tests to fail inconsistently depending on the system timezone.



## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).




