### PR TITLE
Fix issue no. #233233 : frontend pagination-reset search state and handle sparse data lo…

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page.component.ts
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.ts
@@ -196,9 +196,16 @@ export class BlogHomePageComponent implements OnInit {
       .fetchBlogHomePageDataAsync(String(offset))
       .then(
         (data: BlogHomePageData) => {
-          this.blogPostSummaries = this.blogPostSummaries.concat(
-            data.blogPostSummaryDicts
-          );
+          while (this.blogPostSummaries.length < offset) {
+            this.blogPostSummaries.push(
+              undefined as unknown as BlogPostSummary
+            );
+          }
+
+          data.blogPostSummaryDicts.forEach((summary, index) => {
+            this.blogPostSummaries[offset + index] = summary;
+          });
+
           this.selectBlogPostSummariesToShow();
           this.calculateLastPostOnPageNum(
             this.page,
@@ -220,7 +227,10 @@ export class BlogHomePageComponent implements OnInit {
   }
 
   loadPage(): void {
-    if (this.blogPostSummaries.length < this.firstPostOnPageNum) {
+    if (
+      this.blogPostSummaries.length < this.firstPostOnPageNum ||
+      this.blogPostSummaries[this.firstPostOnPageNum - 1] === undefined
+    ) {
       this.showBlogPostCardsLoadingScreen = true;
       if (!this.searchPageIsActive) {
         this.loadMoreBlogPostSummaries(this.firstPostOnPageNum - 1);
@@ -293,6 +303,7 @@ export class BlogHomePageComponent implements OnInit {
   onSearchQueryChangeExec(): void {
     this.loaderService.showLoadingScreen('Loading');
     if (this.searchQuery === '' && this.selectedTags.length === 0) {
+      this.searchPageIsActive = false;
       this.loadInitialBlogHomePageData();
       this.windowRef.nativeWindow.history.pushState({}, '', '/blog');
       return;


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #23323 .
2. This PR fixes two frontend pagination issues on the blog homepage. The first issue happened when a user performed a search and then cleared it — the searchPageIsActive flag stayed true, so clicking “Next Page” continued calling the search API instead of the normal listing API. The second issue occurred when jumping directly to a later page (for example, from page 1 to page 7). The component appended new results instead of placing them at the correct indices, which caused blank or misaligned data. This PR resets searchPageIsActive when the query and tags are cleared, adds sparse-array support by padding skipped pages, inserts fetched results at the correct page index, and validates page data before rendering.
3. The original bug occurred because pagination logic assumed sequential page navigation and did not fully reset state after clearing a search.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x ] I have written tests for my code.
- [ x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

[Screencast from 2025-12-11 18-56-39.webm](https://github.com/user-attachments/assets/b8f1ca47-eb5f-40e9-829a-6cc7020e5367)

## Proof that changes are correct
 I have uploaded the video of testing of web app.


