### PR TITLE
Fix: Visibility of new progress bar in the diagnostic player

### DIFF
--- a/core/templates/pages/diagnostic-test-player-page/diagnostic-test-player.component.html
+++ b/core/templates/pages/diagnostic-test-player-page/diagnostic-test-player.component.html
@@ -45,7 +45,7 @@
         <span><i>{{ getProgressText() }}</i></span>
       </div>
     </div>
-    <div class="oppia-new-question-player-card">
+    <div class="oppia-new-question-player-card" *ngIf="isNewLessonPlayerEnabled()">
       <div class="oppia-progress-percentage-container">
         <p>{{ getProgressText() }}</p>
       </div>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A
2. This PR does the following: 
    - Restrict the display of the new progress bar when new_lesson_player flag is on.
3. (For bug-fixing PRs only) The original bug occurred because: 
    - [This line](https://github.com/oppia/oppia/pull/23087/files#diff-622dda187dadb08fd8f94874018a1ba4815df87c5ebef371e5f8bbc7c668b41eR48) was not covered with a feature flag usage.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

[Screencast From 2025-10-25 23-47-36.webm](https://github.com/user-attachments/assets/8ee1a5a2-a07a-4ef7-8899-1cf8e92ad17c)


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
