### PR TITLE
Pass oppiabot params and secrets as inputs not env vars

### DIFF
--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -33,7 +33,6 @@ jobs:
         uses: oppia/oppiabot@master
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
-        env:
-          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
-          SHEETS_CRED: ${{ secrets.SHEETS_CRED }}
-          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
+          sheets-cred: ${{ secrets.SHEETS_CRED }}
+          sheets-token: ${{ secrets.SHEETS_TOKEN }}
+          cla-sheet-id: ${{ secrets.SPREADSHEET_ID }}


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of n/a.
2. This PR does the following: The latest version of Oppiabot requires that parameters and secrets be passed as inputs (i.e. under the `with` key) instead of as environment variables (i.e. under the `env` key). This change was implemented in oppia/oppiabot#283.
3. (For bug-fixing PRs only) The original bug occurred because: n/a

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Fixing-forward a bug in production. Testing in prod since the fix is straightforward

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
