### PR TITLE
Fix #22648 : Preferred site language is not updating language properly

### DIFF
--- a/core/templates/pages/preferences-page/preferences-page.component.ts
+++ b/core/templates/pages/preferences-page/preferences-page.component.ts
@@ -30,6 +30,8 @@ import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {ImageUploadHelperService} from 'services/image-upload-helper.service';
 import {LoaderService} from 'services/loader.service';
+import {I18nService} from 'i18n/i18n.service';
+
 import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import {
   BackendPreferenceUpdateType,
@@ -113,7 +115,8 @@ export class PreferencesPageComponent {
     private preventPageUnloadEventService: PreventPageUnloadEventService,
     private urlInterpolationService: UrlInterpolationService,
     private userBackendApiService: UserBackendApiService,
-    private userService: UserService
+    private userService: UserService,
+    private i18nService: I18nService
   ) {}
 
   getStaticImageUrl(imagePath: string): string {
@@ -368,11 +371,26 @@ export class PreferencesPageComponent {
     this.userBackendApiService
       .updateMultiplePreferencesDataAsync(updates)
       .then(returnData => {
-        if (this.preferencesForm.controls.preferredSiteLanguageCode.dirty) {
-          this.i18nLanguageCodeService.setI18nLanguageCode(
-            this.preferencesForm.controls.preferredSiteLanguageCode.value
-          );
+        const languageChanged =
+          this.preferencesForm.controls.preferredSiteLanguageCode.dirty;
+        const profilePicChanged =
+          this.preferencesForm.controls.profilePicturePngDataUrl.dirty;
+
+        if (languageChanged) {
+          const newLangCode =
+            this.preferencesForm.controls.preferredSiteLanguageCode.value;
+          this.i18nService.setLocalStorageKeys(newLangCode);
+          this.preventPageUnloadEventService.removeListener();
+          this.windowRef.nativeWindow.location.reload();
+          return;
         }
+
+        if (profilePicChanged) {
+          this.preventPageUnloadEventService.removeListener();
+          this.windowRef.nativeWindow.location.reload();
+          return;
+        }
+
         if (returnData.bulk_email_signup_message_should_be_shown) {
           const formGrp = this.preferencesForm.controls
             .emailPreferences as FormGroup;
@@ -381,19 +399,6 @@ export class PreferencesPageComponent {
         } else {
           this.alertsService.addInfoMessage('Saved!', 3000);
         }
-        if (this.preferencesForm.controls.profilePicturePngDataUrl.dirty) {
-          // TODO(#19737): Remove the following 'if' condition.
-          if (AssetsBackendApiService.EMULATOR_MODE) {
-            this._saveProfileImageToLocalStorage(
-              this.preferencesForm.controls.profilePicturePngDataUrl.value
-            );
-          }
-          // The reload is needed in order to update the profile picture
-          // in the top-right corner(Nav Bar).
-          this.preventPageUnloadEventService.removeListener();
-          this.windowRef.nativeWindow.location.reload();
-        }
-        // Marks all the preferences as unchanged and updates the form status.
         this.preferencesForm.markAsPristine();
         this.preferencesForm.updateValueAndValidity();
       });


### PR DESCRIPTION
…g for eng and arabic

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->
demo
1. This PR fixes or fixes #22648 
2. This PR does the following: fixes the Preferred site language alignment issue(RTL OR LTR) when changing back from arabic to english
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

https://github.com/user-attachments/assets/bd1df5e3-4529-41d0-b3aa-237755e54f71



#### Proof of changes on desktop with slow/throttled network
<img width="2834" height="1562" alt="image" src="https://github.com/user-attachments/assets/a25995ab-daa5-4228-8237-7bc7579be84d" />

<img width="1440" height="775" alt="image" src="https://github.com/user-attachments/assets/88515eba-3eff-4eab-a7b3-ae380ec0731f" />

#### Proof of changes on mobile phone
<img width="784" height="1354" alt="image" src="https://github.com/user-attachments/assets/a047c429-a931-4518-ae67-c8004da42bfd" />
<img width="756" height="1348" alt="image" src="https://github.com/user-attachments/assets/01c120c2-3e93-4866-b946-47e92e1ae3e1" />

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
