### PR TITLE
Fix #23645 , #23644 : Resolves the issues of empty stories in Completed section and removes them from appearing on the goal list tab.

### DIFF
--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -354,8 +354,18 @@ def mark_topic_as_learnt(user_id: str, topic_id: str) -> None:
     )
     completed_story_ids = get_all_completed_story_ids(user_id)
 
+    valid_story_ids = []
+    for story_id in all_story_ids_in_topic:
+        story = story_fetchers.get_story_by_id(story_id)
+        if (
+            story
+            and story.story_contents
+            and len(story.story_contents.nodes) > 0
+        ):
+            valid_story_ids.append(story_id)
+
     all_completed = all(
-        story_id in completed_story_ids for story_id in all_story_ids_in_topic
+        story_id in completed_story_ids for story_id in valid_story_ids
     )
 
     if not all_completed:

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
@@ -1,4 +1,5 @@
 <ng-container *ngFor="let story of goalTopic.canonicalStorySummaryDicts; let i = index">
+  <ng-container *ngIf="story.getAllNodes().length > 0">
   <div class="oppia-learner-dash-section goal-list-container">
     <div class="goal-list-stretch w-100">
       <img class="goal-list-img" [src]="imgUrl" alt="" >
@@ -58,6 +59,7 @@
       </ng-container>
     </div>
   </div>
+  </ng-container>
 </ng-container>
 
 <style>

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
@@ -1,64 +1,64 @@
 <ng-container *ngFor="let story of goalTopic.canonicalStorySummaryDicts; let i = index">
   <ng-container *ngIf="story.getAllNodes().length > 0">
-  <div class="oppia-learner-dash-section goal-list-container">
-    <div class="goal-list-stretch w-100">
-      <img class="goal-list-img" [src]="imgUrl" alt="" >
-      <div class="goal-list-stretch flex-grow-1">
-        <div class="goal-list-details flex-grow-1">
-          <p class="goal-list-title e2e-test-goal-title">
-            {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_STORY_TITLE_NEW' | translate: { topic: goalTopic.getName(), story: story.getTitle() } }}
-          </p>
-          <div class="goal-list-center">
-            <p class="goal-list-progress-text">
-              {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_STORY_PROGRESS' | translate: {current: story.getCompletedNodeTitles().length, total: story.getNodeTitles().length} }}
+    <div class="oppia-learner-dash-section goal-list-container">
+      <div class="goal-list-stretch w-100">
+        <img class="goal-list-img" [src]="imgUrl" alt="" >
+        <div class="goal-list-stretch flex-grow-1">
+          <div class="goal-list-details flex-grow-1">
+            <p class="goal-list-title e2e-test-goal-title">
+              {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_STORY_TITLE_NEW' | translate: { topic: goalTopic.getName(), story: story.getTitle() } }}
             </p>
-            <div class="goal-list-progress-bar">
-              <div [ngStyle]="{'width': getStoryProgress(story) + '%'}"> </div>
-            </div>
-          </div>
-        </div>
-        <div class="goal-list-options">
-          <div class="goal-list-center">
-            <ng-content></ng-content>
-            <oppia-content-toggle-button (contentToggleEmitter)="handleToggleState($event, story.getId())"> </oppia-content-toggle-button>
-          </div>
-            <!--TODO(#18384): Resume state, can only check if node is completed or not.-->
-          <a *ngIf="story.getAllNodes().length !== story.getCompletedNodeTitles().length && !isExpanded(story.getId())"
-             class="oppia-learner-dash-button-sm oppia-learner-dash-button--goals-list align-self-end e2e-test-start-lesson-button"
-             [ngClass]="getStartButtonClass(story, allCurrentNodes[i])"
-             [attr.href]="getStartButtonHref(story, allCurrentNodes[i])"
-            >
-              {{ getStartButtonLabel(story, allCurrentNodes[i]) | translate }}
-          </a>
-        </div>
-      </div>
-    </div>
-    <div *ngIf="isExpanded(story.getId())" class="goal-list-story-nodes">
-      <ng-container *ngFor="let storyNode of story.getAllNodes(); let j = index">
-        <div class="d-flex flex-column">
-          <div class="goal-list-story-node-line-container">
-            <div *ngIf="j !== 0" class="goal-list-story-node-line"></div>
-          </div>
-          <div class="goal-list-center justify-content-between">
             <div class="goal-list-center">
-              <circle-progress [percent]="story.isNodeCompleted(storyNode.getTitle()) ? 100 : 0"> </circle-progress>
-              <p class="mb-0"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_NODE_TITLE' | translate: {number: (j + 1), title: storyNode.getTitle()} }} </p>
+              <p class="goal-list-progress-text">
+                {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_STORY_PROGRESS' | translate: {current: story.getCompletedNodeTitles().length, total: story.getNodeTitles().length} }}
+              </p>
+              <div class="goal-list-progress-bar">
+                <div [ngStyle]="{'width': getStoryProgress(story) + '%'}"> </div>
+              </div>
             </div>
-            <a *ngIf="!story.isNodeCompleted(storyNode.getTitle())"
-               class="oppia-learner-dash-button-sm oppia-learner-dash-button--goals-list"
-               [ngClass]="getStartButtonClass(story, j)"
-               [attr.href]="getStartButtonHref(story, j)"
+          </div>
+          <div class="goal-list-options">
+            <div class="goal-list-center">
+              <ng-content></ng-content>
+              <oppia-content-toggle-button (contentToggleEmitter)="handleToggleState($event, story.getId())"> </oppia-content-toggle-button>
+            </div>
+              <!--TODO(#18384): Resume state, can only check if node is completed or not.-->
+            <a *ngIf="story.getAllNodes().length !== story.getCompletedNodeTitles().length && !isExpanded(story.getId())"
+               class="oppia-learner-dash-button-sm oppia-learner-dash-button--goals-list align-self-end e2e-test-start-lesson-button"
+               [ngClass]="getStartButtonClass(story, allCurrentNodes[i])"
+               [attr.href]="getStartButtonHref(story, allCurrentNodes[i])"
               >
-                {{ getStartButtonLabel(story, j) | translate }}
+                {{ getStartButtonLabel(story, allCurrentNodes[i]) | translate }}
             </a>
           </div>
-          <div class="goal-list-story-node-line-container">
-            <div *ngIf="j !== story.getAllNodes().length - 1" class="goal-list-story-node-line"></div>
-          </div>
         </div>
-      </ng-container>
+      </div>
+      <div *ngIf="isExpanded(story.getId())" class="goal-list-story-nodes">
+        <ng-container *ngFor="let storyNode of story.getAllNodes(); let j = index">
+          <div class="d-flex flex-column">
+            <div class="goal-list-story-node-line-container">
+              <div *ngIf="j !== 0" class="goal-list-story-node-line"></div>
+            </div>
+            <div class="goal-list-center justify-content-between">
+              <div class="goal-list-center">
+                <circle-progress [percent]="story.isNodeCompleted(storyNode.getTitle()) ? 100 : 0"> </circle-progress>
+                <p class="mb-0"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_NODE_TITLE' | translate: {number: (j + 1), title: storyNode.getTitle()} }} </p>
+              </div>
+              <a *ngIf="!story.isNodeCompleted(storyNode.getTitle())"
+                 class="oppia-learner-dash-button-sm oppia-learner-dash-button--goals-list"
+                 [ngClass]="getStartButtonClass(story, j)"
+                 [attr.href]="getStartButtonHref(story, j)"
+                >
+                  {{ getStartButtonLabel(story, j) | translate }}
+              </a>
+            </div>
+            <div class="goal-list-story-node-line-container">
+              <div *ngIf="j !== story.getAllNodes().length - 1" class="goal-list-story-node-line"></div>
+            </div>
+          </div>
+        </ng-container>
+      </div>
     </div>
-  </div>
   </ng-container>
 </ng-container>
 

--- a/core/templates/pages/learner-dashboard-page/progress-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/progress-tab.component.html
@@ -398,9 +398,9 @@
   </ng-container>
   <div *ngIf="learnerDashboardRedesignFeatureFlag">
     <ng-container *ngIf="!isLearnerStateEmpty(); else empty">
-      <div tabindex="0" class="oppia-learner-dash-section e2e-test-in-progress-community-lessons-section">
+      <div tabindex="0" class="oppia-learner-dash-section e2e-test-in-progress-community-lessons-section" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
         <p class="oppia-learner-dash-section-heading">{{ 'I18N_LEARNER_DASHBOARD_INCOMPLETE_SECTION' | translate }}</p>
-        <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" *ngIf="totalIncompleteLessonsList.length !== 0 || partiallyLearntTopicsList.length !== 0">
+        <div class="incomplete-section e2e-test-incomplete-community-lessons-section w-100" >
           <!--TODO(#18384): Display all lessons in topic or just the most recent/last?-->
           <oppia-card-display *ngIf="partiallyLearntTopicsList.length !== 0" [headingI18n]="'I18N_LEARNER_DASHBOARD_PROGRESS_SECTION_CLASSROOM'" [numCards]="partialTopicMastery.length" [controlType]="'toggle'">
             <ng-container *ngFor="let topicObj of partialTopicMastery">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/23644 and fixes https://github.com/oppia/oppia/issues/23645
2. This PR does the following: Corrected the backend logic for empty stories , now for checking if a topic is completed or not we only consider stories having more than 0 chapters . Also added a condition on goal-list html file for onnly allowing stories with more than 0 chapters.
3. (For bug-fixing PRs only) The original bug occurred because: There was no logic before for stories having 0 chapter.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

[Screencast from 2025-10-23 00-30-56.webm](https://github.com/user-attachments/assets/1da34024-4bfa-4b24-b7e9-b849e7323cbe)

Note- those dummy chapters showing along side are already resolved here :https://github.com/oppia/oppia/pull/23630

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
