### PR TITLE
Fix empty skill proficiency check in learner dashboard

### DIFF
--- a/core/templates/pages/learner-dashboard-page/old-progress-tab.component.html
+++ b/core/templates/pages/learner-dashboard-page/old-progress-tab.component.html
@@ -37,7 +37,7 @@
         </span>
       </a>
     </div>
-    <div *ngIf="emptySkillProficiency" class="empty-skill-proficiency-section">
+    <div *ngIf="topicsInSkillProficiency.length === 0" class="empty-skill-proficiency-section">
       <p class="empty-skill-proficiency" [innerHTML]="'I18N_LEARNER_DASHBOARD_EMPTY_SKILL_PROFICIENCY' | translate">
       </p>
       <a id="setting-a-goal-link" (click)="changeActiveSection()" tabindex="0" (keydown.enter)="changeActiveSection()">


### PR DESCRIPTION
## Overview
This PR fixes an issue in the learner dashboard's old progress tab where the empty skill proficiency section was not being displayed correctly. The condition was changed from checking a boolean `emptySkillProficiency` to checking if the `topicsInSkillProficiency` array is empty, which provides a more accurate representation of whether there are any skill proficiencies to display.

## Checklist
- [ ] Code changes are complete
- [ ] Tests pass
- [ ] Documentation updated (if applicable)

## Proof that changes are correct
The change modifies the conditional rendering logic in the template to use `topicsInSkillProficiency.length === 0` instead of the boolean `emptySkillProficiency`. This ensures that the empty state is displayed only when the topics array is actually empty, providing a more reliable check for the UI state. The fix addresses issue #23811 by ensuring the empty skill proficiency section appears when appropriate.