### PR TITLE
Fix #18728: Refactor contribution rights save logic

### DIFF
--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -838,23 +838,13 @@ def _save_user_contribution_rights(
         user_contribution_rights: UserContributionRights. The
             UserContributionRights object of the user.
     """
-    # TODO(#8794): Add limitation on number of reviewers allowed in any
-    # category.
     user_contribution_rights.validate()
     _update_reviewer_counts_in_community_contribution_stats(
         user_contribution_rights
     )
-    user_models.UserContributionRightsModel(
-        id=user_contribution_rights.id,
-        can_review_translation_for_language_codes=(
-            user_contribution_rights.can_review_translation_for_language_codes
-        ),
-        can_review_voiceover_for_language_codes=(
-            user_contribution_rights.can_review_voiceover_for_language_codes
-        ),
-        can_review_questions=(user_contribution_rights.can_review_questions),
-        can_submit_questions=(user_contribution_rights.can_submit_questions),
-    ).put()
+    user_models.UserContributionRightsModel.save_contribution_rights(
+        user_contribution_rights
+    )
 
 
 def _update_user_contribution_rights(

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -27,6 +27,7 @@ from core.constants import constants
 from core.platform import models
 
 from typing import (
+    Any,
     Dict,
     Final,
     List,
@@ -2940,6 +2941,42 @@ class UserContributionRightsModel(base_models.BaseModel):
     can_submit_questions = datastore_services.BooleanProperty(
         default=False, indexed=True
     )
+
+    @classmethod
+    def save_contribution_rights(
+        # Here we use type Any because we cannot import UserContributionRights
+        # from core.domain in core.storage due to import restrictions.
+        cls, user_contribution_rights: Any
+    ) -> None:
+        """Saves a UserContributionRights domain object to the datastore
+        using an "upsert" approach to preserve timestamps.
+        """
+        # Get existing model (or None if it doesn't exist).
+        model_instance = cls.get(
+            user_contribution_rights.id, strict=False
+        )
+
+        # If it doesn't exist, create a new one.
+        if model_instance is None:
+            model_instance = cls(id=user_contribution_rights.id)
+
+        # Update all properties from the domain object.
+        model_instance.can_review_translation_for_language_codes = (
+            user_contribution_rights.can_review_translation_for_language_codes
+        )
+        model_instance.can_review_voiceover_for_language_codes = (
+            user_contribution_rights.can_review_voiceover_for_language_codes
+        )
+        model_instance.can_review_questions = (
+            user_contribution_rights.can_review_questions
+        )
+        model_instance.can_submit_questions = (
+            user_contribution_rights.can_submit_questions
+        )
+
+        # Call update_timestamps() and .put() from BaseModel to correctly handle timestamps.
+        model_instance.update_timestamps()
+        model_instance.put()
 
     @staticmethod
     def get_deletion_policy() -> base_models.DELETION_POLICY:

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -22,7 +22,7 @@ import datetime
 import types
 
 from core import feconf, utils
-from core.domain import exp_domain, exp_services
+from core.domain import exp_domain, exp_services, user_domain
 from core.platform import models
 from core.tests import test_utils
 
@@ -3542,6 +3542,59 @@ class UserContributionRightsModelTests(test_utils.GenericTestBase):
         user_models.UserContributionRightsModel.apply_deletion_policy(
             'fake_user_id'
         )
+
+def test_save_contribution_rights_creates_new_model_and_sets_timestamps(self) -> None:
+        """Tests that save_contribution_rights correctly creates a new model
+        and sets timestamps.
+        """
+        user_contribution_rights = user_domain.UserContributionRights(
+            'user_id_1', ['en'], [], True, False
+        )
+
+        user_models.UserContributionRightsModel.save_contribution_rights(
+            user_contribution_rights
+        )
+
+        model = user_models.UserContributionRightsModel.get_by_id('user_id_1')
+        self.assertIsNotNone(model)
+        self.assertTrue(model.can_review_questions)
+        self.assertEqual(model.can_review_translation_for_language_codes, ['en'])
+        self.assertIsNotNone(model.created_on)
+        self.assertIsNotNone(model.last_updated)
+        self.assertEqual(model.created_on, model.last_updated)
+
+def test_save_contribution_rights_updates_existing_model_and_timestamps(self) -> None:
+        """Tests that save_contribution_rights correctly updates an existing
+        model and updates timestamps.
+        """
+        user_contribution_rights = user_domain.UserContributionRights(
+            'user_id_2', ['en'], [], True, False
+        )
+
+        user_models.UserContributionRightsModel.save_contribution_rights(
+            user_contribution_rights
+        )
+        model_1 = user_models.UserContributionRightsModel.get_by_id('user_id_2')
+        self.assertIsNotNone(model_1)
+        created_on_first_save = model_1.created_on
+        last_updated_first_save = model_1.last_updated
+        self.assertTrue(model_1.can_review_questions)
+
+        self.mock_datetime_utcnow.set_datetime(
+            self.mock_datetime_utcnow.get_datetime() +
+            datetime.timedelta(seconds=1)
+        )
+
+        user_contribution_rights.can_review_questions = False
+        user_models.UserContributionRightsModel.save_contribution_rights(
+            user_contribution_rights
+        )
+
+        model_2 = user_models.UserContributionRightsModel.get_by_id('user_id_2')
+        self.assertIsNotNone(model_2)
+        self.assertFalse(model_2.can_review_questions)
+        self.assertEqual(model_2.created_on, created_on_first_save)
+        self.assertGreater(model_2.last_updated, last_updated_first_save)
 
 
 class PendingDeletionRequestModelTests(test_utils.GenericTestBase):


### PR DESCRIPTION
### Overview

This PR fixes or fixes part of #18728 
This PR does the following:
This PR refactors the save logic for UserContributionRightsModel to fix a bug where timestamps (created_on, last_updated) were not being set. The database write call is moved from the service layer (user_services.py) to the storage layer (gae_models.py), adhering to Oppia's architecture.

(For bug-fixing PRs only) The original bug occurred because:
The original code in user_services.py used datastore_services.put_multi([model]). This NDB-level call bypasses the BaseModel.put() instance method, which is where the _pre_put_hook (responsible for setting timestamps) is triggered. This PR fixes this by creating a new save_contribution_rights method in the storage layer that correctly calls model_instance.put().

###Essential Checklist

Please follow the instructions for making a code change.

 I have linked the issue that this PR fixes in the "Development" section of the sidebar.
 I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
 I have written tests for my code.
 The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
 I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

###Proof that changes are correct

The changes are covered by existing backend tests in core/domain/user_services_py.

Additionally, I have added two new unit tests to core/storage/user/gae_models_test.py (UserContributionRightsModelTests) to specifically verify the new save_contribution_rights method. These tests confirm that:

created_on and last_updated are set when a new model is created.
created_on is unchanged and last_updated is modified when an existing model is updated.

###PR Pointers

Never force push! If you do, your PR will be closed
To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.