### PR TITLE
Update comment workflow to accept cancelled and timed_out check run conclusions.

### DIFF
--- a/.github/workflows/comment_on_ci_workflow.yml
+++ b/.github/workflows/comment_on_ci_workflow.yml
@@ -55,6 +55,8 @@ jobs:
             success
             failure
             action_required
+            cancelled
+            timed_out
       - name: Verify Manual Approval Requirement
         if: ${{ steps.wait_for_completion_of_workflow.outputs.run-conclusion == 'action_required' }}
         run: |


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Updates the comment-on-ci workflow to accept cancelled and timed_out check run conclusions. (I noticed that that workflow was failing unnecessarily when a new push was made to a PR and the old run was cancelled -- see [here](https://github.com/oppia/oppia/actions/runs/19742668117/job/56570119713) which failed on https://github.com/oppia/oppia/pull/23956 -- screenshot below.)

<img width="1192" height="743" alt="Screenshot from 2025-11-28 01-00-52" src="https://github.com/user-attachments/assets/a4bb0cbb-562e-4be5-99b4-9c019ab52c53" />

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (N/A)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (N/A)
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

No proof of changes needed because the action in question just comments on a PR and the change is self-evident (we just don't want the "Await Test Workflow Completion" step to fail if the run is cancelled or times out). All the steps after that are gated on `action_required or `failure` completion statuses and will not trigger with the new statuses (so the new statuses are no-ops with regards to those later steps).

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
