### PR TITLE
[GSoC 2025 - Acceptance Tests] M1.12 - Fixis failing E2E tests by updating the tests to enable newly added feature flags

### DIFF
--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -86,7 +86,7 @@ jobs:
         id: check_skip
         # TODO(#22448): Remove once all suites are fixed.
         run: |
-          broken_suites=("contributorDashboard" "contributorAdminDashboard" "explorationTranslationTab" "fileUploadFeatures")
+          broken_suites=("contributorDashboard" "contributorAdminDashboard")
           for suite in "${broken_suites[@]}"; do
             if [[ "${{ matrix.suite.name }}" == "$suite" ]]; then
               echo "Suite '${{ matrix.suite.name }}' is marked to be skipped."

--- a/core/templates/pages/exploration-editor-page/translation-tab/translation-tab.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/translation-tab.component.html
@@ -19,7 +19,7 @@
   </p>
 </ng-template>
 
-<div class="oppia-translation-tab" *ngIf="showTranslationTabSubDirectives">
+<div class="oppia-translation-tab e2e-test-translation-tab" *ngIf="showTranslationTabSubDirectives">
   <div class="oppia-translator-overview">
     <oppia-translator-overview [isTranslationTabBusy]="isTranslationTabBusy" joyrideStep="translationTabOverview" [stepContent]="TranslationTabOverview"></oppia-translator-overview>
   </div>

--- a/core/tests/webdriverio_desktop/explorationTranslationTab.js
+++ b/core/tests/webdriverio_desktop/explorationTranslationTab.js
@@ -20,6 +20,7 @@
 var forms = require('../webdriverio_utils/forms.js');
 var general = require('../webdriverio_utils/general.js');
 var users = require('../webdriverio_utils/users.js');
+var waitFor = require('../webdriverio_utils/waitFor.js');
 var workflow = require('../webdriverio_utils/workflow.js');
 var AdminPage = require('../webdriverio_utils/AdminPage.js');
 
@@ -141,8 +142,11 @@ describe('Exploration translation and voiceover tab', function () {
   it('should walkthrough translation tutorial when user clicks next', async function () {
     await users.login('user@editorTab.com');
     await creatorDashboardPage.get();
+    await waitFor.pageToFullyLoad();
     await creatorDashboardPage.editExploration('Test Exploration');
+    await waitFor.pageToFullyLoad();
     await explorationEditorPage.navigateToTranslationTab();
+    await waitFor.pageToFullyLoad();
     await explorationEditorTranslationTab.startTutorial();
     await explorationEditorTranslationTab.playTutorial();
     await explorationEditorTranslationTab.finishTutorial();
@@ -162,8 +166,11 @@ describe('Exploration translation and voiceover tab', function () {
   it('should cache the selected language for translation and voiceover', async function () {
     await users.login('voiceArtist@translationTab.com');
     await creatorDashboardPage.get();
+    await waitFor.pageToFullyLoad();
     await creatorDashboardPage.editExploration('Test Exploration');
+    await waitFor.pageToFullyLoad();
     await explorationEditorPage.navigateToTranslationTab();
+    await waitFor.pageToFullyLoad();
     await explorationEditorTranslationTab.expectSelectedLanguageToBe('English');
     await explorationEditorTranslationTab.changeLanguage('हिन्दी (Hindi)');
     await browser.refresh();

--- a/core/tests/webdriverio_desktop/explorationTranslationTab.js
+++ b/core/tests/webdriverio_desktop/explorationTranslationTab.js
@@ -69,6 +69,12 @@ describe('Exploration translation and voiceover tab', function () {
     var voiceoverContributionFlag =
       await releaseCoordinatorPage.getVoiceoverContributionFeatureElement();
     await releaseCoordinatorPage.enableFeature(voiceoverContributionFlag);
+    var voiceoverForNonCuratedExplorationsFlag =
+      await releaseCoordinatorPage.getShowVoiceoverTabForNonCuratedExplorationsFeatureElement();
+    await releaseCoordinatorPage.enableFeature(
+      voiceoverForNonCuratedExplorationsFlag
+    );
+
     await users.logout();
 
     await users.login('user@editorTab.com');

--- a/core/tests/webdriverio_desktop/voiceoverUploadFeatures.js
+++ b/core/tests/webdriverio_desktop/voiceoverUploadFeatures.js
@@ -64,6 +64,11 @@ describe('Voiceover upload features', function () {
     var voiceoverContributionFlag =
       await releaseCoordinatorPage.getVoiceoverContributionFeatureElement();
     await releaseCoordinatorPage.enableFeature(voiceoverContributionFlag);
+    var voiceoverForNonCuratedExplorationsFlag =
+      await releaseCoordinatorPage.getShowVoiceoverTabForNonCuratedExplorationsFeatureElement();
+    await releaseCoordinatorPage.enableFeature(
+      voiceoverForNonCuratedExplorationsFlag
+    );
     await users.logout();
 
     await users.createUser(TEST_EMAIL, TEST_USERNAME);

--- a/core/tests/webdriverio_utils/ExplorationEditorPage.js
+++ b/core/tests/webdriverio_utils/ExplorationEditorPage.js
@@ -67,6 +67,7 @@ var ExplorationEditorPage = function () {
   );
   var sharePublishModalElement = $('.e2e-test-share-publish-modal');
   var toastMessage = $('.e2e-test-toast-message');
+  var translationTabContentContainer = $('.e2e-test-translation-tab');
 
   /*
    * Non-Interactive elements
@@ -503,6 +504,10 @@ var ExplorationEditorPage = function () {
     await action.click(
       'Translation tab button',
       navigateToTranslationTabButton
+    );
+    await waitFor.presenceOf(
+      translationTabContentContainer,
+      'Failed to navigate to tanslation tab'
     );
     await waitFor.pageToFullyLoad();
   };

--- a/core/tests/webdriverio_utils/ReleaseCoordinatorPage.js
+++ b/core/tests/webdriverio_utils/ReleaseCoordinatorPage.js
@@ -135,6 +135,25 @@ var ReleaseCoordinatorPage = function () {
     return null;
   };
 
+  // Remove this method after the show_voiceover_tab_for_non_curated_explorations
+  // feature flag is deprecated.
+  this.getShowVoiceoverTabForNonCuratedExplorationsFeatureElement =
+    async function () {
+      var featureFlagElements = await featureFlagElementsSelector();
+      var count = featureFlagElements.length;
+      for (let i = 0; i < count; i++) {
+        var elem = featureFlagElements[i];
+        if (
+          (await action.getText('Feature Flag', elem.$(featureNameLocator))) ===
+          'show_voiceover_tab_for_non_curated_explorations'
+        ) {
+          return elem;
+        }
+      }
+
+      return null;
+    };
+
   // This function is meant to be used to enable a feature gated behind
   // a feature flag.
   this.enableFeature = async function (featureElement) {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #22716 and #22448.
2. This PR does the following: 
    In E2E tests `fileUploadFeatures` and `explorationTranslationTab` enables feature flag to allow translation/voiceovers for non-curated explorations due to which tests were failing.

[**Debugging Doc**](https://docs.google.com/document/d/1x56f92835Mi6VYabsnwIUuvjDSSwrt_PwrZWwPA5Tck/edit?tab=t.0)

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
