### PR TITLE
correct ellipsis menu option alignment

### DIFF
--- a/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.component.html
@@ -269,21 +269,23 @@
   }
 
   .skill-list-options-container {
-    display: inline;
-    position: relative;
-  }
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+}
 
   .skill-edit-options {
-    background-color: #fff;
-    border: 1px solid #000;
-    display: flex;
-    flex-wrap: wrap;
-    position: absolute;
-    right: 0;
-    text-align: left;
-    top: 0;
-    width: 140px;
-  }
+  background-color: #fff;
+  border: 1px solid #000;
+  display: flex;
+  flex-wrap: wrap;
+  left: auto; /* add this */
+  position: absolute;
+  right: 0;
+  text-align: left;
+  top: 0;
+  width: 140px;
+}
 
   .assign-skill-box,
   .merge-skill-box,
@@ -354,10 +356,17 @@
     }
 
     .skill-edit-options {
-      right: 15px;
-      text-align: left;
-      top: -5px;
-      width: 140px;
+        left: auto; /* add this */
+        right: 15px;
+        text-align: left;
+        top: -5px;
+        width: 140px;
+      }
+
+     .skill-list-options-container {
+        display: flex;
+        justify-content: flex-end;
+        position: relative;
     }
 
     .skill-edit-box-icon {


### PR DESCRIPTION
Overview
This PR fixes [#23000](https://github.com/oppia/oppia/issues/23000):
Ellipses menu option box alignment bug in Topics and Skills Dashboard.

Previously, the options box appeared misaligned, making it harder for users to access menu choices.
This PR re-positions the options box so it appears directly below the ellipsis button, providing a consistent and expected UI.
### Checklist

- [x] Branch is based on the latest Oppia `develop`
- [x] Only intended file(s) were changed
- [x] Screenshot/video proof of fix is provided below
- [x] Tested in Chrome, Firefox, and mobile emulator
- [x] Verified RTL (Arabic) layout and standard (English)
- [x] No console errors/warnings after change
- [x] All local linters and tests passed

Proof of Correct Changes
After (Fixed UI):
<img width="1916" height="1003" alt="Screenshot 2025-09-23 093738" src="https://github.com/user-attachments/assets/63b3ccfe-c668-4ce7-8bae-3de63dfad0b8" />

[Demo video showing correct menu behavior](https://github.com/user-attachments/assets/b74c34d4-c519-4882-8e87-56f5e10e271d)

