### PR TITLE
Clean up more CodeQL errors.

### DIFF
--- a/assets/scripts/embedding_tests_dev_0.0.1.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.1.min.html
@@ -68,7 +68,8 @@
     iframes.forEach(function(iframe) {
       var currentSrc = iframe.getAttribute('src');
       if (currentSrc && currentSrc.includes(placeholderExplorationId)) {
-        var updatedSrc = currentSrc.replace(placeholderExplorationId, newExplorationId);
+        var updatedSrc = currentSrc.replace(
+          placeholderExplorationId, encodeURIComponent(newExplorationId));
         iframe.setAttribute('src', updatedSrc);
       }
     });
@@ -77,7 +78,7 @@
 
     var oppiaElements = document.querySelectorAll('oppia[oppia-id="idToBeReplaced"]');
     oppiaElements.forEach(function(element) {
-      element.setAttribute('oppia-id', newExplorationId);
+      element.setAttribute('oppia-id', encodeURIComponent(newExplorationId));
     });
 
     var results = document.querySelector('.e2e-test-results');

--- a/assets/scripts/embedding_tests_dev_0.0.2.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.2.min.html
@@ -62,7 +62,8 @@
     var iframes = document.querySelectorAll('div > iframe');
     iframes.forEach(function(iframe) {
       var src = iframe.getAttribute('src');
-      iframe.setAttribute('src', src.replace(placeholderExplorationId, newExplorationId));
+      iframe.setAttribute('src', src.replace(
+        placeholderExplorationId, encodeURIComponent(newExplorationId)));
     });
 
     placeholderExplorationId = newExplorationId;

--- a/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
+++ b/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
@@ -36,7 +36,8 @@
     var iframes = document.querySelectorAll('div > iframe');
     iframes.forEach(function(iframe) {
       var src = iframe.getAttribute('src');
-      var updatedSrc = src.replace(placeholderExplorationId, newExplorationId);
+      var updatedSrc = src.replace(
+        placeholderExplorationId, encodeURIComponent(newExplorationId));
       iframe.setAttribute('src', updatedSrc);
     });
 

--- a/core/templates/domain/objects/number-with-units.model.ts
+++ b/core/templates/domain/objects/number-with-units.model.ts
@@ -85,15 +85,15 @@ export class NumberWithUnits {
     // which isn't allowed. Refer objects.py L#956.
     let unitsString = Units.fromList(this.units).toString();
     if (unitsString.includes('$')) {
-      unitsString = unitsString.replace('$', '');
+      unitsString = unitsString.replace(/\$/g, '');
       numberWithUnitsString += '$' + ' ';
     }
     if (unitsString.includes('Rs')) {
-      unitsString = unitsString.replace('Rs', '');
+      unitsString = unitsString.replace(/Rs/g, '');
       numberWithUnitsString += 'Rs' + ' ';
     }
     if (unitsString.includes('₹')) {
-      unitsString = unitsString.replace('₹', '');
+      unitsString = unitsString.replace(/₹/g, '');
       numberWithUnitsString += '₹' + ' ';
     }
 


### PR DESCRIPTION
## Overview

1. This PR fixes CodeQL Issues 83, 84, 85 and 91.
2. This PR does the following: Adds URI component encoding to the embedding code, and tightens replacement of a regex in the number-with-units interaction. (Strictly speaking, the former is not needed because there's validation of the explorationId before the new check, but it does no harm to add it.)

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A -- existing tests suffice.)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because the changes in this PR do not affect functionality.


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
