### PR TITLE
Fix #22817: Fix Elasticsearch under docker

### DIFF
--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -119,8 +119,9 @@ runs:
         #
         # Note that we need to include install_python_dev_dependencies.py in
         # the cache key because it has the version numbers for pip, pip-tools
-        # and setuptools.
-        key: ${{ runner.os }}-proddeps-${{ hashFiles('/home/runner/work/.pyversion', 'yarn.lock', 'requirements_dev.txt', 'requirements.txt', 'dependencies.json',  'scripts/install_python_dev_dependencies.py') }}
+        # and setuptools. We include scripts/common.py because it has version
+        # numbers for dependencies like Elasticsearch.
+        key: ${{ runner.os }}-proddeps-${{ hashFiles('/home/runner/work/.pyversion', 'yarn.lock', 'requirements_dev.txt', 'requirements.txt', 'dependencies.json',  'scripts/install_python_dev_dependencies.py', 'scripts/common.py') }}
         path: |
           /home/runner/work/oppia/oppia_tools
           /home/runner/work/oppia/yarn_cache

--- a/core/platform/search/elastic_search_services.py
+++ b/core/platform/search/elastic_search_services.py
@@ -57,7 +57,7 @@ class ElasticSearchClient:
                         platform_parameter_list.ParamName.ES_USERNAME.value))
                 self._client = elasticsearch.Elasticsearch(
                     ('%s:%s' % (feconf.ES_HOST, feconf.ES_LOCALHOST_PORT))
-                    if es_cloud_id is None else None,
+                    if es_cloud_id == '' else None,
                     cloud_id=es_cloud_id,
                     http_auth=(
                         (es_username, secrets_services.get_secret(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
     command: redis-server /app/oppia/redis_docker.conf
 
   elasticsearch:
-    image: elasticsearch:7.17.0
+    image: elasticsearch:7.17.27
     container_name: oppia-elasticsearch
     ports:
       - "9200:9200"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - DATASTORE_USE_PROJECT_ID_AS_APP_ID=true
       - GOOGLE_CLOUD_PROJECT=dev-project-id
       - REDIS_HOST=redis
+      - ES_HOST=oppia-elasticsearch
     depends_on:
       - angular-build
       - webpack-compiler
@@ -141,6 +142,8 @@ services:
   elasticsearch:
     image: elasticsearch:7.17.0
     container_name: oppia-elasticsearch
+    ports:
+      - "9200:9200"
     environment:
       - ES_JAVA_OPTS=-Xms100m -Xmx500m
       - ES_PATH_CONF=/usr/share/elasticsearch/config

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -71,7 +71,7 @@ YARN_VERSION = '1.22.15'
 #    the upgrade to develop.
 # 7. If any tests fail, DO NOT upgrade to this newer version of the redis cli.
 REDIS_CLI_VERSION = '6.2.4'
-ELASTICSEARCH_VERSION = '7.17.0'
+ELASTICSEARCH_VERSION = '7.17.27'
 
 RELEASE_BRANCH_NAME_PREFIX = 'release-'
 CURR_DIR = os.path.abspath(os.getcwd())


### PR DESCRIPTION
## Overview

1. This PR fixes #22817.
2. This PR does the following: Elasticsearch stopped working under docker due to PR #20809 because of a bug in how we checked whether we were running in a local development environment when creating an Elasticsearch client. This PR fixes the bug.

Bug was introduced here:

https://github.com/oppia/oppia/commit/67ef98885e5d276004999fad47bdba8981c1eb92#diff-239fa449be5187645161df3fcaeb62363cda3d5ca6c29ba9666cee2f8e078678R60

by commit 67ef98885e5d276004999fad47bdba8981c1eb92 merged from PR #20809. The problem is that this code checks whether `ES_CLOUD_ID` is `None` to see if we are running in a development environment, but the default value of `ES_CLOUD_ID` is the empty string, not `None`:

https://github.com/oppia/oppia/blob/a4a9ab484abba477993b94ae85e966ac5808aa8e/core/domain/platform_parameter_registry.py#L560-L565

In addition, this PR configures the `oppia-dev-server` container to query the elasticsearch container at its `oppia-elasticsearch` hostname created by docker instead of at `localhost`, and this PR makes the elasticsearch 9200 port accessible locally for easier debugging in the future.

**Note:** This PR changes a file in the datastore layer, namely `core/platform/search/elastic_search_services.py`, but this change does not affect how we save data to the datastore, so no server jobs testing is required.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<img width="1853" height="957" alt="Screenshot from 2025-08-20 22-55-16" src="https://github.com/user-attachments/assets/24d2241d-802a-4844-bce5-3d42fd69b1f2" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
