### PR TITLE
fix: handle 'undefined' string as None in contributor dashboard

### DIFF
--- a/core/controllers/contributor_dashboard.py
+++ b/core/controllers/contributor_dashboard.py
@@ -318,6 +318,9 @@ class ReviewableOpportunitiesHandler(
         # Default value is None, since this is a GET request handler, which
         # means all request parameters come in as strings.
         topic_name = self.normalized_request.get('topic_name', None)
+        # Treat the string 'undefined' as if it were None
+        if topic_name == 'undefined':
+            topic_name = None
         language = self.normalized_request.get('language_code')
         opportunity_dicts: List[
             opportunity_domain.PartialExplorationOpportunitySummaryDict
@@ -363,6 +366,10 @@ class ReviewableOpportunitiesHandler(
         # 3. Fetch all exploration opportunity summaries for the resulting set
         #    of explorations.
         # 4. Move any pinned summaries to the top.
+
+        # Treat the string 'undefined' as if it were None
+        if topic_name == 'undefined':
+            topic_name = None
 
         pinned_opportunity_summary = None
         if topic_name is None:
@@ -453,6 +460,9 @@ class LessonsPinningHandler(
         assert self.normalized_payload is not None
         assert self.user_id is not None
         topic_name = self.normalized_payload.get('topic_id')
+        # Treat the string 'undefined' as if it were None
+        if topic_name == 'undefined':
+            topic_name = None
         language_code = self.normalized_payload.get('language_code')
         opportunity_id = self.normalized_payload.get('opportunity_id')
         if language_code and topic_name:


### PR DESCRIPTION
## Summary of Changes
This PR addresses an issue where the string 'undefined' was being passed as a topic name parameter in the contributor dashboard, causing unexpected behavior. The fix ensures these string values are properly converted to `None` to maintain consistent behavior across the application.

## Technical Details
- Added checks in `ReviewableOpportunitiesHandler` to convert 'undefined' string to `None` in two locations
- Added similar check in `LessonsPinningHandler`
- This ensures that when frontend sends 'undefined' as a string, it's treated the same as an actual `None` value

## Issue
Fixes issue #23790

## Testing
- Verified that 'undefined' string values are now properly handled
- Confirmed existing functionality with actual topic names remains unaffected
- Tested edge cases where topic_name is None and with valid topic names