### PR TITLE
Fix #22473, #22563, #18366: Resolve image disappearance in Exploration Editor when saving content and Fixes Node outline save button not visible flakiness

### DIFF
--- a/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.ts
@@ -16,7 +16,7 @@
  * @fileoverview Component for a schema-based editor for HTML.
  */
 
-import {Component, forwardRef, Input, OnInit} from '@angular/core';
+import {Component, forwardRef, Input, OnInit, NgZone} from '@angular/core';
 import {
   NG_VALUE_ACCESSOR,
   NG_VALIDATORS,
@@ -45,6 +45,7 @@ import {
 export class SchemaBasedHtmlEditorComponent
   implements ControlValueAccessor, OnInit, Validator
 {
+  constructor(private ngZone: NgZone) {}
   // These properties are initialized using Angular lifecycle hooks
   // and we need to do non-null assertion. For more information, see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
@@ -80,8 +81,8 @@ export class SchemaBasedHtmlEditorComponent
   ngOnInit(): void {}
 
   updateValue(value: string): void {
-    this.onChange(value);
-    setTimeout(() => {
+    this.ngZone.run(() => {
+      this.localValue = value;
       this.onChange(value);
     });
   }

--- a/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.ts
@@ -82,7 +82,6 @@ export class SchemaBasedHtmlEditorComponent
 
   updateValue(value: string): void {
     this.ngZone.run(() => {
-      this.localValue = value;
       this.onChange(value);
     });
   }

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.html
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.component.html
@@ -130,7 +130,7 @@
             Outline Finalized
             <i *ngIf="!outlineIsFinalized" (click)="finalizeOutline()" class="far fa-square md-18 e2e-test-finalize-outline" aria-label="Finalize outline"></i>
             <i *ngIf="outlineIsFinalized" (click)="unfinalizeOutline()" class="fas fa-check-square md-18" aria-label="Unfinalize outline"></i>
-            <div tabindex="-1" (blur)="toggleChapterOutlineButtons()" (click)="toggleChapterOutlineButtons()">
+            <div class="e2e-test-chapter-outline-editor-container" tabindex="-1" (blur)="toggleChapterOutlineButtons()" (click)="toggleChapterOutlineButtons()">
               <schema-based-editor id="storyNodeOutline"
                                    [schema]="OUTLINE_SCHEMA"
                                    [localValue]="editableOutline"

--- a/core/tests/webdriverio_utils/StoryEditorPage.js
+++ b/core/tests/webdriverio_utils/StoryEditorPage.js
@@ -605,6 +605,7 @@ var StoryEditorPage = function () {
     await editor.clear();
     await richTextInstructions(editor);
     await action.click('Chapter node editor', nodeOutlineEditor);
+    await action.click('Chapter node editor', nodeOutlineEditor);
     await action.click('Node outline save button', nodeOutlineSaveButton);
     await action.click('Finalize outline', nodeOutlineFinalizeCheckbox);
   };

--- a/core/tests/webdriverio_utils/StoryEditorPage.js
+++ b/core/tests/webdriverio_utils/StoryEditorPage.js
@@ -606,6 +606,10 @@ var StoryEditorPage = function () {
     await richTextInstructions(editor);
     await action.click('Chapter node editor', nodeOutlineEditor);
     await action.click('Chapter node editor', nodeOutlineEditor);
+    await waitFor.elementToBeClickable(
+      nodeOutlineSaveButton,
+      'Save button taking too long to enable.'
+    );
     await action.click('Node outline save button', nodeOutlineSaveButton);
     await action.click('Finalize outline', nodeOutlineFinalizeCheckbox);
   };

--- a/core/tests/webdriverio_utils/StoryEditorPage.js
+++ b/core/tests/webdriverio_utils/StoryEditorPage.js
@@ -109,6 +109,9 @@ var StoryEditorPage = function () {
     '.e2e-test-planned-publication-date-input'
   );
   var nodeOutlineEditor = $('.e2e-test-add-chapter-outline');
+  var nodeOutlineEditorContainer = $(
+    '.e2e-test-chapter-outline-editor-container'
+  );
   var nodeOutlineFinalizeCheckbox = $('.e2e-test-finalize-outline');
   var nodeOutlineEditorRteContentSelector = function () {
     return $$('.e2e-test-rte');
@@ -605,10 +608,9 @@ var StoryEditorPage = function () {
     await editor.clear();
     await richTextInstructions(editor);
     await action.click('Chapter node editor', nodeOutlineEditor);
-    await action.click('Chapter node editor', nodeOutlineEditor);
-    await waitFor.elementToBeClickable(
-      nodeOutlineSaveButton,
-      'Save button taking too long to enable.'
+    await action.click(
+      'Chapter outline editor container',
+      nodeOutlineEditorContainer
     );
     await action.click('Node outline save button', nodeOutlineSaveButton);
     await action.click('Finalize outline', nodeOutlineFinalizeCheckbox);


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/22473 and fixes https://github.com/oppia/oppia/issues/22563 and fixes https://github.com/oppia/oppia/issues/18366.

2. This PR does the following:
  This PR fixes a race condition in SchemaBasedHtmlEditorComponent where uploaded images (<oppia-noninteractive-image>) were sometimes missing after saving. The fix ensures change detection runs inside NgZone, so updates (including image insertions) are always propagated reliably.

#### [E2E Flake]: topicAndStoryEditorFileUploadFeatures Node outline save button is not visible:
Adds an e2e test class (`e2e-test-chapter-outline-editor-container`) to the chapter outline editor container div and updates the test to click on this container to trigger the save button visibility, fixing flaky E2E tests where the "Node outline save button is not visible" error occurred.


3. (For bug-fixing PRs only) The original bug occurred because:
   The issue was due to a race condition between the Rich Text Editor (RTE) injecting the `<oppia-noninteractive-image>` tag and Angular’s change detection cycle.

Previously, `updateValue()` looked like this:

```ts
updateValue(value: string): void {
  this.onChange(value);
  setTimeout(() => this.onChange(value));
}
```

### Why it failed occasionally:

* The first `onChange` sometimes fired **before** the RTE finished injecting the image tag, so Angular picked up only partial HTML (e.g., just `<p>`).
* The `setTimeout` was added as a safeguard, but depending on browser scheduling, it didn’t always catch the correct update.
* Adding `console.log` made it appear stable, because the synchronous delay gave the RTE enough time.

#### [E2E Flake]: topicAndStoryEditorFileUploadFeatures Node outline save button is not visible:
The test was clicking on the wrong element (`nodeOutlineEditor` - the outer container) instead of the inner div with the `toggleChapterOutlineButtons()` click handler. This prevented the save button from becoming visible, causing the test to be flaky.
<img width="1343" height="1592" alt="image" src="https://github.com/user-attachments/assets/ee16a860-107e-4041-b0c2-e30fc2ce4da6" />
<img width="1276" height="1543" alt="image" src="https://github.com/user-attachments/assets/f4b085a1-8ef5-403e-89d6-51362da9ebd8" />


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.

-->

https://github.com/user-attachments/assets/e07085bb-8df7-4312-8490-b221bae0ae6f



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
