### PR TITLE
Fix #23573: Add newsletter validation messages for email input in footer section

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -754,6 +754,8 @@
     "I18N_FOOTER_NEWSLETTER_HEADING": "Subscribe To Our Newsletter",
     "I18N_FOOTER_NEWSLETTER_TEXT": "Be a part of the Oppia community! Our bi-weekly newsletter keeps you informed on new features, lessons and how Oppia is making a worldwide impact.",
     "I18N_FOOTER_NEWSLETTER_WARNING": "You have already signed up with this email address",
+    "I18N_FOOTER_NEWSLETTER_INVALID": "Please enter a valid email address",
+    "I18N_FOOTER_NEWSLETTER_REQUIRED": "Email is required",
     "I18N_FOOTER_OPPIA_FOUNDATION": "The Oppia Foundation",
     "I18N_FOOTER_OPPIA_MISSION": "Oppia’s mission is to provide a learning platform that meets the unique needs for under resourced communities.",
     "I18N_FOOTER_OPPIA_MISSION_DONATE_VOLUNTEER": "<a href=\"/donate\">Donate</a> or <a href=\"/volunteer\">volunteer</a> today!",

--- a/core/templates/base-components/oppia-footer.component.html
+++ b/core/templates/base-components/oppia-footer.component.html
@@ -27,7 +27,7 @@
         <div class="oppia-footer-newsletter-warning" *ngIf="emailDuplicated">
           <p>{{ 'I18N_FOOTER_NEWSLETTER_WARNING' | translate }}</p>
         </div>
-          <div class="oppia-footer-newsletter-warning" *ngIf="newsletterTouched && (!emailAddress || (emailAddress && emailAddress.trim() === ''))">
+        <div class="oppia-footer-newsletter-warning" *ngIf="newsletterTouched && (!emailAddress || (emailAddress && emailAddress.trim() === ''))">
           <p>{{ 'I18N_FOOTER_NEWSLETTER_REQUIRED' | translate }}</p>
         </div>
         <div class="oppia-footer-newsletter-warning" *ngIf="newsletterTouched && emailAddress && !validateEmailAddress()">

--- a/core/templates/base-components/oppia-footer.component.html
+++ b/core/templates/base-components/oppia-footer.component.html
@@ -15,6 +15,7 @@
                  [(ngModel)]="emailAddress"
                  [ngModelOptions]="{standalone: true}"
                  (ngModelChange)="clearNewsletterWarning()"
+                 (blur)="newsletterTouched = true"
                  required="true"
                  aria-labelledby="email">
           <button class="oppia-footer-newsletter-button e2e-test-newsletter-subscribe-btn"
@@ -25,6 +26,12 @@
         </div>
         <div class="oppia-footer-newsletter-warning" *ngIf="emailDuplicated">
           <p>{{ 'I18N_FOOTER_NEWSLETTER_WARNING' | translate }}</p>
+        </div>
+          <div class="oppia-footer-newsletter-warning" *ngIf="newsletterTouched && (!emailAddress || (emailAddress && emailAddress.trim() === ''))">
+          <p>{{ 'I18N_FOOTER_NEWSLETTER_REQUIRED' | translate }}</p>
+        </div>
+        <div class="oppia-footer-newsletter-warning" *ngIf="newsletterTouched && emailAddress && !validateEmailAddress()">
+          <p>{{ 'I18N_FOOTER_NEWSLETTER_INVALID' | translate }}</p>
         </div>
       </div>
     </div>

--- a/core/templates/base-components/oppia-footer.component.ts
+++ b/core/templates/base-components/oppia-footer.component.ts
@@ -39,6 +39,7 @@ import './oppia-footer.component.css';
 export class OppiaFooterComponent {
   emailAddress: string | null = null;
   name: string | null = null;
+  newsletterTouched: boolean = false;
   siteFeedbackFormUrl: string = AppConstants.SITE_FEEDBACK_FORM_URL;
   currentYear: number = new Date().getFullYear();
   PAGES_REGISTERED_WITH_FRONTEND = AppConstants.PAGES_REGISTERED_WITH_FRONTEND;
@@ -68,6 +69,9 @@ export class OppiaFooterComponent {
   }
 
   validateEmailAddress(): boolean {
+    if (!this.emailAddress) {
+      return false;
+    }
     let regex = new RegExp(AppConstants.EMAIL_REGEX);
     return regex.test(String(this.emailAddress));
   }
@@ -88,6 +92,10 @@ export class OppiaFooterComponent {
   }
 
   subscribeToMailingList(): void {
+    this.newsletterTouched = true;
+    if (!this.validateEmailAddress()) {
+      return;
+    }
     // Convert null or empty string to null for consistency.
     const userName = this.name ? String(this.name) : null;
     if (this.isAlreadySubscribed(String(this.emailAddress))) {


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #23573 .
2. This PR does the following: Adds validation messages for the email input field in the footer newsletter subscription section. When users interact with the email field, they now receive appropriate feedback messages:
   - A "required" message when the field is empty or contains only whitespace
   - An "invalid email" message when the email format is incorrect
   - These messages appear after the user has interacted with the field (touched) to improve user experience
3. (For bug-fixing PRs only) N/A - This is a feature enhancement, not a bug fix

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #23573: Add newsletter validation messages for email input in footer section"
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
https://github.com/user-attachments/assets/b8241301-6adf-49c0-b5d1-b9e51c3aaa4a
1. Empty field validation - showing "Email is required" message when field is left empty after being touched
2. Invalid email validation - showing "Please enter a valid email address" message when invalid format is entered
3. Valid email acceptance - showing the field accepts properly formatted emails
4. Test with throttled network (3G) to ensure no performance issues]
