### PR TITLE
Fix #20414: Improve customization args validation error messages

### DIFF
--- a/core/domain/customization_args_util.py
+++ b/core/domain/customization_args_util.py
@@ -121,4 +121,7 @@ def validate_customization_args_and_values(
             # not involved (If they are, can we get sample values for the
             # state context parameters?).
             if fail_on_validation_errors:
-                raise utils.ValidationError(e)
+                raise utils.ValidationError(
+                    'Interaction %s has invalid customization arg %s: %s'
+                    % (item_type, ca_spec.name, e)
+                ) from e

--- a/core/domain/customization_args_util_test.py
+++ b/core/domain/customization_args_util_test.py
@@ -336,6 +336,41 @@ class CustomizationArgsUtilUnitTests(test_utils.GenericTestBase):
             all_interaction_ids, interaction_ids_with_ca_frontend_interfaces
         )
 
+    def test_invalid_customization_args_raise_validation_error_with_context(
+        self,
+    ) -> None:
+        """Test that invalid customization args raise a ValidationError with
+        contextual information about the interaction and customization arg.
+        """
+        ca_item_selection_specs = (
+            interaction_registry.Registry.get_interaction_by_id(
+                'ItemSelectionInput'
+            ).customization_arg_specs
+        )
+
+        invalid_customization_args: Dict[
+            str, Dict[str, Union[str, int, List[str]]]
+        ] = {
+            'minAllowableSelectionCount': {'value': 'not-an-int'},
+            'maxAllowableSelectionCount': {'value': 1},
+            'choices': {'value': ['']},
+        }
+
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            (
+                'Interaction ItemSelectionInput has invalid customization arg '
+                'minAllowableSelectionCount'
+            ),
+        ):
+            customization_args_util.validate_customization_args_and_values(
+                'interaction',
+                'ItemSelectionInput',
+                invalid_customization_args,
+                ca_item_selection_specs,
+                fail_on_validation_errors=True,
+            )
+
     def test_frontend_customization_args_constructor_coverage(self) -> None:
         """Test to ensure that interaction.model.ts covers constructing
         customization arguments for each interaction. Uses regex to confirm


### PR DESCRIPTION
## Overview

1. This PR fixes #20414.
2. This PR does the following:
   - Improves the `validate_customization_args_and_values` error message by including `item_name` and `item_type` so developers can more easily identify which interaction’s customization args failed validation.
   - Adds a regression test to ensure that invalid customization args raise a `ValidationError` that contains this extra context.
3. (For bug-fixing PRs only) The original bug occurred because:
   - The backend raised a `ValidationError` without specifying which interaction failed, which made it hard to track down the source of invalid customization args.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of UI changes needed because this PR only modifies backend validation logic and unit tests (no user-facing UI is affected).

Backend tests:

- `python -m scripts.run_backend_tests --test_targets=core.domain.customization_args_util_test`
