### PR TITLE
[GSoC 2025] M2 - Fix part of #19851: Update rte_components to rte_component_config_id

### DIFF
--- a/assets/rich_text_components_definitions.ts
+++ b/assets/rich_text_components_definitions.ts
@@ -43,7 +43,7 @@ export default {
       "schema": {
         "type": "html",
         "ui_config": {
-          "rte_components": "ALL_COMPONENTS",
+          "rte_component_config_id": "ALL_COMPONENTS",
           "hide_complex_extensions": true
         }
       },
@@ -205,7 +205,7 @@ export default {
       "description": "The tab titles and contents.",
       "schema": {
         "ui_config": {
-          "rte_components": "ALL_COMPONENTS",
+          "rte_component_config_id": "ALL_COMPONENTS",
           "hide_complex_extensions": true
         },
         "type": "custom",
@@ -291,7 +291,7 @@ export default {
       "schema": {
         "type": "html",
         "ui_config": {
-          "rte_components": "WORKED_EXAMPLE_MODAL_COMPONENTS",
+          "rte_component_config_id": "WORKED_EXAMPLE_MODAL_COMPONENTS",
           "hide_complex_extensions": true
         }
       },
@@ -303,7 +303,7 @@ export default {
       "schema": {
         "type": "html",
         "ui_config": {
-          "rte_components": "WORKED_EXAMPLE_MODAL_COMPONENTS",
+          "rte_component_config_id": "WORKED_EXAMPLE_MODAL_COMPONENTS",
           "hide_complex_extensions": true
         }
       },

--- a/core/schema_utils_test.py
+++ b/core/schema_utils_test.py
@@ -98,7 +98,7 @@ UI_CONFIG_SPECS: Dict[str, Dict[str, Any]] = {
         'hide_complex_extensions': {
             'type': SCHEMA_TYPE_BOOL,
         },
-        'rte_components': {
+        'rte_component_config_id': {
             'type': SCHEMA_TYPE_UNICODE_OR_NONE,
         },
     },
@@ -108,7 +108,7 @@ UI_CONFIG_SPECS: Dict[str, Dict[str, Any]] = {
         'hide_complex_extensions': {
             'type': SCHEMA_TYPE_BOOL,
         },
-        'rte_components': {
+        'rte_component_config_id': {
             'type': SCHEMA_TYPE_UNICODE_OR_NONE,
         },
         'placeholder': {

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -59,7 +59,7 @@ import {Subscription} from 'rxjs';
 
 interface UiConfig {
   (): UiConfig;
-  rte_components: string;
+  rte_component_config_id: string;
   hide_complex_extensions: boolean;
   startupFocusEnabled?: boolean;
   language?: string;
@@ -67,12 +67,12 @@ interface UiConfig {
 }
 
 interface ExtendedCKEditorConfig extends CKEDITOR.config {
-  rte_components?: string;
+  rte_component_config_id?: string;
 }
 export interface RteConfig extends CKEDITOR.config {
   format_heading?: CKEDITOR.config.styleObject;
   format_normal?: CKEDITOR.config.styleObject;
-  rte_components?: string;
+  rte_component_config_id?: string;
 }
 
 @Component({
@@ -134,14 +134,14 @@ export class CkEditor4RteComponent
   }
 
   private validateConfiguration(): void {
-    if (!this.uiConfig || !this.uiConfig.rte_components) {
+    if (!this.uiConfig || !this.uiConfig.rte_component_config_id) {
       this.configError =
-        'No component set specified. Please provide a "rte_components" config in uiConfig.';
+        'No component set specified. Please provide a "rte_component_config_id" config in uiConfig.';
       console.error('Error: ' + this.configError);
       return;
     }
 
-    const rteComponents = this.uiConfig.rte_components;
+    const rteComponents = this.uiConfig.rte_component_config_id;
     const componentList = AppConstants.RTE_COMPONENT_CONFIGS[rteComponents];
 
     if (!componentList) {
@@ -513,7 +513,7 @@ export class CkEditor4RteComponent
     }
 
     // Get component list from AppConstants.
-    const rteComponents = this.uiConfig.rte_components;
+    const rteComponents = this.uiConfig.rte_component_config_id;
     const componentList = AppConstants.RTE_COMPONENT_CONFIGS[rteComponents];
 
     // Filter components based on the defined list and other criteria.
@@ -627,8 +627,8 @@ export class CkEditor4RteComponent
       sharedSpaces
     ) as ExtendedCKEditorConfig;
 
-    if (this.uiConfig && this.uiConfig.rte_components) {
-      ckConfig.rte_components = this.uiConfig.rte_components;
+    if (this.uiConfig && this.uiConfig.rte_component_config_id) {
+      ckConfig.rte_component_config_id = this.uiConfig.rte_component_config_id;
     }
 
     // Initialize CKEditor.

--- a/core/templates/components/review-material-editor/review-material-editor.component.spec.ts
+++ b/core/templates/components/review-material-editor/review-material-editor.component.spec.ts
@@ -76,7 +76,7 @@ describe('Review Material Editor Component', () => {
     expect(component.HTML_SCHEMA).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+        rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
       },
     });
     expect(component.editableExplanation).toBe('Explanation');
@@ -144,7 +144,7 @@ describe('Review Material Editor Component', () => {
     expect(schema).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
       },
     });
   });
@@ -185,7 +185,7 @@ describe('Review Material Editor Component', () => {
     expect(schema).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+        rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
       },
     });
   });

--- a/core/templates/components/review-material-editor/review-material-editor.component.ts
+++ b/core/templates/components/review-material-editor/review-material-editor.component.ts
@@ -56,7 +56,7 @@ export class ReviewMaterialEditorComponent implements OnInit {
   HTML_SCHEMA: HtmlSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+      rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
     },
   };
 
@@ -79,7 +79,7 @@ export class ReviewMaterialEditorComponent implements OnInit {
       this.HTML_SCHEMA = {
         type: 'html',
         ui_config: {
-          rte_components: 'ALL_COMPONENTS',
+          rte_component_config_id: 'ALL_COMPONENTS',
         },
       };
     }

--- a/core/templates/components/rubrics-editor/rubrics-editor.component.ts
+++ b/core/templates/components/rubrics-editor/rubrics-editor.component.ts
@@ -80,7 +80,7 @@ export class RubricsEditorComponent {
   EXPLANATION_FORM_SCHEMA: ExplanationFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
     },
   };
 

--- a/core/templates/components/state-directives/hint-editor/hint-editor.component.spec.ts
+++ b/core/templates/components/state-directives/hint-editor/hint-editor.component.spec.ts
@@ -138,7 +138,7 @@ describe('HintEditorComponent', () => {
     const schema = (component.HINT_FORM_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions: true,
       },
     });

--- a/core/templates/components/state-directives/hint-editor/hint-editor.component.ts
+++ b/core/templates/components/state-directives/hint-editor/hint-editor.component.ts
@@ -118,7 +118,7 @@ export class HintEditorComponent implements OnInit, OnDestroy {
     this.HINT_FORM_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions:
           this.pageContextService.getEntityType() === 'question',
       },

--- a/core/templates/components/state-directives/outcome-editor/outcome-feedback-editor.component.spec.ts
+++ b/core/templates/components/state-directives/outcome-editor/outcome-feedback-editor.component.spec.ts
@@ -52,7 +52,7 @@ describe('Outcome Feedback Editor Component', () => {
     expect(component.OUTCOME_FEEDBACK_SCHEMA).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions: false,
       },
     });

--- a/core/templates/components/state-directives/outcome-editor/outcome-feedback-editor.component.ts
+++ b/core/templates/components/state-directives/outcome-editor/outcome-feedback-editor.component.ts
@@ -47,7 +47,7 @@ export class OutcomeFeedbackEditorComponent implements OnInit {
     this.OUTCOME_FEEDBACK_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions:
           this.pageContextService.getEntityType() === 'question',
       },

--- a/core/templates/components/state-directives/solution-editor/solution-editor.component.spec.ts
+++ b/core/templates/components/state-directives/solution-editor/solution-editor.component.spec.ts
@@ -112,7 +112,7 @@ describe('Solution editor component', () => {
     expect(component.EXPLANATION_FORM_SCHEMA).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
       },
     });
   });

--- a/core/templates/components/state-directives/solution-editor/solution-editor.component.ts
+++ b/core/templates/components/state-directives/solution-editor/solution-editor.component.ts
@@ -77,7 +77,7 @@ export class SolutionEditor implements OnInit {
     this.EXPLANATION_FORM_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
       },
     };
   }

--- a/core/templates/components/state-directives/solution-editor/solution-explanation-editor.component.spec.ts
+++ b/core/templates/components/state-directives/solution-editor/solution-explanation-editor.component.spec.ts
@@ -108,7 +108,7 @@ describe('Solution explanation editor', () => {
     const schema = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions: true,
       },
     };
@@ -130,7 +130,7 @@ describe('Solution explanation editor', () => {
     const schema = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions: true,
       },
     };

--- a/core/templates/components/state-directives/solution-editor/solution-explanation-editor.component.ts
+++ b/core/templates/components/state-directives/solution-editor/solution-explanation-editor.component.ts
@@ -126,7 +126,7 @@ export class SolutionExplanationEditor implements OnDestroy, OnInit {
     this.EXPLANATION_FORM_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions:
           this.pageContextService.getEntityType() === 'question',
       },

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
@@ -38,7 +38,7 @@ import {Subscription} from 'rxjs';
 interface HTMLSchema {
   type: string;
   ui_config: {
-    rte_components: 'ALL_COMPONENTS';
+    rte_component_config_id: 'ALL_COMPONENTS';
     hide_complex_extensions: boolean;
   };
 }
@@ -76,7 +76,7 @@ export class StateContentEditorComponent implements OnInit {
     this.HTML_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         hide_complex_extensions:
           this.pageContextService.getEntityType() === 'question',
       },

--- a/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
+++ b/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
@@ -85,7 +85,7 @@ export class BlogPostEditorComponent implements OnInit {
   HTML_SCHEMA: EditorSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'BLOG_COMPONENTS',
+      rte_component_config_id: 'BLOG_COMPONENTS',
       hide_complex_extensions: false,
       startupFocusEnabled: false,
     },

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.ts
@@ -57,7 +57,7 @@ const INTERACTION_SPECS = require('interactions/interaction_specs.json');
 
 class UiConfig {
   'hide_complex_extensions': boolean;
-  'rte_components': string;
+  'rte_component_config_id': string;
   'startupFocusEnabled'?: boolean;
   'language'?: string;
   'languageDirection'?: string;
@@ -258,7 +258,7 @@ export class TranslationModalComponent {
         // properly since contributors will not be able to view and translate
         // complex extensions.
         hide_complex_extensions: false,
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         language: this.translationLanguageService.getActiveLanguageCode(),
         languageDirection:
           this.translationLanguageService.getActiveLanguageDirection(),

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-hint-modal.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-hint-modal.component.ts
@@ -54,7 +54,7 @@ export class AddHintModalComponent
   HINT_FORM_SCHEMA: HintFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       hide_complex_extensions:
         this.pageContextService.getEntityType() === 'question',
     },

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.ts
@@ -83,7 +83,7 @@ export class AddOrUpdateSolutionModalComponent
   EXPLANATION_FORM_SCHEMA: HtmlFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       hide_complex_extensions:
         this.pageContextService.getEntityType() === 'question',
     },

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.ts
@@ -41,7 +41,7 @@ import {EntityVoiceoversService} from 'services/entity-voiceovers.services';
 interface HTMLSchema {
   type: string;
   ui_config: {
-    rte_components: string;
+    rte_component_config_id: string;
     language: string;
     languageDirection: string;
   };
@@ -141,7 +141,7 @@ export class StateTranslationEditorComponent implements OnInit, OnDestroy {
     this.HTML_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         language: this.languageCode,
         languageDirection:
           this.translationLanguageService.getActiveLanguageDirection(),

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-misconceptions-editor/misconception-editor.component.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-misconceptions-editor/misconception-editor.component.ts
@@ -67,14 +67,14 @@ export class MisconceptionEditorComponent implements OnInit {
   NOTES_FORM_SCHEMA: MisconceptionFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
     },
   };
 
   FEEDBACK_FORM_SCHEMA: MisconceptionFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       hide_complex_extensions: 'true',
     },
   };

--- a/core/templates/pages/skill-editor-page/modal-templates/add-misconception-modal.component.ts
+++ b/core/templates/pages/skill-editor-page/modal-templates/add-misconception-modal.component.ts
@@ -54,7 +54,7 @@ export class AddMisconceptionModalComponent
   MISCONCEPTION_PROPERTY_FORM_SCHEMA: MisconceptionFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       startupFocusEnabled: false,
     },
   };
@@ -62,7 +62,7 @@ export class AddMisconceptionModalComponent
   MISCONCEPTION_FEEDBACK_PROPERTY_FORM_SCHEMA: MisconceptionFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       hide_complex_extensions: true,
       startupFocusEnabled: false,
     },

--- a/core/templates/pages/story-editor-page/editor-tab/story-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-editor.component.ts
@@ -77,7 +77,7 @@ export class StoryEditorComponent implements OnInit, OnDestroy {
   NOTES_SCHEMA = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       startupFocusEnabled: false,
     },
   };

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.ts
@@ -97,7 +97,7 @@ export class StoryNodeEditorComponent implements OnInit, OnDestroy {
   OUTLINE_SCHEMA = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       startupFocusEnabled: false,
       rows: 100,
     },

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
@@ -129,14 +129,14 @@ describe('create new subtopic modal', function () {
   let DefaultSubtopicPageSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+      rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
       rows: 100,
     },
   };
   let AllComponentsSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'ALL_COMPONENTS',
+      rte_component_config_id: 'ALL_COMPONENTS',
       rows: 100,
     },
   };

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
@@ -89,7 +89,7 @@ export class CreateNewSubtopicModalComponent
     this.SUBTOPIC_PAGE_SCHEMA = {
       type: 'html',
       ui_config: {
-        rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+        rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
         rows: 100,
       },
     };
@@ -118,7 +118,7 @@ export class CreateNewSubtopicModalComponent
       this.SUBTOPIC_PAGE_SCHEMA = {
         type: 'html',
         ui_config: {
-          rte_components: 'ALL_COMPONENTS',
+          rte_component_config_id: 'ALL_COMPONENTS',
           rows: 100,
         },
       };

--- a/core/templates/pages/topic-editor-page/subtopic-editor/add-study-guide-section.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/add-study-guide-section.component.spec.ts
@@ -127,7 +127,7 @@ describe('Add Study Guide Section Modal Component', () => {
     expect(schema).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         rows: 100,
       },
     });

--- a/core/templates/pages/topic-editor-page/subtopic-editor/add-study-guide-section.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/add-study-guide-section.component.ts
@@ -44,7 +44,7 @@ export class AddStudyGuideSectionModalComponent extends ConfirmOrCancelModal {
   SECTION_FORM_CONTENT_SCHEMA: HtmlFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+      rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
     },
   };
   SECTION_FORM_HEADING_SCHEMA: HtmlFormSchema = {
@@ -65,7 +65,7 @@ export class AddStudyGuideSectionModalComponent extends ConfirmOrCancelModal {
       this.SECTION_FORM_CONTENT_SCHEMA = {
         type: 'html',
         ui_config: {
-          rte_components: 'ALL_COMPONENTS',
+          rte_component_config_id: 'ALL_COMPONENTS',
           rows: 100,
         },
       };

--- a/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.spec.ts
@@ -131,7 +131,7 @@ describe('Study Guide Section editor component', () => {
     expect(component.STUDY_GUIDE_SECTION_CONTENT_FORM_SCHEMA).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+        rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
       },
     });
   });
@@ -245,7 +245,7 @@ describe('Study Guide Section editor component', () => {
     expect(schema).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
         rows: 100,
       },
     });

--- a/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.ts
@@ -63,7 +63,7 @@ export class StudyGuideSectionEditorComponent implements OnInit {
   STUDY_GUIDE_SECTION_CONTENT_FORM_SCHEMA: HtmlFormSchema = {
     type: 'html',
     ui_config: {
-      rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+      rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
     },
   };
 
@@ -89,7 +89,7 @@ export class StudyGuideSectionEditorComponent implements OnInit {
       this.STUDY_GUIDE_SECTION_CONTENT_FORM_SCHEMA = {
         type: 'html',
         ui_config: {
-          rte_components: 'ALL_COMPONENTS',
+          rte_component_config_id: 'ALL_COMPONENTS',
           rows: 100,
         },
       };

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.spec.ts
@@ -348,7 +348,7 @@ describe('Subtopic editor tab', () => {
     expect(component.SUBTOPIC_PAGE_SCHEMA).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+        rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
         rows: 100,
       },
     });

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
@@ -85,7 +85,7 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
   SUBTOPIC_PAGE_SCHEMA: {
     type: string;
     ui_config: {
-      rte_components: string;
+      rte_component_config_id: string;
       rows: number;
     };
   };
@@ -442,7 +442,7 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
         : 'ALL_COMPONENTS';
     this.SUBTOPIC_PAGE_SCHEMA = {
       type: 'html',
-      ui_config: {rte_components: rteComponents, rows: 100},
+      ui_config: {rte_component_config_id: rteComponents, rows: 100},
     };
     this.htmlData = '';
     this.sections = [];

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-skill-modal.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-skill-modal.component.spec.ts
@@ -111,7 +111,7 @@ describe('Create new skill modal', () => {
     expect(result).toEqual({
       type: 'html',
       ui_config: {
-        rte_components: 'ALL_COMPONENTS',
+        rte_component_config_id: 'ALL_COMPONENTS',
       },
     });
   });

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-skill-modal.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-skill-modal.component.ts
@@ -51,7 +51,7 @@ export class CreateNewSkillModalComponent {
   HTML_SCHEMA = {
     type: 'html',
     ui_config: {
-      rte_components: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
+      rte_component_config_id: 'SKILL_AND_STUDY_GUIDE_EDITOR_COMPONENTS',
     },
   };
   MAX_CHARS_IN_SKILL_DESCRIPTION = AppConstants.MAX_CHARS_IN_SKILL_DESCRIPTION;
@@ -92,7 +92,7 @@ export class CreateNewSkillModalComponent {
       this.HTML_SCHEMA = {
         type: 'html',
         ui_config: {
-          rte_components: 'ALL_COMPONENTS',
+          rte_component_config_id: 'ALL_COMPONENTS',
         },
       };
     }

--- a/core/templates/services/rte-helper.service.spec.ts
+++ b/core/templates/services/rte-helper.service.spec.ts
@@ -49,7 +49,7 @@ describe('Rte Helper Service', () => {
             schema: {
               type: 'html',
               ui_config: {
-                rte_components: 'ALL_COMPONENTS',
+                rte_component_config_id: 'ALL_COMPONENTS',
                 hide_complex_extensions: true,
               },
             },
@@ -228,7 +228,7 @@ describe('Rte Helper Service', () => {
             description: 'The tab titles and contents.',
             schema: {
               ui_config: {
-                rte_components: 'ALL_COMPONENTS',
+                rte_component_config_id: 'ALL_COMPONENTS',
                 hide_complex_extensions: true,
               },
               type: 'custom',
@@ -333,7 +333,7 @@ describe('Rte Helper Service', () => {
             schema: {
               type: 'html',
               ui_config: {
-                rte_components: 'WORKED_EXAMPLE_MODAL_COMPONENTS',
+                rte_component_config_id: 'WORKED_EXAMPLE_MODAL_COMPONENTS',
                 hide_complex_extensions: true,
               },
             },
@@ -346,7 +346,7 @@ describe('Rte Helper Service', () => {
             schema: {
               type: 'html',
               ui_config: {
-                rte_components: 'WORKED_EXAMPLE_MODAL_COMPONENTS',
+                rte_component_config_id: 'WORKED_EXAMPLE_MODAL_COMPONENTS',
                 hide_complex_extensions: true,
               },
             },

--- a/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
+++ b/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
@@ -60,7 +60,7 @@ class DragAndDropSortInput(base.BaseInteraction):
                     'id': 'has_subtitled_html_non_empty'
                 }],
                 'replacement_ui_config': {
-                    'rte_components': 'ALL_COMPONENTS',
+                    'rte_component_config_id': 'ALL_COMPONENTS',
                     'html': {
                         'hide_complex_extensions': True,
                         'placeholder': (

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
@@ -79,7 +79,7 @@ class ItemSelectionInput(base.BaseInteraction):
                     'id': 'has_subtitled_html_non_empty'
                 }],
                 'replacement_ui_config': {
-                    'rte_components': 'ALL_COMPONENTS',
+                    'rte_component_config_id': 'ALL_COMPONENTS',
                     'html': {
                         'hide_complex_extensions': True,
                         'placeholder': 'Sample item answer',

--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.py
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.py
@@ -66,7 +66,7 @@ class MultipleChoiceInput(base.BaseInteraction):
                     'id': 'has_subtitled_html_non_empty'
                 }],
                 'replacement_ui_config': {
-                    'rte_components': 'ALL_COMPONENTS',
+                    'rte_component_config_id': 'ALL_COMPONENTS',
                     'html': {
                         'hide_complex_extensions': True,
                         'placeholder': (

--- a/extensions/interactions/interaction_specs.json
+++ b/extensions/interactions/interaction_specs.json
@@ -159,7 +159,7 @@
               "id": "has_subtitled_html_non_empty"
             }],
             "replacement_ui_config": {
-              "rte_components": "ALL_COMPONENTS",
+              "rte_component_config_id": "ALL_COMPONENTS",
               "html": {
                 "hide_complex_extensions": true,
                 "placeholder": "Enter an option for the learner to drag and drop."
@@ -258,7 +258,7 @@
               "id": "has_subtitled_html_non_empty"
             }],
             "replacement_ui_config": {
-              "rte_components": "ALL_COMPONENTS",
+              "rte_component_config_id": "ALL_COMPONENTS",
               "html": {
                 "hide_complex_extensions": true,
                 "placeholder": "Sample item answer"
@@ -651,7 +651,7 @@
               "id": "has_subtitled_html_non_empty"
             }],
             "replacement_ui_config": {
-              "rte_components": "ALL_COMPONENTS",
+              "rte_component_config_id": "ALL_COMPONENTS",
               "html": {
                 "hide_complex_extensions": true,
                 "placeholder": "Enter an option for the learner to select"

--- a/extensions/objects/templates/list-of-tabs-editor.component.spec.ts
+++ b/extensions/objects/templates/list-of-tabs-editor.component.spec.ts
@@ -70,7 +70,7 @@ describe('ListOfTabsEditorComponent', () => {
             schema: {
               type: 'html',
               ui_config: {
-                rte_components: 'ALL_COMPONENTS',
+                rte_component_config_id: 'ALL_COMPONENTS',
                 hide_complex_extensions: true,
               },
             },

--- a/extensions/objects/templates/list-of-tabs-editor.component.ts
+++ b/extensions/objects/templates/list-of-tabs-editor.component.ts
@@ -45,7 +45,7 @@ interface ListOfTabsEditorSchema {
         schema: {
           type: 'html';
           ui_config: {
-            rte_components: 'ALL_COMPONENTS';
+            rte_component_config_id: 'ALL_COMPONENTS';
             hide_complex_extensions: true;
           };
         };
@@ -92,7 +92,7 @@ export class ListOfTabsEditorComponent implements OnInit {
           schema: {
             type: 'html',
             ui_config: {
-              rte_components: 'ALL_COMPONENTS',
+              rte_component_config_id: 'ALL_COMPONENTS',
               hide_complex_extensions: true,
             },
           },


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19851.
2. This PR does the following: Updates the property `rte_components` of ui_config to `rte_component_config_id` as suggested [here](https://github.com/oppia/oppia-web-developer-docs/pull/468/files#r2315949207)

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

This is just a rename PR, the CI tests passing is the proof



<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->


<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
