### PR TITLE
Remove psutil from requirements_dev.in and ensure it's listed in requ…

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,6 +27,7 @@ mutagen==1.47.0
 Pillow==10.1.0
 # Note: proto-plus is added temporarily based on https://github.com/googleapis/python-bigquery/issues/1908#issuecomment-2077899818. We use 1.25.0 since it includes the fix in https://github.com/googleapis/proto-plus-python/pull/474.
 proto-plus==1.25.0
+psutil==7.0.0
 pylatexenc==2.10
 PyYAML==6.0.2
 redis==5.3.1

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -11,7 +11,6 @@ filetype==1.2.0
 isort==5.13.2
 mypy==1.0.1
 Pillow==10.1.0
-psutil==7.0.0
 pycodestyle==2.14.0
 pylint==2.17.7
 pylint-quotes==0.2.3


### PR DESCRIPTION

The issue was that psutil was only listed in requirements_dev.txt, but servers.py imports it, and that file is used by run_acceptance_tests.py. The acceptance-test CI installs only requirements.txt, so psutil wasn’t available, resulting in ModuleNotFoundError: No module named 'psutil'.

This pull request updates the project dependencies to ensure that `psutil==7.0.0` is included only in the main requirements and not in the development requirements. This helps clarify which dependencies are necessary for production versus development environments.

Dependency management:

* Added `psutil==7.0.0` to `requirements.in` to include it as a main dependency.
* Removed `psutil==7.0.0` from `requirements_dev.in` to avoid redundancy and ensure it is only specified in the main requirements.

Resolving Issue #24073