### PR TITLE
Fix regex issues.

### DIFF
--- a/core/domain/app_feedback_report_domain.py
+++ b/core/domain/app_feedback_report_domain.py
@@ -994,9 +994,10 @@ class AndroidDeviceSystemContext(DeviceSystemContext):
 
         Returns:
             bool. Whether the given code is valid. Valid codes are alphabetic
-            string that may contain a number of single hyphens.
+            strings (typically 2 letters long) that may optionally include a
+            hyphen followed by another alphabetic string.
         """
-        regex_string = r'^([a-z]+[-]?[a-z]+)+$'
+        regex_string = r'^[a-z]+[-]?[a-z]+$'
         return re.compile(regex_string).match(code.lower())
 
     @classmethod
@@ -1275,9 +1276,10 @@ class AndroidAppContext(AppContext):
 
         Returns:
             bool. Whether the given code is valid. Valid codes are alphabetic
-            string that may contain a number of single hyphens.
+            strings (typically 2 letters long) that may optionally include a
+            hyphen followed by another alphabetic string.
         """
-        regex_string = r'^([a-z]+[-]?[a-z]+)+$'
+        regex_string = r'^[a-z]+[-]?[a-z]+$'
         return re.compile(regex_string).match(code)
 
     @classmethod

--- a/core/templates/pages/exploration-editor-page/changes-in-human-readable-form/changes-in-human-readable-form.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/changes-in-human-readable-form/changes-in-human-readable-form.component.spec.ts
@@ -45,7 +45,7 @@ describe('Changes in Human Readable Form Component', () => {
     let prev;
     do {
       prev = htmlStr;
-      htmlStr = htmlStr.replace.replace(/<\!--[\s\S]*?-->/gm, '');
+      htmlStr = htmlStr.replace(/<\!--[\s\S]*?-->/gm, '');
     } while (htmlStr !== prev);
 
     // Remove marker.

--- a/core/templates/pages/exploration-editor-page/changes-in-human-readable-form/changes-in-human-readable-form.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/changes-in-human-readable-form/changes-in-human-readable-form.component.spec.ts
@@ -37,15 +37,19 @@ describe('Changes in Human Readable Form Component', () => {
   // This is a helper function to clean the compiled html
   // for each test, in order to make a cleaner assertion.
   const removeComments = (HTML: {toString: () => string}) => {
-    return (
-      HTML.toString()
-        // Removes Unecessary white spaces and new lines.
-        .replace(/^\s+|\r\n|\n|\r|(>)\s+(<)|\s+$/gm, '$1$2')
-        // Removes Comments.
-        .replace(/<\!--[\s\S]*?-->/gm, '')
-        // Removes marker.
-        .replace(/::marker/, '')
-    );
+    let htmlStr = HTML.toString()
+      // Removes unnecessary white spaces and new lines.
+      .replace(/^\s+|\r\n|\n|\r|(>)\s+(<)|\s+$/gm, '$1$2');
+
+    // Repeatedly remove comments until none remain.
+    let prev;
+    do {
+      prev = htmlStr;
+      htmlStr = htmlStr.replace.replace(/<\!--[\s\S]*?-->/gm, '');
+    } while (htmlStr !== prev);
+
+    // Remove marker.
+    return htmlStr.replace(/::marker/, '');
   };
 
   beforeEach(waitForAsync(() => {

--- a/core/templates/pages/exploration-editor-page/changes-in-human-readable-form/changes-in-human-readable-form.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/changes-in-human-readable-form/changes-in-human-readable-form.component.spec.ts
@@ -42,7 +42,7 @@ describe('Changes in Human Readable Form Component', () => {
         // Removes Unecessary white spaces and new lines.
         .replace(/^\s+|\r\n|\n|\r|(>)\s+(<)|\s+$/gm, '$1$2')
         // Removes Comments.
-        .replace(/<\!--.*?-->/gm, '')
+        .replace(/<\!--[\s\S]*?-->/gm, '')
         // Removes marker.
         .replace(/::marker/, '')
     );


### PR DESCRIPTION
## Overview


1. This PR fixes code scanning alerts 78, 79, 80, 81, 90, 93 in CodeQL.
2. This PR does the following: 
   - Fixes comment removal regex to include comments with newlines.
   - Restricts the regex used in app_feedback_report_domain.py to make it more efficient.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

The code in app_feedback_report_domain.py is not used yet since the Android app is not yet sending us feedback reports, but I checked the format of ISO-639 codes and the new regex matches those.

The comment-removal code is in a test file and the tests still pass.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
