### PR TITLE
Fix #21889 inconsistent blog URLs between footer and teach page

### DIFF
--- a/core/templates/app.constants.ts
+++ b/core/templates/app.constants.ts
@@ -333,7 +333,7 @@ export const AppConstants = {
   PARENTS_TEACHERS_PDF_GUIDE_LINK:
     'https://drive.google.com/file/d/1gMixZ2c0j5XAGPx4qDBDvRgiFvF6PMkk/view',
   TEACHER_STORY_TAGGED_BLOGS_LINK:
-    'https://www.oppia.org/blog/search/find?q=&tags=(%22Teacher%20story%22)',
+    '/blog/search/find?q=&tags=(%22Teacher%20story%22)',
   VOLUNTEER_EXPECTATIONS: [
     'I18N_VOLUNTEER_PAGE_VOLUNTEER_SECTION_EXPECTATION_1',
     'I18N_VOLUNTEER_PAGE_VOLUNTEER_SECTION_EXPECTATION_2',

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/test-constants.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/test-constants.ts
@@ -120,7 +120,7 @@ export default {
       GoogleSignUp: 'https://accounts.google.com/lifecycle/steps/signup/name',
     },
     TeacherStoryTaggedBlogsLink:
-      'https://www.oppia.org/blog/search/find?q=&tags=(%22Teacher%20story%22)',
+      '/blog/search/find?q=&tags=(%22Teacher%20story%22)',
     ParentsTeachersGuideUrl:
       'https://drive.google.com/file/d/1gMixZ2c0j5XAGPx4qDBDvRgiFvF6PMkk/view',
     LessonCreatorLinkedInUrl:


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21889.
2. This PR does the following: This PR fixes inconsistent blog URL navigation by changing TEACHER_STORY_TAGGED_BLOGS_LINK from an absolute URL to a relative one. Now both the footer blog link and the teach page "Check out our blog" button stay on the same domain.
3. (For bug-fixing PRs only) The original bug occurred because: teach page link used a hardcoded absolute URL, unlike the footer link which used a relative URL.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before changes - 



https://github.com/user-attachments/assets/43918d58-3532-40c5-be09-d85c4f57e76a



After changes -

https://github.com/user-attachments/assets/14d9e608-7c7e-4925-9aee-396d3a28dee1


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
