### PR TITLE
Fix #23440: Make unpublished topics filterable on CD

### DIFF
--- a/core/controllers/contributor_dashboard.py
+++ b/core/controllers/contributor_dashboard.py
@@ -858,8 +858,7 @@ class TranslatableTopicNamesHandler(
 
     @acl_decorators.open_access
     def get(self) -> None:
-        # Only published topics are translatable.
-        topic_summaries = topic_fetchers.get_published_topic_summaries()
+        topic_summaries = topic_fetchers.get_all_topic_summaries()
         topic_names = [summary.name for summary in topic_summaries]
         self.values = {'topic_names': topic_names}
         self.render_json(self.values)
@@ -896,7 +895,7 @@ class TranslatableTopicNamesPerClassroomHandler(
 
         # Group topics by classroom and format response.
         topics_per_classroom: Dict[str, List[str]] = {}
-        for summary in topic_fetchers.get_published_topic_summaries():
+        for summary in topic_fetchers.get_all_topic_summaries():
             classroom_name = topic_id_to_classroom.get(summary.id, '')
             topics_per_classroom.setdefault(classroom_name, []).append(
                 summary.name

--- a/core/controllers/contributor_dashboard_test.py
+++ b/core/controllers/contributor_dashboard_test.py
@@ -2008,12 +2008,13 @@ class TranslatableTopicNamesHandlerTest(test_utils.GenericTestBase):
         topic.skill_ids_for_diagnostic_test = ['skill_id_3']
         topic_services.save_new_topic(self.owner_id, topic)
 
-        # Unpublished topics should not be returned.
+        # Unpublished topics should be translatable.
         response = self.get_json('/gettranslatabletopicnames')
-        self.assertEqual(len(response['topic_names']), 0)
+        self.assertEqual(response, {'topic_names': ['topic']})
 
         topic_services.publish_topic(topic_id, self.admin_id)
 
+        # Published topics should be translatable.
         response = self.get_json('/gettranslatabletopicnames')
         self.assertEqual(response, {'topic_names': ['topic']})
 
@@ -2037,7 +2038,7 @@ class TranslatableTopicNamesPerClassroomHandlerTest(test_utils.GenericTestBase):
         response = self.get_json('/gettranslatabletopicnamesperclassroom')
         self.assertEqual(response, {'topic_names_per_classroom': []})
 
-    def test_no_topic_name_should_be_returned_when_topic_is_not_published(
+    def test_topic_name_should_be_returned_when_topic_is_not_published(
         self,
     ) -> None:
         # Create a topic.
@@ -2074,7 +2075,14 @@ class TranslatableTopicNamesPerClassroomHandlerTest(test_utils.GenericTestBase):
         )
 
         response = self.get_json('/gettranslatabletopicnamesperclassroom')
-        self.assertEqual(response, {'topic_names_per_classroom': []})
+        self.assertEqual(
+            response,
+            {
+                'topic_names_per_classroom': [
+                    {'classroom': 'Class 1', 'topics': ['topic 1']}
+                ]
+            },
+        )
 
     def test_topic_name_should_be_returned_when_topic_is_published(
         self,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #23440.
2. This PR does the following: Updates CD controllers to reflect the fact that we now allow contributors to submit translations for unpublished topics. This has the effect of making unpublished topics options for filtering as requested in #23440.
3. (For bug-fixing PRs only) The original bug occurred because: n/a

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

See #23440 for the existing behavior.

Demonstrates that the bug where translation contributors are warned about unsaved changes when submitting a translation exists before the changes in this PR are made:

[Screencast from 2025-11-07 19-24-08.webm](https://github.com/user-attachments/assets/239f512c-bb39-43a2-8675-eccbbe1f8c0e)

Submitting translations. Notice that translations can be submitted for both published ("Fraction") and un-published ("Division") topics (publishing status shown in next video).

[Screencast from 2025-11-04 21-52-59.webm](https://github.com/user-attachments/assets/96aa8f86-4b1b-46aa-9d33-cd8f019c0ab8)

Reviewing suggested translations. Notice that suggestions can be filtered by both published ("Fraction") and un-published ("Division") topics. Topic publication status is shown at the start of the screen recording.

[Screencast from 2025-11-04 21-55-15.webm](https://github.com/user-attachments/assets/10146317-dcbd-4c27-86f3-b21a5f8547e6)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
