### PR TITLE
[GSoC 2025] M2.10 - Fix part of #18305: Added study guide translation feature flag

### DIFF
--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -71,6 +71,9 @@ class FeatureNames(enum.Enum):
     ENABLE_WORKED_EXAMPLES_RTE_COMPONENT = (
         'enable_worked_examples_rte_component'
      )
+    ENABLE_STUDY_GUIDE_TRANSLATIONS = (
+        'enable_study_guide_translations'
+    )
 
 
 # Names of feature objects defined in FeatureNames should be added
@@ -96,7 +99,8 @@ DEV_FEATURES_LIST = [
     FeatureNames.SHOW_TRANSLATION_SIZE,
     FeatureNames.REDESIGNED_TOPIC_VIEWER_PAGE,
     FeatureNames.ENABLE_TRANSLATION_OPPORTUNITIES_WITH_NEW_OPP_MODELS,
-    FeatureNames.ENABLE_WORKED_EXAMPLES_RTE_COMPONENT
+    FeatureNames.ENABLE_WORKED_EXAMPLES_RTE_COMPONENT,
+    FeatureNames.ENABLE_STUDY_GUIDE_TRANSLATIONS
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -305,6 +309,13 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
         (
             'Allows creators to add worked examples to the review material '
             'section of skills and explanation of the study guides.',
+            feature_flag_domain.ServerMode.DEV
+        )
+    ),
+    FeatureNames.ENABLE_STUDY_GUIDE_TRANSLATIONS.value: (
+        (
+            'Study guide translations will be accessible via a temporary '
+            'form on the admin page.',
             feature_flag_domain.ServerMode.DEV
         )
     )

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -47,6 +47,7 @@ export enum FeatureNames {
   ShowRestructuredStudyGuides = 'show_restructured_study_guides',
   EnableTranslationOppsWithNewOppModels = 'enable_translation_opps_with_new_opp_models',
   EnableWorkedExamplesRteComponent = 'enable_worked_examples_rte_component',
+  EnableStudyGuideTranslations = 'enable_study_guide_translations',
 }
 
 export interface FeatureStatusSummaryBackendDict {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #18305.
2. This PR does the following: Adds the `enable_study_guide_translations` feature flag.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

<img width="1744" height="912" alt="image" src="https://github.com/user-attachments/assets/fc3a0a63-0ad2-458f-a7a5-f82823032c0b" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
