### PR TITLE
Fixes #23332 : Corrects the anchor link for the "BROWSE OUR LESSONS" button on Home tab in learner dashboard

### DIFF
--- a/core/templates/pages/learner-dashboard-page/home-tab.component.ts
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.ts
@@ -65,6 +65,8 @@ export class HomeTabComponent {
   directiveSubscriptions = new Subscription();
   currentGoalIds: Set<string> = new Set();
   storySummariesWithAvailableNodes: Set<string> = new Set();
+  communityLibraryUrl =
+    '/' + AppConstants.PAGES_REGISTERED_WITH_FRONTEND.LIBRARY_INDEX.ROUTE;
 
   constructor(
     private i18nLanguageCodeService: I18nLanguageCodeService,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/23332.
2. This PR does the following: Defined communityLibraryUrl in .ts file .
3. (For bug-fixing PRs only) The original bug occurred because: The issue is that when both href and routerLink are present, Angular's router takes precedence, and here communityLibraryUrl is undefined so, no navigation occurs. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
## Before:

https://private-user-images.githubusercontent.com/148185732/488093184-2902510a-991f-4d5c-a67c-a2218714a75e.webm?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTc4NzEwMTQsIm5iZiI6MTc1Nzg3MDcxNCwicGF0aCI6Ii8xNDgxODU3MzIvNDg4MDkzMTg0LTI5MDI1MTBhLTk5MWYtNGQ1Yy1hNjdjLWEyMjE4NzE0YTc1ZS53ZWJtP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDkxNCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA5MTRUMTcyNTE0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MDE3Njc0MmZjZWJhYWY4YmNiZDQ5NmViMDRhMjY0MTVlNzYzOTIwOGQzZGExZmEyMDY4MDAxMTNhOWIwNjQxNiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.0vsoVYse6sFrniNsbjmNfrSqiPb8n6WUCsll7Gx2mrg

## After:

https://github.com/user-attachments/assets/f794b188-b518-4ded-b401-07b3891bb572


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
