### PR TITLE
Relax the regex for app feedback domain reports

### DIFF
--- a/core/domain/app_feedback_report_domain.py
+++ b/core/domain/app_feedback_report_domain.py
@@ -993,11 +993,10 @@ class AndroidDeviceSystemContext(DeviceSystemContext):
             code: str. The device's country locale code that sent the report.
 
         Returns:
-            bool. Whether the given code is valid. Valid codes are alphabetic
-            strings (typically 2 letters long) that may optionally include a
-            hyphen followed by another alphabetic string.
+            bool. Whether the given code is valid. Valid codes contain only
+            letters, digits, and hyphens.
         """
-        regex_string = r'^[a-z]+[-]?[a-z]+$'
+        regex_string = r'^[a-zA-Z0-9-]+$'
         return re.compile(regex_string).match(code.lower())
 
     @classmethod
@@ -1275,11 +1274,10 @@ class AndroidAppContext(AppContext):
             code: str. The language code set on the app.
 
         Returns:
-            bool. Whether the given code is valid. Valid codes are alphabetic
-            strings (typically 2 letters long) that may optionally include a
-            hyphen followed by another alphabetic string.
+            bool. Whether the given code is valid. Valid codes contain only
+            letters, digits, and hyphens.
         """
-        regex_string = r'^[a-z]+[-]?[a-z]+$'
+        regex_string = r'^[a-zA-Z0-9-]+$'
         return re.compile(regex_string).match(code)
 
     @classmethod


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A
2. This PR does the following: Relax the regex for app feedback domain reports.
   - **Background:** PR #23804 fixed some regex issues identified by CodeQL; in subsequent discussion with @BenHenning we noted that Android devices vary and the existing regex might be restrictive (it was also incorrect because digits can appear in language codes, e.g. es-419). This PR updates the regex to include digits and be a bit less prescriptive about the structure of the language code.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (The existing tests suffice.)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this functionality isn't live yet (Android has not written their side of it).

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
