### PR TITLE
Removes screen recording for mobile acceptance tests in CI. Potentially fixes #23079

### DIFF
--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -290,9 +290,13 @@ jobs:
         if: ${{ failure() }}
         # We use xvfb-run to create a virtual screen to run tests without headless mode.
         # Numbers in 1920x1080x24 represents screen width, height and color depth respectively.
+
+        # TODO(#23155): We are temporarily disabling video recording for mobile tests.
+        # Once the issue is resolved (see: https://github.com/oppia/oppia/issues/23155),
+        # update the VIDEO_RECORDING_IS_ENABLED flag to 1.
         run: >
           set -o pipefail;
-          VIDEO_RECORDING_IS_ENABLED=1
+          VIDEO_RECORDING_IS_ENABLED=0
           xvfb-run -a --server-args="-screen 0, 1920x1080x24"
           python -m scripts.run_acceptance_tests --skip-build
           --suite=${{ matrix.suite.name }} --prod_env --mobile --server_log_level=info

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -73,8 +73,8 @@ export class BaseUser {
   page!: Page;
   browserObject!: Browser;
   userHasAcceptedCookies: boolean = false;
-  email: string;
-  username: string;
+  email: string | null = null;
+  username: string | null = null;
   startTimeInMilliseconds: number = -1;
   screenRecorder!: PuppeteerScreenRecorder;
   static instances: BaseUser[] = []; // Track instances.

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -444,35 +444,38 @@ export class BaseUser {
    * The function clicks the element using the text on the button.
    * @param selector The text of the button to click on.
    * @param forceSelector If true, the function will try to find the element by its CSS selector.
-   * @param parentElement The parent element to search within.
+   * @param timeoutForTextButton The timeout for the text button.
    */
   async clickOn(
     selector: string,
     forceSelector: boolean = false,
-    parentElement?: puppeteer.ElementHandle
+    timeoutForTextButton: number = 1000
   ): Promise<void> {
-    const context = parentElement ?? this.page;
     /** Normalize-space is used to remove the extra spaces in the text.
      * Check the documentation for the normalize-space function here :
      * https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/normalize-space */
-    const [button] = await context.$x(
-      `\/\/*[contains(text(), normalize-space('${selector}'))]`
-    );
-    // If we fail to find the element by its XPATH, then the button is undefined and
-    // we try to find it by its CSS selector.
-    if (button !== undefined && !forceSelector) {
+    const xpath = `\/\/*[contains(text(), normalize-space('${selector}'))]`;
+    let button: ElementHandle | null = null;
+    try {
+      button = await this.page.waitForXPath(xpath, {
+        visible: true,
+        timeout: timeoutForTextButton,
+      });
+    } catch (error) {
+      if (!(error instanceof puppeteer.errors.TimeoutError)) {
+        throw error;
+      }
+      showMessage(`Using CSS selector to find button: ${selector}`);
+    }
+    if (button !== null && !forceSelector) {
       await this.waitForElementToBeClickable(button);
-      showMessage(`Button (text: ${selector}) is clickable, as expected.`);
       await button.click();
       showMessage(`Button (text: ${selector}) is clicked.`);
     } else {
-      const element = await context.waitForSelector(selector, {visible: true});
-      if (!element) {
-        throw new Error(`Element not found for selector ${selector}`);
-      }
-      await this.waitForElementToBeClickable(element);
+      showMessage(`Clicking on button with selector: ${selector}`);
+      await this.waitForElementToBeClickable(selector);
       showMessage(`Element (selector: ${selector}) is clickable, as expected.`);
-      await element.click();
+      await this.page.click(selector);
       showMessage(`Element (selector: ${selector}) is clicked.`);
     }
   }

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -73,8 +73,8 @@ export class BaseUser {
   page!: Page;
   browserObject!: Browser;
   userHasAcceptedCookies: boolean = false;
-  email: string = '';
-  username: string = '';
+  email: string;
+  username: string;
   startTimeInMilliseconds: number = -1;
   screenRecorder!: PuppeteerScreenRecorder;
   static instances: BaseUser[] = []; // Track instances.

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -5726,17 +5726,7 @@ export class LoggedOutUser extends BaseUser {
     await this.waitForElementToStabilize(conceptCard);
 
     await this.clickOn(conceptCardLinkSelector);
-    const conceptCardContent: string =
-      (await this.page.$eval(
-        conceptCardViewerSelector,
-        el => (el as HTMLElement).textContent
-      )) ?? '';
-
-    if (!conceptCardContent.includes(content)) {
-      throw new Error(
-        `Expected concept card content to be ${content}, but it was ${conceptCardContent}`
-      );
-    }
+    await this.expectTextContentToContain(conceptCardViewerSelector, content);
 
     await this.waitForElementToStabilize(conceptCardCloseButtonSelector);
     await this.clickOn(conceptCardCloseButtonSelector);


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR potentially fixes #23079
3. This PR does the following: 
    - Removes screen recording from mobile acceptance tests in CI.
    - Fixes a flake by waiting for element before checking it's value.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
