### PR TITLE
Fix #23439: Fix button overlap in inline rule editor on mobile

### DIFF
--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
@@ -136,8 +136,34 @@
   }
 
   @media screen and (max-width: 700px) {
-  .oppia-editor-card-section {
+    .oppia-editor-card-section {
       padding: 20px 10px;
+    }
+
+    .e2e-test-answer-body ::ng-deep .form-justify {
+        margin-bottom: 0 !important;
+    }
+    .e2e-test-answer-body ::ng-deep .form-group.oppia-rule-editor-span {
+        top: 0 !important;
+    }
+
+    .e2e-test-answer-body ::ng-deep .position-relative {
+        flex-wrap: wrap !important;
+        display: flex !important;
+    }
+    .e2e-test-answer-body ::ng-deep .form-justify {
+        flex-basis: 100% !important;
+    }
+    .e2e-test-answer-body ::ng-deep .oppia-rule-save-cancel-buttons {
+        flex-basis: 100% !important;
+        margin-top: 15px;
+    }
+    
+    .e2e-test-answer-body ::ng-deep .oppia-rule-save-cancel-buttons .float-right {
+        float: none !important;
+        display: flex;
+        justify-content: flex-end;
+        width: 100%;
     }
   }
 


### PR DESCRIPTION
**Overview**

This PR fixes **[BUG]: Answer input is covered by submit buttons in response modal of question in mobile view #23439**.

This PR does the following:
* Fixes a responsiveness bug in the `answer-group-editor.component.html` (the inline rule editor).
* It adds custom CSS styles for viewports under 700px to ensure the rule input form and the action buttons ("Cancel" / "Save Answer") stack vertically instead of overlapping.

(For bug-fixing PRs only) The original bug occurred because:
The parent flex container for the rule form and its buttons was missing `flex-wrap: wrap`. More importantly, CSS from the child `oppia-rule-editor` component included a negative margin (`margin-bottom: -80px`), which pulled the buttons up and caused them to overlap the input fields on mobile screens. The new CSS in this PR overrides this negative margin and correctly applies a flex-wrap layout.

**Essential Checklist**

*Please follow the instructions for making a code change.*

* [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [ ] I have written tests for my code. 
* [x] The PR title starts with "Fix #[bugnum]: " or "Fix part of #[bugnum]: ...", followed by a short, clear summary of the changes.
* [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

**Proof that changes are correct**

Here is a recording showing the layout before and after the fix on a small screen.

**Before (Buggy Behavior):**

<img width="295" height="536" alt="image" src="https://github.com/user-attachments/assets/352ed605-8a6b-4ee9-a8f8-e6b7a6158c9d" />

*(The buttons overlap the input field, making it unusable)*


**After (With Fix):**


![Demonstração da Correção](https://github.com/user-attachments/assets/b9509d98-e40a-4bb2-af11-89708a8aff95)

*(The buttons now stack correctly below the input field)*

**PR Pointers**

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve