### PR TITLE
feat-Adding the missing functionality of auto-saving in text field of exploration editor...

### DIFF
--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
@@ -55,14 +55,7 @@
 
 <div *ngIf="contentEditorIsOpen" class="e2e-test-state-content-editor">
   <!-- TODO(sll): Find a way to do this without resorting to private properties like _html -->
-  <div class="d-flex justify-content-between align-items-center">
-    <p class="oppia-rte-keyboard-accessibility-text mb-0" tabindex="0">Alt+0 for keyboard accessibility</p>
-    <div *ngIf="autoSaveStatus !== 'idle'" class="oppia-auto-save-status">
-      <i *ngIf="autoSaveStatus === 'saving'" class="fas fa-circle-notch fa-spin"></i>
-      <i *ngIf="autoSaveStatus === 'saved'" class="fas fa-check-circle text-success"></i>
-      <span class="ms-1">{{ autoSaveStatus === 'saving' ? 'Saving...' : 'Saved' }}</span>
-    </div>
-  </div>
+  <p class="oppia-rte-keyboard-accessibility-text" tabindex="0">Alt+0 for keyboard accessibility</p>
   <schema-based-editor [schema]="HTML_SCHEMA"
                        [(localValue)]="stateContentService.displayed._html"
                        (localValueChange)="onContentChange()">
@@ -75,6 +68,11 @@
     <div *ngIf="isCardContentLengthLimitReached()" class="oppia-card-content-limit-error e2e-test-card-height-limit-warning mt-2">
       <i class="fas fa-exclamation-triangle oppia-hide-card-content-error-icon e2e-test-hide-card-height-warning-icon" ngbTooltip="Hide warning" (click)="hideCardHeightLimitWarning()"></i>
       <span [innerHTML]="'I18N_CARD_CONTENT_LIMIT_ERROR_MESSAGE' | translate"></span>
+    </div>
+    <div *ngIf="autoSaveStatus !== 'idle'" class="oppia-auto-save-status float-start">
+      <i *ngIf="autoSaveStatus === 'saving'" class="fas fa-circle-notch fa-spin"></i>
+      <i *ngIf="autoSaveStatus === 'saved'" class="fas fa-check-circle text-success"></i>
+      <span class="ms-1">{{ autoSaveStatus === 'saving' ? 'Saving...' : 'Saved' }}</span>
     </div>
     <button type="button"
             [disabled]="isCardContentLengthLimitReached()"

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
@@ -55,7 +55,14 @@
 
 <div *ngIf="contentEditorIsOpen" class="e2e-test-state-content-editor">
   <!-- TODO(sll): Find a way to do this without resorting to private properties like _html -->
-  <p class="oppia-rte-keyboard-accessibility-text" tabindex="0">Alt+0 for keyboard accessibility</p>
+  <div class="d-flex justify-content-between align-items-center">
+    <p class="oppia-rte-keyboard-accessibility-text mb-0" tabindex="0">Alt+0 for keyboard accessibility</p>
+    <div *ngIf="autoSaveStatus !== 'idle'" class="oppia-auto-save-status">
+      <i *ngIf="autoSaveStatus === 'saving'" class="fas fa-circle-notch fa-spin"></i>
+      <i *ngIf="autoSaveStatus === 'saved'" class="fas fa-check-circle text-success"></i>
+      <span class="ms-1">{{ autoSaveStatus === 'saving' ? 'Saving...' : 'Saved' }}</span>
+    </div>
+  </div>
   <schema-based-editor [schema]="HTML_SCHEMA"
                        [(localValue)]="stateContentService.displayed._html"
                        (localValueChange)="onContentChange()">
@@ -112,6 +119,10 @@
     max-width: 560px;
     position: fixed;
     top: -30000px;
+  }
+  .oppia-auto-save-status {
+    color: #666;
+    font-size: 0.875rem;
   }
   .oppia-editor-edit-icon-position {
     border: 0;

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
@@ -57,7 +57,8 @@
   <!-- TODO(sll): Find a way to do this without resorting to private properties like _html -->
   <p class="oppia-rte-keyboard-accessibility-text" tabindex="0">Alt+0 for keyboard accessibility</p>
   <schema-based-editor [schema]="HTML_SCHEMA"
-                       [(localValue)]="stateContentService.displayed._html">
+                       [(localValue)]="stateContentService.displayed._html"
+                       (localValueChange)="onContentChange()">
   </schema-based-editor>
   <div *ngIf="cardHeightLimitReached && cardHeightLimitWarningIsShown" class="oppia-card-height-limit-warning e2e-test-card-height-limit-warning mt-2">
     <i class="fas fa-exclamation-triangle oppia-hide-card-height-warning-icon e2e-test-hide-card-height-warning-icon" ngbTooltip="Hide warning" (click)="hideCardHeightLimitWarning()"></i>

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
@@ -181,4 +181,142 @@ describe('StateHintsEditorComponent', () => {
 
     expect(result).toBeFalse();
   });
+
+  describe('Auto-save functionality', () => {
+    beforeEach(() => {
+      stateContentService.displayed = _getContent('content', 'Initial content');
+      stateContentService.savedMemento = _getContent('content', 'Initial content');
+    });
+
+    it('should trigger content change when onContentChange is called with editor open', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      spyOn(component, 'autoSaveContent');
+
+      component.onContentChange();
+      
+      expect(component.autoSaveStatus).toBe('idle');
+      
+      tick(3000); // Wait for debounce delay.
+
+      expect(component.autoSaveContent).toHaveBeenCalled();
+    }));
+
+    it('should not trigger auto-save when editor is closed', fakeAsync(() => {
+      component.contentEditorIsOpen = false;
+      spyOn(component, 'autoSaveContent');
+
+      component.onContentChange();
+      tick(3000); // Wait for debounce delay.
+
+      // Auto-save should still be called, but will return early.
+      expect(component.autoSaveContent).toHaveBeenCalled();
+    }));
+
+    it('should debounce multiple rapid content changes', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      spyOn(component, 'autoSaveContent');
+
+      // Trigger multiple changes rapidly.
+      component.onContentChange();
+      tick(1000);
+      component.onContentChange();
+      tick(1000);
+      component.onContentChange();
+      tick(3000); // Wait for debounce delay.
+
+      // Should only trigger once after debounce period.
+      expect(component.autoSaveContent).toHaveBeenCalledTimes(1);
+    }));
+
+    it('should auto-save when content has changed', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      stateContentService.displayed = _getContent('content', 'New content');
+      stateContentService.savedMemento = _getContent('content', 'Old content');
+      spyOn(component.saveStateContent, 'emit');
+      spyOn(stateContentService, 'saveDisplayedValue');
+
+      expect(component.autoSaveStatus).toBe('idle');
+
+      component.autoSaveContent();
+
+      expect(component.autoSaveStatus).toBe('saved');
+      expect(stateContentService.saveDisplayedValue).toHaveBeenCalled();
+      expect(component.saveStateContent.emit).toHaveBeenCalledWith(
+        stateContentService.displayed
+      );
+
+      tick(2000); // Wait for status reset.
+      expect(component.autoSaveStatus).toBe('idle');
+    }));
+
+    it('should not auto-save when content has not changed', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      stateContentService.displayed = _getContent('content', 'Same content');
+      stateContentService.savedMemento = _getContent('content', 'Same content');
+      spyOn(component.saveStateContent, 'emit');
+      spyOn(stateContentService, 'saveDisplayedValue');
+
+      component.autoSaveContent();
+
+      expect(stateContentService.saveDisplayedValue).not.toHaveBeenCalled();
+      expect(component.saveStateContent.emit).not.toHaveBeenCalled();
+    }));
+
+    it('should not auto-save when editor is closed', fakeAsync(() => {
+      component.contentEditorIsOpen = false;
+      stateContentService.displayed = _getContent('content', 'New content');
+      stateContentService.savedMemento = _getContent('content', 'Old content');
+      spyOn(component.saveStateContent, 'emit');
+
+      component.autoSaveContent();
+
+      expect(component.saveStateContent.emit).not.toHaveBeenCalled();
+    }));
+
+    it('should not auto-save when content is not editable', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      stateContentService.displayed = _getContent('content', 'New content');
+      stateContentService.savedMemento = _getContent('content', 'Old content');
+      spyOn(component, 'isContentEditable').and.returnValue(false);
+      spyOn(component.saveStateContent, 'emit');
+
+      component.autoSaveContent();
+
+      expect(component.saveStateContent.emit).not.toHaveBeenCalled();
+    }));
+
+    it('should not auto-save when displayed content is null', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      // @ts-ignore: Testing null case.
+      stateContentService.displayed = null;
+      stateContentService.savedMemento = _getContent('content', 'Old content');
+      spyOn(component.saveStateContent, 'emit');
+
+      component.autoSaveContent();
+
+      expect(component.saveStateContent.emit).not.toHaveBeenCalled();
+    }));
+
+    it('should not auto-save when saved memento is null', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      stateContentService.displayed = _getContent('content', 'New content');
+      // @ts-ignore: Testing null case.
+      stateContentService.savedMemento = null;
+      spyOn(component.saveStateContent, 'emit');
+
+      component.autoSaveContent();
+
+      expect(component.saveStateContent.emit).not.toHaveBeenCalled();
+    }));
+
+    it('should preserve editor open state after auto-save', fakeAsync(() => {
+      component.contentEditorIsOpen = true;
+      stateContentService.displayed = _getContent('content', 'New content');
+      stateContentService.savedMemento = _getContent('content', 'Old content');
+
+      component.autoSaveContent();
+
+      expect(component.contentEditorIsOpen).toBeTrue();
+    }));
+  });
 });

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
@@ -33,7 +33,8 @@ import {StateContentService} from 'components/state-editor/state-editor-properti
 import {StateEditorService} from 'components/state-editor/state-editor-properties-services/state-editor.service';
 
 import {SubtitledHtml} from 'domain/exploration/subtitled-html.model';
-import {Subscription} from 'rxjs';
+import {Subscription, Subject} from 'rxjs';
+import {debounceTime} from 'rxjs/operators';
 
 interface HTMLSchema {
   type: string;
@@ -61,6 +62,8 @@ export class StateContentEditorComponent implements OnInit {
   HTML_SCHEMA!: HTMLSchema;
 
   cardHeightLimitReached = false;
+  private contentChanged$ = new Subject<void>();
+  private readonly AUTO_SAVE_DELAY_MS = 3000;
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
@@ -93,6 +96,16 @@ export class StateContentEditorComponent implements OnInit {
         }
       })
     );
+
+    // Setup auto-save on content changes.
+    this.directiveSubscriptions.add(
+      this.contentChanged$
+        .pipe(debounceTime(this.AUTO_SAVE_DELAY_MS))
+        .subscribe(() => {
+          this.autoSaveContent();
+        })
+    );
+
     this.stateEditorService.updateStateContentEditorInitialised();
   }
 
@@ -145,6 +158,16 @@ export class StateContentEditorComponent implements OnInit {
   cancelEdit(): void {
     this.stateContentService.restoreFromMemento();
     this.contentEditorIsOpen = false;
+  }
+
+  onContentChange(): void {
+    if (this.contentEditorIsOpen) {
+      this.contentChanged$.next();
+    }
+  }
+
+  autoSaveContent(): void {
+    // Placeholder for auto-save logic - will be implemented in next commit.
   }
 
   isContentEditable(): boolean {

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
@@ -64,6 +64,8 @@ export class StateContentEditorComponent implements OnInit {
   cardHeightLimitReached = false;
   private contentChanged$ = new Subject<void>();
   private readonly AUTO_SAVE_DELAY_MS = 3000;
+  autoSaveStatus: 'idle' | 'saving' | 'saved' = 'idle';
+  private autoSaveStatusTimeout?: ReturnType<typeof setTimeout>;
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
@@ -162,6 +164,10 @@ export class StateContentEditorComponent implements OnInit {
 
   onContentChange(): void {
     if (this.contentEditorIsOpen) {
+      this.autoSaveStatus = 'idle';
+      if (this.autoSaveStatusTimeout) {
+        clearTimeout(this.autoSaveStatusTimeout);
+      }
       this.contentChanged$.next();
     }
   }
@@ -177,9 +183,18 @@ export class StateContentEditorComponent implements OnInit {
 
     if (currentContent && savedContent && 
         currentContent.html !== savedContent.html) {
+      // Show saving status.
+      this.autoSaveStatus = 'saving';
+      
       // Save the content without closing the editor.
       this.stateContentService.saveDisplayedValue();
       this.saveStateContent.emit(this.stateContentService.displayed);
+      
+      // Show saved status briefly.
+      this.autoSaveStatus = 'saved';
+      this.autoSaveStatusTimeout = setTimeout(() => {
+        this.autoSaveStatus = 'idle';
+      }, 2000);
     }
   }
 
@@ -189,5 +204,9 @@ export class StateContentEditorComponent implements OnInit {
 
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
+    this.contentChanged$.complete();
+    if (this.autoSaveStatusTimeout) {
+      clearTimeout(this.autoSaveStatusTimeout);
+    }
   }
 }

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
@@ -167,7 +167,20 @@ export class StateContentEditorComponent implements OnInit {
   }
 
   autoSaveContent(): void {
-    // Placeholder for auto-save logic - will be implemented in next commit.
+    if (!this.contentEditorIsOpen || !this.isContentEditable()) {
+      return;
+    }
+
+    // Check if content has actually changed from the saved state.
+    const currentContent = this.stateContentService.displayed;
+    const savedContent = this.stateContentService.savedMemento;
+
+    if (currentContent && savedContent && 
+        currentContent.html !== savedContent.html) {
+      // Save the content without closing the editor.
+      this.stateContentService.saveDisplayedValue();
+      this.saveStateContent.emit(this.stateContentService.displayed);
+    }
   }
 
   isContentEditable(): boolean {


### PR DESCRIPTION
# Overview
Adds auto-save functionality to the state content editor to prevent accidental data loss.

# Description
This PR implements automatic saving after 3 seconds of inactivity when editing state content, along with visual feedback to keep users informed.

# What Changed:

- Auto-save triggers 3 seconds after user stops typing (using RxJS debounceTime)
- Shows "Saving..." with spinner, then "Saved ✓" with checkmark
- Status indicators positioned at bottom-left of editor
- Users can still manually save anytime
- Proper cleanup to prevent memory leaks

# Technical Details:

Uses RxJS Subject for change detection
Leverages existing ExternalSaveService.saveStateContent() - no backend changes needed
Added ~147 lines of unit tests

# Files Changed
state-content-editor.component.ts (logic)
state-content-editor.component.html (UI)
state-content-editor.component.spec.ts (tests)

Ready for review will share proof, later