### PR TITLE
Fix #22985: Enforce 64 char limit on email local part in newsletter signup

### DIFF
--- a/core/templates/base-components/oppia-footer.component.ts
+++ b/core/templates/base-components/oppia-footer.component.ts
@@ -67,10 +67,21 @@ export class OppiaFooterComponent {
     return '/blog';
   }
 
-  validateEmailAddress(): boolean {
-    let regex = new RegExp(AppConstants.EMAIL_REGEX);
-    return regex.test(String(this.emailAddress));
+validateEmailAddress(): boolean {
+  const email = String(this.emailAddress);
+  const regex = new RegExp(AppConstants.EMAIL_REGEX);
+
+  if (!regex.test(email)) {
+    return false;
   }
+
+  const [localPart] = email.split('@');
+  if (localPart.length > 64) {
+    return false;
+  }
+  return true;
+}
+
 
   disableNewsletterSubscription(): boolean {
     if (!this.subscriptionProcessing) {


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #22985.
2. This PR does the following: Enforces the RFC-5321 limit of 64 characters on the local part of email addresses in the newsletter signup form. Previously, users could enter excessively long emails that were considered valid.
3. (For bug-fixing PRs only) The original bug occurred because: The email validation regex did not restrict the local part length. The previous implementation only used a general regex check without enforcing RFC-5321 constraints.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (Optional but highly encouraged!)
- [x] The **PR title** starts with "Fix #22985: " followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with "@reviewer_username PTAL" if I can't assign them directly).

## Proof that changes are correct

### Desktop
Before: Email with 300-character local part was accepted.
After: Emails with >64 characters in local part are now rejected, as expected.
