### PR TITLE
Fix#20015: Duplicate content ids beam jobs

### DIFF
--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -301,9 +301,10 @@ def _replace_content_id_in_state(
                 state.interaction.solution.explanation.content_id = (
                     new_content_id)
 
-    # Here we use type Any because the customization arg value can be of
-    # various types including lists, dicts, or objects with content_id
-    # attributes, and we need to handle all these cases recursively.
+
+# Here we use type Any because the customization arg value can be of
+# various types including lists, dicts, or objects with content_id
+# attributes, and we need to handle all these cases recursively.
 def _replace_content_id_in_value(
     value: Any, old_content_id: str, new_content_id: str
 ) -> None:

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -27,7 +27,7 @@ from core.jobs.types import job_run_result
 from core.platform import models
 
 import apache_beam as beam
-from typing import Dict, List, Set, Union
+from typing import Any, Dict, List, Set, Union
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -265,13 +265,11 @@ def _replace_content_id_in_state(
 
     if state.interaction:
         for ca_value in state.interaction.customization_args.values():
-            if (hasattr(ca_value, 'value') and
-                    hasattr(ca_value.value, 'content_id')):
-                if ca_value.value.content_id == old_content_id:
-                    ca_value.value.content_id = new_content_id
-            elif (hasattr(ca_value, 'content_id') and
-                  ca_value.content_id == old_content_id):
-                ca_value.content_id = new_content_id
+            # Get all content IDs from this customization arg
+            content_ids = ca_value.get_content_ids()
+            if old_content_id in content_ids:
+                # Replace the content ID in the value
+                _replace_content_id_in_value(ca_value.value, old_content_id, new_content_id)
 
         for answer_group in state.interaction.answer_groups:
             if (hasattr(answer_group.outcome, 'feedback') and
@@ -301,6 +299,26 @@ def _replace_content_id_in_state(
                     old_content_id):
                 state.interaction.solution.explanation.content_id = (
                     new_content_id)
+
+
+def _replace_content_id_in_value(
+    value: Any, old_content_id: str, new_content_id: str
+) -> None:
+    """Replace a content ID in a customization arg value.
+
+    Args:
+        value: Any. The value to search and replace in.
+        old_content_id: str. The old content ID to replace.
+        new_content_id: str. The new content ID to use.
+    """
+    if hasattr(value, 'content_id') and value.content_id == old_content_id:
+        value.content_id = new_content_id
+    elif isinstance(value, list):
+        for item in value:
+            _replace_content_id_in_value(item, old_content_id, new_content_id)
+    elif isinstance(value, dict):
+        for item_value in value.values():
+            _replace_content_id_in_value(item_value, old_content_id, new_content_id)
 
 
 class AuditIdentifyExplorationsWithDuplicateContentIdsJob(

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -301,7 +301,9 @@ def _replace_content_id_in_state(
                 state.interaction.solution.explanation.content_id = (
                     new_content_id)
 
-
+    # Here we use type Any because the customization arg value can be of
+    # various types including lists, dicts, or objects with content_id
+    # attributes, and we need to handle all these cases recursively.
 def _replace_content_id_in_value(
     value: Any, old_content_id: str, new_content_id: str
 ) -> None:
@@ -312,9 +314,6 @@ def _replace_content_id_in_value(
         old_content_id: str. The old content ID to replace.
         new_content_id: str. The new content ID to use.
     """
-    # Here we use type Any because the customization arg value can be of
-    # various types including lists, dicts, or objects with content_id
-    # attributes, and we need to handle all these cases recursively.
     if hasattr(value, 'content_id') and value.content_id == old_content_id:
         value.content_id = new_content_id
     elif isinstance(value, list):

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -169,8 +169,9 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
     @staticmethod
     def _check_and_fix_duplicate_content_ids(
         exploration: exp_domain.Exploration
-    ) -> (Dict[str, Union[str, int, List[str], 'exp_models.ExplorationModel']] | 
-          None):
+        ) -> (
+        Dict[str, Union[str, int, List[str], 'exp_models.ExplorationModel']] | None
+    ):
         """Check and fix duplicate content IDs in an exploration.
 
         Args:

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -170,7 +170,8 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
     def _check_and_fix_duplicate_content_ids(
         exploration: exp_domain.Exploration
         ) -> (
-        Dict[str, Union[str, int, List[str], 'exp_models.ExplorationModel']] | None
+        Dict[str, Union[str, int, List[str], 
+                       'exp_models.ExplorationModel']] | None
     ):
         """Check and fix duplicate content IDs in an exploration.
 

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -265,11 +265,12 @@ def _replace_content_id_in_state(
 
     if state.interaction:
         for ca_value in state.interaction.customization_args.values():
-            # Get all content IDs from this customization arg
+            # Get all content IDs from this customization arg.
             content_ids = ca_value.get_content_ids()
             if old_content_id in content_ids:
-                # Replace the content ID in the value
-                _replace_content_id_in_value(ca_value.value, old_content_id, new_content_id)
+                # Replace the content ID in the value.
+                _replace_content_id_in_value(
+                    ca_value.value, old_content_id, new_content_id)
 
         for answer_group in state.interaction.answer_groups:
             if (hasattr(answer_group.outcome, 'feedback') and
@@ -311,6 +312,9 @@ def _replace_content_id_in_value(
         old_content_id: str. The old content ID to replace.
         new_content_id: str. The new content ID to use.
     """
+    # Here we use type Any because the customization arg value can be of
+    # various types including lists, dicts, or objects with content_id
+    # attributes, and we need to handle all these cases recursively.
     if hasattr(value, 'content_id') and value.content_id == old_content_id:
         value.content_id = new_content_id
     elif isinstance(value, list):
@@ -318,7 +322,8 @@ def _replace_content_id_in_value(
             _replace_content_id_in_value(item, old_content_id, new_content_id)
     elif isinstance(value, dict):
         for item_value in value.values():
-            _replace_content_id_in_value(item_value, old_content_id, new_content_id)
+            _replace_content_id_in_value(
+                item_value, old_content_id, new_content_id)
 
 
 class AuditIdentifyExplorationsWithDuplicateContentIdsJob(

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -82,7 +82,7 @@ class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
                 to check.
 
         Returns:
-            Dict containing exploration info and duplicates if found,
+            dict|None. Dict containing exploration info and duplicates if found,
             None otherwise.
         """
         all_content_ids: List[str] = []
@@ -176,8 +176,8 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
                 to check and fix.
 
         Returns:
-            Dict containing fix results if duplicates were found and fixed,
-            None otherwise.
+            dict|None. Dict containing fix results if duplicates were found and
+            fixed, None otherwise.
         """
         all_content_ids: List[str] = []
         state_to_content_ids: Dict[str, List[str]] = {}
@@ -212,7 +212,7 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
                 if duplicate_id in content_ids
             ]
 
-            # Keep the first occurrence, regenerate others
+            # Keep the first occurrence, regenerate others.
             for state_name in states_with_duplicate[1:]:
                 state = exploration.states[state_name]
 
@@ -312,4 +312,4 @@ class AuditFixExplorationsWithDuplicateContentIdsJob(
 ):
     """Audit job for FixExplorationsWithDuplicateContentIdsJob."""
 
-    DATASTORE_UPDATES_ALLOWED = False 
+    DATASTORE_UPDATES_ALLOWED = False

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -170,7 +170,7 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
     def _check_and_fix_duplicate_content_ids(
         exploration: exp_domain.Exploration
         ) -> (
-        Dict[str, Union[str, int, List[str], 
+        Dict[str, Union[str, int, List[str],
                        'exp_models.ExplorationModel']] | None
     ):
         """Check and fix duplicate content IDs in an exploration.

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 
 from core.domain import exp_domain
 from core.domain import exp_fetchers
+from core.domain import state_domain
 from core.jobs import base_jobs
 from core.jobs.io import ndb_io
 from core.jobs.types import job_run_result
 from core.platform import models
 
 import apache_beam as beam
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Union
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -74,7 +75,7 @@ class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
     @staticmethod
     def _check_for_duplicate_content_ids(
         exploration: exp_domain.Exploration
-    ) -> Dict[str, str] | None:
+    ) -> Dict[str, Union[str, int, Dict[str, List[str]]]] | None:
         """Check if an exploration has duplicate content IDs.
 
         Args:
@@ -168,7 +169,7 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
     @staticmethod
     def _check_and_fix_duplicate_content_ids(
         exploration: exp_domain.Exploration
-    ) -> Dict[str, str] | None:
+    ) -> Dict[str, Union[str, int, List[str], 'exp_models.ExplorationModel']] | None:
         """Check and fix duplicate content IDs in an exploration.
 
         Args:
@@ -243,7 +244,7 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
 
 
 def _replace_content_id_in_state(
-    state, old_content_id: str, new_content_id: str
+    state: state_domain.State, old_content_id: str, new_content_id: str
 ) -> None:
     """Replace a content ID in a state with a new one.
 

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -1,0 +1,289 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Jobs for identifying and fixing duplicate content IDs in explorations."""
+
+from __future__ import annotations
+
+import logging
+
+from core.domain import exp_domain
+from core.domain import exp_fetchers
+from core.domain import exp_services
+from core.jobs import base_jobs
+from core.jobs.io import ndb_io
+from core.jobs.transforms import job_result_transforms
+from core.jobs.types import job_run_result
+from core.platform import models
+
+import apache_beam as beam
+from typing import Dict, List, Set, Tuple
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import datastore_services
+    from mypy_imports import exp_models
+
+(exp_models,) = models.Registry.import_models([models.Names.EXPLORATION])
+datastore_services = models.Registry.import_datastore_services()
+
+
+class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
+    """Job that identifies explorations with duplicate content IDs."""
+
+    def run(self) -> beam.PCollection[job_run_result.JobRunResult]:
+        """Identifies explorations with duplicate content IDs.
+
+        Returns:
+            PCollection. A PCollection of 'SUCCESS' or 'FAILURE' results from
+            identifying explorations with duplicate content IDs.
+        """
+        
+        explorations_with_duplicates = (
+            self.pipeline
+            | 'Get all exploration models' >> ndb_io.GetModels(
+                exp_models.ExplorationModel.get_all(include_deleted=False))
+            | 'Transform to exploration domain objects' >> beam.Map(
+                exp_fetchers.get_exploration_from_model)
+            | 'Check for duplicate content IDs' >> beam.Map(
+                self._check_for_duplicate_content_ids)
+            | 'Filter explorations with duplicates' >> beam.Filter(
+                lambda result: result is not None)
+        )
+
+        return (
+            explorations_with_duplicates
+            | 'Create job run results' >> beam.Map(
+                lambda result: job_run_result.JobRunResult.as_stdout(
+                    f'Exploration {result["exp_id"]} (version {result["version"]}) '
+                    f'has duplicate content IDs: {result["duplicates"]}'
+                )
+            )
+        )
+
+    @staticmethod
+    def _check_for_duplicate_content_ids(
+        exploration: exp_domain.Exploration
+    ) -> Dict[str, str] | None:
+        """Check if an exploration has duplicate content IDs.
+
+        Args:
+            exploration: The exploration domain object to check.
+
+        Returns:
+            Dict containing exploration info and duplicates if found, None otherwise.
+        """
+        all_content_ids: List[str] = []
+        state_to_content_ids: Dict[str, List[str]] = {}
+
+        for state_name, state in exploration.states.items():
+            state_content_ids = state.get_translatable_content_ids()
+            all_content_ids.extend(state_content_ids)
+            state_to_content_ids[state_name] = state_content_ids
+
+        seen_content_ids: Set[str] = set()
+        duplicate_content_ids: Set[str] = set()
+
+        for content_id in all_content_ids:
+            if content_id in seen_content_ids:
+                duplicate_content_ids.add(content_id)
+            else:
+                seen_content_ids.add(content_id)
+
+        if duplicate_content_ids:
+            duplicate_details = {}
+            for duplicate_id in duplicate_content_ids:
+                states_with_duplicate = [
+                    state_name for state_name, content_ids in state_to_content_ids.items()
+                    if duplicate_id in content_ids
+                ]
+                duplicate_details[duplicate_id] = states_with_duplicate
+
+            return {
+                'exp_id': exploration.id,
+                'version': exploration.version,
+                'duplicates': duplicate_details
+            }
+
+        return None
+
+
+class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
+    """Job that fixes explorations with duplicate content IDs by regenerating them."""
+
+    DATASTORE_UPDATES_ALLOWED = True
+
+    def run(self) -> beam.PCollection[job_run_result.JobRunResult]:
+        """Fixes explorations with duplicate content IDs.
+
+        Returns:
+            PCollection. A PCollection of 'SUCCESS' or 'FAILURE' results from
+            fixing explorations with duplicate content IDs.
+        """
+        
+        explorations_to_fix = (
+            self.pipeline
+            | 'Get all exploration models' >> ndb_io.GetModels(
+                exp_models.ExplorationModel.get_all(include_deleted=False))
+            | 'Transform to exploration domain objects' >> beam.Map(
+                exp_fetchers.get_exploration_from_model)
+            | 'Check for duplicate content IDs' >> beam.Map(
+                self._check_and_fix_duplicate_content_ids)
+            | 'Filter fixed explorations' >> beam.Filter(
+                lambda result: result is not None)
+        )
+
+        if self.DATASTORE_UPDATES_ALLOWED:
+            unused_put_results = (
+                explorations_to_fix
+                | 'Extract fixed exploration models' >> beam.Map(
+                    lambda result: result['fixed_model'])
+                | 'Put fixed models' >> ndb_io.PutModels()
+            )
+
+        return (
+            explorations_to_fix
+            | 'Create job run results' >> beam.Map(
+                lambda result: job_run_result.JobRunResult.as_stdout(
+                    f'Fixed exploration {result["exp_id"]} (version {result["version"]}) '
+                    f'- regenerated content IDs: {result["fixed_content_ids"]}'
+                )
+            )
+        )
+
+    @staticmethod
+    def _check_and_fix_duplicate_content_ids(
+        exploration: exp_domain.Exploration
+    ) -> Dict[str, str] | None:
+        """Check and fix duplicate content IDs in an exploration.
+
+        Args:
+            exploration: The exploration domain object to check and fix.
+
+        Returns:
+            Dict containing fix results if duplicates were found and fixed, None otherwise.
+        """
+        all_content_ids: List[str] = []
+        state_to_content_ids: Dict[str, List[str]] = {}
+
+        for state_name, state in exploration.states.items():
+            state_content_ids = state.get_translatable_content_ids()
+            all_content_ids.extend(state_content_ids)
+            state_to_content_ids[state_name] = state_content_ids
+
+        seen_content_ids: Set[str] = set()
+        duplicate_content_ids: Set[str] = set()
+
+        for content_id in all_content_ids:
+            if content_id in seen_content_ids:
+                duplicate_content_ids.add(content_id)
+            else:
+                seen_content_ids.add(content_id)
+
+        if not duplicate_content_ids:
+            return None
+
+        from core.domain import translation_domain
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index)
+
+        fixed_content_ids = []
+
+        for duplicate_id in duplicate_content_ids:
+            states_with_duplicate = [
+                state_name for state_name, content_ids in state_to_content_ids.items()
+                if duplicate_id in content_ids
+            ]
+
+            # Keep the first occurrence, regenerate others
+            for i, state_name in enumerate(states_with_duplicate[1:], 1):
+                state = exploration.states[state_name]
+                
+                new_content_id = content_id_generator.generate(
+                    translation_domain.ContentType.CONTENT)
+                
+                _replace_content_id_in_state(state, duplicate_id, new_content_id)
+                fixed_content_ids.append(f'{duplicate_id} -> {new_content_id} in {state_name}')
+
+        exploration.next_content_id_index = content_id_generator.next_content_id_index
+
+        with datastore_services.get_ndb_context():
+            updated_model = exp_models.ExplorationModel.get(exploration.id)
+            updated_model.states = exploration.to_dict()['states']
+            updated_model.next_content_id_index = exploration.next_content_id_index
+            updated_model.version += 1
+
+            return {
+                'exp_id': exploration.id,
+                'version': exploration.version,
+                'fixed_content_ids': fixed_content_ids,
+                'fixed_model': updated_model
+            }
+
+
+def _replace_content_id_in_state(state, old_content_id: str, new_content_id: str) -> None:
+    """Replace a content ID in a state with a new one.
+    
+    This is a helper function that updates content IDs throughout a state object.
+    """
+    if hasattr(state.content, 'content_id') and state.content.content_id == old_content_id:
+        state.content.content_id = new_content_id
+
+    if state.interaction:
+        for ca_name, ca_value in state.interaction.customization_args.items():
+            if hasattr(ca_value, 'value') and hasattr(ca_value.value, 'content_id'):
+                if ca_value.value.content_id == old_content_id:
+                    ca_value.value.content_id = new_content_id
+            elif hasattr(ca_value, 'content_id') and ca_value.content_id == old_content_id:
+                ca_value.content_id = new_content_id
+
+        for answer_group in state.interaction.answer_groups:
+            if hasattr(answer_group.outcome, 'feedback') and hasattr(answer_group.outcome.feedback, 'content_id'):
+                if answer_group.outcome.feedback.content_id == old_content_id:
+                    answer_group.outcome.feedback.content_id = new_content_id
+
+        if (state.interaction.default_outcome and 
+            hasattr(state.interaction.default_outcome, 'feedback') and 
+            hasattr(state.interaction.default_outcome.feedback, 'content_id')):
+            if state.interaction.default_outcome.feedback.content_id == old_content_id:
+                state.interaction.default_outcome.feedback.content_id = new_content_id
+
+        for hint in state.interaction.hints:
+            if hasattr(hint, 'hint_content') and hasattr(hint.hint_content, 'content_id'):
+                if hint.hint_content.content_id == old_content_id:
+                    hint.hint_content.content_id = new_content_id
+
+        if (state.interaction.solution and 
+            hasattr(state.interaction.solution, 'explanation') and 
+            hasattr(state.interaction.solution.explanation, 'content_id')):
+            if state.interaction.solution.explanation.content_id == old_content_id:
+                state.interaction.solution.explanation.content_id = new_content_id
+
+
+class AuditIdentifyExplorationsWithDuplicateContentIdsJob(
+    IdentifyExplorationsWithDuplicateContentIdsJob
+):
+    """Audit job for IdentifyExplorationsWithDuplicateContentIdsJob."""
+
+    DATASTORE_UPDATES_ALLOWED = False
+
+
+class AuditFixExplorationsWithDuplicateContentIdsJob(
+    FixExplorationsWithDuplicateContentIdsJob
+):
+    """Audit job for FixExplorationsWithDuplicateContentIdsJob."""
+
+    DATASTORE_UPDATES_ALLOWED = False 

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -18,22 +18,18 @@
 
 from __future__ import annotations
 
-import logging
-
 from core.domain import exp_domain
 from core.domain import exp_fetchers
-from core.domain import exp_services
 from core.jobs import base_jobs
 from core.jobs.io import ndb_io
-from core.jobs.transforms import job_result_transforms
 from core.jobs.types import job_run_result
 from core.platform import models
 
 import apache_beam as beam
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set
 
 MYPY = False
-if MYPY: # pragma: no cover
+if MYPY:  # pragma: no cover
     from mypy_imports import datastore_services
     from mypy_imports import exp_models
 
@@ -51,7 +47,7 @@ class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
             PCollection. A PCollection of 'SUCCESS' or 'FAILURE' results from
             identifying explorations with duplicate content IDs.
         """
-        
+
         explorations_with_duplicates = (
             self.pipeline
             | 'Get all exploration models' >> ndb_io.GetModels(
@@ -68,7 +64,8 @@ class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
             explorations_with_duplicates
             | 'Create job run results' >> beam.Map(
                 lambda result: job_run_result.JobRunResult.as_stdout(
-                    f'Exploration {result["exp_id"]} (version {result["version"]}) '
+                    f'Exploration {result["exp_id"]} '
+                    f'(version {result["version"]}) '
                     f'has duplicate content IDs: {result["duplicates"]}'
                 )
             )
@@ -81,10 +78,12 @@ class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
         """Check if an exploration has duplicate content IDs.
 
         Args:
-            exploration: The exploration domain object to check.
+            exploration: exp_domain.Exploration. The exploration domain object
+                to check.
 
         Returns:
-            Dict containing exploration info and duplicates if found, None otherwise.
+            Dict containing exploration info and duplicates if found,
+            None otherwise.
         """
         all_content_ids: List[str] = []
         state_to_content_ids: Dict[str, List[str]] = {}
@@ -107,7 +106,8 @@ class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
             duplicate_details = {}
             for duplicate_id in duplicate_content_ids:
                 states_with_duplicate = [
-                    state_name for state_name, content_ids in state_to_content_ids.items()
+                    state_name for state_name, content_ids in
+                    state_to_content_ids.items()
                     if duplicate_id in content_ids
                 ]
                 duplicate_details[duplicate_id] = states_with_duplicate
@@ -122,7 +122,7 @@ class IdentifyExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
 
 
 class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
-    """Job that fixes explorations with duplicate content IDs by regenerating them."""
+    """Job that fixes explorations with duplicate content IDs."""
 
     DATASTORE_UPDATES_ALLOWED = True
 
@@ -133,7 +133,7 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
             PCollection. A PCollection of 'SUCCESS' or 'FAILURE' results from
             fixing explorations with duplicate content IDs.
         """
-        
+
         explorations_to_fix = (
             self.pipeline
             | 'Get all exploration models' >> ndb_io.GetModels(
@@ -158,8 +158,9 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
             explorations_to_fix
             | 'Create job run results' >> beam.Map(
                 lambda result: job_run_result.JobRunResult.as_stdout(
-                    f'Fixed exploration {result["exp_id"]} (version {result["version"]}) '
-                    f'- regenerated content IDs: {result["fixed_content_ids"]}'
+                    f'Fixed exploration {result["exp_id"]} '
+                    f'(version {result["version"]}) - '
+                    f'regenerated content IDs: {result["fixed_content_ids"]}'
                 )
             )
         )
@@ -171,10 +172,12 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
         """Check and fix duplicate content IDs in an exploration.
 
         Args:
-            exploration: The exploration domain object to check and fix.
+            exploration: exp_domain.Exploration. The exploration domain object
+                to check and fix.
 
         Returns:
-            Dict containing fix results if duplicates were found and fixed, None otherwise.
+            Dict containing fix results if duplicates were found and fixed,
+            None otherwise.
         """
         all_content_ids: List[str] = []
         state_to_content_ids: Dict[str, List[str]] = {}
@@ -204,26 +207,31 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
 
         for duplicate_id in duplicate_content_ids:
             states_with_duplicate = [
-                state_name for state_name, content_ids in state_to_content_ids.items()
+                state_name for state_name, content_ids in
+                state_to_content_ids.items()
                 if duplicate_id in content_ids
             ]
 
             # Keep the first occurrence, regenerate others
-            for i, state_name in enumerate(states_with_duplicate[1:], 1):
+            for state_name in states_with_duplicate[1:]:
                 state = exploration.states[state_name]
-                
+
                 new_content_id = content_id_generator.generate(
                     translation_domain.ContentType.CONTENT)
-                
-                _replace_content_id_in_state(state, duplicate_id, new_content_id)
-                fixed_content_ids.append(f'{duplicate_id} -> {new_content_id} in {state_name}')
 
-        exploration.next_content_id_index = content_id_generator.next_content_id_index
+                _replace_content_id_in_state(
+                    state, duplicate_id, new_content_id)
+                fixed_content_ids.append(
+                    f'{duplicate_id} -> {new_content_id} in {state_name}')
+
+        exploration.next_content_id_index = (
+            content_id_generator.next_content_id_index)
 
         with datastore_services.get_ndb_context():
             updated_model = exp_models.ExplorationModel.get(exploration.id)
             updated_model.states = exploration.to_dict()['states']
-            updated_model.next_content_id_index = exploration.next_content_id_index
+            updated_model.next_content_id_index = (
+                exploration.next_content_id_index)
             updated_model.version += 1
 
             return {
@@ -234,43 +242,61 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
             }
 
 
-def _replace_content_id_in_state(state, old_content_id: str, new_content_id: str) -> None:
+def _replace_content_id_in_state(
+    state, old_content_id: str, new_content_id: str
+) -> None:
     """Replace a content ID in a state with a new one.
-    
-    This is a helper function that updates content IDs throughout a state object.
+
+    This is a helper function that updates content IDs throughout a state
+    object.
+
+    Args:
+        state: State. The state object to update.
+        old_content_id: str. The old content ID to replace.
+        new_content_id: str. The new content ID to use.
     """
-    if hasattr(state.content, 'content_id') and state.content.content_id == old_content_id:
+    if (hasattr(state.content, 'content_id') and
+            state.content.content_id == old_content_id):
         state.content.content_id = new_content_id
 
     if state.interaction:
-        for ca_name, ca_value in state.interaction.customization_args.items():
-            if hasattr(ca_value, 'value') and hasattr(ca_value.value, 'content_id'):
+        for ca_value in state.interaction.customization_args.values():
+            if (hasattr(ca_value, 'value') and
+                    hasattr(ca_value.value, 'content_id')):
                 if ca_value.value.content_id == old_content_id:
                     ca_value.value.content_id = new_content_id
-            elif hasattr(ca_value, 'content_id') and ca_value.content_id == old_content_id:
+            elif (hasattr(ca_value, 'content_id') and
+                  ca_value.content_id == old_content_id):
                 ca_value.content_id = new_content_id
 
         for answer_group in state.interaction.answer_groups:
-            if hasattr(answer_group.outcome, 'feedback') and hasattr(answer_group.outcome.feedback, 'content_id'):
+            if (hasattr(answer_group.outcome, 'feedback') and
+                    hasattr(answer_group.outcome.feedback, 'content_id')):
                 if answer_group.outcome.feedback.content_id == old_content_id:
                     answer_group.outcome.feedback.content_id = new_content_id
 
-        if (state.interaction.default_outcome and 
-            hasattr(state.interaction.default_outcome, 'feedback') and 
-            hasattr(state.interaction.default_outcome.feedback, 'content_id')):
-            if state.interaction.default_outcome.feedback.content_id == old_content_id:
-                state.interaction.default_outcome.feedback.content_id = new_content_id
+        if (state.interaction.default_outcome and
+                hasattr(state.interaction.default_outcome, 'feedback') and
+                hasattr(state.interaction.default_outcome.feedback,
+                        'content_id')):
+            if (state.interaction.default_outcome.feedback.content_id ==
+                    old_content_id):
+                state.interaction.default_outcome.feedback.content_id = (
+                    new_content_id)
 
         for hint in state.interaction.hints:
-            if hasattr(hint, 'hint_content') and hasattr(hint.hint_content, 'content_id'):
+            if (hasattr(hint, 'hint_content') and
+                    hasattr(hint.hint_content, 'content_id')):
                 if hint.hint_content.content_id == old_content_id:
                     hint.hint_content.content_id = new_content_id
 
-        if (state.interaction.solution and 
-            hasattr(state.interaction.solution, 'explanation') and 
-            hasattr(state.interaction.solution.explanation, 'content_id')):
-            if state.interaction.solution.explanation.content_id == old_content_id:
-                state.interaction.solution.explanation.content_id = new_content_id
+        if (state.interaction.solution and
+                hasattr(state.interaction.solution, 'explanation') and
+                hasattr(state.interaction.solution.explanation, 'content_id')):
+            if (state.interaction.solution.explanation.content_id ==
+                    old_content_id):
+                state.interaction.solution.explanation.content_id = (
+                    new_content_id)
 
 
 class AuditIdentifyExplorationsWithDuplicateContentIdsJob(

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs.py
@@ -169,7 +169,8 @@ class FixExplorationsWithDuplicateContentIdsJob(base_jobs.JobBase):
     @staticmethod
     def _check_and_fix_duplicate_content_ids(
         exploration: exp_domain.Exploration
-    ) -> Dict[str, Union[str, int, List[str], 'exp_models.ExplorationModel']] | None:
+    ) -> (Dict[str, Union[str, int, List[str], 'exp_models.ExplorationModel']] | 
+          None):
         """Check and fix duplicate content IDs in an exploration.
 
         Args:

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -26,13 +26,10 @@ from core.jobs import job_test_utils
 from core.jobs.batch_jobs import fix_duplicate_content_ids_jobs
 from core.jobs.types import job_run_result
 from core.platform import models
-from core.tests import test_utils
-
-import apache_beam as beam
 
 MYPY = False
 if MYPY:  # pragma: no cover
-    from mypy_imports import datastore_services
+    pass
 
 (exp_models,) = models.Registry.import_models([models.Names.EXPLORATION])
 datastore_services = models.Registry.import_datastore_services()
@@ -49,8 +46,8 @@ class IdentifyExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_identify_job_with_no_duplicates(self) -> None:
-        """Test that the job finds no duplicates when there are none.
-        """
+        """Test that the job finds no duplicates when there are none."""
+        
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
         exp_services.save_new_exploration('owner_id', exploration)
@@ -99,8 +96,8 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_fix_job_with_no_duplicates(self) -> None:
-        """Test that the job does nothing when there are no duplicates.
-        """
+        """Test that the job does nothing when there are no duplicates."""
+        
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
         exp_services.save_new_exploration('owner_id', exploration)
@@ -141,7 +138,6 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
         state1_updated = updated_exploration.states['Introduction']
         state2_updated = updated_exploration.states['State2']
 
-
         self.assertEqual(state1_updated.content.content_id, 'content_0')
         self.assertEqual(state2_updated.content.content_id, 'content_2')
 
@@ -157,8 +153,8 @@ class AuditIdentifyExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_audit_identify_job_with_duplicates(self) -> None:
-        """Test that the audit job correctly identifies duplicates.
-        """
+        """Test that the audit job correctly identifies duplicates."""
+
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
 
@@ -197,8 +193,8 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_audit_fix_job_with_duplicates(self) -> None:
-        """Test that the audit fix job shows what would be fixed.
-        """
+        """Test that the audit fix job shows what would be fixed."""
+
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
 

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -47,7 +47,7 @@ class IdentifyExplorationsWithDuplicateContentIdsJobTests(
 
     def test_identify_job_with_no_duplicates(self) -> None:
         """Test that the job finds no duplicates when there are none."""
-        
+
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
         exp_services.save_new_exploration('owner_id', exploration)
@@ -97,7 +97,7 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
 
     def test_fix_job_with_no_duplicates(self) -> None:
         """Test that the job does nothing when there are no duplicates."""
-        
+
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
         exp_services.save_new_exploration('owner_id', exploration)

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -49,7 +49,8 @@ class IdentifyExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_identify_job_with_no_duplicates(self) -> None:
-        """Test that the job finds no duplicates when there are none."""
+        """Test that the job finds no duplicates when there are none.
+        """
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
         exp_services.save_new_exploration('owner_id', exploration)
@@ -58,7 +59,8 @@ class IdentifyExplorationsWithDuplicateContentIdsJobTests(
 
     def test_identify_job_with_duplicates(self) -> None:
         """Test that the job correctly identifies explorations with
-        duplicate content IDs."""
+        duplicate content IDs.
+        """
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
 
@@ -69,8 +71,6 @@ class IdentifyExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        # Create duplicate content IDs by setting the same content_id
-        # for both states
         duplicate_content_id = 'content_0'
         state1.content.content_id = duplicate_content_id
         state2.content.content_id = duplicate_content_id
@@ -83,7 +83,7 @@ class IdentifyExplorationsWithDuplicateContentIdsJobTests(
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
                 'Exploration exp_id (version 1) has duplicate content IDs: '
-                "{'content_0': ['Introduction', 'State2']}"
+                '{\'content_0\': [\'Introduction\', \'State2\']}'
             )
         ])
 
@@ -99,7 +99,8 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_fix_job_with_no_duplicates(self) -> None:
-        """Test that the job does nothing when there are no duplicates."""
+        """Test that the job does nothing when there are no duplicates.
+        """
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
         exp_services.save_new_exploration('owner_id', exploration)
@@ -108,7 +109,8 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
 
     def test_fix_job_with_duplicates(self) -> None:
         """Test that the job correctly fixes explorations with duplicate
-        content IDs."""
+        content IDs.
+        """
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
 
@@ -119,7 +121,6 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        # Create duplicate content IDs
         duplicate_content_id = 'content_0'
         state1.content.content_id = duplicate_content_id
         state2.content.content_id = duplicate_content_id
@@ -136,14 +137,12 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
             )
         ])
 
-        # Verify the fix was applied
         updated_exploration = exp_fetchers.get_exploration_by_id('exp_id')
         state1_updated = updated_exploration.states['Introduction']
         state2_updated = updated_exploration.states['State2']
 
-        # State1 should keep the original content_id
+
         self.assertEqual(state1_updated.content.content_id, 'content_0')
-        # State2 should have a new content_id
         self.assertEqual(state2_updated.content.content_id, 'content_2')
 
 
@@ -158,7 +157,8 @@ class AuditIdentifyExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_audit_identify_job_with_duplicates(self) -> None:
-        """Test that the audit job correctly identifies duplicates."""
+        """Test that the audit job correctly identifies duplicates.
+        """
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
 
@@ -181,7 +181,7 @@ class AuditIdentifyExplorationsWithDuplicateContentIdsJobTests(
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
                 'Exploration exp_id (version 1) has duplicate content IDs: '
-                "{'content_0': ['Introduction', 'State2']}"
+                '{\'content_0\': [\'Introduction\', \'State2\']}'
             )
         ])
 
@@ -197,7 +197,8 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
     )
 
     def test_audit_fix_job_with_duplicates(self) -> None:
-        """Test that the audit fix job shows what would be fixed."""
+        """Test that the audit fix job shows what would be fixed.
+        """
         exploration = exp_domain.Exploration.create_default_exploration(
             'exp_id', title='Test Exploration', category='Test')
 
@@ -224,11 +225,9 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
             )
         ])
 
-        # Verify that the audit job did NOT actually fix anything
         updated_exploration = exp_fetchers.get_exploration_by_id('exp_id')
         state1_updated = updated_exploration.states['Introduction']
         state2_updated = updated_exploration.states['State2']
 
-        # Both states should still have the duplicate content_id
         self.assertEqual(state1_updated.content.content_id, 'content_0')
-        self.assertEqual(state2_updated.content.content_id, 'content_0') 
+        self.assertEqual(state2_updated.content.content_id, 'content_0')

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -128,7 +128,7 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
         exp_services.save_new_exploration('owner_id', exploration)
 
         original_content_id = state1.content.content_id
-       
+
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
                 f'Fixed exploration exp_id (version 1) - regenerated content '
@@ -209,7 +209,7 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
 
         state1.content.content_id = content_id_generator.generate(
             translation_domain.ContentType.CONTENT)
-        state2.content.content_id = state1.content.content_id  # Create duplicate
+        state2.content.content_id = state1.content.content_id
 
         exploration.next_content_id_index = (
             content_id_generator.next_content_id_index)
@@ -217,7 +217,7 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
         exp_services.save_new_exploration('owner_id', exploration)
 
         original_content_id = state1.content.content_id
-        
+
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
                 f'Fixed exploration exp_id (version 1) - regenerated content '

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -1,0 +1,268 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for fix_duplicate_content_ids_jobs."""
+
+from __future__ import annotations
+
+from core.domain import exp_domain
+from core.domain import exp_services
+from core.domain import rights_manager
+from core.domain import state_domain
+from core.domain import user_services
+from core.jobs import job_test_utils
+from core.jobs.batch_jobs import fix_duplicate_content_ids_jobs
+from core.jobs.types import job_run_result
+from core.platform import models
+from core.tests import test_utils
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import exp_models
+
+(exp_models,) = models.Registry.import_models([models.Names.EXPLORATION])
+
+
+class IdentifyExplorationsWithDuplicateContentIdsJobTests(
+    job_test_utils.PipelinedTestBase
+):
+    """Tests for IdentifyExplorationsWithDuplicateContentIdsJob."""
+
+    JOB_CLASS = fix_duplicate_content_ids_jobs.IdentifyExplorationsWithDuplicateContentIdsJob
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
+        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+
+    def test_empty_storage(self) -> None:
+        self.assert_job_output_is_empty()
+
+    def test_exploration_without_duplicates(self) -> None:
+        """Test that explorations without duplicates are not flagged."""
+        # Create exploration with unique content IDs
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id1', title='Test Exploration', category='Algebra')
+        
+        # Modify states to have unique content IDs
+        exploration.states['Introduction'].content.content_id = 'content_1'
+        exploration.states['Introduction'].interaction.default_outcome.feedback.content_id = 'default_outcome_1'
+        
+        exp_services.save_new_exploration(self.owner_id, exploration)
+        
+        self.assert_job_output_is_empty()
+
+    def test_exploration_with_duplicates(self) -> None:
+        """Test that explorations with duplicate content IDs are identified."""
+        # Create exploration with duplicate content IDs
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id2', title='Test Exploration', category='Algebra')
+        
+        # Create a second state
+        exploration.add_states(['State2'])
+        
+        # Set duplicate content IDs
+        duplicate_content_id = 'solution_137'
+        exploration.states['Introduction'].content.content_id = duplicate_content_id
+        exploration.states['State2'].content.content_id = duplicate_content_id
+        
+        exp_services.save_new_exploration(self.owner_id, exploration)
+        
+        self.assert_job_output_is([
+            job_run_result.JobRunResult.as_stdout(
+                'Exploration exp_id2 (version 1) has duplicate content IDs: '
+                '{\'solution_137\': [\'Introduction\', \'State2\']}'
+            )
+        ])
+
+    def test_multiple_explorations_with_duplicates(self) -> None:
+        """Test multiple explorations with different duplicate patterns."""
+        # First exploration with duplicates
+        exploration1 = exp_domain.Exploration.create_default_exploration(
+            'exp_id3', title='Test Exploration 1', category='Algebra')
+        exploration1.add_states(['State2'])
+        
+        duplicate_id1 = 'solution_139'
+        exploration1.states['Introduction'].content.content_id = duplicate_id1
+        exploration1.states['State2'].content.content_id = duplicate_id1
+        
+        exp_services.save_new_exploration(self.owner_id, exploration1)
+        
+        # Second exploration with different duplicates
+        exploration2 = exp_domain.Exploration.create_default_exploration(
+            'exp_id4', title='Test Exploration 2', category='Algebra')
+        exploration2.add_states(['State2', 'State3'])
+        
+        duplicate_id2 = 'hint_140'
+        exploration2.states['Introduction'].content.content_id = duplicate_id2
+        exploration2.states['State2'].content.content_id = duplicate_id2
+        exploration2.states['State3'].content.content_id = duplicate_id2
+        
+        exp_services.save_new_exploration(self.owner_id, exploration2)
+        
+        expected_outputs = [
+            job_run_result.JobRunResult.as_stdout(
+                'Exploration exp_id3 (version 1) has duplicate content IDs: '
+                '{\'solution_139\': [\'Introduction\', \'State2\']}'
+            ),
+            job_run_result.JobRunResult.as_stdout(
+                'Exploration exp_id4 (version 1) has duplicate content IDs: '
+                '{\'hint_140\': [\'Introduction\', \'State2\', \'State3\']}'
+            )
+        ]
+        
+        self.assert_job_output_is(expected_outputs)
+
+
+class FixExplorationsWithDuplicateContentIdsJobTests(
+    job_test_utils.PipelinedTestBase
+):
+    """Tests for FixExplorationsWithDuplicateContentIdsJob."""
+
+    JOB_CLASS = fix_duplicate_content_ids_jobs.FixExplorationsWithDuplicateContentIdsJob
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
+        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+
+    def test_empty_storage(self) -> None:
+        self.assert_job_output_is_empty()
+
+    def test_exploration_without_duplicates_not_modified(self) -> None:
+        """Test that explorations without duplicates are not modified."""
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id5', title='Test Exploration', category='Algebra')
+        
+        # Set unique content IDs
+        exploration.states['Introduction'].content.content_id = 'content_1'
+        exploration.states['Introduction'].interaction.default_outcome.feedback.content_id = 'default_outcome_1'
+        
+        exp_services.save_new_exploration(self.owner_id, exploration)
+        
+        self.assert_job_output_is_empty()
+
+    def test_exploration_with_duplicates_gets_fixed(self) -> None:
+        """Test that explorations with duplicate content IDs get fixed."""
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id6', title='Test Exploration', category='Algebra')
+        
+        # Create additional states
+        exploration.add_states(['State2'])
+        
+        # Set duplicate content IDs
+        duplicate_content_id = 'solution_137'
+        exploration.states['Introduction'].content.content_id = duplicate_content_id
+        exploration.states['State2'].content.content_id = duplicate_content_id
+        
+        # Set next_content_id_index to a known value
+        exploration.next_content_id_index = 10
+        
+        exp_services.save_new_exploration(self.owner_id, exploration)
+        
+        # Run the job
+        self.run_job()
+        
+        # Verify the exploration was fixed
+        updated_exploration = exp_services.get_exploration_by_id('exp_id6')
+        
+        # Check that content IDs are now unique
+        intro_content_id = updated_exploration.states['Introduction'].content.content_id
+        state2_content_id = updated_exploration.states['State2'].content.content_id
+        
+        self.assertNotEqual(intro_content_id, state2_content_id)
+        
+        # The first occurrence should keep the original ID
+        self.assertEqual(intro_content_id, duplicate_content_id)
+        
+        # The second occurrence should have a new ID
+        self.assertNotEqual(state2_content_id, duplicate_content_id)
+        
+        # The next_content_id_index should be updated
+        self.assertGreater(updated_exploration.next_content_id_index, 10)
+
+    def test_multiple_duplicates_in_single_exploration(self) -> None:
+        """Test fixing multiple different duplicate content IDs in one exploration."""
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id7', title='Test Exploration', category='Algebra')
+        
+        # Create multiple states
+        exploration.add_states(['State2', 'State3', 'State4'])
+        
+        # Set multiple duplicate content IDs
+        duplicate_id1 = 'solution_137'
+        duplicate_id2 = 'hint_140'
+        
+        exploration.states['Introduction'].content.content_id = duplicate_id1
+        exploration.states['State2'].content.content_id = duplicate_id1
+        exploration.states['State3'].content.content_id = duplicate_id2
+        exploration.states['State4'].content.content_id = duplicate_id2
+        
+        exploration.next_content_id_index = 15
+        
+        exp_services.save_new_exploration(self.owner_id, exploration)
+        
+        # Run the job
+        self.run_job()
+        
+        # Verify the exploration was fixed
+        updated_exploration = exp_services.get_exploration_by_id('exp_id7')
+        
+        # Collect all content IDs
+        all_content_ids = []
+        for state in updated_exploration.states.values():
+            all_content_ids.extend(state.get_translatable_content_ids())
+        
+        # Check that all content IDs are now unique
+        self.assertEqual(len(all_content_ids), len(set(all_content_ids)))
+        
+        # Check that first occurrences keep original IDs
+        self.assertEqual(
+            updated_exploration.states['Introduction'].content.content_id, 
+            duplicate_id1
+        )
+        self.assertEqual(
+            updated_exploration.states['State3'].content.content_id, 
+            duplicate_id2
+        )
+        
+        # Check that duplicate occurrences got new IDs
+        self.assertNotEqual(
+            updated_exploration.states['State2'].content.content_id, 
+            duplicate_id1
+        )
+        self.assertNotEqual(
+            updated_exploration.states['State4'].content.content_id, 
+            duplicate_id2
+        )
+
+
+class AuditJobsTests(job_test_utils.PipelinedTestBase):
+    """Tests for audit versions of the jobs."""
+
+    def test_audit_identify_job_does_not_update_datastore(self) -> None:
+        """Test that the audit identify job does not make datastore updates."""
+        job = fix_duplicate_content_ids_jobs.AuditIdentifyExplorationsWithDuplicateContentIdsJob(
+            self.pipeline
+        )
+        self.assertFalse(job.DATASTORE_UPDATES_ALLOWED)
+
+    def test_audit_fix_job_does_not_update_datastore(self) -> None:
+        """Test that the audit fix job does not make datastore updates."""
+        job = fix_duplicate_content_ids_jobs.AuditFixExplorationsWithDuplicateContentIdsJob(
+            self.pipeline
+        )
+        self.assertFalse(job.DATASTORE_UPDATES_ALLOWED) 

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -118,19 +118,23 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        duplicate_content_id = 'content_0'
-        state1.content.content_id = duplicate_content_id
-        state2.content.content_id = duplicate_content_id
+        # Generate content IDs properly
+        state1.content.content_id = content_id_generator.generate(
+            translation_domain.ContentType.CONTENT)
+        state2.content.content_id = state1.content.content_id  # Create duplicate
 
         exploration.next_content_id_index = (
             content_id_generator.next_content_id_index)
 
         exp_services.save_new_exploration('owner_id', exploration)
 
+        # Get the actual content ID that was generated
+        original_content_id = state1.content.content_id
+        
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
-                'Fixed exploration exp_id (version 1) - regenerated content '
-                'IDs: [\'content_0 -> content_2 in State2\']'
+                f'Fixed exploration exp_id (version 1) - regenerated content '
+                f'IDs: [\'{original_content_id} -> content_2 in State2\']'
             )
         ])
 
@@ -138,7 +142,7 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
         state1_updated = updated_exploration.states['Introduction']
         state2_updated = updated_exploration.states['State2']
 
-        self.assertEqual(state1_updated.content.content_id, 'content_0')
+        self.assertEqual(state1_updated.content.content_id, original_content_id)
         self.assertEqual(state2_updated.content.content_id, 'content_2')
 
 
@@ -165,9 +169,10 @@ class AuditIdentifyExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        duplicate_content_id = 'content_0'
-        state1.content.content_id = duplicate_content_id
-        state2.content.content_id = duplicate_content_id
+        # Generate content IDs properly
+        state1.content.content_id = content_id_generator.generate(
+            translation_domain.ContentType.CONTENT)
+        state2.content.content_id = state1.content.content_id  # Create duplicate
 
         exploration.next_content_id_index = (
             content_id_generator.next_content_id_index)
@@ -205,19 +210,23 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        duplicate_content_id = 'content_0'
-        state1.content.content_id = duplicate_content_id
-        state2.content.content_id = duplicate_content_id
+        # Generate content IDs properly
+        state1.content.content_id = content_id_generator.generate(
+            translation_domain.ContentType.CONTENT)
+        state2.content.content_id = state1.content.content_id  # Create duplicate
 
         exploration.next_content_id_index = (
             content_id_generator.next_content_id_index)
 
         exp_services.save_new_exploration('owner_id', exploration)
 
+        # Get the actual content ID that was generated
+        original_content_id = state1.content.content_id
+        
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
-                'Fixed exploration exp_id (version 1) - regenerated content '
-                'IDs: [\'content_0 -> content_2 in State2\']'
+                f'Fixed exploration exp_id (version 1) - regenerated content '
+                f'IDs: [\'{original_content_id} -> content_2 in State2\']'
             )
         ])
 
@@ -225,5 +234,9 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
         state1_updated = updated_exploration.states['Introduction']
         state2_updated = updated_exploration.states['State2']
 
-        self.assertEqual(state1_updated.content.content_id, 'content_0')
-        self.assertEqual(state2_updated.content.content_id, 'content_0')
+        self.assertEqual(
+            state1_updated.content.content_id, original_content_id
+        )
+        self.assertEqual(
+            state2_updated.content.content_id, original_content_id
+        )

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -118,19 +118,17 @@ class FixExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        # Generate content IDs properly
         state1.content.content_id = content_id_generator.generate(
             translation_domain.ContentType.CONTENT)
-        state2.content.content_id = state1.content.content_id  # Create duplicate
+        state2.content.content_id = state1.content.content_id
 
         exploration.next_content_id_index = (
             content_id_generator.next_content_id_index)
 
         exp_services.save_new_exploration('owner_id', exploration)
 
-        # Get the actual content ID that was generated
         original_content_id = state1.content.content_id
-        
+       
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
                 f'Fixed exploration exp_id (version 1) - regenerated content '
@@ -169,10 +167,9 @@ class AuditIdentifyExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        # Generate content IDs properly
         state1.content.content_id = content_id_generator.generate(
             translation_domain.ContentType.CONTENT)
-        state2.content.content_id = state1.content.content_id  # Create duplicate
+        state2.content.content_id = state1.content.content_id
 
         exploration.next_content_id_index = (
             content_id_generator.next_content_id_index)
@@ -210,7 +207,6 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
         state1 = exploration.states['Introduction']
         state2 = exploration.states['State2']
 
-        # Generate content IDs properly
         state1.content.content_id = content_id_generator.generate(
             translation_domain.ContentType.CONTENT)
         state2.content.content_id = state1.content.content_id  # Create duplicate
@@ -220,7 +216,6 @@ class AuditFixExplorationsWithDuplicateContentIdsJobTests(
 
         exp_services.save_new_exploration('owner_id', exploration)
 
-        # Get the actual content ID that was generated
         original_content_id = state1.content.content_id
         
         self.assert_job_output_is([

--- a/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
+++ b/core/jobs/batch_jobs/fix_duplicate_content_ids_jobs_test.py
@@ -19,250 +19,216 @@
 from __future__ import annotations
 
 from core.domain import exp_domain
+from core.domain import exp_fetchers
 from core.domain import exp_services
-from core.domain import rights_manager
-from core.domain import state_domain
-from core.domain import user_services
+from core.domain import translation_domain
 from core.jobs import job_test_utils
 from core.jobs.batch_jobs import fix_duplicate_content_ids_jobs
 from core.jobs.types import job_run_result
 from core.platform import models
 from core.tests import test_utils
 
+import apache_beam as beam
+
 MYPY = False
-if MYPY: # pragma: no cover
-    from mypy_imports import exp_models
+if MYPY:  # pragma: no cover
+    from mypy_imports import datastore_services
 
 (exp_models,) = models.Registry.import_models([models.Names.EXPLORATION])
+datastore_services = models.Registry.import_datastore_services()
 
 
 class IdentifyExplorationsWithDuplicateContentIdsJobTests(
-    job_test_utils.PipelinedTestBase
+    job_test_utils.JobTestBase
 ):
     """Tests for IdentifyExplorationsWithDuplicateContentIdsJob."""
 
-    JOB_CLASS = fix_duplicate_content_ids_jobs.IdentifyExplorationsWithDuplicateContentIdsJob
+    JOB_CLASS = (
+        fix_duplicate_content_ids_jobs.
+        IdentifyExplorationsWithDuplicateContentIdsJob
+    )
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
-        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+    def test_identify_job_with_no_duplicates(self) -> None:
+        """Test that the job finds no duplicates when there are none."""
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id', title='Test Exploration', category='Test')
+        exp_services.save_new_exploration('owner_id', exploration)
 
-    def test_empty_storage(self) -> None:
         self.assert_job_output_is_empty()
 
-    def test_exploration_without_duplicates(self) -> None:
-        """Test that explorations without duplicates are not flagged."""
-        # Create exploration with unique content IDs
+    def test_identify_job_with_duplicates(self) -> None:
+        """Test that the job correctly identifies explorations with
+        duplicate content IDs."""
         exploration = exp_domain.Exploration.create_default_exploration(
-            'exp_id1', title='Test Exploration', category='Algebra')
-        
-        # Modify states to have unique content IDs
-        exploration.states['Introduction'].content.content_id = 'content_1'
-        exploration.states['Introduction'].interaction.default_outcome.feedback.content_id = 'default_outcome_1'
-        
-        exp_services.save_new_exploration(self.owner_id, exploration)
-        
-        self.assert_job_output_is_empty()
+            'exp_id', title='Test Exploration', category='Test')
 
-    def test_exploration_with_duplicates(self) -> None:
-        """Test that explorations with duplicate content IDs are identified."""
-        # Create exploration with duplicate content IDs
-        exploration = exp_domain.Exploration.create_default_exploration(
-            'exp_id2', title='Test Exploration', category='Algebra')
-        
-        # Create a second state
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index)
+
         exploration.add_states(['State2'])
-        
-        # Set duplicate content IDs
-        duplicate_content_id = 'solution_137'
-        exploration.states['Introduction'].content.content_id = duplicate_content_id
-        exploration.states['State2'].content.content_id = duplicate_content_id
-        
-        exp_services.save_new_exploration(self.owner_id, exploration)
-        
+        state1 = exploration.states['Introduction']
+        state2 = exploration.states['State2']
+
+        # Create duplicate content IDs by setting the same content_id
+        # for both states
+        duplicate_content_id = 'content_0'
+        state1.content.content_id = duplicate_content_id
+        state2.content.content_id = duplicate_content_id
+
+        exploration.next_content_id_index = (
+            content_id_generator.next_content_id_index)
+
+        exp_services.save_new_exploration('owner_id', exploration)
+
         self.assert_job_output_is([
             job_run_result.JobRunResult.as_stdout(
-                'Exploration exp_id2 (version 1) has duplicate content IDs: '
-                '{\'solution_137\': [\'Introduction\', \'State2\']}'
+                'Exploration exp_id (version 1) has duplicate content IDs: '
+                "{'content_0': ['Introduction', 'State2']}"
             )
         ])
 
-    def test_multiple_explorations_with_duplicates(self) -> None:
-        """Test multiple explorations with different duplicate patterns."""
-        # First exploration with duplicates
-        exploration1 = exp_domain.Exploration.create_default_exploration(
-            'exp_id3', title='Test Exploration 1', category='Algebra')
-        exploration1.add_states(['State2'])
-        
-        duplicate_id1 = 'solution_139'
-        exploration1.states['Introduction'].content.content_id = duplicate_id1
-        exploration1.states['State2'].content.content_id = duplicate_id1
-        
-        exp_services.save_new_exploration(self.owner_id, exploration1)
-        
-        # Second exploration with different duplicates
-        exploration2 = exp_domain.Exploration.create_default_exploration(
-            'exp_id4', title='Test Exploration 2', category='Algebra')
-        exploration2.add_states(['State2', 'State3'])
-        
-        duplicate_id2 = 'hint_140'
-        exploration2.states['Introduction'].content.content_id = duplicate_id2
-        exploration2.states['State2'].content.content_id = duplicate_id2
-        exploration2.states['State3'].content.content_id = duplicate_id2
-        
-        exp_services.save_new_exploration(self.owner_id, exploration2)
-        
-        expected_outputs = [
-            job_run_result.JobRunResult.as_stdout(
-                'Exploration exp_id3 (version 1) has duplicate content IDs: '
-                '{\'solution_139\': [\'Introduction\', \'State2\']}'
-            ),
-            job_run_result.JobRunResult.as_stdout(
-                'Exploration exp_id4 (version 1) has duplicate content IDs: '
-                '{\'hint_140\': [\'Introduction\', \'State2\', \'State3\']}'
-            )
-        ]
-        
-        self.assert_job_output_is(expected_outputs)
-
 
 class FixExplorationsWithDuplicateContentIdsJobTests(
-    job_test_utils.PipelinedTestBase
+    job_test_utils.JobTestBase
 ):
     """Tests for FixExplorationsWithDuplicateContentIdsJob."""
 
-    JOB_CLASS = fix_duplicate_content_ids_jobs.FixExplorationsWithDuplicateContentIdsJob
+    JOB_CLASS = (
+        fix_duplicate_content_ids_jobs.
+        FixExplorationsWithDuplicateContentIdsJob
+    )
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
-        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+    def test_fix_job_with_no_duplicates(self) -> None:
+        """Test that the job does nothing when there are no duplicates."""
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id', title='Test Exploration', category='Test')
+        exp_services.save_new_exploration('owner_id', exploration)
 
-    def test_empty_storage(self) -> None:
         self.assert_job_output_is_empty()
 
-    def test_exploration_without_duplicates_not_modified(self) -> None:
-        """Test that explorations without duplicates are not modified."""
+    def test_fix_job_with_duplicates(self) -> None:
+        """Test that the job correctly fixes explorations with duplicate
+        content IDs."""
         exploration = exp_domain.Exploration.create_default_exploration(
-            'exp_id5', title='Test Exploration', category='Algebra')
-        
-        # Set unique content IDs
-        exploration.states['Introduction'].content.content_id = 'content_1'
-        exploration.states['Introduction'].interaction.default_outcome.feedback.content_id = 'default_outcome_1'
-        
-        exp_services.save_new_exploration(self.owner_id, exploration)
-        
-        self.assert_job_output_is_empty()
+            'exp_id', title='Test Exploration', category='Test')
 
-    def test_exploration_with_duplicates_gets_fixed(self) -> None:
-        """Test that explorations with duplicate content IDs get fixed."""
-        exploration = exp_domain.Exploration.create_default_exploration(
-            'exp_id6', title='Test Exploration', category='Algebra')
-        
-        # Create additional states
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index)
+
         exploration.add_states(['State2'])
-        
-        # Set duplicate content IDs
-        duplicate_content_id = 'solution_137'
-        exploration.states['Introduction'].content.content_id = duplicate_content_id
-        exploration.states['State2'].content.content_id = duplicate_content_id
-        
-        # Set next_content_id_index to a known value
-        exploration.next_content_id_index = 10
-        
-        exp_services.save_new_exploration(self.owner_id, exploration)
-        
-        # Run the job
-        self.run_job()
-        
-        # Verify the exploration was fixed
-        updated_exploration = exp_services.get_exploration_by_id('exp_id6')
-        
-        # Check that content IDs are now unique
-        intro_content_id = updated_exploration.states['Introduction'].content.content_id
-        state2_content_id = updated_exploration.states['State2'].content.content_id
-        
-        self.assertNotEqual(intro_content_id, state2_content_id)
-        
-        # The first occurrence should keep the original ID
-        self.assertEqual(intro_content_id, duplicate_content_id)
-        
-        # The second occurrence should have a new ID
-        self.assertNotEqual(state2_content_id, duplicate_content_id)
-        
-        # The next_content_id_index should be updated
-        self.assertGreater(updated_exploration.next_content_id_index, 10)
+        state1 = exploration.states['Introduction']
+        state2 = exploration.states['State2']
 
-    def test_multiple_duplicates_in_single_exploration(self) -> None:
-        """Test fixing multiple different duplicate content IDs in one exploration."""
+        # Create duplicate content IDs
+        duplicate_content_id = 'content_0'
+        state1.content.content_id = duplicate_content_id
+        state2.content.content_id = duplicate_content_id
+
+        exploration.next_content_id_index = (
+            content_id_generator.next_content_id_index)
+
+        exp_services.save_new_exploration('owner_id', exploration)
+
+        self.assert_job_output_is([
+            job_run_result.JobRunResult.as_stdout(
+                'Fixed exploration exp_id (version 1) - regenerated content '
+                'IDs: [\'content_0 -> content_2 in State2\']'
+            )
+        ])
+
+        # Verify the fix was applied
+        updated_exploration = exp_fetchers.get_exploration_by_id('exp_id')
+        state1_updated = updated_exploration.states['Introduction']
+        state2_updated = updated_exploration.states['State2']
+
+        # State1 should keep the original content_id
+        self.assertEqual(state1_updated.content.content_id, 'content_0')
+        # State2 should have a new content_id
+        self.assertEqual(state2_updated.content.content_id, 'content_2')
+
+
+class AuditIdentifyExplorationsWithDuplicateContentIdsJobTests(
+    job_test_utils.JobTestBase
+):
+    """Tests for AuditIdentifyExplorationsWithDuplicateContentIdsJob."""
+
+    JOB_CLASS = (
+        fix_duplicate_content_ids_jobs.
+        AuditIdentifyExplorationsWithDuplicateContentIdsJob
+    )
+
+    def test_audit_identify_job_with_duplicates(self) -> None:
+        """Test that the audit job correctly identifies duplicates."""
         exploration = exp_domain.Exploration.create_default_exploration(
-            'exp_id7', title='Test Exploration', category='Algebra')
-        
-        # Create multiple states
-        exploration.add_states(['State2', 'State3', 'State4'])
-        
-        # Set multiple duplicate content IDs
-        duplicate_id1 = 'solution_137'
-        duplicate_id2 = 'hint_140'
-        
-        exploration.states['Introduction'].content.content_id = duplicate_id1
-        exploration.states['State2'].content.content_id = duplicate_id1
-        exploration.states['State3'].content.content_id = duplicate_id2
-        exploration.states['State4'].content.content_id = duplicate_id2
-        
-        exploration.next_content_id_index = 15
-        
-        exp_services.save_new_exploration(self.owner_id, exploration)
-        
-        # Run the job
-        self.run_job()
-        
-        # Verify the exploration was fixed
-        updated_exploration = exp_services.get_exploration_by_id('exp_id7')
-        
-        # Collect all content IDs
-        all_content_ids = []
-        for state in updated_exploration.states.values():
-            all_content_ids.extend(state.get_translatable_content_ids())
-        
-        # Check that all content IDs are now unique
-        self.assertEqual(len(all_content_ids), len(set(all_content_ids)))
-        
-        # Check that first occurrences keep original IDs
-        self.assertEqual(
-            updated_exploration.states['Introduction'].content.content_id, 
-            duplicate_id1
-        )
-        self.assertEqual(
-            updated_exploration.states['State3'].content.content_id, 
-            duplicate_id2
-        )
-        
-        # Check that duplicate occurrences got new IDs
-        self.assertNotEqual(
-            updated_exploration.states['State2'].content.content_id, 
-            duplicate_id1
-        )
-        self.assertNotEqual(
-            updated_exploration.states['State4'].content.content_id, 
-            duplicate_id2
-        )
+            'exp_id', title='Test Exploration', category='Test')
+
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index)
+
+        exploration.add_states(['State2'])
+        state1 = exploration.states['Introduction']
+        state2 = exploration.states['State2']
+
+        duplicate_content_id = 'content_0'
+        state1.content.content_id = duplicate_content_id
+        state2.content.content_id = duplicate_content_id
+
+        exploration.next_content_id_index = (
+            content_id_generator.next_content_id_index)
+
+        exp_services.save_new_exploration('owner_id', exploration)
+
+        self.assert_job_output_is([
+            job_run_result.JobRunResult.as_stdout(
+                'Exploration exp_id (version 1) has duplicate content IDs: '
+                "{'content_0': ['Introduction', 'State2']}"
+            )
+        ])
 
 
-class AuditJobsTests(job_test_utils.PipelinedTestBase):
-    """Tests for audit versions of the jobs."""
+class AuditFixExplorationsWithDuplicateContentIdsJobTests(
+    job_test_utils.JobTestBase
+):
+    """Tests for AuditFixExplorationsWithDuplicateContentIdsJob."""
 
-    def test_audit_identify_job_does_not_update_datastore(self) -> None:
-        """Test that the audit identify job does not make datastore updates."""
-        job = fix_duplicate_content_ids_jobs.AuditIdentifyExplorationsWithDuplicateContentIdsJob(
-            self.pipeline
-        )
-        self.assertFalse(job.DATASTORE_UPDATES_ALLOWED)
+    JOB_CLASS = (
+        fix_duplicate_content_ids_jobs.
+        AuditFixExplorationsWithDuplicateContentIdsJob
+    )
 
-    def test_audit_fix_job_does_not_update_datastore(self) -> None:
-        """Test that the audit fix job does not make datastore updates."""
-        job = fix_duplicate_content_ids_jobs.AuditFixExplorationsWithDuplicateContentIdsJob(
-            self.pipeline
-        )
-        self.assertFalse(job.DATASTORE_UPDATES_ALLOWED) 
+    def test_audit_fix_job_with_duplicates(self) -> None:
+        """Test that the audit fix job shows what would be fixed."""
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'exp_id', title='Test Exploration', category='Test')
+
+        content_id_generator = translation_domain.ContentIdGenerator(
+            exploration.next_content_id_index)
+
+        exploration.add_states(['State2'])
+        state1 = exploration.states['Introduction']
+        state2 = exploration.states['State2']
+
+        duplicate_content_id = 'content_0'
+        state1.content.content_id = duplicate_content_id
+        state2.content.content_id = duplicate_content_id
+
+        exploration.next_content_id_index = (
+            content_id_generator.next_content_id_index)
+
+        exp_services.save_new_exploration('owner_id', exploration)
+
+        self.assert_job_output_is([
+            job_run_result.JobRunResult.as_stdout(
+                'Fixed exploration exp_id (version 1) - regenerated content '
+                'IDs: [\'content_0 -> content_2 in State2\']'
+            )
+        ])
+
+        # Verify that the audit job did NOT actually fix anything
+        updated_exploration = exp_fetchers.get_exploration_by_id('exp_id')
+        state1_updated = updated_exploration.states['Introduction']
+        state2_updated = updated_exploration.states['State2']
+
+        # Both states should still have the duplicate content_id
+        self.assertEqual(state1_updated.content.content_id, 'content_0')
+        self.assertEqual(state2_updated.content.content_id, 'content_0') 

--- a/core/jobs/registry.py
+++ b/core/jobs/registry.py
@@ -52,6 +52,7 @@ from core.jobs.batch_jobs import exp_migration_jobs                  # pylint: d
 from core.jobs.batch_jobs import (                                   # pylint: disable=unused-import  # isort: skip
     exp_recommendation_computation_jobs)
 from core.jobs.batch_jobs import exp_search_indexing_jobs            # pylint: disable=unused-import  # isort: skip
+from core.jobs.batch_jobs import fix_duplicate_content_ids_jobs      # pylint: disable=unused-import  # isort: skip
 from core.jobs.batch_jobs import model_validation_jobs               # pylint: disable=unused-import  # isort: skip
 from core.jobs.batch_jobs import opportunity_management_jobs         # pylint: disable=unused-import  # isort: skip
 from core.jobs.batch_jobs import question_migration_jobs             # pylint: disable=unused-import  # isort: skip


### PR DESCRIPTION
## Overview

1. This PR fixes #[20015].
2. This PR does the following:

- Implements Apache Beam jobs to identify and fix explorations with duplicate content IDs
- Creates IdentifyExplorationsWithDuplicateContentIdsJob to detect explorations containing duplicate content IDs across states
- Creates FixExplorationsWithDuplicateContentIdsJob to fix duplicate content IDs by regenerating unique IDs for duplicates
- Includes audit versions of both jobs (AuditIdentifyExplorationsWithDuplicateContentIdsJob and AuditFixExplorationsWithDuplicateContentIdsJob) for safe testing
- Adds proper content ID replacement logic that handles complex customization arguments and nested structures
- Follows Oppia's Beam job naming conventions and architecture patterns

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)


- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
