### PR TITLE
remove non-line-length errors

### DIFF
--- a/extensions/interactions/base_test.py
+++ b/extensions/interactions/base_test.py
@@ -792,7 +792,8 @@ class InteractionUnitTests(test_utils.GenericTestBase):
             # returns correctly, we are accessing private attribute for this
             # test.
             self.assertEqual(
-                interaction.dependency_ids, interaction._dependency_ids) # pylint: disable=protected-access
+                interaction.dependency_ids, interaction._dependency_ids # pylint: disable=protected-access
+            )
 
     def test_linear_interactions(self) -> None:
         """Sanity-check for the number of linear interactions."""

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -965,7 +965,9 @@ class ObjectDefinitionTests(test_utils.GenericTestBase):
                     # skew between it and the key that is used in the default
                     # value.
                     self.assertEqual(
-                        sorted(['contentId', member._value_key_name]),  # pylint: disable=protected-access
+                        sorted(
+                            ['contentId', member._value_key_name] # pylint: disable=protected-access
+                        ),
                         sorted(member.default_value.keys()))
                     self.assertIsNone(member.default_value['contentId'])
 


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #[N/A].
2. This PR does the following: remove non-line-length error in preparation for Black formatter installation.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).




