### PR TITLE
Fix : 23757 Minor issue in order of learner groups

### DIFF
--- a/core/templates/pages/facilitator-dashboard-page/facilitator-dashboard-page.component.spec.ts
+++ b/core/templates/pages/facilitator-dashboard-page/facilitator-dashboard-page.component.spec.ts
@@ -137,4 +137,31 @@ describe('FacilitatorDashboardPageComponent', () => {
       '/create-learner-group/groupId1'
     );
   });
+
+  it('should sort learner group summaries by title in alphabetical order', fakeAsync(() => {
+    const shortSummaryBackendDict2 = {
+      id: 'groupId2',
+      title: 'A group title',
+      description: 'group description',
+      facilitator_usernames: ['facilitator2'],
+      learners_count: 3,
+    };
+    const shortLearnerGroupSummary2 =
+      ShortLearnerGroupSummary.createFromBackendDict(shortSummaryBackendDict2);
+
+    spyOn(
+      facilitatorDashboardBackendApiService,
+      'fetchTeacherDashboardLearnerGroupsAsync'
+    ).and.returnValue(
+      Promise.resolve([shortLearnerGroupSummary, shortLearnerGroupSummary2])
+    );
+
+    component.ngOnInit();
+    tick();
+
+    expect(component.shortLearnerGroupSummaries).toEqual([
+      shortLearnerGroupSummary2,
+      shortLearnerGroupSummary,
+    ]);
+  }));
 });

--- a/core/templates/pages/facilitator-dashboard-page/facilitator-dashboard-page.component.ts
+++ b/core/templates/pages/facilitator-dashboard-page/facilitator-dashboard-page.component.ts
@@ -78,6 +78,7 @@ export class FacilitatorDashboardPageComponent implements OnInit, OnDestroy {
     this.facilitatorDashboardBackendApiService
       .fetchTeacherDashboardLearnerGroupsAsync()
       .then(shortGroupSummaries => {
+        shortGroupSummaries.sort((a, b) => a.title.localeCompare(b.title));
         this.shortLearnerGroupSummaries = shortGroupSummaries;
         this.loaderService.hideLoadingScreen();
       });


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #23757.
2. This PR does the following: 
Added sorting for learner groups title on facilitator dashboard 


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
Before : 

<img width="1853" height="1002" alt="Screenshot from 2025-11-04 16-33-15" src="https://github.com/user-attachments/assets/90246db9-e353-46ce-8464-96dc09b4a3a0" />

After : 

<img width="1853" height="1002" alt="Screenshot from 2025-11-04 16-33-52" src="https://github.com/user-attachments/assets/d77710b9-f500-46de-bb21-200f4ae743c8" />

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
