### PR TITLE
Fix #23598: Resolve 'Sign In' button flash during chapter to quiz navigation

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -521,11 +521,10 @@
             <span [innerHTML]="'I18N_TOPNAV_LOGOUT' | translate"></span>
           </a>
         </li>
-      </ul>
+      </ul>  
     </li>
-
     <li ngbDropdown
-        *ngIf="!userIsLoggedIn && username !== '' && !pageIsIframed"
+        *ngIf="userStatusLoaded && !userIsLoggedIn && username !== '' && !pageIsIframed"
         class="nav-item oppia-navbar-clickable-dropdown dropdown">
       <div class="oppia-navbar-button-container dropdown oppia-navbar-button-container-extra-info sinin">
         <button ngbDropdownToggle

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -523,9 +523,12 @@
         </li>
       </ul>  
     </li>
+
+    <!-- Shows login dropdown menu only after user authentication status is determined. -->
     <li ngbDropdown
         *ngIf="userStatusLoaded && !userIsLoggedIn && username !== '' && !pageIsIframed"
         class="nav-item oppia-navbar-clickable-dropdown dropdown">
+        
       <div class="oppia-navbar-button-container dropdown oppia-navbar-button-container-extra-info sinin">
         <button ngbDropdownToggle
                 class="btn dropdown-toggle oppia-navbar-button e2e-mobile-test-login sinin"

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -100,7 +100,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   isBlogPostEditor: boolean = false;
   userIsLoggedIn: boolean = false;
 
-  // AJT
+  // Whether the user authentication status has been loaded from the backend.
   userStatusLoaded: boolean = false;
 
   currentUrl!: string;
@@ -316,7 +316,8 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
             AppConstants.DEFAULT_PROFILE_IMAGE_WEBP_PATH
           );
       }
-      // AJT
+
+      // Mark user authentication status as loaded once the check is complete.
       this.userStatusLoaded = true;
     });
 

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -99,6 +99,10 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   isBlogAdmin: boolean = false;
   isBlogPostEditor: boolean = false;
   userIsLoggedIn: boolean = false;
+
+  // AJT
+  userStatusLoaded: boolean = false;
+
   currentUrl!: string;
   userMenuIsShown: boolean = false;
   inClassroomPage: boolean = false;
@@ -312,6 +316,8 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
             AppConstants.DEFAULT_PROFILE_IMAGE_WEBP_PATH
           );
       }
+      // AJT
+      this.userStatusLoaded = true;
     });
 
     for (var i = 0; i < this.NAV_ELEMENTS_ORDER.length; i++) {


### PR DESCRIPTION
## Overview

1. This PR fixes #23598.
2. This PR does the following: Resolves the issue where the "Sign In" button briefly appears before showing the profile icon while navigating from chapter to quiz page.
3. The original bug occurred because: The navigation bar was showing the login dropdown before the user authentication status was fully loaded from the backend.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #23598: Resolve 'Sign In' button flash during chapter to quiz navigation"
- [x] I have assigned the correct reviewers to this PR (mentioning @oppia/lace-leads PTAL)

## Testing doc

- [ ] A testing doc has been written: N/A (not applicable for this frontend fix)
- [ ] All jobs in this PR have been verified on a live server: N/A (no Beam jobs)

## Proof that changes are correct

### Before the fix:
https://github.com/user-attachments/assets/9c7cc183-ec9f-4889-b99a-69d001b07b2c

### After the fix:  
https://github.com/user-attachments/assets/283e4119-8111-45e3-afcd-b6d2eddbbec0

#### Proof of changes on desktop with slow/throttled network
The fix works correctly even with throttled network as it's based on authentication status timing.

#### Proof of changes on mobile phone
N/A - The navigation bar behavior is consistent across devices.

#### Proof of changes in Arabic language
N/A - The fix is logic-based and not language-specific.
