### PR TITLE
Fix #23815: scripts - Inherit system environment for ElasticSearch startup

### DIFF
--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -291,11 +291,12 @@ def managed_elasticsearch_dev_server() -> Iterator[psutil.Process]:
         '-q',
     ]
     # Override the default path to ElasticSearch config files.
-    es_env = {
+    es_env = os.environ.copy()
+    es_env.update({
         'ES_PATH_CONF': common.ES_PATH_CONFIG_DIR,
         # Set the minimum heap size to 100 MB and maximum to 500 MB.
         'ES_JAVA_OPTS': '-Xms100m -Xmx500m',
-    }
+    })
     # OK to use shell=True here because we are passing string literals and
     # constants, so there is no risk of a shell-injection attack.
     proc_context = managed_process(

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -290,7 +290,7 @@ def managed_elasticsearch_dev_server() -> Iterator[psutil.Process]:
         # -q is the quiet flag.
         '-q',
     ]
-    # Override the default path to ElasticSearch config files.
+    # Inherit system environment variables and override the ElasticSearch config path.
     es_env = os.environ.copy()
     es_env.update({
         'ES_PATH_CONF': common.ES_PATH_CONFIG_DIR,

--- a/scripts/servers_test.py
+++ b/scripts/servers_test.py
@@ -532,16 +532,14 @@ class ManagedProcessTests(test_utils.TestBase):
             popen_calls[0].program_args,
             '%s/bin/elasticsearch -q' % common.ES_PATH,
         )
-        self.assertEqual(
-            popen_calls[0].kwargs,
-            {
-                'shell': True,
-                'env': {
-                    'ES_JAVA_OPTS': '-Xms100m -Xmx500m',
-                    'ES_PATH_CONF': common.ES_PATH_CONFIG_DIR,
-                },
-            },
-        )
+        self.assertEqual(popen_calls[0].kwargs['shell'], True)
+
+        env_vars = popen_calls[0].kwargs['env']
+
+        self.assertEqual(env_vars['ES_JAVA_OPTS'], '-Xms100m -Xmx500m')
+        self.assertEqual(env_vars['ES_PATH_CONF'], common.ES_PATH_CONFIG_DIR)
+
+        self.assertIn('PATH', env_vars)
 
     def test_start_server_removes_elasticsearch_data(self) -> None:
         check_function_calls = {'shutil_rmtree_is_called': False}


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #23815. 
2. This PR does the following:
Updates the Elasticsearch startup process in the scripts/servers.py to inherit the system environment variables.
This change ensures that the managed Elasticsearch development server starts correctly in environments where essential system variables (like PATH) are required for execution.
Additionally, the corresponding test test_managed_elasticsearch_dev_server in scripts/servers_test.py was updated to reflect this behavior.
4. (For bug-fixing PRs only) The original bug occurred because: The env dictionary for the managed Elasticsearch process was not inheriting system environment variables, causing missing configuration in some setups.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
<img width="3840" height="1080" alt="OppiaWorking" src="https://github.com/user-attachments/assets/2e887548-e96a-451d-a540-b90a3383dbda" />
<img width="967" height="755" alt="Computer" src="https://github.com/user-attachments/assets/cf622cfc-a189-4864-a639-484082bdb778" />
<img width="1912" height="1070" alt="Oppia2" src="https://github.com/user-attachments/assets/2b081cec-04e6-4af7-a551-9710e7369184" />

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
