### PR TITLE
Fix part of #18305: Added recorded_voiceovers and written_translations fields to the android study guide data for backward compatibility

### DIFF
--- a/core/domain/study_guide_domain.py
+++ b/core/domain/study_guide_domain.py
@@ -354,7 +354,8 @@ class StudyGuide:
                 'subtitled_html': {
                     'content_id': 'content',
                     'html': concatenated_html,
-                }
+                },
+                'recorded_voiceovers': {},
             },
             'page_contents_schema_version': self.sections_schema_version,
             'language_code': self.language_code,

--- a/core/domain/study_guide_domain.py
+++ b/core/domain/study_guide_domain.py
@@ -23,6 +23,7 @@ from core.constants import constants
 from core.domain import change_domain, state_domain, translation_domain
 
 from typing import (
+    Any,
     Callable,
     Dict,
     Final,
@@ -266,8 +267,12 @@ class StudyGuidePageContentsDict(TypedDict):
     """
 
     subtitled_html: state_domain.SubtitledHtmlDict
-    recorded_voiceovers: Dict
-    written_translations: Dict
+    # Here we use type Any because dict 'recorded_voiceovers' is a
+    # legacy field that will always be empty for study guides.
+    recorded_voiceovers: Dict[str, Any]
+    # Here we use type Any because dict 'written_translations' is a
+    # legacy field that will always be empty for study guides.
+    written_translations: Dict[str, Any]
 
 
 class StudyGuideAndroidDict(TypedDict):

--- a/core/domain/study_guide_domain.py
+++ b/core/domain/study_guide_domain.py
@@ -257,6 +257,7 @@ class StudyGuidePageContentsDict(TypedDict):
     """
 
     subtitled_html: state_domain.SubtitledHtmlDict
+    recorded_voiceovers: state_domain.RecordedVoiceoversDict
 
 
 class StudyGuideAndroidDict(TypedDict):

--- a/core/domain/study_guide_domain.py
+++ b/core/domain/study_guide_domain.py
@@ -257,7 +257,8 @@ class StudyGuidePageContentsDict(TypedDict):
     """
 
     subtitled_html: state_domain.SubtitledHtmlDict
-    recorded_voiceovers: state_domain.RecordedVoiceoversDict
+    recorded_voiceovers: dict
+    written_translations: dict
 
 
 class StudyGuideAndroidDict(TypedDict):
@@ -357,6 +358,7 @@ class StudyGuide:
                     'html': concatenated_html,
                 },
                 'recorded_voiceovers': {},
+                'written_translations': {},
             },
             'page_contents_schema_version': self.sections_schema_version,
             'language_code': self.language_code,

--- a/core/domain/study_guide_domain.py
+++ b/core/domain/study_guide_domain.py
@@ -22,7 +22,16 @@ from core import feconf, utils
 from core.constants import constants
 from core.domain import change_domain, state_domain, translation_domain
 
-from typing import Callable, Final, List, Literal, Optional, TypedDict, Union
+from typing import (
+    Callable,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+)
 
 STUDY_GUIDE_PROPERTY_SECTIONS: Final = 'sections'
 
@@ -257,8 +266,8 @@ class StudyGuidePageContentsDict(TypedDict):
     """
 
     subtitled_html: state_domain.SubtitledHtmlDict
-    recorded_voiceovers: dict
-    written_translations: dict
+    recorded_voiceovers: Dict
+    written_translations: Dict
 
 
 class StudyGuideAndroidDict(TypedDict):

--- a/core/domain/study_guide_domain_test.py
+++ b/core/domain/study_guide_domain_test.py
@@ -172,7 +172,7 @@ class StudyGuideDomainUnitTests(test_utils.GenericTestBase):
         # Check that HTML is concatenated properly.
         page_contents = android_dict['page_contents']
         self.assertIn('subtitled_html', page_contents)
-        self.assertIn('recordered_voiceovers', page_contents)
+        self.assertIn('recorded_voiceovers', page_contents)
 
         html_content = page_contents['subtitled_html']['html']
         self.assertIn('<p><strong>Test Heading</strong></p>', html_content)

--- a/core/domain/study_guide_domain_test.py
+++ b/core/domain/study_guide_domain_test.py
@@ -172,6 +172,7 @@ class StudyGuideDomainUnitTests(test_utils.GenericTestBase):
         # Check that HTML is concatenated properly.
         page_contents = android_dict['page_contents']
         self.assertIn('subtitled_html', page_contents)
+        self.assertIn('recordered_voiceovers', page_contents)
 
         html_content = page_contents['subtitled_html']['html']
         self.assertIn('<p><strong>Test Heading</strong></p>', html_content)


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #18305.
2. This PR does the following: Adds recorded_voiceovers and written_translations to the page_contents field of the study guide data for the android handler for backward compatibility.
3. (For bug-fixing PRs only) The original bug occurred because: Downloading android data fails when using the study guide migration endpoint as the android download scripts are not configured to data without the recorded_voiceovers and written_translations fields.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

(@BenHenning will test on the backup server to confirm)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
