### PR TITLE
Update codeql config to ignore unparseable test file

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,3 +8,7 @@ paths-ignore:
   # for SHA-1. We can migrate to a stronger cryptographic algorithm, replacing
   # all SHA-1, but that would require changes to the existing data we have.
   - core/utils.py
+  # This file is ignored because it is a test file that represents an invalid
+  # merge conflict (and thus is not a valid Python file). Including it in the
+  # list of files to be scanned causes CodeQL to run into a parsing error.
+  - scripts/linters/test_files/invalid_merge_conflict.py


### PR DESCRIPTION
## Overview

1. This PR fixes #N/A.
2. This PR does the following: Adds a file to the codeql config that can't be parsed via the Python scanner. This file that has no impact on the rest of the codebase and is used to test linter detection of unresolved merge conflicts. The CodeQL Python check are showing an error because it is trying to scan this file and can't parse it.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL"  (if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this file has no impact on the codebase.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
