### PR TITLE
Bind portserver to the loopback interface.

### DIFF
--- a/scripts/run_portserver.py
+++ b/scripts/run_portserver.py
@@ -127,7 +127,9 @@ def sock_bind(
             continue
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(('', port))
+            # Restrict connections to originate from the local machine only.
+            ip_address = '::1' if family == socket.AF_INET6 else '127.0.0.1'
+            sock.bind((ip_address, port))
             if socket_type == socket.SOCK_STREAM:
                 sock.listen(1)
             port = sock.getsockname()[1]


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of security/code-scanning/30.
2. This PR does the following: Binds portserver to the loopback interface, instead of all interfaces. This restricts connections to originate from the local machine only.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This fixes a security issue. The portserver is used by the acceptance tests, so if these tests complete correctly on CI, then the changes should be correct.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.