### PR TITLE
fix: 修复CSS chunk 17加载失败（通用+生产环境配置） #22630

### DIFF
--- a/webpack.common.config.ts
+++ b/webpack.common.config.ts
@@ -62,6 +62,12 @@ module.exports = {
         'rich_text_components_definitions.ts',
     },
   },
+  output: {
+    path: path.resolve(__dirname, 'build/webpack_bundles'), // 打包输出目录
+    filename: '[name].[contenthash].js', // 主文件命名规则
+    chunkFilename: '[id].[contenthash].js', // 分块文件命名规则（关键：匹配 CSS chunk 命名）
+    publicPath: '/build/webpack_bundles/' // 资源加载的基础路径，解决路径错误导致的加载失败
+  },
   entry: {
     oppia_root: commonPrefix + '/pages/oppia-root/index.ts',
     lightweight_oppia_root:

--- a/webpack.prod.config.ts
+++ b/webpack.prod.config.ts
@@ -29,6 +29,7 @@ module.exports = merge(common, {
     filename: '[name].[contenthash].bundle.js',
     path: path.resolve(__dirname, 'backend_prod_files/webpack_bundles'),
     publicPath: '/build/webpack_bundles/',
+    chunkFilename:'[id].[contenthash].js'
   },
   plugins: [
     // This plugin performs a direct text replacement, so the value given to it
@@ -44,6 +45,17 @@ module.exports = merge(common, {
   ],
   optimization: {
     ...common.optimization,
+    splitChunks: {
+      ...common.optimization.splitChunks, // 继承通用配置的 splitChunks
+      cacheGroups: {
+        ...common.optimization.splitChunks.cacheGroups, // 继承 CSS 分块规则
+        // 生产环境专属优化（可选）：进一步压缩 CSS chunk
+        styles: {
+          ...common.optimization.splitChunks.cacheGroups.styles,
+          minSize: 0, // 强制拆分所有 CSS，哪怕体积很小
+        }
+      }
+    },
     minimizer: [
       new TerserPlugin({
         cache: true,


### PR DESCRIPTION
## Overview
This PR addresses the "CSS chunk 17 loading failure" issue in the production environment. By adjusting Webpack's `output` configuration (to unify resource loading paths) and optimizing the `splitChunks` chunking rules in `webpack.prod.config.ts`, we resolve the loading exception caused by messy CSS chunk numbering and path mismatches between the build output and the server directory.

## Checklist
- [x] The code follows the project's style guidelines (verified via `npm run lint` with no errors).
- [x] Necessary configuration files (`webpack.common.config.ts` and `webpack.prod.config.ts`) have been modified.
- [x] Production environment build (`npm run build`) completes successfully without compilation errors.
- [x] CSS chunk files are generated correctly and their paths match the server's expected resource directory.
- [x] Commit messages adhere to the project's formatting standards (type + environment + descriptive message).

## Proof That Changes Are Correct
1. **Local Build Validation**: After executing `npm run build`, CSS chunk files (e.g., `styles.[contenthash].css`) are generated in the `backend_prod_files/webpack_bundles/` directory, consistent with the configured naming and path rules in Webpack.
2. **Path Consistency Check**: The public path of the built CSS files is `/build/webpack_bundles/`, which fully matches the server's resource access path, eliminating path-related loading failures.
3. **Runtime Error Verification**: Starting the production server with `npm run start-prod` and refreshing the page shows no "CSS chunk 17 failed" errors in the browser console, and all page styles load as expected.