### PR TITLE
Fix #20003: Dashboard button fix

### DIFF
--- a/core/templates/components/question-directives/question-player/question-player.component.html
+++ b/core/templates/components/question-directives/question-player/question-player.component.html
@@ -114,7 +114,7 @@
         <ng-container *ngFor="let actionButton of questionPlayerConfig.resultActionButtons">
           <span *ngIf="!(actionButton.type === 'RETRY_SESSION') && !(actionButton.type === 'DASHBOARD' && !userIsLoggedIn) && !(actionButton.type === 'REVIEW_LOWEST_SCORED_SKILL' && getWorstSkillIds().length === 0)"
                 (click)="performAction(actionButton)">
-            <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}" 
+            <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
                  role="button"
                  tabindex="0">
               <span [innerHTML]="getActionButtonIconHtml(actionButton.type)"></span>

--- a/core/templates/components/question-directives/question-player/question-player.component.html
+++ b/core/templates/components/question-directives/question-player/question-player.component.html
@@ -111,16 +111,17 @@
 
     <div class="results-footer">
       <div class="question-player-results-footer" *ngIf="showActionButtonsFooter()">
-        <span *ngFor="let actionButton of questionPlayerConfig.resultActionButtons"
-              (click)="performAction(actionButton)">
-          <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
-               role="button"
-               tabindex="0"
-               *ngIf="!(actionButton.type === 'RETRY_SESSION') && !(actionButton.type === 'DASHBOARD' && !userIsLoggedIn) && !(actionButton.type === 'REVIEW_LOWEST_SCORED_SKILL' && getWorstSkillIds().length === 0)">
-            <span [innerHTML]="getActionButtonIconHtml(actionButton.type)"></span>
-            <span class="action-button-text" translate="{{actionButton.i18nId}}"></span>
-          </div>
-        </span>
+        <ng-container *ngFor="let actionButton of questionPlayerConfig.resultActionButtons">
+          <span *ngIf="!(actionButton.type === 'RETRY_SESSION') && !(actionButton.type === 'DASHBOARD' && !userIsLoggedIn) && !(actionButton.type === 'REVIEW_LOWEST_SCORED_SKILL' && getWorstSkillIds().length === 0)"
+                (click)="performAction(actionButton)">
+            <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
+                role="button"
+                tabindex="0">
+              <span [innerHTML]="getActionButtonIconHtml(actionButton.type)"></span>
+              <span class="action-button-text" translate="{{actionButton.i18nId}}"></span>
+            </div>
+          </span>
+        </ng-container>
       </div>
       <div class="question-player-results-footer" *ngIf="showActionButtonsFooter()">
         <span *ngFor="let actionButton of questionPlayerConfig.resultActionButtons"
@@ -457,8 +458,13 @@
   .oppia-question-player-container .question-player-results-footer {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    /* justify-content: space-between; */
     padding-top: 2px;
+  }
+
+  /* new rule to keep the last child(my-dashboard-inner) right-aligned*/
+  .oppia-question-player-container .question-player-results-footer > span:last-child {
+    margin-left: auto;
   }
 
   .oppia-question-player-container .practice-questions-coming-soon-header {

--- a/core/templates/components/question-directives/question-player/question-player.component.html
+++ b/core/templates/components/question-directives/question-player/question-player.component.html
@@ -458,11 +458,9 @@
   .oppia-question-player-container .question-player-results-footer {
     display: flex;
     flex-wrap: wrap;
-    /* justify-content: space-between; */
     padding-top: 2px;
   }
 
-  /* new rule to keep the last child(my-dashboard-inner) right-aligned*/
   .oppia-question-player-container .question-player-results-footer > span:last-child {
     margin-left: auto;
   }

--- a/core/templates/components/question-directives/question-player/question-player.component.html
+++ b/core/templates/components/question-directives/question-player/question-player.component.html
@@ -114,9 +114,9 @@
         <ng-container *ngFor="let actionButton of questionPlayerConfig.resultActionButtons">
           <span *ngIf="!(actionButton.type === 'RETRY_SESSION') && !(actionButton.type === 'DASHBOARD' && !userIsLoggedIn) && !(actionButton.type === 'REVIEW_LOWEST_SCORED_SKILL' && getWorstSkillIds().length === 0)"
                 (click)="performAction(actionButton)">
-            <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}"
-                role="button"
-                tabindex="0">
+            <div class="action-button-inner {{getActionButtonInnerClass(actionButton.type)}}" 
+                 role="button"
+                 tabindex="0">
               <span [innerHTML]="getActionButtonIconHtml(actionButton.type)"></span>
               <span class="action-button-text" translate="{{actionButton.i18nId}}"></span>
             </div>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes issue #20003 . 
2. This PR does the following: Correct the misaligned 'My Dashboard' button on the practice session page.
3. (For bug-fixing PRs only) The original bug occurred because: The bug happens because the *ngFor loop is rendering a third, hidden element in the DOM. Although it's not visible, this element is still a child of the flex container. As a result, space-between distributes the space among three elements instead of two, which incorrectly pushes the 'My Dashboard' button away from the far right.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

[cinnamon-2025-10-15T203042+0700.webm](https://github.com/user-attachments/assets/63b90790-b7b3-4820-be55-ce183facd0b2)

Before:
<img width="1920" height="1080" alt="Screenshot from 2025-10-08 22-27-23" src="https://github.com/user-attachments/assets/9f1bc4a6-20b3-4584-8a54-e0ab5366fab5" />

<img width="1920" height="1080" alt="Screenshot from 2025-10-08 22-11-27" src="https://github.com/user-attachments/assets/4579560e-815a-452e-ba1e-7b25e9dc6476" />

After:
<img width="1920" height="1080" alt="Screenshot from 2025-10-09 01-40-04" src="https://github.com/user-attachments/assets/3a953e0f-bf16-4f55-aee1-03d7455880e6" />

<img width="1920" height="1080" alt="Screenshot from 2025-10-09 02-55-28" src="https://github.com/user-attachments/assets/e9039d8e-1c60-4eac-b845-6fbda3beab87" />


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
