### PR TITLE
Get project ID from env variables and not from platform parameters

### DIFF
--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -666,10 +666,6 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
                 platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
                 'system@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_send_post_signup_email(self) -> None:
@@ -1112,10 +1108,6 @@ class SignupTests(test_utils.GenericTestBase):
                 platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_user_settings_of_existing_user(self) -> None:

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -699,10 +699,6 @@ class TopicEditorTests(
                 'system@example.com'
             ),
             (platform_parameter_list.ParamName.SYSTEM_EMAIL_NAME, '.'),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_editable_topic_handler_get(self) -> None:
@@ -820,10 +816,6 @@ class TopicEditorTests(
                 'system@example.com'
             ),
             (platform_parameter_list.ParamName.SYSTEM_EMAIL_NAME, '.'),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_editable_topic_handler_put(self) -> None:
@@ -1277,10 +1269,6 @@ class TopicPublishSendMailHandlerTests(
                 'system@example.com'
             ),
             (platform_parameter_list.ParamName.SYSTEM_EMAIL_NAME, '.'),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_send_mail(self) -> None:

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -188,10 +188,6 @@ class TopicPageDataHandlerTests(
                 'system@example.com'
             ),
             (platform_parameter_list.ParamName.SYSTEM_EMAIL_NAME, '.'),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_get_with_user_logged_in(self) -> None:

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -83,7 +83,6 @@ class EmailToAdminTest(test_utils.EmailTestBase):
             (param_list.ParamName.ADMIN_EMAIL_ADDRESS, 'admin@system.com'),
             (param_list.ParamName.SYSTEM_EMAIL_ADDRESS, 'dummy@system.com'),
             (param_list.ParamName.SYSTEM_EMAIL_NAME, 'DUMMY_SYSTEM_NAME'),
-            (param_list.ParamName.OPPIA_PROJECT_ID, 'dev-project-id')
         ]
     )
     def test_email_to_admin_is_sent_correctly(self) -> None:
@@ -706,10 +705,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
               param_list.ParamName.SYSTEM_EMAIL_ADDRESS,
               'system@example.com'
             ),
-            (
-              param_list.ParamName.OPPIA_PROJECT_ID,
-              'dev-project-id'
-            )
         ]
     )
     def test_email_not_sent_if_config_does_not_permit_it(self) -> None:
@@ -759,10 +754,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_email_not_sent_if_content_parameter_is_not_modified(self) -> None:
@@ -822,10 +813,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
               param_list.ParamName.SYSTEM_EMAIL_ADDRESS,
               'system@example.com'
             ),
-            (
-              param_list.ParamName.OPPIA_PROJECT_ID,
-              'dev-project-id'
-            )
         ]
     )
     def test_email_not_sent_if_content_config_is_partially_modified(
@@ -914,10 +901,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_email_with_bad_content_is_not_sent(self) -> None:
@@ -986,10 +969,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_contents_of_signup_email_are_correct(self) -> None:
@@ -1096,10 +1075,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_email_only_sent_once_for_repeated_signups_by_same_user(
@@ -1176,10 +1151,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_email_only_sent_if_signup_was_successful(self) -> None:
@@ -1254,10 +1225,6 @@ class SignupEmailTests(test_utils.EmailTestBase):
                 param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_record_of_sent_email_is_written_to_datastore(self) -> None:
@@ -6896,10 +6863,6 @@ class QueryStatusNotificationEmailTests(test_utils.EmailTestBase):
                 param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_that_correct_failure_email_is_sent(self) -> None:
@@ -7062,10 +7025,6 @@ class AccountDeletionEmailUnitTest(test_utils.EmailTestBase):
                 param_list.ParamName.SYSTEM_EMAIL_NAME,
                 '.'
             ),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_account_deletion_failed_email_is_sent_correctly(self) -> None:
@@ -7929,10 +7888,6 @@ class NotMergeableChangesEmailUnitTest(test_utils.EmailTestBase):
                 'system@example.com'
             ),
             (param_list.ParamName.SYSTEM_EMAIL_NAME, '.'),
-            (
-                param_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_not_mergeable_change_list_email_is_sent_correctly(self) -> None:

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -17632,10 +17632,6 @@ class ExplorationChangesMergeabilityUnitTests(
                 'system@example.com'
             ),
             (platform_parameter_list.ParamName.SYSTEM_EMAIL_NAME, '.'),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_email_is_sent_to_admin_in_case_of_adding_deleting_state_changes(
@@ -17982,10 +17978,6 @@ class ExplorationChangesMergeabilityUnitTests(
                 'system@example.com'
             ),
             (platform_parameter_list.ParamName.SYSTEM_EMAIL_NAME, '.'),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_email_is_sent_to_admin_in_case_of_state_renames_changes_conflict(

--- a/core/domain/fs_services.py
+++ b/core/domain/fs_services.py
@@ -429,16 +429,8 @@ def get_static_asset_url(filepath: str) -> str:
     oppia_site_url = platform_parameter_services.get_platform_parameter_value(
         platform_parameter_list.ParamName.OPPIA_SITE_URL_FOR_EMAILS.value
     )
-    oppia_project_id = (
-        platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
     logging.info(
         'Logging OPPIA_SITE_URL_FOR_EMAILS for debugging: %s' % oppia_site_url
-    )
-    logging.info(
-        'Logging OPPIA_PROJECT_ID platform param for debugging: %s' % (
-            oppia_project_id
-        )
     )
     if constants.EMULATOR_MODE:
         # By using assetsstatic the app returns the requested
@@ -448,6 +440,5 @@ def get_static_asset_url(filepath: str) -> str:
         return 'http://localhost:8181/assetsstatic/%s' % (
             filepath
         )
-    assert isinstance(oppia_project_id, str)
     return 'https://storage.googleapis.com/%s-static/%s' % (
-        oppia_project_id, filepath)
+        app_identity_services.get_application_id(), filepath)

--- a/core/domain/fs_services_test.py
+++ b/core/domain/fs_services_test.py
@@ -27,7 +27,14 @@ from core.domain import (
     platform_parameter_list,
     user_services,
 )
+from core.platform import models
 from core.tests import test_utils
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import app_identity_services
+
+app_identity_services = models.Registry.import_app_identity_services()
 
 
 class GcsFileSystemUnitTests(test_utils.GenericTestBase):
@@ -360,7 +367,6 @@ class GetStaticAssetUrlTests(test_utils.GenericTestBase):
 
     @test_utils.set_platform_parameters(
         [
-            (platform_parameter_list.ParamName.OPPIA_PROJECT_ID, 'project-id'),
             (
                 platform_parameter_list.ParamName.OPPIA_SITE_URL_FOR_EMAILS,
                 'test-url'
@@ -369,7 +375,9 @@ class GetStaticAssetUrlTests(test_utils.GenericTestBase):
     )
     def test_function_returns_correct_url_for_non_emulator_mode(self) -> None:
         with self.swap(constants, 'EMULATOR_MODE', False):
-            with self.swap(feconf, 'OPPIA_PROJECT_ID', 'project-id'):
+            with self.swap(
+                    app_identity_services, 'get_application_id',
+                    lambda: 'project-id'):
                 self.assertEqual(
                     fs_services.get_static_asset_url('test/image.png'),
                     'https://storage.googleapis.com/project-id-static/'

--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -64,7 +64,6 @@ class ParamName(enum.Enum):
     MAILGUN_DOMAIN_NAME = 'mailgun_domain_name'
     ES_CLOUD_ID = 'es_cloud_id'
     ES_USERNAME = 'es_username'
-    OPPIA_PROJECT_ID = 'oppia_project_id'
     OPPIA_SITE_URL_FOR_EMAILS = 'oppia_site_url_for_emails'
 
 
@@ -103,6 +102,5 @@ ALL_PLATFORM_PARAMS_LIST: List[ParamName] = [
     ParamName.MAILGUN_DOMAIN_NAME,
     ParamName.ES_CLOUD_ID,
     ParamName.ES_USERNAME,
-    ParamName.OPPIA_PROJECT_ID,
     ParamName.OPPIA_SITE_URL_FOR_EMAILS
 ]

--- a/core/domain/platform_parameter_list_test.py
+++ b/core/domain/platform_parameter_list_test.py
@@ -47,7 +47,6 @@ class ExistingPlatformParameterValidityTests(test_utils.GenericTestBase):
                             'max_number_of_tags_assigned_to_blog_post',
                             'notify_admins_suggestions_waiting_too_long_is_enabled', # pylint: disable=line-too-long
                             'noreply_email_address',
-                            'oppia_project_id',
                             'oppia_site_url_for_emails',
                             'promo_bar_enabled',
                             'promo_bar_message',

--- a/core/domain/platform_parameter_registry.py
+++ b/core/domain/platform_parameter_registry.py
@@ -573,13 +573,6 @@ Registry.create_platform_parameter(
 )
 
 Registry.create_platform_parameter(
-    ParamName.OPPIA_PROJECT_ID,
-    'Project ID of oppia server.',
-    platform_parameter_domain.DataTypes.STRING,
-    default='dev-project-id'
-)
-
-Registry.create_platform_parameter(
     ParamName.OPPIA_SITE_URL_FOR_EMAILS,
     'Oppia site URL used in emails.',
     platform_parameter_domain.DataTypes.STRING,

--- a/core/domain/wipeout_service_test.py
+++ b/core/domain/wipeout_service_test.py
@@ -696,10 +696,6 @@ class WipeoutServiceRunFunctionsTests(test_utils.GenericTestBase):
                 platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
                 'system@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_run_user_deletion_completion_with_user_properly_deleted(
@@ -746,10 +742,6 @@ class WipeoutServiceRunFunctionsTests(test_utils.GenericTestBase):
                 platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
                 'system@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_run_user_deletion_completion_user_wrongly_deleted_emails_enabled(
@@ -5706,10 +5698,6 @@ class PendingUserDeletionTaskServiceTests(test_utils.GenericTestBase):
                 platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
                 'system@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_repeated_deletion_is_successful_when_emails_enabled(
@@ -5763,10 +5751,6 @@ class PendingUserDeletionTaskServiceTests(test_utils.GenericTestBase):
                 platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
                 'system@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_regular_deletion_is_successful(self) -> None:
@@ -5876,10 +5860,6 @@ class CheckCompletionOfUserDeletionTaskServiceTests(
                 platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_verification_when_user_is_deleted_is_successful(self) -> None:
@@ -5905,10 +5885,6 @@ class CheckCompletionOfUserDeletionTaskServiceTests(
                 platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
                 'system@example.com'
             ),
-            (
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID,
-                'dev-project-id'
-            )
         ]
     )
     def test_verification_when_user_is_wrongly_deleted_fails(self) -> None:

--- a/core/jobs/io/ndb_io.py
+++ b/core/jobs/io/ndb_io.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-from core.domain import platform_parameter_list, platform_parameter_services
 from core.jobs import job_utils
 from core.platform import models
 
@@ -29,8 +28,9 @@ from typing import Optional
 
 MYPY = False
 if MYPY:  # pragma: no cover
-    from mypy_imports import datastore_services
+    from mypy_imports import app_identity_services, datastore_services
 
+app_identity_services = models.Registry.import_app_identity_services()
 datastore_services = models.Registry.import_datastore_services()
 
 
@@ -100,10 +100,7 @@ class PutModels(beam.PTransform): # type: ignore[misc]
             PCollection. An empty PCollection. This is needed because all
             expand() methods need to return some PCollection.
         """
-        oppia_project_id = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
-        assert isinstance(oppia_project_id, str)
+        oppia_project_id = app_identity_services.get_application_id()
         return (
             entities
             | 'Transforming the NDB models into Apache Beam entities' >> (
@@ -135,10 +132,7 @@ class DeleteModels(beam.PTransform): # type: ignore[misc]
             PCollection. An empty PCollection. This is needed because all
             expand() methods need to return some PCollection.
         """
-        oppia_project_id = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
-        assert isinstance(oppia_project_id, str)
+        oppia_project_id = app_identity_services.get_application_id()
         return (
             entities
             | 'Transforming the NDB keys into Apache Beam keys' >> (

--- a/core/jobs/job_options.py
+++ b/core/jobs/job_options.py
@@ -21,7 +21,13 @@ from __future__ import annotations
 import argparse
 
 from core import feconf
-from core.domain import platform_parameter_list, platform_parameter_services
+from core.platform import models
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import app_identity_services
+
+app_identity_services = models.Registry.import_app_identity_services()
 
 from apache_beam.options import pipeline_options
 from typing import List, Optional
@@ -63,9 +69,7 @@ class JobOptions(pipeline_options.PipelineOptions): # type: ignore[misc]
             joined_unsupported_options = ', '.join(sorted(unsupported_options))
             raise ValueError(
                 'Unsupported option(s): %s' % joined_unsupported_options)
-        oppia_project_id = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
+        oppia_project_id = app_identity_services.get_application_id()
         assert isinstance(oppia_project_id, str)
         super().__init__(
             # Needed by PipelineOptions.

--- a/core/jobs/job_options.py
+++ b/core/jobs/job_options.py
@@ -23,14 +23,14 @@ import argparse
 from core import feconf
 from core.platform import models
 
+from apache_beam.options import pipeline_options
+from typing import List, Optional
+
 MYPY = False
 if MYPY: # pragma: no cover
     from mypy_imports import app_identity_services
 
 app_identity_services = models.Registry.import_app_identity_services()
-
-from apache_beam.options import pipeline_options
-from typing import List, Optional
 
 
 # TODO(#15613): Here we use MyPy ignore because the incomplete typing of

--- a/core/jobs/job_utils.py
+++ b/core/jobs/job_utils.py
@@ -30,7 +30,7 @@ if MYPY: # pragma: no cover
     from mypy_imports import (
         app_identity_services,
         base_models,
-        datastore_services
+        datastore_services,
     )
 
 app_identity_services = models.Registry.import_app_identity_services()

--- a/core/jobs/job_utils.py
+++ b/core/jobs/job_utils.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-from core.domain import platform_parameter_list, platform_parameter_services
 from core.platform import models
 
 from apache_beam.io.gcp.datastore.v1new import types as beam_datastore_types
@@ -28,10 +27,14 @@ from typing import Any, List, Optional, Tuple, Type, Union, cast
 
 MYPY = False
 if MYPY: # pragma: no cover
-    from mypy_imports import base_models, datastore_services
+    from mypy_imports import (
+        app_identity_services,
+        base_models,
+        datastore_services
+    )
 
+app_identity_services = models.Registry.import_app_identity_services()
 datastore_services = models.Registry.import_datastore_services()
-
 (base_models,) = models.Registry.import_models([models.Names.BASE_MODEL])
 
 
@@ -288,10 +291,7 @@ def get_beam_query_from_ndb_query(
         # its results by __key__ (the models' .key() value).
         order = ('__key__',)
 
-    oppia_project_id = (
-        platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
-    assert isinstance(oppia_project_id, str)
+    oppia_project_id = app_identity_services.get_application_id()
     return beam_datastore_types.Query(
         kind=kind, namespace=namespace, project=oppia_project_id,
         filters=filters, order=order)

--- a/core/jobs/jobs_manager.py
+++ b/core/jobs/jobs_manager.py
@@ -24,7 +24,7 @@ import pprint
 import traceback
 
 from core import feconf
-from core.domain import beam_job_services, caching_services,
+from core.domain import beam_job_services, caching_services
 from core.jobs import base_jobs, job_options
 from core.jobs.io import cache_io, job_io
 from core.platform import models

--- a/core/jobs/jobs_manager.py
+++ b/core/jobs/jobs_manager.py
@@ -27,8 +27,6 @@ from core import feconf
 from core.domain import (
     beam_job_services,
     caching_services,
-    platform_parameter_list,
-    platform_parameter_services,
 )
 from core.jobs import base_jobs, job_options
 from core.jobs.io import cache_io, job_io
@@ -42,8 +40,9 @@ from typing import Iterator, Optional, Type
 
 MYPY = False
 if MYPY: # pragma: no cover
-    from mypy_imports import datastore_services
+    from mypy_imports import app_identity_services, datastore_services
 
+app_identity_services = models.Registry.import_app_identity_services()
 datastore_services = models.Registry.import_datastore_services()
 
 # This is a mapping from the Google Cloud Dataflow JobState enum to our enum.
@@ -186,10 +185,7 @@ def refresh_state_of_beam_job_run_model(
         return
 
     try:
-        oppia_project_id = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
-        assert isinstance(oppia_project_id, str)
+        oppia_project_id = app_identity_services.get_application_id()
         job = dataflow.JobsV1Beta3Client().get_job(dataflow.GetJobRequest(
             job_id=job_id, project_id=oppia_project_id,
             location=feconf.GOOGLE_APP_ENGINE_REGION))
@@ -238,10 +234,7 @@ def cancel_job(beam_job_run_model: beam_job_models.BeamJobRunModel) -> None:
         raise ValueError('dataflow_job_id must not be None')
 
     try:
-        oppia_project_id = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
-        assert isinstance(oppia_project_id, str)
+        oppia_project_id = app_identity_services.get_application_id()
         dataflow.JobsV1Beta3Client().update_job(dataflow.UpdateJobRequest(
             job_id=job_id, project_id=oppia_project_id,
             location=feconf.GOOGLE_APP_ENGINE_REGION,

--- a/core/jobs/jobs_manager.py
+++ b/core/jobs/jobs_manager.py
@@ -24,10 +24,7 @@ import pprint
 import traceback
 
 from core import feconf
-from core.domain import (
-    beam_job_services,
-    caching_services,
-)
+from core.domain import beam_job_services, caching_services,
 from core.jobs import base_jobs, job_options
 from core.jobs.io import cache_io, job_io
 from core.platform import models

--- a/core/jobs/jobs_manager_test.py
+++ b/core/jobs/jobs_manager_test.py
@@ -189,9 +189,7 @@ class RefreshStateOfBeamJobRunModelTests(test_utils.GenericTestBase):
             jobs_manager.refresh_state_of_beam_job_run_model(self.run_model)
 
         self.assertGreater(len(logs), 0)
-        # TODO(release-scripts#137): Update once project ID is verified on
-        # all servers. logs[0] is the debug message to verify project ID.
-        self.assertIn('uh-oh', logs[1])
+        self.assertIn('uh-oh', logs[0])
 
 
 class CancelJobTests(test_utils.GenericTestBase):
@@ -242,6 +240,4 @@ class CancelJobTests(test_utils.GenericTestBase):
             jobs_manager.cancel_job(self.run_model)
 
         self.assertGreater(len(logs), 0)
-        # TODO(release-scripts#137): Update once project ID is verified on
-        # all servers. logs[0] is the debug message to verify project ID.
-        self.assertIn('uh-oh', logs[1])
+        self.assertIn('uh-oh', logs[0])

--- a/core/platform/auth/firebase_auth_services.py
+++ b/core/platform/auth/firebase_auth_services.py
@@ -75,15 +75,14 @@ if MYPY: # pragma: no cover
     from mypy_imports import (
         app_identity_services,
         auth_models,
-        datastore_services
+        datastore_services,
     )
 
 auth_models, user_models = (
     models.Registry.import_models([models.Names.AUTH, models.Names.USER]))
-
 app_identity_services = models.Registry.import_app_identity_services()
-transaction_services = models.Registry.import_transaction_services()
 datastore_services = models.Registry.import_datastore_services()
+transaction_services = models.Registry.import_transaction_services()
 
 
 def establish_firebase_connection() -> None:

--- a/core/platform/auth/firebase_auth_services.py
+++ b/core/platform/auth/firebase_auth_services.py
@@ -72,11 +72,16 @@ from typing import List, Optional
 
 MYPY = False
 if MYPY: # pragma: no cover
-    from mypy_imports import auth_models, datastore_services
+    from mypy_imports import (
+        app_identity_services,
+        auth_models,
+        datastore_services
+    )
 
 auth_models, user_models = (
     models.Registry.import_models([models.Names.AUTH, models.Names.USER]))
 
+app_identity_services = models.Registry.import_app_identity_services()
 transaction_services = models.Registry.import_transaction_services()
 datastore_services = models.Registry.import_datastore_services()
 
@@ -97,12 +102,7 @@ def establish_firebase_connection() -> None:
             firebase_admin.get_app()
         except ValueError as error:
             if 'initialize_app' in str(error):
-                oppia_project_id = (
-                    platform_parameter_services.get_platform_parameter_value(
-                        platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value
-                    )
-                )
-                assert isinstance(oppia_project_id, str)
+                oppia_project_id = app_identity_services.get_application_id()
                 firebase_admin.initialize_app(
                     options={'projectId': oppia_project_id})
             else:

--- a/core/platform/secrets/cloud_secrets_services.py
+++ b/core/platform/secrets/cloud_secrets_services.py
@@ -21,11 +21,17 @@ from __future__ import annotations
 import functools
 
 from core.constants import constants
-from core.domain import platform_parameter_list, platform_parameter_services
+from core.platform import models
 
 from google import auth
 from google.cloud import secretmanager
 from typing import Optional
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import app_identity_services
+
+app_identity_services = models.Registry.import_app_identity_services()
 
 # The 'auth.default()' returns tuple of credentials and project ID. As we are
 # only interested in credentials, we are using '[0]' to access it.
@@ -45,10 +51,7 @@ def get_secret(name: str) -> Optional[str]:
     Returns:
         str. The value of the secret.
     """
-    oppia_project_id = (
-        platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
-    assert isinstance(oppia_project_id, str)
+    oppia_project_id = app_identity_services.get_application_id()
     secret_name = (
         f'projects/{oppia_project_id}/secrets/{name}/versions/latest')
     try:

--- a/core/platform/taskqueue/cloud_taskqueue_services.py
+++ b/core/platform/taskqueue/cloud_taskqueue_services.py
@@ -25,6 +25,7 @@ import logging
 from core import feconf
 from core.constants import constants
 from core.platform import models
+
 from google import auth
 from google.api_core import retry
 from google.cloud import tasks_v2

--- a/core/platform/taskqueue/cloud_taskqueue_services.py
+++ b/core/platform/taskqueue/cloud_taskqueue_services.py
@@ -24,13 +24,18 @@ import logging
 
 from core import feconf
 from core.constants import constants
-from core.domain import platform_parameter_list, platform_parameter_services
-
+from core.platform import models
 from google import auth
 from google.api_core import retry
 from google.cloud import tasks_v2
 from google.protobuf import timestamp_pb2
 from typing import Any, Dict, Optional
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import app_identity_services
+
+app_identity_services = models.Registry.import_app_identity_services()
 
 # The 'auth.default()' returns tuple of credentials and project ID. As we are
 # only interested in credentials, we are using '[0]' to access it.
@@ -69,10 +74,7 @@ def create_http_task(
     """
     # The cloud tasks library requires the Oppia project id and region, as well
     # as the queue name as the path to be able to find the correct queue.
-    oppia_project_id = (
-        platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.OPPIA_PROJECT_ID.value))
-    assert isinstance(oppia_project_id, str)
+    oppia_project_id = app_identity_services.get_application_id()
     parent = CLIENT.queue_path(
         oppia_project_id, feconf.GOOGLE_APP_ENGINE_REGION, queue_name)
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -134,6 +134,7 @@ HOTFIX_BRANCH_REGEX = r'release-(\d+\.\d+\.\d+)-hotfix-[1-9]+$'
 TEST_BRANCH_REGEX = r'test-[A-Za-z0-9-]*$'
 USER_PREFERENCES: Dict[str, Optional[str]] = {'open_new_tab_in_browser': None}
 
+DEV_PROJECT_ID = 'dev-project-id'
 FECONF_PATH = os.path.join('core', 'feconf.py')
 CONSTANTS_FILE_PATH = os.path.join('assets', 'constants.ts')
 APP_DEV_YAML_PATH = os.path.join('app_dev.yaml')

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -228,7 +228,7 @@ def managed_firebase_auth_emulator(
     """
     emulator_args = [
         common.FIREBASE_PATH, 'emulators:start', '--only', 'auth',
-        '--project', feconf.OPPIA_PROJECT_ID,
+        '--project', common.DEV_PROJECT_ID,
         '--config', feconf.FIREBASE_EMULATOR_CONFIG_PATH,
     ]
 
@@ -298,7 +298,7 @@ def managed_cloud_datastore_emulator(
         feconf.CLOUD_DATASTORE_EMULATOR_PORT)
     emulator_args = [
         common.GCLOUD_PATH, 'beta', 'emulators', 'datastore', 'start',
-        '--project', feconf.OPPIA_PROJECT_ID,
+        '--project', common.DEV_PROJECT_ID,
         '--data-dir', common.CLOUD_DATASTORE_EMULATOR_DATA_DIR,
         '--host-port', emulator_hostport,
         '--consistency=1.0',
@@ -328,7 +328,7 @@ def managed_cloud_datastore_emulator(
 
         # Environment variables required to communicate with the emulator.
         stack.enter_context(common.swap_env(
-            'DATASTORE_DATASET', feconf.OPPIA_PROJECT_ID))
+            'DATASTORE_DATASET', common.DEV_PROJECT_ID))
         stack.enter_context(common.swap_env(
             'DATASTORE_EMULATOR_HOST', emulator_hostport))
         stack.enter_context(common.swap_env(
@@ -336,11 +336,11 @@ def managed_cloud_datastore_emulator(
         stack.enter_context(common.swap_env(
             'DATASTORE_HOST', 'http://%s' % emulator_hostport))
         stack.enter_context(common.swap_env(
-            'DATASTORE_PROJECT_ID', feconf.OPPIA_PROJECT_ID))
+            'DATASTORE_PROJECT_ID', common.DEV_PROJECT_ID))
         stack.enter_context(common.swap_env(
             'DATASTORE_USE_PROJECT_ID_AS_APP_ID', 'true'))
         stack.enter_context(common.swap_env(
-            'GOOGLE_CLOUD_PROJECT', feconf.OPPIA_PROJECT_ID))
+            'GOOGLE_CLOUD_PROJECT', common.DEV_PROJECT_ID))
 
         yield proc
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: When restoring the backup server, the platform parameters are copied over from the main server, including the oppia-project-id. This breaks login and, since login is required to fix the platform parameter values, results in the server being irrecoverably broken. This PR fetches the project ID from env variables instead.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This will be deployed and tested on the backup server to confirm that it fixes the problem. If things work correctly there, then it should be fine for other servers as well as the backup-server project ID is hardcoded nowhere in the codebase.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
