### PR TITLE
#Fix 23679 : Displaying horizontal scroll and Cards are not visible

### DIFF
--- a/core/templates/components/summary-tile/collection-summary-tile.component.html
+++ b/core/templates/components/summary-tile/collection-summary-tile.component.html
@@ -106,10 +106,10 @@
   }
   .oppia-activity-summary-tile .layout-row {
     align-items: center;
-    justify-content: space-between;
-    max-width: 100%;
     display: flex;
     flex-direction: row;
+    justify-content: space-between;
+    max-width: 100%;
   }
   .mobile-activity-summary-card {
     box-shadow: slategrey 2px 4px 4px 0;

--- a/core/templates/components/summary-tile/collection-summary-tile.component.html
+++ b/core/templates/components/summary-tile/collection-summary-tile.component.html
@@ -22,7 +22,7 @@
           {{ getObjective | truncateAndCapitalize: 95 }}
           <span *ngIf="!getObjective">No objective specified.</span>
         </div>
-        <ul class="metrics layout-align-space-between-center layout-row">
+        <ul class="metrics layout-row">
           <li>
             <span>
               {{ 'I18N_COMMUNITY_LIBRARY_PAGE_COLLECTION' | translate }} ({{ getNodeCount }})
@@ -104,7 +104,13 @@
     position: absolute;
     width: 36px;
   }
-
+  .oppia-activity-summary-tile .layout-row {
+    align-items: center;
+    justify-content: space-between;
+    max-width: 100%;
+    display: flex;
+    flex-direction: row;
+  }
   .mobile-activity-summary-card {
     box-shadow: slategrey 2px 4px 4px 0;
     padding: 0 0 0 0;

--- a/core/templates/components/summary-tile/exploration-summary-tile.component.css
+++ b/core/templates/components/summary-tile/exploration-summary-tile.component.css
@@ -110,6 +110,13 @@ oppia-exploration-summary-tile .exploration-summary-btn span {
   font-size: 16px;
 }
 
+oppia-exploration-summary-tile .oppia-exploration-dashboard-card .layout-row {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  max-width: 100%;
+}
 @media (max-width: 480px) {
   oppia-exploration-summary-tile .exploration-summary-btn {
     font-size: 13px;
@@ -123,4 +130,5 @@ oppia-exploration-summary-tile .exploration-summary-btn span {
   oppia-exploration-summary-tile .exploration-summary-btn span {
     font-size: 13px;
   }
+
 }

--- a/core/templates/components/summary-tile/exploration-summary-tile.component.html
+++ b/core/templates/components/summary-tile/exploration-summary-tile.component.html
@@ -64,7 +64,7 @@
           <span [innerHTML]="'I18N_LIBRARY_NO_OBJECTIVE' | translate">
           </span>
         </div>
-        <ul *ngIf="!isCollectionPreviewTile" class="metrics layout-align-space-between-center layout-row">
+        <ul *ngIf="!isCollectionPreviewTile" class="metrics layout-row">
           <li>
             <span class="e2e-test-exp-summary-tile-rating" [ngClass]="{'rating-disabled': !avgRating}">
               <span class="fas fa-star" [ngbTooltip]="'I18N_LIBRARY_RATINGS_TOOLTIP' | translate" placement="top" container="body">

--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -223,6 +223,7 @@ oppia-library-page .button-alignment-div {
   background-color: #afd2eb;
   min-height: 100vh;
   overflow-y: auto;
+  overflow-x: hidden;
   position: relative;
   width: 100%;
 }

--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -222,8 +222,8 @@ oppia-library-page .button-alignment-div {
 .oppia-library-container {
   background-color: #afd2eb;
   min-height: 100vh;
-  overflow-y: auto;
   overflow-x: hidden;
+  overflow-y: auto;
   position: relative;
   width: 100%;
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #[23679]  and #[23670].
2. This PR does the following: 
-Horizontal scroll disabled.
-CSS fixed for card content. 
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

Before :
<img width="1909" height="1054" alt="image" src="https://github.com/user-attachments/assets/e0f7885f-819b-45dc-9167-b1023f1add68" />

<img width="1909" height="1054" alt="image" src="https://github.com/user-attachments/assets/0bea8758-c676-4e7e-a4fe-5a9241852dc7" />

 
After : 
<img width="1835" height="1000" alt="image" src="https://github.com/user-attachments/assets/41f5117f-d1be-4af7-b9c8-4e99c77a8039" />

<img width="1835" height="1000" alt="image" src="https://github.com/user-attachments/assets/ce32d428-9d81-4cce-abcf-dff2689028f4" />



#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
