### PR TITLE
[REVERTED] Always run the latest version of Oppiabot

### DIFF
--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Merge develop branch into the current branch
         uses: ./.github/actions/merge
       - name: Github Actions from Oppiabot
+        # Since we control the oppia/oppiabot repository, we can safely
+        # automatically run the latest version of its code. This is generally
+        # not a safe practice for dependencies we do not control.
         uses: oppia/oppiabot
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Merge develop branch into the current branch
         uses: ./.github/actions/merge
       - name: Github Actions from Oppiabot
-        uses: oppia/oppiabot@1.4.0
+        uses: oppia/oppiabot
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
         env:


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of n/a.
2. This PR does the following: Makes our GitHub Actions workflow always run the latest version of Oppiabot. Currently, we specify a particular version of Oppiabot to run, which is unnecessary since we control the Oppiabot repository and always want to run the latest version.
3. (For bug-fixing PRs only) The original bug occurred because: n/a

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No code changes here.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
