### PR TITLE
Fix #23670: community library tiles overflowing container

### DIFF
--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -180,16 +180,22 @@ oppia-library-page .community-library-breadcrumbs-container i {
   width: 100%;
 }
 .oppia-library-carousel-tiles {
-  /*The height is adjusted to hide the scrollbars*/
-  height: 290px;
+  /* Allow full tile height — no clipping */
+  height: auto; /* grow as needed */
   left: 0;
   margin: 0;
-  overflow: hidden;
+  min-height: 320px; /* slightly taller than 290px */
+  overflow: visible; /* let full tile show */
   padding: 0;
   position: relative;
   top: 0;
   white-space: nowrap;
 }
+.oppia-library-carousel {
+  height: auto !important;
+  overflow: visible !important;
+}
+
 oppia-library-page .oppia-mobile-activity-cards-container {
   overflow-y: hidden;
 }
@@ -212,13 +218,7 @@ oppia-library-page .height-toggle-btn-container {
 oppia-library-page .button-alignment-div {
   width: 350px;
 }
-.oppia-library-carousel {
-  float: left;
-  height: 282px;
-  max-width: 848px;
-  overflow: hidden;
-  position: relative;
-}
+
 .oppia-library-container {
   background-color: #afd2eb;
   min-height: 100vh;
@@ -226,10 +226,7 @@ oppia-library-page .button-alignment-div {
   position: relative;
   width: 100%;
 }
-.oppia-library-container-inner {
-  position: relative;
-  z-index: 3;
-}
+
 
 .left-carousel-btn {
   position: relative;
@@ -734,4 +731,23 @@ oppia-library-page .oppia-exp-summary-tiles-container {
     margin-right: 2vw;
     max-width: 96vw;
   }
+}
+
+
+/* Make sure the library container grows naturally */
+oppia-library-page .oppia-library-container {
+  height: auto !important;
+  min-height: auto !important;
+  overflow-y: visible !important;
+}
+
+oppia-library-page .oppia-library-container-inner {
+  height: auto !important;
+  overflow: visible !important;
+  position: relative;
+}
+
+oppia-library-page .oppia-library-group {
+  height: auto !important;
+  overflow: visible !important;
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #23670 .
2. This PR does the following: 
- Fixes the issue where the community library page was clipped and didn’t allow full scrolling.
- Ensures the `.oppia-library-container`, `.oppia-library-container-inner`, and `.oppia-library-group` elements dynamically expand based on their content.
- Verified the fix locally using Docker and Oppia’s development server.

4. (For bug-fixing PRs only) The original bug occurred because: The `.oppia-library-container` and its inner elements (`.oppia-library-container-inner` and `.oppia-library-group`) had fixed `min-height` and `overflow-y` properties, which restricted the page layout and prevented the community library from scrolling naturally. As a result, the bottom of the page was being clipped, especially when tiles overflowed the container.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [] I have written tests for my code (this is a UI change, I don't think I can write tests for this other than running it on different machines)
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
Before
<img width="973" height="832" alt="image" src="https://github.com/user-attachments/assets/97eec9d1-ea1e-4b18-a655-1cae5d88e9b6" />


After changes
<img width="924" height="794" alt="Screenshot 2025-11-04 031147" src="https://github.com/user-attachments/assets/1ed95b03-6a88-4c78-a713-1a4dfb50d825" />

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->


References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
