### PR TITLE
Fix #22937: Expected XXX to be YYY | Fixes flake where textcontent is checked before it's updated.

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -947,15 +947,23 @@ export class BaseUser {
   async expectTextContentToBe(selector: string, text: string): Promise<void> {
     await this.expectElementToBeVisible(selector);
 
-    await this.page.waitForFunction(
-      (selector: string, text: string) => {
-        const element = document.querySelector(selector);
-        return element?.textContent?.trim() === text.trim();
-      },
-      {},
-      selector,
-      text
-    );
+    try {
+      await this.page.waitForFunction(
+        (selector: string, text: string) => {
+          const element = document.querySelector(selector);
+          return element?.textContent?.trim() === text.trim();
+        },
+        {},
+        selector,
+        text
+      );
+
+      showMessage(`Text content of "${selector}" is "${text}".`);
+    } catch (error) {
+      throw new Error(
+        `Failed: Text content of "${selector}" is not "${text}".\nOriginal Error:\n${error.stack}`
+      );
+    }
   }
 
   /**
@@ -969,15 +977,23 @@ export class BaseUser {
   ): Promise<void> {
     await this.expectElementToBeVisible(selector);
 
-    await this.page.waitForFunction(
-      (selector: string, text: string) => {
-        const element = document.querySelector(selector);
-        return element?.textContent?.includes(text);
-      },
-      {},
-      selector,
-      text
-    );
+    try {
+      await this.page.waitForFunction(
+        (selector: string, text: string) => {
+          const element = document.querySelector(selector);
+          return element?.textContent?.includes(text);
+        },
+        {},
+        selector,
+        text
+      );
+
+      showMessage(`Text content of "${selector}" contains "${text}".`);
+    } catch (error) {
+      throw new Error(
+        `Failed: Text content of "${selector}" does not contain "${text}".\nOriginal Error:\n${error.stack}`
+      );
+    }
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -932,20 +932,52 @@ export class BaseUser {
   }
 
   /**
+   * Checks if the element is visible or not.
+   * @param selector The selector of the element.
+   */
+  async expectElementToBeVisible(selector: string): Promise<void> {
+    expect(await this.isElementVisible(selector)).toBe(true);
+  }
+
+  /**
    * Verify text content inside an element
    * @param {string} selector - The selector of the element to get text from.
-   * @param {string} textContent - The expected text content.
+   * @param {string} text - The expected text content.
    */
-  async expectTextContentToMatch(
+  async expectTextContentToBe(selector: string, text: string): Promise<void> {
+    await this.expectElementToBeVisible(selector);
+
+    await this.page.waitForFunction(
+      (selector: string, text: string) => {
+        const element = document.querySelector(selector);
+        return element?.textContent?.trim() === text.trim();
+      },
+      {},
+      selector,
+      text
+    );
+  }
+
+  /**
+   * Checks if the text content of the element contains the given text.
+   * @param selector The selector of the element.
+   * @param text The text to check for.
+   */
+  async expectTextContentToContain(
     selector: string,
-    textContent: string
+    text: string
   ): Promise<void> {
-    const currentTextContent = await this.getTextContent(selector);
-    if (currentTextContent !== textContent) {
-      throw new Error(
-        `Text did not match within the specified time. Actual text: "${currentTextContent}", expected text: "${textContent}"`
-      );
-    }
+    await this.expectElementToBeVisible(selector);
+
+    await this.page.waitForFunction(
+      (selector: string, text: string) => {
+        const element = document.querySelector(selector);
+        return element?.textContent?.includes(text);
+      },
+      {},
+      selector,
+      text
+    );
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/blog-post-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/blog-post-editor.ts
@@ -212,7 +212,7 @@ export class BlogPostEditor extends BaseUser {
     await this.isElementVisible(blogBodyInput);
     await this.type(blogBodyInput, newBodyText);
 
-    await this.expectTextContentToMatch(blogBodyInput, newBodyText);
+    await this.expectTextContentToBe(blogBodyInput, newBodyText);
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -1335,15 +1335,10 @@ export class ExplorationEditor extends BaseUser {
       const headingName = !cardName.trimEnd().endsWith('...')
         ? cardName
         : cardName.trimEnd().slice(0, -3);
-      const currentCardTitle = await this.page.$eval(
+      await this.expectTextContentToContain(
         currentCardNameSelector,
-        element => (element as HTMLElement).innerText.trim()
+        headingName
       );
-      if (!currentCardTitle.includes(headingName)) {
-        throw new Error(
-          `Failed to navigate to card ${cardName}. Current card is ${currentCardTitle}.`
-        );
-      }
     } catch (error) {
       const newError = new Error(
         `Error navigating to card ${cardName}: ${error.message}`

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
@@ -517,7 +517,7 @@ export class TopicManager extends BaseUser {
       await this.page.waitForSelector(topicStatusDropdownSelector);
       await this.selectOption(topicStatusDropdownSelector, status);
 
-      await this.expectTextContentToMatch(
+      await this.expectTextContentToBe(
         `${topicStatusDropdownSelector} .mat-select-value-text`,
         status
       );
@@ -544,7 +544,7 @@ export class TopicManager extends BaseUser {
       await this.page.waitForSelector(classroomDropdownSelector);
       await this.selectOption(classroomDropdownSelector, classroom);
 
-      await this.expectTextContentToMatch(
+      await this.expectTextContentToBe(
         `${classroomDropdownSelector} .mat-select-min-line`,
         classroom
       );
@@ -573,7 +573,7 @@ export class TopicManager extends BaseUser {
       await this.page.waitForSelector(multiSelectionInputSelector);
       await this.type(multiSelectionInputSelector, keyword);
       await this.page.keyboard.press('Enter');
-      await this.expectTextContentToMatch(
+      await this.expectTextContentToBe(
         `${multiSelectionInputChipSelector}`,
         // We are checking multi-selection-field components and it has cancel
         // icon (text) within the chip element, so we need to add cancel.
@@ -601,7 +601,7 @@ export class TopicManager extends BaseUser {
       }
       await this.page.waitForSelector(sortDropdownSelector);
       await this.selectOption(sortDropdownSelector, sortOption);
-      await this.expectTextContentToMatch(
+      await this.expectTextContentToBe(
         `${sortDropdownSelector} .mat-select-value-text`,
         sortOption
       );
@@ -1350,7 +1350,7 @@ export class TopicManager extends BaseUser {
       }
       await this.page.waitForSelector(skillStatusDropdownSelector);
       await this.selectOption(skillStatusDropdownSelector, status);
-      await this.expectTextContentToMatch(
+      await this.expectTextContentToBe(
         `${skillStatusDropdownSelector} .mat-select-value-text`,
         status
       );
@@ -1380,7 +1380,7 @@ export class TopicManager extends BaseUser {
       await this.page.waitForSelector(multiSelectionInputSelector);
       await this.type(multiSelectionInputSelector, keyword);
       await this.page.keyboard.press('Enter');
-      await this.expectTextContentToMatch(
+      await this.expectTextContentToBe(
         `${multiSelectionInputChipSelector}`,
         // We are checking multi-selection-field components and it has cancel
         // icon (text) within the chip element, so we need to add cancel.
@@ -1410,7 +1410,7 @@ export class TopicManager extends BaseUser {
       }
       await this.page.waitForSelector(sortDropdownSelector);
       await this.selectOption(sortDropdownSelector, sortOption);
-      await this.expectTextContentToMatch(
+      await this.expectTextContentToBe(
         `${sortDropdownSelector} .mat-select-value-text`,
         sortOption
       );


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/22937
2. This PR does the following: Adds implementation `expectTextContentToBe` to correctly wait for text to change before checking its value.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Debugging the issue.
The issue occurs when we change card in exploration editor. This is because once we change card, we verify the title of the card in exploration editor as a post-check to ensure we have actually changed to different card.

However, currently, we were checking title instantly. This creates a race-condition between updating the card title and checking for the same. 

To fix this, I have updated the post-check to try checking for a new title for a specific amount of time (30000ms by default). This will ensure current-card-title have sufficient time to update.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
