### PR TITLE
Fix #23572: remove duplicate 'Donate' link from Get Involved menu (desktop + mobile)

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
@@ -277,11 +277,11 @@
           </a>
         </div>
         <div class="oppia-sidebar-submenu-upperborder">
-          <a tabindex="-1" href="/donate" class="e2e-mobile-test-sidebar-get-involved-menu-donate-button">
+          <!-- <a tabindex="-1" href="/donate" class="e2e-mobile-test-sidebar-get-involved-menu-donate-button">
             <i class="fas fa-heart oppia-sidebar-submenu-icon donate-icon"></i>
             <span class="oppia-sidebar-submenu-title">{{ 'I18N_SIDEBAR_DONATE' | translate }}</span>
             <p class="oppia-sidebar-submenu-text">{{ 'I18N_SIDEBAR_DONATE_DESCRIPTION' | translate }}</p>
-          </a>
+          </a> -->
         </div>
         <div class="oppia-sidebar-submenu-upperborder">
           <a tabindex="-1" href="/contact" class="e2e-mobile-test-sidebar-get-involved-menu-contact-us-button">

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -297,7 +297,7 @@
                     {{'I18N_TOPNAV_CONTACT_US_DESCRIPTION' | translate}}
                   </div>
                 </a>
-                <a class="item d-flex flex-column innvolved-item e2e-test-navbar-get-involved-menu-donate-button"
+                <!-- <a class="item d-flex flex-column innvolved-item e2e-test-navbar-get-involved-menu-donate-button"
                    href="/donate"
                    (blur)="getInvolvedDropdown.close()"
                    rel="noopener">
@@ -310,7 +310,7 @@
                   <div class="des">
                     {{'I18N_TOPNAV_DONATE_DESCRIPTION' | translate}}
                   </div>
-                </a>
+                </a> -->
               </div>
             </div>
           </ul>


### PR DESCRIPTION
## Overview

1. This PR fixes #23572.
2. This PR does the following:
   - Removes the duplicate **Donate** link from the **Get Involved** menu in both desktop and mobile navs, keeping a single clear Donate CTA.
3. (Bug fix) The original bug occurred because:
   - The nav templates rendered a Donate item inside **Get Involved** while a separate Donate CTA also existed.

## Approach

- Desktop: Removed the `Get Involved → Donate` block in  
  `core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html`
- Mobile: Removed the `Get Involved → Donate` submenu block in  
  `core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html`
- Kept the primary Donate CTA:
  - Desktop: `e2e-test-navbar-donate-desktop-button`
  - Mobile:  `e2e-test-navbar-donate-mobile-button`

## Proof that changes are correct

| Before (Desktop) | After (Desktop) |
|---|---|
| ![Before Desktop](https://github.com/user-attachments/assets/d9fa7db5-b13f-4baf-83c2-243dcb2c0806) | ![After Desktop](https://github.com/user-attachments/assets/3a017387-5a76-4470-8569-b5e9d8fda894) |

| Before (Mobile) | After (Mobile) |
|---|---|
| ![Before Mobile](https://github.com/user-attachments/assets/9141df30-95aa-4af2-a2c7-20fd3382ed3c) | ![After Mobile](https://github.com/user-attachments/assets/c729de40-4e43-4575-8ca2-a21c6cc231dc) |

Manual verification on local dev server (`http://localhost:8181/learner-dashboard`):
- Hovering **Get Involved** no longer shows *Donate*.
- Standalone *Donate* button remains and links to `/donate`.
- Mobile side nav shows a single *Donate*; none inside *Get Involved*.

## Root cause commits (via pickaxe)

- Desktop duplicate introduced in `b9b4a72009` (PR #19659)  
- Mobile duplicate introduced in `192f0a9a48` (PR #19938)

## Essential Checklist
- The PR title follows “Fix #ISSUE: …”
- I have signed the CLA.
- I followed the PR template and filled items 1–3 above.
- I verified locally on desktop and mobile.
- I attached screenshots in the PR.

## PR Pointers
- I read the Oppia guide: “Create a Good PR”.
- I will respond quickly to review feedback.
