### PR TITLE
Fix #18837 : The supplied input topic: undefined is not valid

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
@@ -107,7 +107,7 @@
           </select>
         </span>
       </div>
-      <lazy-loading *ngIf="!topicReady"></lazy-loading>
+      <lazy-loading *ngIf="activeExplorationId === null && isReviewTranslationsTab() && !isAccomplishmentsTabActive() && !topicReady"></lazy-loading>
       <oppia-opportunities-list *ngIf="activeExplorationId === null && isReviewTranslationsTab() && !isAccomplishmentsTabActive() && topicReady"
                                 [loadOpportunities]="loadReviewableTranslationOpportunities.bind(this)"
                                 (clickActionButton)="onClickReviewableTranslations($event)"

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
@@ -107,7 +107,7 @@
           </select>
         </span>
       </div>
-      <oppia-opportunities-list *ngIf="activeExplorationId === null && isReviewTranslationsTab() && !isAccomplishmentsTabActive()"
+      <oppia-opportunities-list *ngIf="topicReady && activeExplorationId === null && isReviewTranslationsTab() && !isAccomplishmentsTabActive()"
                                 [loadOpportunities]="loadReviewableTranslationOpportunities.bind(this)"
                                 (clickActionButton)="onClickReviewableTranslations($event)"
                                 (clickPinButton)="pinReviewableTranslationOpportunity($event)"

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
@@ -107,7 +107,8 @@
           </select>
         </span>
       </div>
-      <oppia-opportunities-list *ngIf="topicReady && activeExplorationId === null && isReviewTranslationsTab() && !isAccomplishmentsTabActive()"
+      <lazy-loading *ngIf="!topicReady"></lazy-loading>
+      <oppia-opportunities-list *ngIf="activeExplorationId === null && isReviewTranslationsTab() && !isAccomplishmentsTabActive() && topicReady"
                                 [loadOpportunities]="loadReviewableTranslationOpportunities.bind(this)"
                                 (clickActionButton)="onClickReviewableTranslations($event)"
                                 (clickPinButton)="pinReviewableTranslationOpportunity($event)"

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
@@ -2216,6 +2216,24 @@ describe('Contributions and review component', () => {
         'translate_content'
       );
     });
+    it('should update topicReady when active topic changes', fakeAsync(() => {
+      const getActiveTopicNameSpy = spyOn(
+        translationTopicService,
+        'getActiveTopicName'
+      );
+
+      getActiveTopicNameSpy.and.returnValue(null);
+      mockActiveTopicEventEmitter.emit();
+      tick();
+
+      expect(component.topicReady).toBeFalse();
+
+      getActiveTopicNameSpy.and.returnValue('Math');
+      mockActiveTopicEventEmitter.emit();
+      tick();
+
+      expect(component.topicReady).toBeTrue();
+    }));
   });
 
   describe(

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
@@ -22,6 +22,7 @@ import {
   OnInit,
   ViewChild,
   HostListener,
+  Input,
 } from '@angular/core';
 import {NgbModalRef, NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {AppConstants} from 'app.constants';
@@ -129,6 +130,7 @@ const COMMIT_TIMEOUT_DURATION = 30000;
   templateUrl: './contributions-and-review.component.html',
 })
 export class ContributionsAndReview implements OnInit, OnDestroy {
+  @Input() activeTopicName: string;
   @ViewChild('opportunitiesList')
   opportunitiesListRef!: OpportunitiesListComponent;
 
@@ -158,6 +160,7 @@ export class ContributionsAndReview implements OnInit, OnDestroy {
   reviewableQuestionsSortKey: string;
   userCreatedTranslationsSortKey: string;
   reviewableTranslationsSortKey: string;
+  topicReady: boolean;
   commitTimeout?: NodeJS.Timeout;
   queuedSuggestionSummary = null;
   queuedSuggestion = null;
@@ -797,6 +800,7 @@ export class ContributionsAndReview implements OnInit, OnDestroy {
     this.contributions = {};
     this.userDetailsLoading = true;
     this.userIsLoggedIn = false;
+    this.topicReady = false;
     this.languageCode = this.translationLanguageService.getActiveLanguageCode();
     this.activeTabType = '';
     this.activeTabSubtype = '';
@@ -831,6 +835,15 @@ export class ContributionsAndReview implements OnInit, OnDestroy {
         enabled: true,
       },
     ];
+
+    // Whenever the active topic changes, update the `topicReady` flag.
+    // `topicReady` is true if there is an active topic, false otherwise.
+    // This flag can be used to conditionally render parts of the UI or
+    // enable/disable features that depend on a selected topic.
+    this.translationTopicService.onActiveTopicChanged.subscribe(() => {
+      const topic = this.translationTopicService.getActiveTopicName();
+      this.topicReady = !!topic;
+    });
 
     // Reset active exploration when changing topics.
     this.directiveSubscriptions.add(

--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -151,7 +151,7 @@
     </div>
   </div>
   <div *ngIf="activeTabName === 'myContributionTab' || !activeTabName">
-    <oppia-contributions-and-review>
+    <oppia-contributions-and-review [activeTopicName]="topicName">
     </oppia-contributions-and-review>
   </div>
   <div *ngIf="activeTabName === 'submitQuestionTab'"


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18837.
2. This PR does the following: Displaying opportunity list  when Topic is set .
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

Before : 

[Screencast from 2025-11-09 14-55-44.webm](https://github.com/user-attachments/assets/91b13e42-6604-4e93-be11-605ac822e584)

After : 

[Screencast from 2025-11-09 14-57-13.webm](https://github.com/user-attachments/assets/8fcd12b9-ca5e-464e-9d5a-7220c0ef2d80)


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
