### PR TITLE
Fix issue with pip tools install changing the command in requirements_dev.txt

### DIFF
--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -28,6 +28,10 @@ runs:
         ls -la oppia/build
         echo "Files in third_party:"
         ls -la oppia/third_party
+        echo "Contents of requirements_dev.txt:"
+        cat ./oppia/requirements_dev.txt
+        echo "Contents of requirements.txt:"
+        cat ./oppia/requirements.txt
       working-directory: /home/runner/work/oppia
       shell: bash
     - name: Build Webpack

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -135,6 +135,7 @@ runs:
         cat /home/runner/work/oppia/oppia/requirements_dev.txt
         echo "Contents of requirements.txt (before):"
         cat /home/runner/work/oppia/oppia/requirements.txt
+      shell: bash
 
     - name: Install third-party libs on cache miss (retries on error)
       if: steps.restore_third_party_and_node_modules_cache.outputs.cache-hit == false

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -152,6 +152,7 @@ runs:
         cat /home/runner/work/oppia/oppia/requirements_dev.txt
         echo "Contents of requirements.txt (after):"
         cat /home/runner/work/oppia/oppia/requirements.txt
+      shell: bash
 
     - name: Check Yarn Cache
       # Check the yarn cache again to see what packages were just

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -129,6 +129,13 @@ runs:
           /home/runner/work/oppia/oppia/third_party/python_libs
           /home/runner/work/oppia/oppia/third_party/static
 
+    - name: Print requirements files (before)
+      run: |
+        echo "Contents of requirements_dev.txt (before):"
+        cat /home/runner/work/oppia/oppia/requirements_dev.txt
+        echo "Contents of requirements.txt (before):"
+        cat /home/runner/work/oppia/oppia/requirements.txt
+
     - name: Install third-party libs on cache miss (retries on error)
       if: steps.restore_third_party_and_node_modules_cache.outputs.cache-hit == false
       uses: nick-fields/retry@v3
@@ -138,6 +145,13 @@ runs:
         shell: bash
         timeout_minutes: 30
         command: python -m scripts.install_third_party_libs
+
+    - name: Print requirements files (after)
+      run: |
+        echo "Contents of requirements_dev.txt (after):"
+        cat /home/runner/work/oppia/oppia/requirements_dev.txt
+        echo "Contents of requirements.txt (after):"
+        cat /home/runner/work/oppia/oppia/requirements.txt
 
     - name: Check Yarn Cache
       # Check the yarn cache again to see what packages were just

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -21,8 +21,8 @@ RUN curl -L -o google-chrome.deb https://github.com/webnicer/chrome-downloads/ra
 RUN apt-get install -y ./google-chrome.deb
 RUN rm google-chrome.deb
 
-RUN pip install --upgrade pip==21.2.3
-RUN pip install pip-tools==6.6.2 setuptools==58.5.3 cmake
+RUN pip install --upgrade pip==25.2
+RUN pip install pip-tools==7.5.0 setuptools==80.9.0 cmake
 
 WORKDIR /app/vm_deps
 

--- a/scripts/install_python_dev_dependencies.py
+++ b/scripts/install_python_dev_dependencies.py
@@ -132,6 +132,11 @@ def compile_pip_requirements(
     """
     with open(compiled_path, 'r', encoding='utf-8') as f:
         old_compiled = list(f.readlines())
+    # Warning: In some CI environments, running this command seems to add
+    # --cert=None --client-cert=None --pip-args=None flags to the pip-compile
+    # command referenced at the start of the compiled requirements file. It is
+    # not clear why this happens, since these args are not explicitly being
+    # passed here. We account for that later below when computing the diff.
     subprocess.run(
         [
             'pip-compile', '--no-emit-index-url', '--quiet',
@@ -154,8 +159,8 @@ def compile_pip_requirements(
         i for i, value in enumerate(new_compiled)
         if value.startswith('#    pip-compile')][0]
     diff = list(difflib.unified_diff(
-        old_compiled[old_pip_compile_line_index:],
-        new_compiled[new_pip_compile_line_index:],
+        old_compiled[old_pip_compile_line_index + 1:],
+        new_compiled[new_pip_compile_line_index + 1:],
         lineterm=''))
     print('Printing diff in %s:' % requirements_path)
     print('--------------------------')

--- a/scripts/install_python_dev_dependencies.py
+++ b/scripts/install_python_dev_dependencies.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import os
 import subprocess
 import sys
@@ -129,7 +130,7 @@ def compile_pip_requirements(
         bool. Whether the compiled dev requirements file was changed.
     """
     with open(compiled_path, 'r', encoding='utf-8') as f:
-        old_compiled = f.read()
+        old_compiled = f.readlines()
     subprocess.run(
         [
             'pip-compile', '--no-emit-index-url', '--quiet',
@@ -140,7 +141,14 @@ def compile_pip_requirements(
         encoding='utf-8',
     )
     with open(compiled_path, 'r', encoding='utf-8') as f:
-        new_compiled = f.read()
+        new_compiled = f.readlines()
+
+    diff = difflib.unified_diff(old_compiled, new_compiled, lineterm='')
+    print('Printing diff in %s:' % requirements_path)
+    print('--------------------------')
+    for line in diff:
+        print(line)
+    print('--------------------------')
 
     return old_compiled != new_compiled
 

--- a/scripts/install_python_dev_dependencies.py
+++ b/scripts/install_python_dev_dependencies.py
@@ -119,7 +119,7 @@ def uninstall_dev_dependencies() -> None:
 
 def compile_pip_requirements(
     requirements_path: str, compiled_path: str
-) -> bool:
+) -> str:
     """Compile a requirements.txt file.
 
     Args:
@@ -127,7 +127,8 @@ def compile_pip_requirements(
         compiled_path: str. Path to the requirements.txt file.
 
     Returns:
-        bool. Whether the compiled dev requirements file was changed.
+        str. The diff between the original and compiled requirements files, as
+        a string containing newlines.
     """
     with open(compiled_path, 'r', encoding='utf-8') as f:
         old_compiled = list(f.readlines())
@@ -152,10 +153,9 @@ def compile_pip_requirements(
     new_pip_compile_line_index = [
         i for i, value in enumerate(new_compiled)
         if value.startswith('#    pip-compile')][0]
-
     diff = list(difflib.unified_diff(
-        old_compiled[old_pip_compile_line_index + 1:],
-        new_compiled[new_pip_compile_line_index + 1:],
+        old_compiled[old_pip_compile_line_index:],
+        new_compiled[new_pip_compile_line_index:],
         lineterm=''))
     print('Printing diff in %s:' % requirements_path)
     print('--------------------------')
@@ -163,7 +163,7 @@ def compile_pip_requirements(
         print(line)
     print('--------------------------')
 
-    return bool(diff)
+    return '\n'.join(list(diff))
 
 
 def main(cli_args: Optional[List[str]] = None) -> None:
@@ -171,19 +171,20 @@ def main(cli_args: Optional[List[str]] = None) -> None:
     args = _PARSER.parse_args(cli_args)
     check_python_env_is_suitable()
     install_installation_tools()
-    not_compiled = compile_pip_requirements(
+    diff = compile_pip_requirements(
         REQUIREMENTS_DEV_FILE_PATH, COMPILED_REQUIREMENTS_DEV_FILE_PATH)
     if args.uninstall:
         uninstall_dev_dependencies()
     else:
         install_dev_dependencies()
-        if args.assert_compiled and not_compiled:
+        if args.assert_compiled and diff:
             raise RuntimeError(
                 'The Python development requirements file '
                 f'{COMPILED_REQUIREMENTS_DEV_FILE_PATH} was changed by the '
-                'installation script. Please commit the changes. '
-                'You can get the changes again by running this command: '
-                'python -m scripts.install_python_dev_dependencies')
+                'installation script. See diff:\n%s\n\n. Please commit the '
+                'changes. You can get the changes again by running this '
+                'command: python -m scripts.install_python_dev_dependencies' %
+                diff)
 
 
 # This code cannot be covered by tests since it only runs when this file

--- a/scripts/install_python_dev_dependencies.py
+++ b/scripts/install_python_dev_dependencies.py
@@ -130,7 +130,7 @@ def compile_pip_requirements(
         bool. Whether the compiled dev requirements file was changed.
     """
     with open(compiled_path, 'r', encoding='utf-8') as f:
-        old_compiled = f.readlines()
+        old_compiled = list(f.readlines())
     subprocess.run(
         [
             'pip-compile', '--no-emit-index-url', '--quiet',
@@ -141,16 +141,29 @@ def compile_pip_requirements(
         encoding='utf-8',
     )
     with open(compiled_path, 'r', encoding='utf-8') as f:
-        new_compiled = f.readlines()
+        new_compiled = list(f.readlines())
 
-    diff = difflib.unified_diff(old_compiled, new_compiled, lineterm='')
+    # The options to pip-compile sometimes differ on regeneration (e.g.
+    # cert=None might be passed), so we skip the pip-compile line and those
+    # above it when computing the diff.
+    old_pip_compile_line_index = [
+        i for i, value in enumerate(old_compiled)
+        if value.startswith('#    pip-compile')][0]
+    new_pip_compile_line_index = [
+        i for i, value in enumerate(new_compiled)
+        if value.startswith('#    pip-compile')][0]
+
+    diff = list(difflib.unified_diff(
+        old_compiled[old_pip_compile_line_index + 1:],
+        new_compiled[new_pip_compile_line_index + 1:],
+        lineterm=''))
     print('Printing diff in %s:' % requirements_path)
     print('--------------------------')
     for line in diff:
         print(line)
     print('--------------------------')
 
-    return old_compiled != new_compiled
+    return bool(diff)
 
 
 def main(cli_args: Optional[List[str]] = None) -> None:

--- a/scripts/install_python_dev_dependencies_test.py
+++ b/scripts/install_python_dev_dependencies_test.py
@@ -188,7 +188,7 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
 
         def mock_open(*_args: str, **_kwargs: str) -> io.StringIO:
             return io.StringIO(
-                f'#    pip-compile --generate-hashes\nmock file contents')
+                '#    pip-compile --generate-hashes\nmock file contents')
 
         run_swap = self.swap_with_checks(
             subprocess, 'run', mock_run, expected_args=[
@@ -230,8 +230,7 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
         def mock_open(*_args: str, **_kwargs: str) -> io.StringIO:
             counter.append(1)
             return io.StringIO(
-                f'#    pip-compile --generate-hashes\n'
-                'mock file contents {len(counter)}')
+                f'#    pip-compile --generate-hashes\nmock file {len(counter)}')
 
         run_swap = self.swap_with_checks(
             subprocess, 'run', mock_run, expected_args=[

--- a/scripts/install_python_dev_dependencies_test.py
+++ b/scripts/install_python_dev_dependencies_test.py
@@ -187,7 +187,8 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             pass
 
         def mock_open(*_args: str, **_kwargs: str) -> io.StringIO:
-            return io.StringIO('mock file contents')
+            return io.StringIO(
+                f'#    pip-compile --generate-hashes\nmock file contents')
 
         run_swap = self.swap_with_checks(
             subprocess, 'run', mock_run, expected_args=[
@@ -228,7 +229,9 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
 
         def mock_open(*_args: str, **_kwargs: str) -> io.StringIO:
             counter.append(1)
-            return io.StringIO(f'mock file contents {len(counter)}')
+            return io.StringIO(
+                f'#    pip-compile --generate-hashes\n'
+                'mock file contents {len(counter)}')
 
         run_swap = self.swap_with_checks(
             subprocess, 'run', mock_run, expected_args=[

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -293,7 +293,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    'python', '-m', 'pip', 'install', '--require-hashes',
+                    sys.executable, '-m', 'pip', 'install', '--require-hashes',
                     '--no-deps', '--target',
                     common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--no-dependencies',
@@ -344,27 +344,27 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s#egg=git-dep1' % (
                         self.get_git_version_string('git-dep1', 'a')),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s#egg=git-dep2' % (
                         self.get_git_version_string('git-dep2', 'a')),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s==%s' % ('flask', '1.1.0.1'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s==%s' % ('six', '1.16.0'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
@@ -425,7 +425,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    'python', '-m', 'pip', 'install', '--require-hashes',
+                    sys.executable, '-m', 'pip', 'install', '--require-hashes',
                     '--no-deps', '--target',
                     common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--no-dependencies', '-r',
@@ -510,6 +510,9 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         self.assertEqual(print_statements, [
             'Checking if pip is installed on the local machine',
             'Regenerating "requirements.txt" file...',
+            'Printing diff in requirements.in:',
+            '--------------------------',
+            '--------------------------',
             'All third-party Python libraries are already installed '
             'correctly.'
         ])
@@ -577,25 +580,25 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s==%s' % ('flask', '1.1.1'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s==%s' % ('webencodings', '1.1.1'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s==%s' % ('six', '1.16.0'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    'python', '-m', 'pip', 'install',
+                    sys.executable, '-m', 'pip', 'install',
                     '%s==%s' % ('google-cloud-datastore', '1.15.0'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -293,7 +293,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install', '--require-hashes',
+                    'python', '-m', 'pip', 'install', '--require-hashes',
                     '--no-deps', '--target',
                     common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--no-dependencies',
@@ -344,27 +344,27 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s#egg=git-dep1' % (
                         self.get_git_version_string('git-dep1', 'a')),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s#egg=git-dep2' % (
                         self.get_git_version_string('git-dep2', 'a')),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s==%s' % ('flask', '1.1.0.1'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s==%s' % ('six', '1.16.0'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
@@ -425,7 +425,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install', '--require-hashes',
+                    'python', '-m', 'pip', 'install', '--require-hashes',
                     '--no-deps', '--target',
                     common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--no-dependencies', '-r',
@@ -580,25 +580,25 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--output-file', 'requirements.txt',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s==%s' % ('flask', '1.1.1'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s==%s' % ('webencodings', '1.1.1'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s==%s' % ('six', '1.16.0'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
                 [
-                    sys.executable, '-m', 'pip', 'install',
+                    'python', '-m', 'pip', 'install',
                     '%s==%s' % ('google-cloud-datastore', '1.15.0'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: Fix issue with pip tools install changing the command in requirements_dev.txt. The bug seems to be due to some behaviour in pip-tools that adds extra flags to the compilation command. The fix is to omit the comments at the top of the file when compiling the diff (which is used to determine whether the requirements file has changed).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This will be shown by the CI checks on this PR.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
