### PR TITLE
Remove pkg_resources with importlib.metadata and packaging

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 profile=black
 line_length=80
-known_third_party=apache_beam,backports.functools_lru_cache,browsermobproxy,cloudstorage,contextlib2,elasticsearch,firebase_admin,google.api_core,google.appengine,google.cloud,google.protobuf,mapreduce,mock,mutagen,pipeline,pkg_resources,psutil,pylatexenc,pylint,requests,requests_mock,selenium,six,skulpt,typing,webapp2,webapp2_extras,webtest,yaml
+known_third_party=apache_beam,backports.functools_lru_cache,browsermobproxy,cloudstorage,contextlib2,elasticsearch,firebase_admin,google.api_core,google.appengine,google.cloud,google.protobuf,mapreduce,mock,mutagen,pipeline,psutil,pylatexenc,pylint,requests,requests_mock,selenium,six,skulpt,typing,webapp2,webapp2_extras,webtest,yaml
 sections=FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -435,29 +435,31 @@ def _get_possible_normalized_metadata_directory_names(
         set(str). Set containing the possible normalized directory name strings
         of metadata folders.
     """
-    # Some metadata folders replace the hyphens in the library name with
-    # underscores.
-    return {
-        normalize_directory_name(
-            '%s-%s.dist-info' % (library_name, version_string)
-        ),
-        normalize_directory_name(
-            '%s-%s.dist-info' % (library_name.replace('-', '_'), version_string)
-        ),
-        normalize_directory_name(
-            '%s-%s.egg-info' % (library_name, version_string)
-        ),
-        normalize_directory_name(
-            '%s-%s.egg-info' % (library_name.replace('-', '_'), version_string)
-        ),
-        normalize_directory_name(
-            '%s-%s-py3.10.egg-info' % (library_name, version_string)
-        ),
-        normalize_directory_name(
-            '%s-%s-py3.10.egg-info'
-            % (library_name.replace('-', '_'), version_string)
-        ),
-    }
+    # Metadata folders can use different separators: hyphens, underscores, or
+    # dots. We need to check all possible combinations since different packages
+    # use different conventions (e.g., jaraco.classes, jaraco-classes,
+    # jaraco_classes).
+    name_variations = [
+        library_name,
+        library_name.replace('-', '_'),
+        library_name.replace('-', '.'),
+    ]
+
+    possible_names = set()
+    for name in name_variations:
+        possible_names.add(
+            normalize_directory_name('%s-%s.dist-info' % (name, version_string))
+        )
+        possible_names.add(
+            normalize_directory_name('%s-%s.egg-info' % (name, version_string))
+        )
+        possible_names.add(
+            normalize_directory_name(
+                '%s-%s-py3.10.egg-info' % (name, version_string)
+            )
+        )
+
+    return possible_names
 
 
 def verify_pip_is_installed() -> None:

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -42,23 +42,17 @@ GIT_DIRECT_URL_REQUIREMENT_PATTERN: Final = (
     re.compile(r'^(git\+git://github\.com/.*?@[0-9a-f]{40})#egg=([^\s]*)')
 )
 
-# These are libraries represented in requirements.txt using hyphens after the
-# first word, but in their METADATA files using a period after the first word
-# instead.
-LIBRARY_PREFIXES_WITH_INITIAL_PERIOD: Final = [
-    'backports',
-    'jaraco',
-    'keyrings',
-]
-
 
 def normalize_python_library_name(library_name: str) -> str:
     """Returns a normalized version of the python library name.
 
-    Normalization of a library name means converting the library name to
-    lowercase, and removing any "[...]" suffixes that occur. The reason we do
-    this is because of 3 potential confusions when comparing library names that
-    will cause this script to find incorrect mismatches.
+    Normalization follows PEP 503 to ensure consistency between package names
+    in different contexts (requirements.txt vs installed packages). This means:
+    - Converting to lowercase
+    - Replacing any runs of [-_.] with a single hyphen
+    - Removing any "[...]" extras suffixes
+
+    This resolves several potential confusions when comparing library names:
 
     1. Python library name strings are case-insensitive, which means that
        libraries are considered equivalent even if the casing of the library
@@ -69,27 +63,15 @@ def normalize_python_library_name(library_name: str) -> str:
        the sub-library. These variants can be considered equivalent to an
        individual developer and project because at any point in time, only one
        of these variants is allowed to be installed/used in a project.
-    3. Some python libraries use dots when the entry in requirements.txt uses
-       hyphens.
+    3. Package names may use hyphens, underscores, or dots interchangeably
+       (e.g., importlib-metadata in requirements.txt vs importlib_metadata
+       from importlib.metadata, or backports-tarfile vs backports.tarfile).
 
     Here are some examples of ambiguities that this function resolves:
-    - 'googleappenginemapreduce' is listed in the 'requirements.txt' file as
-      all lowercase. However, the installed directories have names starting with
-      the string 'GoogleAppEngineMapReduce'. This causes confusion when
-      searching for mismatches because python treats the two library names as
-      different even though they are equivalent.
-    - If the name 'google-api-core[grpc]' is listed in the 'requirements.txt'
-      file, this means that a variant of the 'google-api-core' package that
-      supports grpc is required. However, the import names, the package
-      directory names, and the metadata directory names of the installed package
-      do not actually contain the sub-library identifier. This causes
-      incorrect mismatches to be found because the script treats the installed
-      package's library name, 'library', differently from the 'requirements.txt'
-      listed library name, 'library[sub-library]'
-    - For 'backports-tarfile' in the 'requirements.txt' file, the installed
-      directories have names starting with the string 'backports.tarfile'. This
-      causes confusion when searching for mismatches because python treats the
-      two library names as different even though they are equivalent.
+    - 'GoogleAppEngineMapReduce' vs 'googleappenginemapreduce'
+    - 'google-api-core[grpc]' vs 'google-api-core'
+    - 'importlib-metadata' vs 'importlib_metadata'
+    - 'backports-tarfile' vs 'backports.tarfile'
 
     Args:
         library_name: str. The library name to be normalized.
@@ -98,8 +80,7 @@ def normalize_python_library_name(library_name: str) -> str:
         str. A normalized library name.
     """
     # Remove the special support package designation (e.g [grpc]) in the
-    # brackets when parsing the requirements file to resolve confusion 2 in the
-    # docstring.
+    # brackets when parsing the requirements file.
     # NOTE: This does not cause ambiguities because there is no viable scenario
     # where both the library and a variant of the library exist in the
     # directory. Both the default version and the variant are imported in the
@@ -112,16 +93,15 @@ def normalize_python_library_name(library_name: str) -> str:
     # scripts/install_python_prod_dependencies_test.py to ensure that all
     # library names in the requirements files are distinct when normalized.
     library_name = re.sub(r'\[[^\[^\]]+\]', '', library_name)
-    if any(
-        library_name.startswith('%s%s' % (prefix, '-'))
-        for prefix in LIBRARY_PREFIXES_WITH_INITIAL_PERIOD
-    ):
-        library_name_parts = library_name.split('-')
-        library_name = '%s.%s' % (
-            library_name_parts[0],
-            '-'.join(library_name_parts[1:]),
-        )
-    return library_name.lower()
+
+    # Normalize according to PEP 503: convert to lowercase and replace
+    # any runs of [-_.] with a single dash. This ensures that package names
+    # from importlib.metadata (which use underscores) match names from
+    # requirements.txt (which use hyphens), and also handles packages that
+    # use dots (like backports.tarfile) vs hyphens (backports-tarfile).
+    library_name = library_name.lower()
+    library_name = re.sub(r'[-_.]+', '-', library_name)
+    return library_name
 
 
 def normalize_directory_name(directory_name: str) -> str:

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import collections
+import importlib.metadata
 import json
 import os
 import re
@@ -24,11 +25,11 @@ import shutil
 import subprocess
 import sys
 
+from packaging import version
+from typing import Dict, Final, List, Optional, Set, Tuple
+
 from core import utils
 from scripts import install_python_dev_dependencies
-
-import pkg_resources
-from typing import Dict, Final, List, Optional, Set, Tuple
 
 from . import common
 
@@ -195,7 +196,7 @@ def _get_requirements_file_contents() -> Dict[str, str]:
     return requirements_contents
 
 
-def _dist_has_meta_data(dist: pkg_resources.Distribution) -> bool:
+def _dist_has_meta_data(dist: importlib.metadata.Distribution) -> bool:
     """Checks if the Distribution has meta-data.
 
     Args:
@@ -204,7 +205,11 @@ def _dist_has_meta_data(dist: pkg_resources.Distribution) -> bool:
     Returns:
         bool. The distribution has meta-data or not.
     """
-    return dist.has_metadata('direct_url.json')
+    try:
+        dist.read_text('direct_url.json')
+        return True
+    except FileNotFoundError:
+        return False
 
 
 def _get_third_party_python_libs_directory_contents() -> Dict[str, str]:
@@ -217,23 +222,32 @@ def _get_third_party_python_libs_directory_contents() -> Dict[str, str]:
         installed as the key and the version string of that library as the
         value.
     """
+    all_distributions = list(
+        importlib.metadata.distributions(
+            path=[common.THIRD_PARTY_PYTHON_LIBS_DIR]
+        )
+    )
     direct_url_packages, standard_packages = utils.partition(
-        pkg_resources.find_distributions(common.THIRD_PARTY_PYTHON_LIBS_DIR),
+        all_distributions,
         predicate=_dist_has_meta_data,
     )
 
-    installed_packages = {
-        pkg.project_name: pkg.version for pkg in standard_packages
-    }
+    installed_packages = {pkg.name: pkg.version for pkg in standard_packages}
 
     for pkg in direct_url_packages:
-        metadata = json.loads(pkg.get_metadata('direct_url.json'))
+        metadata_text = pkg.read_text('direct_url.json')
+        if not metadata_text:
+            raise Exception(
+                f'Package {pkg.name} was identified as having direct_url.json '
+                'metadata but the file could not be read.'
+            )
+        metadata = json.loads(metadata_text)
         version_string = '%s+%s@%s' % (
             metadata['vcs_info']['vcs'],
             metadata['url'],
             metadata['vcs_info']['commit_id'],
         )
-        installed_packages[pkg.project_name] = version_string
+        installed_packages[pkg.name] = version_string
 
     # Libraries with different case are considered equivalent libraries:
     # e.g 'Flask' is the same library as 'flask'. Therefore, we
@@ -252,9 +266,9 @@ def _remove_metadata(library_name: str, version_string: str) -> None:
     was reinstalled with a new version. The reason we need this function is
     because `pip install --upgrade` upgrades libraries to a new version but
     does not remove the metadata that was installed with the previous version.
-    These metadata files confuse the pkg_resources function that extracts all of
-    the information about the currently installed python libraries and causes
-    this installation script to behave incorrectly.
+    These metadata files confuse the importlib.metadata function that extracts
+    all of the information about the currently installed python libraries and
+    causes this installation script to behave incorrectly.
 
     Args:
         library_name: str. Name of the library to remove the metadata for.
@@ -353,10 +367,10 @@ def _rectify_third_party_directory(mismatches: MismatchType) -> None:
 
     for normalized_library_name, versions in pip_mismatches:
         requirements_version = (
-            pkg_resources.parse_version(versions[0]) if versions[0] else None
+            version.Version(versions[0]) if versions[0] else None
         )
         directory_version = (
-            pkg_resources.parse_version(versions[1]) if versions[1] else None
+            version.Version(versions[1]) if versions[1] else None
         )
 
         # The library listed in 'requirements.txt' is not in the

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -25,11 +25,11 @@ import shutil
 import subprocess
 import sys
 
-from packaging import version
-from typing import Dict, Final, List, Optional, Set, Tuple
-
 from core import utils
 from scripts import install_python_dev_dependencies
+
+from packaging import version
+from typing import Dict, Final, List, Optional, Set, Tuple
 
 from . import common
 

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -196,21 +196,6 @@ def _get_requirements_file_contents() -> Dict[str, str]:
     return requirements_contents
 
 
-def _dist_has_meta_data(dist: importlib.metadata.Distribution) -> bool:
-    """Checks if the Distribution has meta-data.
-
-    Args:
-        dist: Distribution. The distribution.
-
-    Returns:
-        bool. The distribution has meta-data or not.
-    """
-    try:
-        return dist.read_text('direct_url.json') is not None
-    except FileNotFoundError:
-        return False
-
-
 def _get_third_party_python_libs_directory_contents() -> Dict[str, str]:
     """Returns a dictionary containing all of the normalized libraries name
     strings with their corresponding version strings installed in the
@@ -221,32 +206,30 @@ def _get_third_party_python_libs_directory_contents() -> Dict[str, str]:
         installed as the key and the version string of that library as the
         value.
     """
-    all_distributions = list(
-        importlib.metadata.distributions(
-            path=[common.THIRD_PARTY_PYTHON_LIBS_DIR]
-        )
-    )
-    direct_url_packages, standard_packages = utils.partition(
-        all_distributions,
-        predicate=_dist_has_meta_data,
-    )
+    installed_packages = {}
 
-    installed_packages = {pkg.name: pkg.version for pkg in standard_packages}
+    for pkg in importlib.metadata.distributions(
+        path=[common.THIRD_PARTY_PYTHON_LIBS_DIR]
+    ):
+        # Check if this is a direct URL package (from git).
+        metadata_text = None
+        try:
+            metadata_text = pkg.read_text('direct_url.json')
+        except FileNotFoundError:
+            pass
 
-    for pkg in direct_url_packages:
-        metadata_text = pkg.read_text('direct_url.json')
-        if not metadata_text:
-            raise Exception(
-                f'Package {pkg.name} was identified as having direct_url.json '
-                'metadata but the file could not be read.'
+        if metadata_text:
+            # This is a git package with direct URL metadata.
+            metadata = json.loads(metadata_text)
+            version_string = '%s+%s@%s' % (
+                metadata['vcs_info']['vcs'],
+                metadata['url'],
+                metadata['vcs_info']['commit_id'],
             )
-        metadata = json.loads(metadata_text)
-        version_string = '%s+%s@%s' % (
-            metadata['vcs_info']['vcs'],
-            metadata['url'],
-            metadata['vcs_info']['commit_id'],
-        )
-        installed_packages[pkg.name] = version_string
+            installed_packages[pkg.name] = version_string
+        else:
+            # This is a standard package.
+            installed_packages[pkg.name] = pkg.version
 
     # Libraries with different case are considered equivalent libraries:
     # e.g 'Flask' is the same library as 'flask'. Therefore, we
@@ -352,43 +335,48 @@ def _rectify_third_party_directory(mismatches: MismatchType) -> None:
             directory_version,
         )
 
-    git_mismatches, pip_mismatches = utils.partition(
-        validated_mismatches.items(), predicate=_is_git_url_mismatch
-    )
-
-    for normalized_library_name, versions in git_mismatches:
+    for normalized_library_name, versions in validated_mismatches.items():
         requirements_version, directory_version = versions
 
-        # The library listed in 'requirements.txt' is not in the
-        # 'third_party/python_libs' directory.
-        if not directory_version or requirements_version != directory_version:
-            _install_direct_url(normalized_library_name, requirements_version)
+        # Check if this is a git URL dependency.
+        if requirements_version.startswith('git'):
+            # The library listed in 'requirements.txt' is not in the
+            # 'third_party/python_libs' directory.
+            if (
+                not directory_version
+                or requirements_version != directory_version
+            ):
+                _install_direct_url(
+                    normalized_library_name, requirements_version
+                )
+        else:
+            # This is a standard pip package.
+            requirements_version_parsed = (
+                version.Version(requirements_version)
+                if requirements_version
+                else None
+            )
+            directory_version_parsed = (
+                version.Version(directory_version)
+                if directory_version
+                else None
+            )
 
-    for normalized_library_name, versions in pip_mismatches:
-        requirements_version = (
-            version.Version(versions[0]) if versions[0] else None
-        )
-        directory_version = (
-            version.Version(versions[1]) if versions[1] else None
-        )
-
-        # The library listed in 'requirements.txt' is not in the
-        # 'third_party/python_libs' directory.
-        if not directory_version:
-            _install_library(normalized_library_name, str(requirements_version))
-        # The currently installed library version is not equal to the required
-        # 'requirements.txt' version.
-        elif requirements_version != directory_version:
-            _install_library(normalized_library_name, str(requirements_version))
-            _remove_metadata(normalized_library_name, str(directory_version))
-
-
-def _is_git_url_mismatch(
-    mismatch_item: Tuple[str, ValidatedMismatchType],
-) -> bool:
-    """Returns whether the given mismatch item is for a GitHub URL."""
-    _, (required, _) = mismatch_item
-    return required.startswith('git')
+            # The library listed in 'requirements.txt' is not in the
+            # 'third_party/python_libs' directory.
+            if not directory_version_parsed:
+                _install_library(
+                    normalized_library_name, str(requirements_version_parsed)
+                )
+            # The currently installed library version is not equal to the
+            # required 'requirements.txt' version.
+            elif requirements_version_parsed != directory_version_parsed:
+                _install_library(
+                    normalized_library_name, str(requirements_version_parsed)
+                )
+                _remove_metadata(
+                    normalized_library_name, str(directory_version_parsed)
+                )
 
 
 def _install_direct_url(library_name: str, direct_url: str) -> None:

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -206,8 +206,7 @@ def _dist_has_meta_data(dist: importlib.metadata.Distribution) -> bool:
         bool. The distribution has meta-data or not.
     """
     try:
-        dist.read_text('direct_url.json')
-        return True
+        return dist.read_text('direct_url.json') is not None
     except FileNotFoundError:
         return False
 

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -786,8 +786,8 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             return [
                 Distribution('dependency-1', '1.5.1', {}),
                 Distribution('dependency2', '5.0.0', {}),
+                Distribution('dependency3-hyphenated', '3.4.0', {}),
                 Distribution('dependency-5', '0.5.3', {}),
-                Distribution('jaraco-classes', '3.4.0', {}),
                 Distribution(
                     'dependency6',
                     '0.5.3',
@@ -809,8 +809,8 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             return [
                 'dependency-1-1.5.1.dist-info',
                 'dependency2-5.0.0.egg-info',
+                'dependency3.hyphenated-3.4.0.dist-info',
                 'dependency-5-0.5.3-py3.10.egg-info',
-                'jaraco.classes-3.4.0.dist-info',
                 'dependency_6-0.5.3-py3.10.egg-info',
             ]
 

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -206,6 +206,35 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             ):
                 install_python_prod_dependencies.get_mismatches()
 
+    def test_direct_url_package_with_no_metadata_text_raises_exception(
+        self,
+    ) -> None:
+        swap_requirements = self.swap(
+            common,
+            'COMPILED_REQUIREMENTS_FILE_PATH',
+            self.REQUIREMENTS_TEST_TXT_FILE_PATH,
+        )
+
+        def mock_find_distributions(  # pylint: disable=unused-argument
+            paths: List[str],
+        ) -> List[Distribution]:
+            # Create a distribution that will be identified as having
+            # direct_url.json but read_text returns None.
+            dist = Distribution('dependency5', '0.5.3', {'direct_url.json': ''})
+            return [dist]
+
+        swap_find_distributions = self.swap(
+            importlib.metadata, 'distributions', mock_find_distributions
+        )
+
+        with swap_requirements, swap_find_distributions:
+            with self.assertRaisesRegex(
+                Exception,
+                'Package dependency5 was identified as having direct_url.json '
+                'metadata but the file could not be read.',
+            ):
+                install_python_prod_dependencies.get_mismatches()
+
     def test_multiple_discrepancies_returns_correct_mismatches(self) -> None:
         swap_requirements = self.swap(
             common,

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -133,7 +133,10 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         def mock_check_call(
             cmd_tokens: List[str], **_kwargs: str
         ) -> scripts_test_utils.PopenStub:  # pylint: disable=unused-argument
-            if cmd_tokens and cmd_tokens[0].endswith('%spython' % os.path.sep):
+            if cmd_tokens and (
+                cmd_tokens[0].endswith('%spython' % os.path.sep)
+                or cmd_tokens[0].endswith('%spython3' % os.path.sep)
+            ):
                 # Some commands use the path to the Python executable. To make
                 # specifying expected commands easier, replace these with just
                 # "python".
@@ -142,7 +145,10 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             return scripts_test_utils.PopenStub()
 
         def mock_run(cmd_tokens: List[str], **_kwargs: str) -> str:
-            if cmd_tokens and cmd_tokens[0].endswith('python'):
+            if cmd_tokens and (
+                cmd_tokens[0].endswith('python')
+                or cmd_tokens[0].endswith('python3')
+            ):
                 # Some commands use the path to the Python executable. To make
                 # specifying expected commands easier, replace these with just
                 # "python".
@@ -774,7 +780,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         )
 
     def test_correct_metadata_directory_names_do_not_throw_error(self) -> None:
-        def mock_find_distributions(
+        def mock_find_distributions(  # pylint: disable=unused-argument
             path: Optional[List[str]] = None,
         ) -> List[Distribution]:
             return [
@@ -823,7 +829,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
     def test_exception_raised_when_metadata_directory_names_are_missing(
         self,
     ) -> None:
-        def mock_find_distributions(
+        def mock_find_distributions(  # pylint: disable=unused-argument
             path: Optional[List[str]] = None,
         ) -> List[Distribution]:
             return [

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -214,7 +214,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         )
 
         def mock_find_distributions(  # pylint: disable=unused-argument
-            paths: List[str],
+            path: Optional[List[str]] = None,
         ) -> List[Distribution]:
             return [
                 Distribution('dependency1', '1.5.1', {}),
@@ -387,19 +387,27 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 with self.swap_run:
                     install_python_prod_dependencies.main()
 
+        # Check that the pip-compile command was run first.
         self.assertEqual(
-            self.cmd_token_list,
+            self.cmd_token_list[0],
             [
-                [
-                    'pip-compile',
-                    '--no-emit-index-url',
-                    '--quiet',
-                    '--strip-extras',
-                    '--generate-hashes',
-                    'requirements.in',
-                    '--output-file',
-                    'requirements.txt',
-                ],
+                'pip-compile',
+                '--no-emit-index-url',
+                '--quiet',
+                '--strip-extras',
+                '--generate-hashes',
+                'requirements.in',
+                '--output-file',
+                'requirements.txt',
+            ],
+        )
+
+        # Check that all the expected install commands were run (order doesn't
+        # matter for the install commands since dependencies can be processed
+        # in any order).
+        self.assertCountEqual(
+            self.cmd_token_list[1:],
+            [
                 [
                     'python',
                     '-m',
@@ -767,7 +775,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
     def test_correct_metadata_directory_names_do_not_throw_error(self) -> None:
         def mock_find_distributions(
-            unused_paths: List[str],
+            path: Optional[List[str]] = None,
         ) -> List[Distribution]:
             return [
                 Distribution('dependency-1', '1.5.1', {}),
@@ -816,7 +824,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         self,
     ) -> None:
         def mock_find_distributions(
-            unused_paths: List[str],
+            path: Optional[List[str]] = None,
         ) -> List[Distribution]:
             return [
                 Distribution('dependency1', '1.5.1', {}),
@@ -986,12 +994,18 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
     def test_normalize_python_library_name(self) -> None:
         expected_normalized_names = [
-            ('backports-tarfile', 'backports.tarfile'),
-            ('backports-tarfile-2', 'backports.tarfile-2'),
+            ('backports-tarfile', 'backports-tarfile'),
+            ('backports.tarfile', 'backports-tarfile'),
+            ('backports_tarfile', 'backports-tarfile'),
+            ('backports-tarfile-2', 'backports-tarfile-2'),
             ('apache-beam[gcp]', 'apache-beam'),
             ('Pillow', 'pillow'),
             ('pylatexenc', 'pylatexenc'),
             ('PyYAML', 'pyyaml'),
+            ('importlib-metadata', 'importlib-metadata'),
+            ('importlib_metadata', 'importlib-metadata'),
+            ('typing-extensions', 'typing-extensions'),
+            ('typing_extensions', 'typing-extensions'),
         ]
 
         for lib_name, expected_normalized_name in expected_normalized_names:

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -206,35 +206,6 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             ):
                 install_python_prod_dependencies.get_mismatches()
 
-    def test_direct_url_package_with_no_metadata_text_raises_exception(
-        self,
-    ) -> None:
-        swap_requirements = self.swap(
-            common,
-            'COMPILED_REQUIREMENTS_FILE_PATH',
-            self.REQUIREMENTS_TEST_TXT_FILE_PATH,
-        )
-
-        def mock_find_distributions(  # pylint: disable=unused-argument
-            paths: List[str],
-        ) -> List[Distribution]:
-            # Create a distribution that will be identified as having
-            # direct_url.json but read_text returns None.
-            dist = Distribution('dependency5', '0.5.3', {'direct_url.json': ''})
-            return [dist]
-
-        swap_find_distributions = self.swap(
-            importlib.metadata, 'distributions', mock_find_distributions
-        )
-
-        with swap_requirements, swap_find_distributions:
-            with self.assertRaisesRegex(
-                Exception,
-                'Package dependency5 was identified as having direct_url.json '
-                'metadata but the file could not be read.',
-            ):
-                install_python_prod_dependencies.get_mismatches()
-
     def test_multiple_discrepancies_returns_correct_mismatches(self) -> None:
         swap_requirements = self.swap(
             common,

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import builtins
+import importlib.metadata
 import itertools
 import json
 import os
@@ -31,7 +32,6 @@ from core import utils
 from core.tests import test_utils
 from scripts import common, install_python_prod_dependencies, scripts_test_utils
 
-import pkg_resources
 from typing import Dict, List, Optional, Set, Tuple
 
 
@@ -54,31 +54,20 @@ class Distribution:
             metadata_dict: dict(str: str). The stringified metadata contents of
                 the library.
         """
-        self.project_name = library_name
+        self.name = library_name
         self.version = version_string
         self.metadata_dict = metadata_dict
 
-    def has_metadata(self, key: str) -> bool:
-        """Returns whether the given metadata key exists.
+    def read_text(self, filename: str) -> Optional[str]:
+        """Returns the contents of the given metadata file.
 
         Args:
-            key: str. The key corresponding to the metadata.
+            filename: str. The filename corresponding to the metadata.
 
         Returns:
-            bool. Whether the metadata exists.
+            str|None. The contents of the metadata file, or None if not found.
         """
-        return key in self.metadata_dict
-
-    def get_metadata(self, key: str) -> str:
-        """The contents of the corresponding metadata.
-
-        Args:
-            key: str. The key corresponding to the metadata.
-
-        Returns:
-            str. The contents of the metadata.
-        """
-        return self.metadata_dict[key]
+        return self.metadata_dict.get(filename)
 
 
 class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
@@ -263,7 +252,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             ]
 
         swap_find_distributions = self.swap(
-            pkg_resources, 'find_distributions', mock_find_distributions
+            importlib.metadata, 'distributions', mock_find_distributions
         )
         with swap_requirements, swap_find_distributions:
             self.assertEqual(
@@ -813,7 +802,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             return True
 
         swap_find_distributions = self.swap(
-            pkg_resources, 'find_distributions', mock_find_distributions
+            importlib.metadata, 'distributions', mock_find_distributions
         )
         swap_list_dir = self.swap(os, 'listdir', mock_list_dir)
         swap_is_dir = self.swap(os.path, 'isdir', mock_is_dir)
@@ -862,7 +851,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             return True
 
         swap_find_distributions = self.swap(
-            pkg_resources, 'find_distributions', mock_find_distributions
+            importlib.metadata, 'distributions', mock_find_distributions
         )
         swap_list_dir = self.swap(os, 'listdir', mock_list_dir)
         swap_is_dir = self.swap(os.path, 'isdir', mock_is_dir)

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -773,6 +773,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 Distribution('dependency-1', '1.5.1', {}),
                 Distribution('dependency2', '5.0.0', {}),
                 Distribution('dependency-5', '0.5.3', {}),
+                Distribution('jaraco-classes', '3.4.0', {}),
                 Distribution(
                     'dependency6',
                     '0.5.3',
@@ -795,6 +796,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 'dependency-1-1.5.1.dist-info',
                 'dependency2-5.0.0.egg-info',
                 'dependency-5-0.5.3-py3.10.egg-info',
+                'jaraco.classes-3.4.0.dist-info',
                 'dependency_6-0.5.3-py3.10.egg-info',
             ]
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,7 @@ def main() -> None:
 
         # Parse each non-empty, non-comment line as a requirement.
         required_packages = [
-            str(
-                requirements.Requirement(line)
-            )  # pylint: disable=replace-disallowed-function-calls
+            str(requirements.Requirement(line))
             for line in modified_requirements_content.splitlines()
             if line.strip() and not line.strip().startswith('#')
         ]

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ import re
 
 from core import feconf
 
-from packaging import requirements
 import setuptools
+from packaging import requirements
 
 
 def main() -> None:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import re
 
 from core import feconf
 
-import pkg_resources
+from packaging import requirements
 import setuptools
 
 
@@ -36,8 +36,8 @@ def main() -> None:
     ) as requirements_txt:  # pylint: disable=replace-disallowed-function-calls
         requirements_content = requirements_txt.read()
         # Removing the hashes from the requirements.txt file because they are
-        # not supported by the 'pkg_resources.parse_requirements' function while
-        # parsing the requirements.
+        # not supported by the 'Requirement' parsing while parsing the
+        # requirements.
         modified_requirements_content = re.sub(
             r'^\s*--hash=sha256:.*$|\\$',
             '',
@@ -45,16 +45,13 @@ def main() -> None:
             flags=re.MULTILINE,
         )
 
-        # The 'parse_requirements' returns a list of 'Requirement' objects.
-        # We need to transform these to strings using the str() function.
+        # Parse each non-empty, non-comment line as a requirement.
         required_packages = [
             str(
-                requirement
+                requirements.Requirement(line)
             )  # pylint: disable=replace-disallowed-function-calls
-            # Here we use MyPy ignore because mypy type hint on
-            # pkg_resources.parse_requirements is 'TextIO' only, which is wrong,
-            # it can also be a string.
-            for requirement in pkg_resources.parse_requirements(modified_requirements_content)  # type: ignore[arg-type]
+            for line in modified_requirements_content.splitlines()
+            if line.strip() and not line.strip().startswith('#')
         ]
 
     setuptools.setup(

--- a/setup_test.py
+++ b/setup_test.py
@@ -31,7 +31,14 @@ class SetupTests(test_utils.GenericTestBase):
     """Unit tests for setup.py."""
 
     def test_setuptools_is_invoked_with_correct_parameters(self) -> None:
-        packages = 'module1==2.1.2\nmodule2==3.2.3\nmodule3==4.3.4\n'
+        packages = (
+            'module1==2.1.2 \\\n'
+            '    --hash=sha256:abcd1234\n'
+            'module2==3.2.3 \\\n'
+            '    --hash=sha256:efgh5678\n'
+            '# This is a comment\n'
+            'module3==4.3.4\n'
+        )
         with open('dummy_requirements.txt', 'w', encoding='utf-8') as f:
             f.write(packages)
 
@@ -44,7 +51,12 @@ class SetupTests(test_utils.GenericTestBase):
             expected_args=(('requirements.txt',),),
         )
 
-        required_packages = packages.split('\n')[:-1]
+        # The expected packages should not include comments or hashes.
+        required_packages = [
+            'module1==2.1.2',
+            'module2==3.2.3',
+            'module3==4.3.4',
+        ]
 
         swap_setup = self.swap_with_checks(
             setuptools,

--- a/setup_test.py
+++ b/setup_test.py
@@ -31,13 +31,16 @@ class SetupTests(test_utils.GenericTestBase):
     """Unit tests for setup.py."""
 
     def test_setuptools_is_invoked_with_correct_parameters(self) -> None:
-        packages = (
-            'module1==2.1.2 \\\n'
-            '    --hash=sha256:abcd1234\n'
-            'module2==3.2.3 \\\n'
-            '    --hash=sha256:efgh5678\n'
-            '# This is a comment\n'
-            'module3==4.3.4\n'
+        packages = '\n'.join(
+            [
+                'module1==2.1.2 \\',
+                '    --hash=sha256:abcd1234',
+                'module2==3.2.3 \\',
+                '    --hash=sha256:efgh5678',
+                '# This is a comment',
+                'module3==4.3.4',
+                '',
+            ]
         )
         with open('dummy_requirements.txt', 'w', encoding='utf-8') as f:
             f.write(packages)


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A.
2. This PR does the following: Replaces pkg_resources with modern Python standard library alternatives (importlib.metadata and packaging). This addresses the warning message that shows up each time the python install scripts are run:

```
/scripts/install_python_prod_dependencies.py:30: UserWarning: pkg_resources is deprecated as an API.
See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for
removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources
```

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

The main proof here is to confirm that the CI checks pass. If so, then it means that the Python setup script steps have all completed successfully.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
