### PR TITLE
Fixes  #23482: Fixes Docker issue where Debian buster is deprecated while building angular-build.

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:16.13.0-slim AS frontend
+FROM node:20.17.0-slim as frontend
 
 WORKDIR /app/oppia
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [✅ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ✅] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [✅ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ✅] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
** Before**:
When trying to build the angular build using docker it was failing. This was happening because the version of node which was being used didn't support Debian. 
Issue #23482  this issue exactly talks about what is the problem which is being caused in detail.
<img width="1920" height="1020" alt="Debbian_error-oppia" src="https://github.com/user-attachments/assets/14ea3dd3-cf0e-4d3e-8242-20351cf0880f" />
This image shows how while building the Debian Error is being caused because of older node js version when compiling DockerFile.Frontend. 


**After**:
After updating the node version in DockerFrontend.file 
<img width="1920" height="1020" alt="debian-fixed" src="https://github.com/user-attachments/assets/a8091e97-5f42-4063-8371-c7e463b929f4" />

After Updating the DockerFronted.File the build happens successfully.



#### Proof of changes on desktop with slow/throttled network
**The change made in the DockerFrontend.file:**
<img width="1599" height="737" alt="DockerFile Frontend" src="https://github.com/user-attachments/assets/ab00eb39-3eb3-4ed8-957d-819041ea5f98" />
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
