### PR TITLE
Fix newsletter subscription validation: show error messages for blank and invalid email .

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -754,6 +754,8 @@
     "I18N_FOOTER_NEWSLETTER_HEADING": "Subscribe To Our Newsletter",
     "I18N_FOOTER_NEWSLETTER_TEXT": "Be a part of the Oppia community! Our bi-weekly newsletter keeps you informed on new features, lessons and how Oppia is making a worldwide impact.",
     "I18N_FOOTER_NEWSLETTER_WARNING": "You have already signed up with this email address",
+    "I18N_FOOTER_NEWSLETTER_INVALID": "Please enter a valid email address",
+    "I18N_FOOTER_NEWSLETTER_REQUIRED": "Email is required",
     "I18N_FOOTER_OPPIA_FOUNDATION": "The Oppia Foundation",
     "I18N_FOOTER_OPPIA_MISSION": "Oppia’s mission is to provide a learning platform that meets the unique needs for under resourced communities.",
     "I18N_FOOTER_OPPIA_MISSION_DONATE_VOLUNTEER": "<a href=\"/donate\">Donate</a> or <a href=\"/volunteer\">volunteer</a> today!",

--- a/core/templates/base-components/oppia-footer.component.html
+++ b/core/templates/base-components/oppia-footer.component.html
@@ -15,6 +15,7 @@
                  [(ngModel)]="emailAddress"
                  [ngModelOptions]="{standalone: true}"
                  (ngModelChange)="clearNewsletterWarning()"
+                 (blur)="newsletterTouched = true"
                  required="true"
                  aria-labelledby="email">
           <button class="oppia-footer-newsletter-button e2e-test-newsletter-subscribe-btn"
@@ -25,6 +26,12 @@
         </div>
         <div class="oppia-footer-newsletter-warning" *ngIf="emailDuplicated">
           <p>{{ 'I18N_FOOTER_NEWSLETTER_WARNING' | translate }}</p>
+        </div>
+          <div class="oppia-footer-newsletter-warning" *ngIf="newsletterTouched && (!emailAddress || (emailAddress && emailAddress.trim() === ''))">
+          <p>{{ 'I18N_FOOTER_NEWSLETTER_REQUIRED' | translate }}</p>
+        </div>
+        <div class="oppia-footer-newsletter-warning" *ngIf="newsletterTouched && emailAddress && !validateEmailAddress()">
+          <p>{{ 'I18N_FOOTER_NEWSLETTER_INVALID' | translate }}</p>
         </div>
       </div>
     </div>

--- a/core/templates/base-components/oppia-footer.component.ts
+++ b/core/templates/base-components/oppia-footer.component.ts
@@ -39,6 +39,7 @@ import './oppia-footer.component.css';
 export class OppiaFooterComponent {
   emailAddress: string | null = null;
   name: string | null = null;
+  newsletterTouched: boolean = false;
   siteFeedbackFormUrl: string = AppConstants.SITE_FEEDBACK_FORM_URL;
   currentYear: number = new Date().getFullYear();
   PAGES_REGISTERED_WITH_FRONTEND = AppConstants.PAGES_REGISTERED_WITH_FRONTEND;
@@ -68,6 +69,9 @@ export class OppiaFooterComponent {
   }
 
   validateEmailAddress(): boolean {
+    if (!this.emailAddress) {
+      return false;
+    }
     let regex = new RegExp(AppConstants.EMAIL_REGEX);
     return regex.test(String(this.emailAddress));
   }
@@ -88,6 +92,10 @@ export class OppiaFooterComponent {
   }
 
   subscribeToMailingList(): void {
+    this.newsletterTouched = true;
+    if (!this.validateEmailAddress()) {
+      return;
+    }
     // Convert null or empty string to null for consistency.
     const userName = this.name ? String(this.name) : null;
     if (this.isAlreadySubscribed(String(this.emailAddress))) {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #23573 .
2.This PR does the following:
Fixes newsletter subscription form validation. Now, when the email field is blank, an error message "Email is required" is shown. When an invalid email is entered, an error message "Please enter a valid email address" is displayed. This improves user feedback and clarity.
3.(For bug-fixing PRs only) The original bug occurred because:
The form only highlighted the email field in red for invalid input but did not display any error messages. The validation logic did not trigger user-facing messages for blank or invalid emails. The issue was present in earlier commits; the exact PR introducing it is not identified.

## Essential Checklist
Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #23573: " followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
https://github.com/user-attachments/assets/ac7ae430-c081-4dd8-a3c1-a1d2301c495e


