### PR TITLE
Fix the Part of #11371 Remove jquery constructs used in angularJS codeRemove jquery constructs

### DIFF
--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -785,7 +785,11 @@ export class CkEditor4RteComponent
       this.clearPasteError();
 
       const wrapperDiv = document.createElement('div');
-      wrapperDiv.innerHTML = ck.getData() || '';
+      const parser = new DOMParser();
+      const htmlString = ck.getData() || '';
+      const doc = parser.parseFromString(htmlString, 'text/html');
+
+      wrapperDiv.replaceChildren(...doc.body.childNodes);
 
       const textElt = wrapperDiv.childNodes;
       for (let i = textElt.length; i > 0; i--) {
@@ -814,8 +818,10 @@ export class CkEditor4RteComponent
           break;
         }
       }
-
-      let html = wrapperDiv.innerHTML;
+      const serializer = new XMLSerializer();
+      let html = Array.from(wrapperDiv.childNodes)
+        .map(node => serializer.serializeToString(node))
+        .join('');
       this.value = html;
       // Refer to the note at the top of the file for the reason behind replace.
       html = html.replace(

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -784,14 +784,12 @@ export class CkEditor4RteComponent
       // Clear paste errors when user types or makes changes.
       this.clearPasteError();
 
-      const wrapperDiv = document.createElement('div');
       const parser = new DOMParser();
-      const htmlString = ck.getData() || '';
-      const doc = parser.parseFromString(htmlString, 'text/html');
-
-      wrapperDiv.replaceChildren(...doc.body.childNodes);
+      const doc = parser.parseFromString(ck.getData(), 'text/html');
+      const wrapperDiv = doc.body;
 
       const textElt = wrapperDiv.childNodes;
+
       for (let i = textElt.length; i > 0; i--) {
         const parent = textElt[i - 1];
         for (let j = parent.childNodes.length; j > 0; j--) {

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -784,36 +784,38 @@ export class CkEditor4RteComponent
       // Clear paste errors when user types or makes changes.
       this.clearPasteError();
 
-      // TODO(#12882): Remove the use of jQuery.
-      var elt = $('<div>' + ck.getData() + '</div>');
-      var textElt = elt[0].childNodes;
-      for (var i = textElt.length; i > 0; i--) {
-        for (var j = textElt[i - 1].childNodes.length; j > 0; j--) {
+      const wrapperDiv = document.createElement('div');
+      wrapperDiv.innerHTML = ck.getData() || '';
+
+      const textElt = wrapperDiv.childNodes;
+      for (let i = textElt.length; i > 0; i--) {
+        const parent = textElt[i - 1];
+        for (let j = parent.childNodes.length; j > 0; j--) {
+          const node = parent.childNodes[j - 1];
           if (
-            textElt[i - 1].childNodes[j - 1].nodeName === 'BR' ||
-            (textElt[i - 1].childNodes[j - 1].nodeName === '#text' &&
-              textElt[i - 1].childNodes[j - 1].nodeValue.trim() === '')
+            node.nodeName === 'BR' ||
+            (node.nodeName === '#text' && node.nodeValue.trim() === '')
           ) {
-            textElt[i - 1].childNodes[j - 1].remove();
+            node.remove();
           } else {
             break;
           }
         }
-        if (textElt[i - 1].childNodes.length === 0) {
+        if (parent.childNodes.length === 0) {
           if (
-            textElt[i - 1].nodeName === 'BR' ||
-            (textElt[i - 1].nodeName === '#text' &&
-              textElt[i - 1].nodeValue.trim() === '') ||
-            textElt[i - 1].nodeName === 'P'
+            parent.nodeName === 'BR' ||
+            (parent.nodeName === '#text' && parent.nodeValue.trim() === '') ||
+            parent.nodeName === 'P'
           ) {
-            textElt[i - 1].remove();
+            parent.remove();
             continue;
           }
         } else {
           break;
         }
       }
-      let html = elt.html();
+
+      let html = wrapperDiv.innerHTML;
       this.value = html;
       // Refer to the note at the top of the file for the reason behind replace.
       html = html.replace(

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
@@ -16,7 +16,13 @@
  * @fileoverview Unit tests for attribution guide component.
  */
 
-import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import {
+  TestBed,
+  async,
+  ComponentFixture,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 
 import {AttributionGuideComponent} from './attribution-guide.component';
 import {PageContextService} from 'services/page-context.service';
@@ -176,20 +182,19 @@ describe('Attribution Guide Component', function () {
     expect(component.getExplorationTitle()).toEqual('Place Values');
   });
 
-  it('should run the copy command and show a tooltip', () => {
+  it('should run the copy command and set and remove title attribute for tooltip', () => {
     let dummyDivElement = document.createElement('div');
     let dummyTextNode = document.createTextNode('Text to be copied');
     dummyDivElement.className = 'class-name';
     dummyDivElement.appendChild(dummyTextNode);
-    let dummyDocumentFragment = document.createDocumentFragment();
+    const dummyDocumentFragment = document.createDocumentFragment();
     dummyDocumentFragment.appendChild(dummyDivElement);
     spyOn(document, 'getElementsByClassName')
       .withArgs('class-name')
       .and.returnValue(dummyDocumentFragment.children);
     spyOn(document, 'execCommand').withArgs('copy');
-    spyOn($.fn, 'tooltip');
     component.copyAttribution('class-name');
     expect(document.execCommand).toHaveBeenCalled();
-    expect($.fn.tooltip).toHaveBeenCalledWith('show');
+    expect(dummyDivElement.getAttribute('title')).toBe('Copied!');
   });
 });

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
@@ -16,7 +16,13 @@
  * @fileoverview Unit tests for attribution guide component.
  */
 
-import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import {
+  TestBed,
+  async,
+  ComponentFixture,
+  tick,
+  fakeAsync,
+} from '@angular/core/testing';
 
 import {AttributionGuideComponent} from './attribution-guide.component';
 import {PageContextService} from 'services/page-context.service';
@@ -176,19 +182,38 @@ describe('Attribution Guide Component', function () {
     expect(component.getExplorationTitle()).toEqual('Place Values');
   });
 
-  it('should run the copy command and set and remove title attribute for tooltip', () => {
+  it('should run the copy command and set and remove title attribute for tooltip', fakeAsync(() => {
     let dummyDivElement = document.createElement('div');
     let dummyTextNode = document.createTextNode('Text to be copied');
     dummyDivElement.className = 'class-name';
     dummyDivElement.appendChild(dummyTextNode);
     const dummyDocumentFragment = document.createDocumentFragment();
     dummyDocumentFragment.appendChild(dummyDivElement);
+
     spyOn(document, 'getElementsByClassName')
       .withArgs('class-name')
       .and.returnValue(dummyDocumentFragment.children);
     spyOn(document, 'execCommand').withArgs('copy');
+
     component.copyAttribution('class-name');
+
     expect(document.execCommand).toHaveBeenCalled();
     expect(dummyDivElement.getAttribute('title')).toBe('Copied!');
+
+    tick(1001);
+
+    expect(dummyDivElement.getAttribute('title')).toBeNull();
+  }));
+
+  it('should return early if element is not found', () => {
+    spyOn(document, 'getElementsByClassName')
+      .withArgs('missing-class')
+      .and.returnValue([] as unknown as HTMLCollectionOf<HTMLElement>);
+
+    const execSpy = spyOn(document, 'execCommand');
+
+    component.copyAttribution('missing-class');
+
+    expect(execSpy).not.toHaveBeenCalled();
   });
 });

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
@@ -16,13 +16,7 @@
  * @fileoverview Unit tests for attribution guide component.
  */
 
-import {
-  TestBed,
-  async,
-  ComponentFixture,
-  fakeAsync,
-  tick,
-} from '@angular/core/testing';
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 
 import {AttributionGuideComponent} from './attribution-guide.component';
 import {PageContextService} from 'services/page-context.service';

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.ts
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.ts
@@ -98,10 +98,15 @@ export class AttributionGuideComponent implements OnInit {
   }
 
   copyAttribution(className: string): void {
-    const codeDiv = document.getElementsByClassName(className)[0];
+    const codeDiv = document.getElementsByClassName(
+      className
+    )[0] as HTMLElement;
+    if (!codeDiv) {
+      return;
+    }
     const range = document.createRange();
-    range.setStartBefore((codeDiv as HTMLDivElement).firstChild as Node);
-    range.setEndAfter((codeDiv as HTMLDivElement).lastChild as Node);
+    range.setStartBefore(codeDiv.firstChild as Node);
+    range.setEndAfter(codeDiv.lastChild as Node);
     // 'getSelection()' will not return 'null' since it is not called on an
     // undisplayed <iframe>. That is why we can use '?'.
     const selection = window.getSelection();
@@ -109,7 +114,8 @@ export class AttributionGuideComponent implements OnInit {
     selection?.addRange(range);
     document.execCommand('copy');
     selection?.removeAllRanges();
-    $(codeDiv).tooltip('show');
-    setTimeout(() => $(codeDiv).tooltip('hide'), 1000);
+    codeDiv.setAttribute('title', 'Copied!');
+    codeDiv.dispatchEvent(new Event('mouseenter'));
+    setTimeout(() => codeDiv.removeAttribute('title'), 1000);
   }
 }

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
@@ -173,4 +173,12 @@ describe('StateHintsEditorComponent', () => {
     expect(component.cardHeightLimitReached).toBeTrue();
     expect(component.isCardHeightLimitReached).toHaveBeenCalled();
   });
+
+  it('should return false if shadow preview card is not present', () => {
+    spyOn(document, 'querySelector').and.returnValue(null);
+
+    const result = component.isCardHeightLimitReached();
+
+    expect(result).toBeFalse();
+  });
 });

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
@@ -102,10 +102,14 @@ export class StateContentEditorComponent implements OnInit {
   }
 
   isCardHeightLimitReached(): boolean {
-    let shadowPreviewCard = $(
+    const shadowPreviewCard = document.querySelector(
       '.oppia-shadow-preview-card .oppia-learner-view-card-top-section'
-    );
-    let height = shadowPreviewCard.height() as number;
+    ) as HTMLElement | null;
+
+    if (!shadowPreviewCard) {
+      return false;
+    }
+    const height = shadowPreviewCard.offsetHeight;
     return height > 630;
   }
 

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -401,11 +401,9 @@ describe('Library Page Component', () => {
     spyOn(componentInstance, 'initCarousels');
     spyOn(loggerService, 'error');
     let actualWidth = 200;
-    spyOn(window, '$').and.returnValue({
-      width: () => {
-        return actualWidth;
-      },
-    } as JQLite);
+    spyOn(document, 'querySelector').and.returnValue({
+      clientWidth: 200,
+    } as HTMLElement);
     componentInstance.ngOnInit();
     tick();
     tick();

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -953,7 +953,7 @@ describe('Library Page Component', () => {
 
   it('should not scroll if activity count is too small to allow scrolling', () => {
     const ind = 0;
-    const isLeftScroll = false;
+    const shouldScrollLeft = false;
 
     const mockCarouselElement = document.createElement('div');
     mockCarouselElement.className = 'oppia-library-carousel-tiles';
@@ -975,7 +975,7 @@ describe('Library Page Component', () => {
       },
     ];
 
-    componentInstance.scroll(ind, isLeftScroll);
+    componentInstance.scroll(ind, shouldScrollLeft);
     expect(componentInstance.leftmostCardIndices[ind]).toBe(0);
   });
 

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -952,4 +952,62 @@ describe('Library Page Component', () => {
 
     flush();
   }));
+
+  it('should not scroll if activity count is too small to allow scrolling', () => {
+    const ind = 0;
+    const isLeftScroll = false;
+
+    const mockCarouselElement = document.createElement('div');
+    mockCarouselElement.className = 'oppia-library-carousel-tiles';
+    mockCarouselElement.scrollLeft = 100;
+    spyOn(document, 'querySelectorAll').and.returnValue([
+      mockCarouselElement,
+    ] as unknown as NodeListOf<HTMLElement>);
+
+    componentInstance.tileDisplayCount = 4;
+    componentInstance.leftmostCardIndices = [0];
+    componentInstance.libraryGroups = [
+      {
+        activity_summary_dicts: new Array(2),
+        categories: [],
+        header_i18n_id: '',
+        has_full_results_page: false,
+        full_results_url: '',
+        protractor_id: '',
+      },
+    ];
+
+    componentInstance.scroll(ind, isLeftScroll);
+    expect(componentInstance.leftmostCardIndices[ind]).toBe(0);
+  });
+
+  it('should decrease leftmostCardIndices when scrolling left', () => {
+    const ind = 0;
+    const isLeftScroll = true;
+
+    const mockCarouselElement = document.createElement('div');
+    mockCarouselElement.className = 'oppia-library-carousel-tiles';
+    mockCarouselElement.scrollLeft = 200;
+
+    spyOn(document, 'querySelectorAll').and.returnValue([
+      mockCarouselElement,
+    ] as unknown as NodeListOf<HTMLElement>);
+
+    componentInstance.tileDisplayCount = 3;
+    componentInstance.leftmostCardIndices = [5];
+    componentInstance.libraryGroups = [
+      {
+        activity_summary_dicts: new Array(10),
+        categories: [],
+        header_i18n_id: '',
+        has_full_results_page: false,
+        full_results_url: '',
+        protractor_id: '',
+      },
+    ];
+
+    componentInstance.scroll(ind, isLeftScroll);
+
+    expect(componentInstance.leftmostCardIndices[ind]).toBe(2);
+  });
 });

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -649,6 +649,18 @@ describe('Library Page Component', () => {
         protractor_id: '',
       },
     ];
+
+    // When jQuery was used in the component, it could directly query DOM globally
+    // using $('.class-name'). In the updated version without jQuery, the component
+    // uses `this.el.nativeElement.querySelectorAll(...)` instead, which only sees
+    // elements appended to `el.nativeElement` (the component's local DOM).
+    //
+    // So here we manually create a div with the expected class and append it
+    // to the component's root element, so the native DOM queries can find it.
+
+    const tile = document.createElement('div');
+    tile.classList.add('oppia-library-carousel-tiles');
+    componentInstance.el.nativeElement.appendChild(tile);
     componentInstance.initCarousels();
     expect(componentInstance.leftmostCardIndices.length).toEqual(1);
   });

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -135,48 +135,40 @@ export class LibraryPageComponent {
       return;
     }
 
-    // This prevents unnecessary execution of this method immediately
-    // after a window resize event is fired.
     if (!this.libraryGroups) {
       return;
     }
 
-    // The number 0 here is just to make sure that the type of width is number,
-    // it is never assigned as the width will never be undefined.
-    let width = $(window).width() || 0;
+    const width = window.innerWidth || 0;
+    const windowWidth = width * 0.85;
 
-    let windowWidth = width * 0.85;
-    // The number 20 is added to LIBRARY_TILE_WIDTH_PX in order to
-    // compensate for padding and margins. 20 is just an arbitrary
-    // number.
     this.tileDisplayCount = Math.min(
       Math.floor(windowWidth / (AppConstants.LIBRARY_TILE_WIDTH_PX + 20)),
       this.MAX_NUM_TILES_PER_ROW
     );
 
-    let maxWidth =
+    const maxWidth =
       this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX + 'px';
-    let carouselElem = this.el.nativeElement.querySelector(
+
+    const carouselElem = this.el.nativeElement.querySelector(
       '.oppia-library-carousel'
     );
 
     if (carouselElem) {
       this.renderer.setStyle(carouselElem, 'max-width', maxWidth);
     }
-
-    // The following determines whether to enable left scroll after
-    // resize.
+    const carouselTileElems = this.el.nativeElement.querySelectorAll(
+      '.oppia-library-carousel-tiles'
+    );
     for (let i = 0; i < this.libraryGroups.length; i++) {
-      let carouselJQuerySelector =
-        '.oppia-library-carousel-tiles:eq(n)'.replace('n', String(i));
-      // The number 0 here is just to make sure that the type of width is
-      // number, it is never assigned as the selector will never be undefined.
-      let carouselScrollPositionPx =
-        $(carouselJQuerySelector).scrollLeft() || 0;
-      let index = Math.ceil(
-        carouselScrollPositionPx / AppConstants.LIBRARY_TILE_WIDTH_PX
-      );
-      this.leftmostCardIndices[i] = index;
+      const carouselTileElem = carouselTileElems[i] as HTMLElement;
+      if (carouselTileElem) {
+        const scrollLeft = carouselTileElem.scrollLeft || 0;
+        const index = Math.ceil(
+          scrollLeft / AppConstants.LIBRARY_TILE_WIDTH_PX
+        );
+        this.leftmostCardIndices[i] = index;
+      }
     }
   }
 
@@ -185,13 +177,17 @@ export class LibraryPageComponent {
       return;
     }
 
-    const carouselElements = document.querySelectorAll(
+    const carouselElems = document.querySelectorAll(
       '.oppia-library-carousel-tiles'
     );
+    const carouselElem = carouselElems[ind] as HTMLElement;
 
-    const carouselElement = carouselElements[ind] as HTMLElement;
+    if (!carouselElem) {
+      return;
+    }
 
-    let direction = isLeftScroll ? -1 : 1;
+    const direction = isLeftScroll ? -1 : 1;
+    let scrollLeft = carouselElem.scrollLeft || 0;
 
     if (
       this.libraryGroups[ind].activity_summary_dicts.length <=
@@ -200,8 +196,7 @@ export class LibraryPageComponent {
       return;
     }
 
-    let currentScrollPosition = carouselElement?.scrollLeft || 0;
-    currentScrollPosition = Math.max(0, currentScrollPosition);
+    scrollLeft = Math.max(0, scrollLeft);
 
     if (isLeftScroll) {
       this.leftmostCardIndices[ind] = Math.max(
@@ -217,36 +212,34 @@ export class LibraryPageComponent {
       );
     }
 
-    let newScrollPositionPx =
-      currentScrollPosition +
-      this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX * direction;
+    const newScrollPositionPx =
+      scrollLeft +
+      this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX * direction; // AppConstants.LIBRARY_TILE_WIDTH_PX  =208
 
-    if (carouselElement) {
-      const scrollDistance = newScrollPositionPx - currentScrollPosition;
-      const duration = 800;
+    const duration = 800;
+    const start = carouselElem.scrollLeft;
+    const distance = newScrollPositionPx - start;
+    const startTime = performance.now();
 
-      let startTime: number;
+    const animateScroll = (currentTime: number) => {
+      const elapsed = currentTime - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const ease =
+        progress < 0.5
+          ? 2 * progress * progress
+          : -1 + (4 - 2 * progress) * progress;
 
-      const scrollStep = (timestamp: number) => {
-        if (!startTime) {
-          startTime = timestamp;
-        }
-        const timeElapsed = timestamp - startTime;
-        const progress = Math.min(timeElapsed / duration, 1);
+      carouselElem.scrollLeft = start + distance * ease;
 
-        carouselElement.scrollLeft =
-          currentScrollPosition + scrollDistance * progress;
+      if (progress < 1) {
+        requestAnimationFrame(animateScroll);
+      } else {
+        this.isAnyCarouselCurrentlyScrolling = false;
+      }
+    };
 
-        if (timeElapsed < duration) {
-          requestAnimationFrame(scrollStep);
-        } else {
-          this.isAnyCarouselCurrentlyScrolling = false;
-        }
-      };
-
-      this.isAnyCarouselCurrentlyScrolling = true;
-      requestAnimationFrame(scrollStep);
-    }
+    this.isAnyCarouselCurrentlyScrolling = true;
+    requestAnimationFrame(animateScroll);
   }
 
   // The carousels do not work when the width is 1 card long, so we need

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -468,7 +468,18 @@ export class LibraryPageComponent {
           // Check if actual and expected widths are the same.
           // If not produce an error that would be caught by e2e tests.
           setTimeout(() => {
-            let actualWidth = $('oppia-exploration-summary-tile').width();
+            let actualWidth = 0;
+            const el = document.querySelector(
+              'oppia-exploration-summary-tile'
+            ) as HTMLElement | null;
+
+            if (el) {
+              actualWidth =
+                el.clientWidth ||
+                el.offsetWidth ||
+                parseFloat(getComputedStyle(el).getPropertyValue('width')) ||
+                0;
+            }
             if (
               actualWidth &&
               actualWidth !== AppConstants.LIBRARY_TILE_WIDTH_PX &&

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -139,7 +139,12 @@ export class LibraryPageComponent {
       return;
     }
 
-    const width = window.innerWidth || 0;
+    // https://stackoverflow.com/questions/49518107
+    const width =
+      window.innerWidth ||
+      document.documentElement?.clientWidth ||
+      document.body?.clientWidth;
+
     const windowWidth = width * 0.85;
 
     this.tileDisplayCount = Math.min(

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -139,7 +139,9 @@ export class LibraryPageComponent {
       return;
     }
 
-    // https://stackoverflow.com/questions/49518107
+    // Replacing jQuery's $(window).width() with vanilla JS.
+    // Using multiple fallbacks to avoid test failures in headless browsers,
+    // Reference: https://stackoverflow.com/a/11744120
     const width =
       window.innerWidth ||
       document.documentElement?.clientWidth ||
@@ -168,7 +170,7 @@ export class LibraryPageComponent {
     for (let i = 0; i < this.libraryGroups.length; i++) {
       const carouselTileElem = carouselTileElems[i] as HTMLElement;
       if (carouselTileElem) {
-        const scrollLeft = carouselTileElem.scrollLeft || 0;
+        const scrollLeft = carouselTileElem.scrollLeft;
         const index = Math.ceil(
           scrollLeft / AppConstants.LIBRARY_TILE_WIDTH_PX
         );
@@ -182,17 +184,17 @@ export class LibraryPageComponent {
       return;
     }
 
-    const carouselElems = document.querySelectorAll(
+    const carouselElements = document.querySelectorAll(
       '.oppia-library-carousel-tiles'
     );
-    const carouselElem = carouselElems[ind] as HTMLElement;
+    const carouselElement = carouselElements[ind] as HTMLElement;
 
-    if (!carouselElem) {
+    if (!carouselElement) {
       return;
     }
 
     const direction = isLeftScroll ? -1 : 1;
-    let scrollLeft = carouselElem.scrollLeft || 0;
+    let scrollLeft = carouselElement.scrollLeft;
 
     if (
       this.libraryGroups[ind].activity_summary_dicts.length <=
@@ -222,7 +224,7 @@ export class LibraryPageComponent {
       this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX * direction;
 
     const duration = 800;
-    const start = carouselElem.scrollLeft;
+    const start = carouselElement.scrollLeft;
     const distance = newScrollPositionPx - start;
     const startTime = performance.now();
 
@@ -234,7 +236,7 @@ export class LibraryPageComponent {
           ? 2 * progress * progress
           : -1 + (4 - 2 * progress) * progress;
 
-      carouselElem.scrollLeft = start + distance * ease;
+      carouselElement.scrollLeft = start + distance * ease;
 
       if (progress < 1) {
         requestAnimationFrame(animateScroll);

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -214,7 +214,7 @@ export class LibraryPageComponent {
 
     const newScrollPositionPx =
       scrollLeft +
-      this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX * direction; // AppConstants.LIBRARY_TILE_WIDTH_PX  =208
+      this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX * direction;
 
     const duration = 800;
     const start = carouselElem.scrollLeft;

--- a/core/templates/services/guppy-initialization.service.spec.ts
+++ b/core/templates/services/guppy-initialization.service.spec.ts
@@ -60,7 +60,7 @@ describe('GuppyInitializationService', () => {
   it('should assign a random id to the guppy divs', function () {
     let mockDocument = document.createElement('div');
     mockDocument.classList.add('guppy-div-creator', 'guppy_active');
-    angular.element(document).find('body').append(mockDocument.outerHTML);
+    document.body.insertAdjacentHTML('beforeend', mockDocument.outerHTML);
 
     guppyInitializationService.init('guppy-div-creator', 'placeholder', 'x=y');
 
@@ -73,7 +73,7 @@ describe('GuppyInitializationService', () => {
   it('should find active guppy div', function () {
     let mockDocument = document.createElement('div');
     mockDocument.classList.add('guppy-div-creator', 'guppy_active');
-    angular.element(document).find('body').append(mockDocument.outerHTML);
+    document.body.insertAdjacentHTML('beforeend', mockDocument.outerHTML);
 
     guppyInitializationService.init('guppy-div-creator', 'placeholder', 'x');
 

--- a/core/templates/services/speech-synthesis-chunker.service.ts
+++ b/core/templates/services/speech-synthesis-chunker.service.ts
@@ -184,89 +184,77 @@ export class SpeechSynthesisChunkerService {
     const rteCompSpecsKeys = Object.keys(
       ServicesConstants.RTE_COMPONENT_SPECS
     ) as RTEComponentSpecsKey[];
+
     rteCompSpecsKeys.forEach(componentSpec => {
       this.RTE_COMPONENT_NAMES[componentSpec] =
         ServicesConstants.RTE_COMPONENT_SPECS[componentSpec].frontend_id;
     });
+
     interface MathExpressionContent {
       raw_latex: string;
       svg_filename: string;
     }
-    var elt = $('<div>' + html + '</div>');
-    // Convert links into speakable text by extracting the readable value.
-    elt
-      .find('oppia-noninteractive-' + this.RTE_COMPONENT_NAMES.Link)
-      .replaceWith(function () {
-        // TODO(#13015): Remove use of unknown as a type.
-        // Unknown has been used here becuase of use of jQuery.
-        var element = this as unknown as HTMLElement;
-        const _newTextAttr = element.attributes[
-          'text-with-value' as keyof NamedNodeMap
-        ] as Attr;
-        // 'Node.textContent' only returns 'null' if the Node is a
-        // 'document' or a 'DocType'. '_newTextAttr' is neither.
-        const newTextContent = _newTextAttr.textContent?.replace(/&quot;/g, '');
-        // Variable newTextContent ends with a " character, so this is being
-        // ignored in the condition below.
-        return newTextContent && newTextContent !== '"'
-          ? newTextContent + ' '
-          : '';
-      });
 
-    var _this = this;
-    // Convert LaTeX to speakable text.
-    elt
-      .find('oppia-noninteractive-' + this.RTE_COMPONENT_NAMES.Math)
-      .replaceWith(function () {
-        // TODO(#13015): Remove use of unknown as a type.
-        // Unknown has been used here becuase of use of jQuery.
-        var element = this as unknown as HTMLElement;
-        const _mathContentAttr = element.attributes[
-          'math_content-with-value' as keyof NamedNodeMap
-        ] as Attr;
-        var mathContent = _this.htmlEscaper.escapedJsonToObj(
-          // 'Node.textContent' only returns 'null' if the Node is a
-          // 'document' or a 'DocType'. '_mathContentAttr' is neither.
-          _mathContentAttr.textContent as string
+    const parser = new DOMParser();
+    const containerDoc = parser.parseFromString(html, 'text/html');
+    const container = containerDoc.body;
+
+    const linkElements = Array.from(
+      container.querySelectorAll(
+        `oppia-noninteractive-${this.RTE_COMPONENT_NAMES.Link}`
+      )
+    );
+    for (const element of linkElements) {
+      const attr = element.getAttribute('text-with-value');
+      const newTextContent = attr?.replace(/&quot;/g, '');
+      const replacementText =
+        newTextContent && newTextContent !== '"' ? newTextContent + ' ' : '';
+      element.replaceWith(replacementText);
+    }
+
+    const mathElements = Array.from(
+      container.querySelectorAll(
+        `oppia-noninteractive-${this.RTE_COMPONENT_NAMES.Math}`
+      )
+    );
+    for (const element of mathElements) {
+      const attr = element.getAttribute('math_content-with-value');
+      if (attr) {
+        const mathContent = this.htmlEscaper.escapedJsonToObj(
+          attr
         ) as MathExpressionContent;
-        const latexSpeakableText = _this._formatLatexToSpeakableText(
+        const latexSpeakableText = this._formatLatexToSpeakableText(
           mathContent.raw_latex
         );
-        return latexSpeakableText.length > 0 ? latexSpeakableText + ' ' : '';
-      });
+        element.replaceWith(
+          latexSpeakableText.length > 0 ? latexSpeakableText + ' ' : ''
+        );
+      }
+    }
+    const serializer = new XMLSerializer();
+    let processedHtml = Array.from(container.childNodes)
+      .map(node => serializer.serializeToString(node))
+      .join('');
+    processedHtml = processedHtml.replace(/<\/li>/g, '.').trim();
 
-    html = elt.html();
-    // Replace certain HTML elements with periods to indicate
-    // pauses in speaking. Also, for some reason, there's a lot
-    // of whitespace (like hundreds of characters) so we trim
-    // it off to avoid blank chunks.
-    html = html.replace(new RegExp('</li>', 'g'), '.').trim();
-    // Strip away HTML tags.
-    var tmp = $('<div></div>');
-    tmp.html(html);
-    var textToSpeakWithoutPauses = tmp.text();
-    var textToSpeak = '';
-    // Insert a space after punctuation marks to ensure that chunking will
-    // end on the desired punctuation marks so that SpeechSynthesis will
-    // pause more naturally. Remove any punctuation marks that have no
-    // effect on speaking.
-    for (var i = 0; i < textToSpeakWithoutPauses.length; i++) {
-      if (
-        this.PUNCTUATION_MARKS_TO_IGNORE.indexOf(
-          textToSpeakWithoutPauses.charAt(i)
-        ) > -1
-      ) {
+    const processedDoc = parser.parseFromString(processedHtml, 'text/html');
+    const textToSpeakWithoutPauses = processedDoc.body.textContent || '';
+
+    let textToSpeak = '';
+
+    for (let i = 0; i < textToSpeakWithoutPauses.length; i++) {
+      const char = textToSpeakWithoutPauses.charAt(i);
+      if (this.PUNCTUATION_MARKS_TO_IGNORE.includes(char)) {
         continue;
       }
-      textToSpeak += textToSpeakWithoutPauses.charAt(i);
-      if (
-        this.PUNCTUATION_MARKS_TO_END_CHUNKS.indexOf(
-          textToSpeakWithoutPauses.charAt(i)
-        ) > -1
-      ) {
+
+      textToSpeak += char;
+
+      if (this.PUNCTUATION_MARKS_TO_END_CHUNKS.includes(char)) {
         textToSpeak += ' ';
       }
     }
+
     return textToSpeak;
   }
 

--- a/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
+++ b/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
@@ -440,160 +440,109 @@ export class MusicNotesInputComponent
   }
 
   // Creates a staff of droppable lines.
-  // TODO(#14340): Remove some usages of jQuery from the codebase.
   buildDroppableStaff(): void {
-    let lineValues = Object.keys(this.NOTE_NAMES_TO_MIDI_VALUES);
-    for (let i = 0; i < lineValues.length; i++) {
-      var staffLineDiv = $('<div class="oppia-music-staff-position"></div>')
-        .css('height', this.VERTICAL_GRID_SPACING)
-        .data('lineValue', lineValues[i])
-        .droppable({
-          accept: '.oppia-music-input-note-choices div',
-          // Over and out are used to remove helper clone if
-          // note is not placed on staff.
-          over: (evt, ui) => {
-            let lineValue = $(evt.target).data('lineValue');
+    const lineValues = Object.keys(this.NOTE_NAMES_TO_MIDI_VALUES);
 
-            // Draws a ledger-line when note is hovering over staff-line.
-            if (this.isLedgerLineNote(lineValue)) {
-              // Position of current dropped note.
-              let leftPos = ui.helper.position().left;
-              let topPos = $(evt.target).position().top;
-              let noteId = $(ui.helper).data('noteId');
-              if (noteId === undefined) {
-                noteId = this.generateNoteId();
-                $(ui.helper).data('noteId', noteId);
-              }
-              this.drawLedgerLine(topPos, leftPos);
-            }
-          },
-          out: () => {
-            // Removes a ledger line when note is dragged out of
-            // droppable.
-            $('.oppia-music-input-ledger-line').last().hide();
-          },
-          hoverClass: 'oppia-music-input-hovered',
-          // Handles note drops and appends new note to noteSequence.
-          drop: (evt, ui) => {
-            // Makes helper clone not disappear when dropped on staff.
-            $.ui.ddmanager.current.cancelHelperRemoval = true;
+    const staffContainer = this.elementRef.nativeElement.querySelector(
+      '.oppia-music-input-staff'
+    );
 
-            $('.oppia-music-input-ledger-line').last().hide();
+    for (const lv of lineValues) {
+      const staffLineDiv = this.renderer.createElement('div');
+      this.renderer.addClass(staffLineDiv, 'oppia-music-staff-position');
+      this.renderer.setStyle(
+        staffLineDiv,
+        'height',
+        `${this.VERTICAL_GRID_SPACING}px`
+      );
+      staffLineDiv.dataset.lineValue = lv;
+      staffLineDiv.addEventListener('dragenter', evt => {
+        evt.preventDefault();
+        const lineValue = staffLineDiv.dataset.lineValue!;
+        if (this.isLedgerLineNote(Number(lineValue))) {
+          const rect = (
+            evt.currentTarget as HTMLElement
+          ).getBoundingClientRect();
+          this.drawLedgerLine(rect.top, (evt as DragEvent).clientX);
+        }
+      });
 
-            // Previous position of note or undefined.
-            let startPos = $(ui.helper).data('leftPosBeforeDrag');
+      staffLineDiv.addEventListener('dragleave', () => {
+        this.hideLastLedgerLine();
+      });
 
-            // Position of current dropped note.
-            let leftPos = ui.helper.position().left;
-            let topPos = $(evt.target).position().top;
+      staffLineDiv.addEventListener('dragover', evt => evt.preventDefault());
 
-            // The staff line's value.
-            let lineValue = $(evt.target).data('lineValue');
-            let noteType = ui.draggable.data('noteType');
+      staffLineDiv.addEventListener('drop', evt => {
+        evt.preventDefault();
+        this.hideLastLedgerLine();
 
-            // A note that is dragged from noteChoices box
-            // has an undefined noteId. This sets the id.
-            // Otherwise, the note has an id.
-            let noteId = $(ui.helper).data('noteId');
-            if (noteId === undefined) {
-              noteId = this.generateNoteId();
-              $(ui.helper).data('noteId', noteId);
-            }
-
-            // Creates a note object.
-            let note = {
-              baseNoteMidiNumber: this.NOTE_NAMES_TO_MIDI_VALUES[lineValue],
-              offset: parseInt(noteType, 10),
-              noteId: noteId,
-              noteStart: null,
-            };
-
-            // When a note is moved, its previous state must be removed
-            // from the noteSequence. Otherwise, the sequence would
-            // erroneously hold notes that have been moved to other
-            // positions. Also this allows an on-staff note's position
-            // to be freed up if it is moved.
-            this._removeNotesFromNoteSequenceWithId(note.noteId);
-
-            // Makes sure that a note can move vertically on it's
-            // position.
-            if (startPos !== leftPos) {
-              // Moves the note to the next available spot on the staff.
-              // If the staff is full, note is moved off staff,
-              // and thus removed.
-              while (this.checkIfNotePositionTaken(leftPos)) {
-                leftPos += this.HORIZONTAL_GRID_SPACING;
-              }
-              if (ui.helper instanceof HTMLElement) {
-                this.renderer.setStyle(ui.helper, 'top', `${topPos}px`);
-                this.renderer.setStyle(ui.helper, 'left', `${leftPos}px`);
-              }
-
-              if (
-                Math.floor(leftPos) >
-                Math.floor(
-                  this.getHorizontalPosition(this.MAXIMUM_NOTES_POSSIBLE - 1)
-                )
-              ) {
-                $(ui.helper).remove();
-                this.repaintLedgerLines();
-                return;
-              }
-            }
-
-            // Adjusts note so it is right on top of the staff line by
-            // calculating half of the VERTICAL_GRID_SPACING and
-            // subtracting that from its current top Position.
-            if (ui.helper instanceof HTMLElement) {
-              this.renderer.setStyle(
-                ui.helper,
-                'top',
-                `${topPos - this.VERTICAL_GRID_SPACING / 2.0}px`
-              );
-            }
-
-            // Add noteStart property to note object.
-            if (this.getNoteStartFromLeftPos(leftPos) !== undefined) {
-              note.noteStart =
-                this.getNoteStartFromLeftPos(leftPos).note.noteStart;
-            } else {
-              this.repaintLedgerLines();
-              return;
-            }
-
-            this._addNoteToNoteSequence(note);
-            this._sortNoteSequence();
-
-            // Sounds the note when it is dropped onto staff.
-            this.playSequence([[this._convertNoteToMidiPitch(note)]]);
-            $(ui.helper).addClass('oppia-music-input-on-staff');
-
-            this.repaintLedgerLines();
-          },
-        });
-      $(
-        this.elementRef.nativeElement.querySelectorAll(
-          '.oppia-music-input-staff'
-        )
-      ).append(staffLineDiv);
-
-      if (i === 0) {
-        this.topPositionForCenterOfTopStaffLine =
-          $(staffLineDiv).position().top + this.VERTICAL_GRID_SPACING;
-      }
-
-      let noteName = lineValues[i];
-
-      // Check if noteName is a valid staff line and if so, paint staff
-      // line.
-      if (this.NOTES_ON_LINES.indexOf(noteName) !== -1) {
-        staffLineDiv.append(
-          $('<div class="oppia-music-staff-line"></div>')
-            // Positions and centers the staff line directly on top of its
-            // associated droppable.
-            .css('margin-top', this.VERTICAL_GRID_SPACING / 2.5)
+        const dropEvent = evt as DragEvent;
+        const draggedElt = document.getElementById(
+          dropEvent.dataTransfer?.getData('text/plain')!
         );
+        if (!draggedElt) return;
+        const noteType = draggedElt.dataset.noteType;
+        let noteId = draggedElt.dataset.noteId;
+        if (!noteId) {
+          noteId = this.generateNoteId();
+          draggedElt.dataset.noteId = noteId;
+        }
+        const leftPos = dropEvent.clientX;
+        const topPos = (
+          evt.currentTarget as HTMLElement
+        ).getBoundingClientRect().top;
+        const noteObj = {
+          baseNoteMidiNumber: this.NOTE_NAMES_TO_MIDI_VALUES[Number(lineValue)],
+          offset: parseInt(noteType || '0', 10),
+          noteId,
+          noteStart:
+            this.getNoteStartFromLeftPos(leftPos)?.note.noteStart ?? null,
+        };
+        this._removeNotesFromNoteSequenceWithId(noteId);
+        this._addNoteToNoteSequence(noteObj);
+        this._sortNoteSequence();
+
+        this.renderer.setStyle(draggedElt, 'position', 'absolute');
+        this.renderer.setStyle(draggedElt, 'left', `${leftPos}px`);
+        this.renderer.setStyle(
+          draggedElt,
+          'top',
+          `${topPos - this.VERTICAL_GRID_SPACING / 2}px`
+        );
+        this.renderer.addClass(draggedElt, 'oppia-music-input-on-staff');
+        this.playSequence([[this._convertNoteToMidiPitch(noteObj)]]);
+        this.repaintLedgerLines();
+      });
+      if (this.NOTES_ON_LINES.includes(lv)) {
+        const innerLine = this.renderer.createElement('div');
+        this.renderer.addClass(innerLine, 'oppia-music-staff-line');
+        this.renderer.setStyle(
+          innerLine,
+          'margin-top',
+          `${this.VERTICAL_GRID_SPACING / 2.5}px`
+        );
+        this.renderer.appendChild(staffLineDiv, innerLine);
       }
+      this.renderer.appendChild(staffContainer, staffLineDiv);
+      if (lv === lineValues[0]) {
+        const topPos = (staffLineDiv as HTMLElement).getBoundingClientRect()
+          .top;
+        this.topPositionForCenterOfTopStaffLine =
+          topPos + this.VERTICAL_GRID_SPACING;
+      }
+    }
+  }
+  // Helper to hide the last ledger-line: similar to jQuery `.last().hide()`
+  hideLastLedgerLine(): void {
+    const all = Array.from(
+      this.elementRef.nativeElement.querySelectorAll(
+        '.oppia-music-input-ledger-line'
+      )
+    ) as HTMLElement[];
+    if (all.length) {
+      const last = all[all.length - 1];
+      this.renderer.setStyle(last, 'display', 'none');
     }
   }
 
@@ -661,11 +610,16 @@ export class MusicNotesInputComponent
 
   // Clear noteSequence values and remove all notes
   // and Ledger Lines from the staff.
-  // TODO(#14340): Remove some usages of jQuery from the codebase.
   clearSequence(): void {
     this.noteSequence = [];
-    $('.oppia-music-input-on-staff').remove();
-    $('.oppia-music-input-ledger-line').remove();
+    const notesOnStaff = this.elementRef.nativeElement.querySelectorAll(
+      '.oppia-music-input-on-staff'
+    );
+    notesOnStaff.forEach(note => note.remove());
+    const ledgerLines = this.elementRef.nativeElement.querySelectorAll(
+      '.oppia-music-input-ledger-line'
+    );
+    ledgerLines.forEach(line => line.remove());
   }
 
   // Converts the midiValue of a droppable line that a note is on
@@ -706,33 +660,27 @@ export class MusicNotesInputComponent
     return this.LEDGER_LINE_NOTES.indexOf(lineValue) !== -1;
   }
 
-  // TODO(#14340): Remove some usages of jQuery from the codebase.
   drawLedgerLine(topPos: number, leftPos: number): void {
-    var ledgerLineDiv = $(
-      '<div class"oppia-music-input-ledger-line ' +
-        'oppia-music-input-natural-note"></div>'
-    )
-      .droppable({
-        accept: '.oppia-music-input-note-choices div',
-        // When a ledgerLine note is moved out of its droppable,
-        // remove ledger line.
-        out: () => {
-          $(ledgerLineDiv).hide();
-        },
-        hoverClass: 'oppia-music-input-hovered',
-        containment: '.oppia-music-input-valid-note-area',
-      })
-      // Adjust ledger line to be centered with the note.
-      .css({
-        left: leftPos - 1,
-        // 0.4 is a little less than half to allow for the height of the
-        // ledger line when considering its placement.
-        top: topPos + this.VERTICAL_GRID_SPACING * 0.4,
-      });
+    const ledgerLineDiv = this.renderer.createElement('div');
+    this.renderer.addClass(ledgerLineDiv, 'oppia-music-input-ledger-line');
+    this.renderer.addClass(ledgerLineDiv, 'oppia-music-input-natural-note');
 
-    $(
-      this.elementRef.nativeElement.querySelectorAll('.oppia-music-input-staff')
-    ).append(ledgerLineDiv);
+    this.renderer.setStyle(ledgerLineDiv, 'position', 'absolute');
+    this.renderer.setStyle(ledgerLineDiv, 'left', `${leftPos - 1}px`);
+    this.renderer.setStyle(
+      ledgerLineDiv,
+      'top',
+      `${topPos + this.VERTICAL_GRID_SPACING * 0.4}px`
+    );
+    ledgerLineDiv.addEventListener('dragleave', () => {
+      this.renderer.setStyle(ledgerLineDiv, 'display', 'none');
+    });
+    const staffContainer = this.elementRef.nativeElement.querySelector(
+      '.oppia-music-input-staff'
+    );
+    if (staffContainer) {
+      this.renderer.appendChild(staffContainer, ledgerLineDiv);
+    }
   }
 
   repaintLedgerLines(): void {

--- a/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
+++ b/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
@@ -267,43 +267,46 @@ export class MusicNotesInputComponent
   }
 
   // Removes all notes from staff.
-  // TODO(#14340): Remove some usages of jQuery from the codebase.
   clearNotesFromStaff(): void {
-    $(
-      this.elementRef.nativeElement.querySelectorAll(
-        '.oppia-music-input-note-choices div'
-      )
-    ).remove();
+    const noteChoiceDivs = this.elementRef.nativeElement.querySelectorAll(
+      '.oppia-music-input-note-choices > div'
+    );
+    noteChoiceDivs.forEach((div: Element) => {
+      if (div.parentNode) {
+        this.renderer.removeChild(div.parentNode, div);
+      }
+    });
   }
 
   // Removes all droppable staff lines.
-  // TODO(#14340): Remove some usages of jQuery from the codebase.
   clearDroppableStaff(): void {
-    $(
-      this.elementRef.nativeElement.querySelectorAll(
-        '.oppia-music-input-staff div'
-      )
-    ).remove();
+    const staffDivs = this.elementRef.nativeElement.querySelectorAll(
+      '.oppia-music-input-staff div'
+    );
+    staffDivs.forEach((div: Element) => {
+      if (div.parentNode) {
+        this.renderer.removeChild(div.parentNode, div);
+      }
+    });
   }
 
   // Returns an Object containing the baseNoteMidiValues (81, 79, 77...)
   // as keys and the vertical positions of the staff lines as values.
-  // TODO(#14340): Remove some usages of jQuery from the codebase.
   getStaffLinePositions(): Object {
-    let staffLinePositionsArray = [];
-    let staffLinePositions = {};
-    let elements = $(
+    const staffLinePositionsArray: number[] = [];
+    const staffLinePositions: {[key: string]: number} = {};
+    const elements: NodeListOf<HTMLElement> =
       this.elementRef.nativeElement.querySelectorAll(
         '.oppia-music-input-staff div.oppia-music-staff-position'
-      )
-    );
-    elements.each((el, val) => {
-      staffLinePositionsArray.push($(val).position().top);
+      );
+
+    elements.forEach((el: HTMLElement) => {
+      staffLinePositionsArray.push(el.offsetTop);
     });
     for (let i = 0; i < staffLinePositionsArray.length; i++) {
       staffLinePositions[this.verticalGridKeys[i]] = staffLinePositionsArray[i];
     }
-    return staffLinePositions;
+    return staffLinePositions as Object;
   }
 
   // Creates the notes and helper-clone notes for the noteChoices div.
@@ -443,9 +446,13 @@ export class MusicNotesInputComponent
     const lineValues = Object.keys(this.NOTE_NAMES_TO_MIDI_VALUES);
     const staffContainer = this.elementRef.nativeElement.querySelector(
       '.oppia-music-input-staff'
-    );
+    ) as HTMLElement;
+    if (!staffContainer) {
+      return;
+    }
 
-    for (const lv of lineValues) {
+    for (let i = 0; i < lineValues.length; i++) {
+      const noteName = lineValues[i];
       const staffLineDiv = this.renderer.createElement('div');
       this.renderer.addClass(staffLineDiv, 'oppia-music-staff-position');
       this.renderer.setStyle(
@@ -453,105 +460,139 @@ export class MusicNotesInputComponent
         'height',
         `${this.VERTICAL_GRID_SPACING}px`
       );
-      staffLineDiv.dataset.lineValue = lv;
+      this.renderer.setAttribute(staffLineDiv, 'data-line-value', noteName);
 
-      staffLineDiv.addEventListener('dragenter', evt => {
+      // DRAG OVER
+      this.renderer.listen(staffLineDiv, 'dragover', (evt: DragEvent) => {
         evt.preventDefault();
-        const lineValue = staffLineDiv.dataset.lineValue!;
-        if (this.isLedgerLineNote(Number(lineValue))) {
-          const rect = (
-            evt.currentTarget as HTMLElement
-          ).getBoundingClientRect();
-          this.drawLedgerLine(rect.top, (evt as DragEvent).clientX);
+        this.renderer.addClass(staffLineDiv, 'oppia-music-input-hovered');
+
+        const lineValue = staffLineDiv.getAttribute('data-line-value');
+        if (this.isLedgerLineNote(lineValue!)) {
+          const relativeCursorX =
+            evt.clientX - staffContainer.getBoundingClientRect().left;
+          const topPos = staffLineDiv.getBoundingClientRect().top;
+          this.drawLedgerLine(topPos, relativeCursorX);
         }
       });
 
-      staffLineDiv.addEventListener('dragleave', () => {
-        this.hideLastLedgerLine();
-      });
-
-      staffLineDiv.addEventListener('dragover', evt => evt.preventDefault());
-
-      staffLineDiv.addEventListener('drop', evt => {
-        evt.preventDefault();
-        this.hideLastLedgerLine();
-
-        const dropEvent = evt as DragEvent;
-        const draggedElt = document.getElementById(
-          dropEvent.dataTransfer?.getData('text/plain')!
+      // DRAG LEAVE
+      this.renderer.listen(staffLineDiv, 'dragleave', () => {
+        this.renderer.removeClass(staffLineDiv, 'oppia-music-input-hovered');
+        const ledgerLines = document.querySelectorAll(
+          '.oppia-music-input-ledger-line'
         );
-        if (!draggedElt) return;
+        if (ledgerLines.length > 0) {
+          const last = ledgerLines[ledgerLines.length - 1];
+          this.renderer.setStyle(last, 'display', 'none');
+        }
+      });
+      // DROP
+      this.renderer.listen(staffLineDiv, 'drop', (evt: DragEvent) => {
+        evt.preventDefault();
+        this.renderer.removeClass(staffLineDiv, 'oppia-music-input-hovered');
 
-        const noteType = draggedElt.dataset.noteType;
-        let noteId = draggedElt.dataset.noteId;
-        if (!noteId) {
-          noteId = this.generateNoteId();
-          draggedElt.dataset.noteId = noteId;
+        const ledgerLines = document.querySelectorAll(
+          '.oppia-music-input-ledger-line'
+        );
+        if (ledgerLines.length > 0) {
+          this.renderer.setStyle(
+            ledgerLines[ledgerLines.length - 1],
+            'display',
+            'none'
+          );
         }
 
-        const leftPos = dropEvent.clientX;
-        const topPos = (evt.currentTarget as HTMLElement).offsetTop;
-        const lineValue = staffLineDiv.dataset.lineValue!;
-        const baseNoteMidiNumber =
-          this.NOTE_NAMES_TO_MIDI_VALUES[Number(lineValue)];
+        const noteId =
+          evt.dataTransfer?.getData('note/id') || this.generateNoteId();
+        const noteType = evt.dataTransfer?.getData('note/type') || '0';
+        const oldLeftPos = evt.dataTransfer?.getData('note/oldLeftPos');
+        const startPos = oldLeftPos ? parseFloat(oldLeftPos) : undefined;
 
-        const noteObj = {
-          baseNoteMidiNumber,
-          offset: Number.isFinite(+noteType) ? parseInt(noteType!, 10) : 0,
+        let noteEl = document.getElementById(`note-${noteId}`) as HTMLElement;
+        if (!noteEl) {
+          noteEl = this.renderer.createElement('div');
+          this.renderer.addClass(noteEl, 'oppia-music-input-note');
+          this.renderer.setAttribute(noteEl, 'draggable', 'true');
+          this.renderer.setAttribute(noteEl, 'id', `note-${noteId}`);
+          this.renderer.setAttribute(noteEl, 'data-note-id', noteId);
+          this.renderer.setAttribute(noteEl, 'data-note-type', noteType);
+          this.renderer.appendChild(staffContainer, noteEl);
+        }
+
+        const leftPos =
+          evt.clientX - staffContainer.getBoundingClientRect().left;
+        const topPos = staffLineDiv.offsetTop;
+        const lineValue = staffLineDiv.getAttribute('data-line-value')!;
+
+        const note = {
+          baseNoteMidiNumber: this.NOTE_NAMES_TO_MIDI_VALUES[lineValue],
+          offset: parseInt(noteType, 10),
           noteId,
-          noteStart:
-            this.getNoteStartFromLeftPos(leftPos)?.note.noteStart ?? null,
+          noteStart: null,
         };
 
-        this._removeNotesFromNoteSequenceWithId(noteId);
-        this._addNoteToNoteSequence(noteObj);
-        this._sortNoteSequence();
+        this._removeNotesFromNoteSequenceWithId(note.noteId);
 
-        if (!draggedElt.classList.contains('oppia-music-input-on-staff')) {
-          this.renderer.setStyle(draggedElt, 'position', 'absolute');
+        let finalLeft = leftPos;
+        if (startPos !== finalLeft) {
+          while (this.checkIfNotePositionTaken(finalLeft)) {
+            finalLeft += this.HORIZONTAL_GRID_SPACING;
+          }
+
+          if (
+            Math.floor(finalLeft) >
+            Math.floor(
+              this.getHorizontalPosition(this.MAXIMUM_NOTES_POSSIBLE - 1)
+            )
+          ) {
+            this.renderer.removeChild(noteEl.parentNode!, noteEl);
+            this.repaintLedgerLines();
+            return;
+          }
         }
-        this.renderer.setStyle(draggedElt, 'left', `${leftPos}px`);
-        this.renderer.setStyle(
-          draggedElt,
-          'top',
-          `${topPos - this.VERTICAL_GRID_SPACING / 2}px`
-        );
-        this.renderer.addClass(draggedElt, 'oppia-music-input-on-staff');
 
-        this.playSequence([[this._convertNoteToMidiPitch(noteObj)]]);
+        this.renderer.setStyle(noteEl, 'position', 'absolute');
+        this.renderer.setStyle(noteEl, 'left', `${finalLeft}px`);
+        this.renderer.setStyle(
+          noteEl,
+          'top',
+          `${topPos - this.VERTICAL_GRID_SPACING / 2.0}px`
+        );
+        this.renderer.addClass(noteEl, 'oppia-music-input-on-staff');
+
+        const noteStartInfo = this.getNoteStartFromLeftPos(finalLeft);
+        if (!noteStartInfo) {
+          this.renderer.removeChild(noteEl.parentNode!, noteEl);
+          this.repaintLedgerLines();
+          return;
+        }
+
+        note.noteStart = noteStartInfo.note.noteStart;
+
+        this._addNoteToNoteSequence(note);
+        this._sortNoteSequence();
+        this.playSequence([[this._convertNoteToMidiPitch(note)]]);
         this.repaintLedgerLines();
       });
 
-      if (this.NOTES_ON_LINES.includes(lv)) {
-        const innerLine = this.renderer.createElement('div');
-        this.renderer.addClass(innerLine, 'oppia-music-staff-line');
+      this.renderer.appendChild(staffContainer, staffLineDiv);
+
+      if (i === 0) {
+        this.topPositionForCenterOfTopStaffLine =
+          staffLineDiv.offsetTop + this.VERTICAL_GRID_SPACING;
+      }
+
+      if (this.NOTES_ON_LINES.includes(noteName)) {
+        const staffLine = this.renderer.createElement('div');
+        this.renderer.addClass(staffLine, 'oppia-music-staff-line');
         this.renderer.setStyle(
-          innerLine,
+          staffLine,
           'margin-top',
           `${this.VERTICAL_GRID_SPACING / 2.5}px`
         );
-        this.renderer.appendChild(staffLineDiv, innerLine);
+        this.renderer.appendChild(staffLineDiv, staffLine);
       }
-
-      this.renderer.appendChild(staffContainer, staffLineDiv);
-
-      if (lv === lineValues[0]) {
-        const topPos = (staffLineDiv as HTMLElement).offsetTop;
-        this.topPositionForCenterOfTopStaffLine =
-          topPos + this.VERTICAL_GRID_SPACING;
-      }
-    }
-  }
-
-  hideLastLedgerLine(): void {
-    const all = Array.from(
-      this.elementRef.nativeElement.querySelectorAll(
-        '.oppia-music-input-ledger-line'
-      )
-    ) as HTMLElement[];
-    if (all.length) {
-      const last = all[all.length - 1];
-      this.renderer.setStyle(last, 'display', 'none');
     }
   }
 
@@ -647,12 +688,18 @@ export class MusicNotesInputComponent
    * Horizontal Position value and return the result.
    */
   getHorizontalPosition(noteStartAsFloat: number): number {
-    let lastHorizontalPositionOffset = $(
-      this.elementRef.nativeElement.querySelector(
-        '.oppia-music-input-note-choices div:first-child'
-      )
-    ).position().left;
-    let leftOffset =
+    const firstNoteDiv = this.elementRef.nativeElement.querySelector(
+      '.oppia-music-input-note-choices div:first-child'
+    ) as HTMLElement;
+
+    if (!firstNoteDiv) {
+      console.warn('First note div not found.');
+      return 0;
+    }
+
+    const lastHorizontalPositionOffset =
+      firstNoteDiv.getBoundingClientRect().left;
+    const leftOffset =
       lastHorizontalPositionOffset -
       (this.MAXIMUM_NOTES_POSSIBLE - 1) * this.HORIZONTAL_GRID_SPACING;
     return leftOffset + noteStartAsFloat * this.HORIZONTAL_GRID_SPACING;

--- a/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
+++ b/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
@@ -439,10 +439,8 @@ export class MusicNotesInputComponent
     this.repaintLedgerLines();
   }
 
-  // Creates a staff of droppable lines.
   buildDroppableStaff(): void {
     const lineValues = Object.keys(this.NOTE_NAMES_TO_MIDI_VALUES);
-
     const staffContainer = this.elementRef.nativeElement.querySelector(
       '.oppia-music-input-staff'
     );
@@ -456,6 +454,7 @@ export class MusicNotesInputComponent
         `${this.VERTICAL_GRID_SPACING}px`
       );
       staffLineDiv.dataset.lineValue = lv;
+
       staffLineDiv.addEventListener('dragenter', evt => {
         evt.preventDefault();
         const lineValue = staffLineDiv.dataset.lineValue!;
@@ -482,28 +481,35 @@ export class MusicNotesInputComponent
           dropEvent.dataTransfer?.getData('text/plain')!
         );
         if (!draggedElt) return;
+
         const noteType = draggedElt.dataset.noteType;
         let noteId = draggedElt.dataset.noteId;
         if (!noteId) {
           noteId = this.generateNoteId();
           draggedElt.dataset.noteId = noteId;
         }
+
         const leftPos = dropEvent.clientX;
-        const topPos = (
-          evt.currentTarget as HTMLElement
-        ).getBoundingClientRect().top;
+        const topPos = (evt.currentTarget as HTMLElement).offsetTop;
+        const lineValue = staffLineDiv.dataset.lineValue!;
+        const baseNoteMidiNumber =
+          this.NOTE_NAMES_TO_MIDI_VALUES[Number(lineValue)];
+
         const noteObj = {
-          baseNoteMidiNumber: this.NOTE_NAMES_TO_MIDI_VALUES[Number(lineValue)],
-          offset: parseInt(noteType || '0', 10),
+          baseNoteMidiNumber,
+          offset: Number.isFinite(+noteType) ? parseInt(noteType!, 10) : 0,
           noteId,
           noteStart:
             this.getNoteStartFromLeftPos(leftPos)?.note.noteStart ?? null,
         };
+
         this._removeNotesFromNoteSequenceWithId(noteId);
         this._addNoteToNoteSequence(noteObj);
         this._sortNoteSequence();
 
-        this.renderer.setStyle(draggedElt, 'position', 'absolute');
+        if (!draggedElt.classList.contains('oppia-music-input-on-staff')) {
+          this.renderer.setStyle(draggedElt, 'position', 'absolute');
+        }
         this.renderer.setStyle(draggedElt, 'left', `${leftPos}px`);
         this.renderer.setStyle(
           draggedElt,
@@ -511,9 +517,11 @@ export class MusicNotesInputComponent
           `${topPos - this.VERTICAL_GRID_SPACING / 2}px`
         );
         this.renderer.addClass(draggedElt, 'oppia-music-input-on-staff');
+
         this.playSequence([[this._convertNoteToMidiPitch(noteObj)]]);
         this.repaintLedgerLines();
       });
+
       if (this.NOTES_ON_LINES.includes(lv)) {
         const innerLine = this.renderer.createElement('div');
         this.renderer.addClass(innerLine, 'oppia-music-staff-line');
@@ -524,16 +532,17 @@ export class MusicNotesInputComponent
         );
         this.renderer.appendChild(staffLineDiv, innerLine);
       }
+
       this.renderer.appendChild(staffContainer, staffLineDiv);
+
       if (lv === lineValues[0]) {
-        const topPos = (staffLineDiv as HTMLElement).getBoundingClientRect()
-          .top;
+        const topPos = (staffLineDiv as HTMLElement).offsetTop;
         this.topPositionForCenterOfTopStaffLine =
           topPos + this.VERTICAL_GRID_SPACING;
       }
     }
   }
-  // Helper to hide the last ledger-line: similar to jQuery `.last().hide()`
+
   hideLastLedgerLine(): void {
     const all = Array.from(
       this.elementRef.nativeElement.querySelectorAll(

--- a/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
+++ b/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
@@ -101,7 +101,7 @@ export class MusicNotesInputComponent
   NOTE_NAMES_TO_MIDI_VALUES =
     InteractionsExtensionsConstants.NOTE_NAMES_TO_MIDI_VALUES;
 
-  staffContainerElt: JQuery<HTMLElement>;
+  staffContainerElt: HTMLElement | null;
 
   constructor(
     private interactionAttributesExtractorService: InteractionAttributesExtractorService,
@@ -134,9 +134,8 @@ export class MusicNotesInputComponent
     this.initialSequence = this.interactionIsActive
       ? initialSequence
       : this.lastAnswer;
-    // TODO(#14340): Remove some usages of jQuery from the codebase.
-    this.staffContainerElt = $(
-      this.elementRef.nativeElement.querySelectorAll('.oppia-music-input-staff')
+    this.staffContainerElt = this.elementRef.nativeElement.querySelector(
+      '.oppia-music-input-staff'
     );
 
     this.directiveSubscriptions.add(
@@ -211,7 +210,6 @@ export class MusicNotesInputComponent
   // Staff has to be reinitialized every time that the staff is resized or
   // displayed. The staffContainerElt and all subsequent measurements
   // must be recalculated in order for the grid to work properly.
-  // TODO(#14340): Remove some usages of jQuery from the codebase.
   reinitStaff(): void {
     var elem = document.querySelector('.oppia-music-input-valid-note-area');
 
@@ -226,7 +224,10 @@ export class MusicNotesInputComponent
   }
 
   init(): void {
-    this.CONTAINER_WIDTH = this.staffContainerElt.width();
+    if (this.staffContainerElt) {
+      this.CONTAINER_WIDTH =
+        this.staffContainerElt.getBoundingClientRect().width;
+    }
     this.CONTAINER_HEIGHT = 0.2 * this.CONTAINER_WIDTH;
 
     // The grid rectangle dimensions defining the grid which the notes

--- a/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
+++ b/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
@@ -462,13 +462,16 @@ export class MusicNotesInputComponent
       );
       this.renderer.setAttribute(staffLineDiv, 'data-line-value', noteName);
 
-      // DRAG OVER
+      // Drag over.
       this.renderer.listen(staffLineDiv, 'dragover', (evt: DragEvent) => {
         evt.preventDefault();
         this.renderer.addClass(staffLineDiv, 'oppia-music-input-hovered');
 
         const lineValue = staffLineDiv.getAttribute('data-line-value');
-        if (this.isLedgerLineNote(lineValue!)) {
+        if (!lineValue) {
+          return;
+        }
+        if (this.isLedgerLineNote(lineValue)) {
           const relativeCursorX =
             evt.clientX - staffContainer.getBoundingClientRect().left;
           const topPos = staffLineDiv.getBoundingClientRect().top;
@@ -476,7 +479,7 @@ export class MusicNotesInputComponent
         }
       });
 
-      // DRAG LEAVE
+      // Drag Leave.
       this.renderer.listen(staffLineDiv, 'dragleave', () => {
         this.renderer.removeClass(staffLineDiv, 'oppia-music-input-hovered');
         const ledgerLines = document.querySelectorAll(
@@ -487,7 +490,7 @@ export class MusicNotesInputComponent
           this.renderer.setStyle(last, 'display', 'none');
         }
       });
-      // DROP
+      // Drop.
       this.renderer.listen(staffLineDiv, 'drop', (evt: DragEvent) => {
         evt.preventDefault();
         this.renderer.removeClass(staffLineDiv, 'oppia-music-input-hovered');
@@ -523,7 +526,10 @@ export class MusicNotesInputComponent
         const leftPos =
           evt.clientX - staffContainer.getBoundingClientRect().left;
         const topPos = staffLineDiv.offsetTop;
-        const lineValue = staffLineDiv.getAttribute('data-line-value')!;
+        const lineValue = staffLineDiv.getAttribute('data-line-value');
+        if (!lineValue) {
+          return;
+        }
 
         const note = {
           baseNoteMidiNumber: this.NOTE_NAMES_TO_MIDI_VALUES[lineValue],
@@ -546,7 +552,10 @@ export class MusicNotesInputComponent
               this.getHorizontalPosition(this.MAXIMUM_NOTES_POSSIBLE - 1)
             )
           ) {
-            this.renderer.removeChild(noteEl.parentNode!, noteEl);
+            const parent = noteEl.parentNode;
+            if (parent) {
+              this.renderer.removeChild(parent, noteEl);
+            }
             this.repaintLedgerLines();
             return;
           }
@@ -563,7 +572,10 @@ export class MusicNotesInputComponent
 
         const noteStartInfo = this.getNoteStartFromLeftPos(finalLeft);
         if (!noteStartInfo) {
-          this.renderer.removeChild(noteEl.parentNode!, noteEl);
+          const parent = noteEl.parentNode;
+          if (parent) {
+            this.renderer.removeChild(parent, noteEl);
+          }
           this.repaintLedgerLines();
           return;
         }

--- a/extensions/visualizations/oppia-visualization-click-hexbins.directive.ts
+++ b/extensions/visualizations/oppia-visualization-click-hexbins.directive.ts
@@ -131,7 +131,10 @@ export class OppiaVisualizationClickHexbinsComponent implements OnInit {
       this.imagePath
     );
 
-    const wrapperWidth = $('.click-hexbin-wrapper').width() || 300;
+    const wrapperEl = document.querySelector(
+      '.click-hexbin-wrapper'
+    ) as HTMLElement;
+    const wrapperWidth = wrapperEl?.offsetWidth || 300;
     const wrapperHeight =
       this.imageSize.width === 0
         ? this.imageSize.height


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #11371, #12882, .
2. This PR does the following: remove j-query like .filter, .text, .html, .position etc.
3. (For bug-fixing PRs only) The original bug occurred because: NA

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

##References:
https://github.com/oppia/oppia/pull/22854

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
