### PR TITLE
Fix #23745 ,#23744,#23743 : Resolves hovering issue , progress sync issue and community lessons comming soon issue.

### DIFF
--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -24,12 +24,12 @@
     <div class="align-items-center d-flex justify-content-between mt-2">
       <circle-progress [percent]="progress"> </circle-progress>
       <a [href]="lessonUrl"
-         *ngIf="statusIsPublished || isSavedSection || !isSerialChapterFeatureLearnerFlagEnabled()"
+         *ngIf="statusIsPublished || isSavedSection || isCommunityLesson || !isSerialChapterFeatureLearnerFlagEnabled()"
          class="align-items-center d-inline-flex justify-content-center lesson-card-button text-decoration-none e2e-test-resume-lesson-btn"
          target="_self">
         {{ getButtonTranslationKey() | translate }}
       </a>
-      <span *ngIf="isSerialChapterFeatureLearnerFlagEnabled() && !statusIsPublished && !isSavedSection"
+      <span *ngIf="isSerialChapterFeatureLearnerFlagEnabled() && !statusIsPublished && !isSavedSection && !isCommunityLesson"
             class="align-items-center d-inline-flex justify-content-center lesson-card-button upcoming"
             [attr.title]="isSerialChapterFeatureLearnerFlagEnabled() ? ('I18N_LEARNER_STORY_TILE_COMING_SOON_TOOLTIP' | translate) : null" >
             {{ 'I18N_LEARNER_STORY_TILE_COMING_SOON' | translate }}

--- a/core/templates/components/summary-tile/lesson-card.component.ts
+++ b/core/templates/components/summary-tile/lesson-card.component.ts
@@ -44,6 +44,7 @@ export class LessonCardComponent implements OnInit {
   desc!: string;
   imgColor!: string;
   imgUrl!: string;
+  isCommunityLesson?: boolean;
   lessonUrl!: string;
   progress!: number;
   title!: string;
@@ -67,8 +68,12 @@ export class LessonCardComponent implements OnInit {
         await this.setStorySummary(this.story);
       } else if (this.story instanceof CollectionSummary) {
         this.setCollectionSummary(this.story);
+        this.statusIsPublished = true;
+        this.isCommunityLesson = true;
       } else {
         this.setExplorationSummary(this.story);
+        this.statusIsPublished = true;
+        this.isCommunityLesson = true;
       }
     } catch (error) {
       console.error('Error initializing lesson card:', error);

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
@@ -41,7 +41,7 @@
             </div>
             <div class="goal-list-center justify-content-between">
               <div class="goal-list-center">
-                <circle-progress [percent]="story.isNodeCompleted(storyNode.getTitle()) ? 100 : 0"> </circle-progress>
+                <circle-progress [percent]="getChapterProgress(storyNode)"> </circle-progress>
                 <p class="mb-0"> {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_NODE_TITLE' | translate: {number: (j + 1), title: storyNode.getTitle()} }} </p>
               </div>
               <a *ngIf="!story.isNodeCompleted(storyNode.getTitle())"

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
@@ -161,11 +161,10 @@ export class GoalListComponent implements OnInit {
   getStartButtonClass(story: StorySummary, nodeIndex: number): string {
     const node = story.getAllNodes()[nodeIndex];
 
-    if (!this.isSerialChapterFeatureLearnerFlagEnabled()) {
-      return 'oppia-learner-dash-button--default';
-    }
-
-    if (!node.getPublishedStatus()) {
+    if (
+      !node.getPublishedStatus() &&
+      this.isSerialChapterFeatureLearnerFlagEnabled()
+    ) {
       return 'oppia-learner-dash-button--disabled';
     }
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/23744 and fixes  https://github.com/oppia/oppia/issues/23745 and fixes https://github.com/oppia/oppia/issues/23743 .
2. (For bug-fixing PRs only) The original bug occurred because: 
Hovering issue : due to wrong condition with serial feature flags , made it return early in the function with class default.

Progress issue : due to not setupping the getChapterProgress in goalListHtml

Community Lesson : no way of knowing if that exploration is community or not , so created a new variable for it.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Hovering issues with serial feature flags turned off

https://github.com/user-attachments/assets/786ba06d-891c-4e3e-8056-1eb7e8f404e5


#### Hovering issues with serial feature flags turned off

https://github.com/user-attachments/assets/c6a68928-f8af-4c00-b643-8c5084b92dec

#### community lessons bug

https://github.com/user-attachments/assets/c6f4379b-e8e4-47a0-a240-35f00408fd1a

#### Progress issue in goals tab


https://github.com/user-attachments/assets/d2e143a4-de2d-4eec-bdd2-cc4ddc4385a6



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
