### PR TITLE
Fix: Hide "Start by setting a goal" when goals are already set (#23574)

### DIFF
--- a/core/templates/pages/learner-dashboard-page/old-progress-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/old-progress-tab.component.html
@@ -37,17 +37,15 @@
         </span>
       </a>
     </div>
-    <div *ngIf="emptySkillProficiency" class="empty-skill-proficiency-section">
-      <p class="empty-skill-proficiency" [innerHTML]="'I18N_LEARNER_DASHBOARD_EMPTY_SKILL_PROFICIENCY' | translate">
-      </p>
-      <a id="setting-a-goal-link" (click)="changeActiveSection()" tabindex="0" (keydown.enter)="changeActiveSection()">
-        <p [innerHTML]="'I18N_LEARNER_DASHBOARD_EMPTY_SKILL_PROFICIENCY_SET_A_GOAL' | translate"
-           class="empty-skill-proficiency">
-        </p>
-      </a>
-      <p class="empty-skill-proficiency" [innerHTML]="'I18N_LEARNER_DASHBOARD_EMPTY_SKILL_PROFICIENCY_REASON_FOR_SETTING_A_GOAL' | translate">
-      </p>
-    </div>
+    <div *ngIf="topicsInSkillProficiency.length === 0" class="empty-skill-proficiency-section">
+  <p class="empty-skill-proficiency" [innerHTML]="'I18N_LEARNER_DASHBOARD_EMPTY_SKILL_PROFICIENCY' | translate"></p>
+  <a id="setting-a-goal-link" (click)="changeActiveSection()" tabindex="0">
+    <p [innerHTML]="'I18N_LEARNER_DASHBOARD_EMPTY_SKILL_PROFICIENCY_SET_A_GOAL' | translate"
+       class="empty-skill-proficiency">
+    </p>
+  </a>
+  <p class="empty-skill-proficiency" [innerHTML]="'I18N_LEARNER_DASHBOARD_EMPTY_SKILL_PROFICIENCY_REASON_FOR_SETTING_A_GOAL' | translate"></p>
+</div>
     <div *ngIf="!emptySkillProficiency">
       <div *ngFor="let tile of topicMastery; index as i" class="skill-proficiency-content">
         <div class="skill-proficiency-topic-tile" [ngStyle]="displaySkills[i] && {'border-bottom': 'none', 'margin-bottom': '0'}" *ngIf="tile[1].practiceTabIsDisplayed">


### PR DESCRIPTION
Fixes #23574

The message "Start by setting a goal" was appearing on the Skill Progress page 
even when the user had already set goals. This happened because the condition 
was based on `emptySkillProficiency` (which checks for practice-enabled topics), 
not on whether goals actually exist.

Since `OldProgressTabComponent` does not receive goal data, the safest fix is to 
only show the message when there are **no skill topics at all** 
(`topicsInSkillProficiency.length === 0`).

This prevents the misleading message from appearing when goals exist but practice 
tabs are unavailable.

Note: I have not run the full Oppia dev server locally due to system constraints, 
but the change is minimal, logic-based, and consistent with Angular best practices. 
I welcome feedback and am happy to make any adjustments!
