### PR TITLE
Fix part of #22725: Increase padding to prevent username/avatar overlap on contributor dashboard

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -251,7 +251,7 @@
     font-family: "Capriola", "Roboto", Arial, sans-serif;
     font-size: 24px;
     height: 30%;
-    padding-top: 10px;
+    padding-top: 20px;
     position: relative;
   }
   .oppia-short-contributor-username-container {


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #22725 .
2. This PR does the following: 
- Increases the padding-top on the contributor dashboard header username container in core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html (from 10px to 20px).
- This extra spacing prevents the username text from visually overlapping on the “My Contributions” tab, while keeping the existing layout and styling consistent with the rest of the page.

## Essential Checklist
Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
**Manual verification**
1. Started the local dev server with `python -m scripts.start --no_browser --no_auto_restart`.
2. Navigated to `http://localhost:8181/contributor-dashboard` while logged in as a test user.
3. Observed the **My Contributions** tab:
   - **Before the change**: the username text could overlap the avatar when the content width was constrained.
   - **After the change**: the username now appears clearly with sufficient vertical spacing and no overlap.
4. Switched to the **Translate Text** tab and confirmed that the header layout still looks consistent and is not affected negatively by the padding change.

**Screenshots**
<img width="2733" height="1482" alt="Screenshot 2025-12-06 191401" src="https://github.com/user-attachments/assets/dc2ade6e-c8e0-4ac8-a478-9451f1d00306" />

