### PR TITLE
Fix #23347: Correct inconsistent spacing in RTL breadcrumb navigation

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -934,6 +934,10 @@ textarea {
   padding-top: 13px;
 }
 
+[dir="rtl"] .oppia-navbar-breadcrumb {
+  margin-right: 10px;
+}
+
 .oppia-navbar-breadcrumb li {
   display: inline-block;
   overflow: hidden;
@@ -942,14 +946,14 @@ textarea {
 }
 
 .oppia-navbar-breadcrumb-separator {
-  margin-right: 8px;
+  margin-inline-end: 8px;
 }
 .oppia-navbar-breadcrumb-separator:after {
   content: ">";
 }
 
 .oppia-navbar-breadcrumb-rtl-separator {
-  margin-left: 8px;
+  margin-inline-start: 8px;
 }
 .oppia-navbar-breadcrumb-rtl-separator:after {
   content: "<";

--- a/core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.css
+++ b/core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.css
@@ -132,7 +132,7 @@ oppia-blog-author-page .blog-post-card {
 
 @media (max-width: 570px) {
   .blog-author-page-breadcrumb .oppia-author-page-back-button {
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
 }
 
@@ -141,7 +141,7 @@ oppia-blog-author-page .blog-post-card {
 }
 
 .blog-author-page-breadcrumb .oppia-navbar-breadcrumb-separator:after {
-  border-left-style: ridge;
+  border-inline-start-style: ridge;
   border-width: 2px;
   content: "";
   font-size: 30px;
@@ -150,7 +150,7 @@ oppia-blog-author-page .blog-post-card {
 .blog-author-page-breadcrumb .oppia-navbar-breadcrumb {
   display: -webkit-inline-box;
   flex-flow: column;
-  margin-left: -10px;
+  margin-inline-start: -10px;
   overflow-wrap: break-word;
   padding-top: 3px;
 }

--- a/core/templates/pages/blog-home-page/blog-home-page.component.css
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.css
@@ -221,7 +221,7 @@ oppia-blog-home-page .blog-post-card {
 }
 
 .blog-homepage .oppia-navbar-breadcrumb-separator:after {
-  border-left-style: ridge;
+  border-inline-start-style: ridge;
   border-width: 2px;
   content: "";
   font-size: 30px;
@@ -230,7 +230,7 @@ oppia-blog-home-page .blog-post-card {
 .blog-homepage .oppia-navbar-breadcrumb {
   display: -webkit-inline-box;
   flex-flow: column;
-  margin-left: -10px;
+  margin-inline-start: -10px;
   overflow-wrap: break-word;
   padding-top: 3px;
 }

--- a/core/templates/pages/blog-post-page/blog-post-page.component.css
+++ b/core/templates/pages/blog-post-page/blog-post-page.component.css
@@ -11,7 +11,7 @@ button:focus {
 
 @media (max-width: 570px) {
   .blog-post-page-breadcrumb .oppia-blog-post-page-back-button {
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
 }
 
@@ -20,7 +20,7 @@ button:focus {
 }
 
 .blog-post-page-breadcrumb .oppia-navbar-breadcrumb-separator:after {
-  border-left-style: ridge;
+  border-inline-start-style: ridge;
   border-width: 2px;
   content: "";
   font-size: 30px;
@@ -29,7 +29,7 @@ button:focus {
 .blog-post-page-breadcrumb .oppia-navbar-breadcrumb {
   display: -webkit-inline-box;
   flex-flow: column;
-  margin-left: -10px;
+  margin-inline-start: -10px;
   overflow-wrap: break-word;
   padding-top: 3px;
 }
@@ -128,7 +128,7 @@ oppia-blog-post-page .blog-card-header-content mat-card-subtitle {
   font-weight: 600;
   line-height: 21px;
   margin-bottom: 3px;
-  margin-left: -10px;
+  margin-inline-start: -10px;
   text-align: left;
 }
 

--- a/core/templates/pages/profile-page/profile-page-navbar.component.css
+++ b/core/templates/pages/profile-page/profile-page-navbar.component.css
@@ -5,9 +5,9 @@
 */
 
 .oppia-username-text {
-  margin-left: 8px;
+  margin-inline-start: 8px;
 }
 
 .oppia-navbar-breadcrumb-separator {
-  margin-right: 8px;
+  margin-inline-end: 8px;
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #23347
2. This PR does the following: This PR fixes uneven spacing around the breadcrumb separator (“<”) to keep the navigation bar balanced in RTL languages like Arabic.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop 
https://github.com/user-attachments/assets/02e69b1d-3d13-41b9-97b0-ca4b7a5a8df3


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
<img width="576" height="1288" alt="image" src="https://github.com/user-attachments/assets/cd2d5ecb-4617-4013-a658-c552164d1c6b" />

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language
<img width="2837" height="1515" alt="image" src="https://github.com/user-attachments/assets/00b96a39-cf42-44df-8efc-c74c47e81159" />


<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
