### PR TITLE
Fix flaky welcome modal dismissal in puppeteer tests

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -2731,6 +2731,7 @@ export class ExplorationEditor extends BaseUser {
    */
   async dismissWelcomeModal(): Promise<void> {
     try {
+      await this.page.waitForNetworkIdle();
       await this.page.waitForSelector(dismissWelcomeModalSelector, {
         visible: true,
         timeout: 5000,

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
@@ -2268,7 +2268,7 @@ export class LoggedInUser extends BaseUser {
       await this.page.waitForNetworkIdle();
       await this.page.waitForSelector(dismissWelcomeModalSelector, {
         visible: true,
-        timeout: 10000,
+        timeout: 5000,
       });
       await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
       await this.page.waitForSelector(dismissWelcomeModalSelector, {


### PR DESCRIPTION
# Overview
This PR addresses issue #23813 by fixing flaky behavior in puppeteer acceptance tests related to dismissing the welcome modal. The changes add a network idle wait before attempting to dismiss the modal and reduce the timeout for the dismissal operation.

# Checklist
- [ ] Code changes have been reviewed
- [ ] Tests have been updated to reflect the fix
- [ ] Documentation has been updated if necessary

# Proof
The changes ensure that the page is fully loaded before attempting to dismiss the welcome modal, which should prevent flakiness in the tests. The reduced timeout for the dismissal operation should also help prevent the tests from hanging.

# Closes
Closes #23813