### PR TITLE
Fix: Prevent username overlapping in Contributor Dashboard by adding max-width and ellipsis styling

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -245,18 +245,27 @@
     font-size: 24px;
     z-index: 100;
   }
-  .oppia-short-contributor-username-container,
-  .oppia-long-contributor-username-container {
-    color: #009688;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
-    font-size: 24px;
-    height: 30%;
-    padding-top: 10px;
-    position: relative;
-  }
-  .oppia-short-contributor-username-container {
-    min-width: 100px;
-  }
+ /* FIXED: Prevent long usernames from overlapping review rights */
+.oppia-short-contributor-username-container,
+.oppia-long-contributor-username-container {
+  color: #009688;
+  font-family: "Capriola", "Roboto", Arial, sans-serif;
+  font-size: 24px;
+  height: 30%;
+  padding-top: 20px; /* increased spacing */
+  position: relative;
+
+  /* Fix overlap */
+  max-width: 200px;        /* restrict width */
+  white-space: nowrap;     /* avoid multiple lines */
+  overflow: hidden;        /* prevent spilling */
+  text-overflow: ellipsis; /* show ... for long usernames */
+}
+
+.oppia-short-contributor-username-container {
+  min-width: 130px; /* expanded from 100px */
+}
+
   .oppia-review-right-details-container {
     font-size: 18px;
     margin-left: 20px;


### PR DESCRIPTION
**Overview**
This PR fixes the layout issue in the Contributor Dashboard where long contributor usernames overlap with the review-rights container. The fix is implemented by updating the CSS to restrict the username container width and apply ellipsis to overflowing text.

**Issue Reference**
  Fixes: #22725
  ("Username overlapping in contributor dashboard" bug)

**Cause of the Bug**
   The username container (.oppia-short-contributor-username-container and .oppia-long-contributor-username-container) had:

- no max-width

- no overflow control

- insufficient vertical padding

As a result, long usernames extended beyond their container and overlapped the elements on the right side.

**What This PR Does**
This PR updates the CSS for the contributor username containers by adding:

- max-width: 200px;

- white-space: nowrap;

- overflow: hidden;

- text-overflow: ellipsis;

- increased padding-top for better spacing

- a slightly increased min-width for the short-username container

These adjustments ensure that long usernames are truncated gracefully and no longer overlap adjacent UI elements.
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
