### PR TITLE
Fix part of #18305: Fixed issue of editing study guides with id having 2 or more digits

### DIFF
--- a/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.spec.ts
@@ -80,7 +80,7 @@ describe('Study Guide Section editor component', () => {
     platformFeatureService = TestBed.inject(PlatformFeatureService);
 
     sampleStudyGuide = new StudyGuide(
-      '1',
+      '10',
       'topic1',
       [
         {
@@ -207,7 +207,7 @@ describe('Study Guide Section editor component', () => {
         content_id: 'section_content_1',
         html: 'content',
       },
-      1
+      10
     );
 
     component.saveSection(false);
@@ -223,7 +223,7 @@ describe('Study Guide Section editor component', () => {
         content_id: 'section_content_1',
         html: 'content',
       },
-      1
+      10
     );
   });
 

--- a/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/study-guide-section-editor.component.ts
@@ -159,7 +159,7 @@ export class StudyGuideSectionEditorComponent implements OnInit {
 
     if (contentHasChanged) {
       let studyGuide = this.topicEditorStateService.getStudyGuide();
-      let subtopicId = studyGuide.getId().slice(-1);
+      let subtopicId = studyGuide.getId().split('-').pop();
       this.topicUpdateService.updateSection(
         studyGuide,
         this.index,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #18305.
2. This PR does the following: Corrects the study guide id extraction logic to account for ids with more than 2 characters
3. (For bug-fixing PRs only) The original bug occurred because: The original logic assumed that study guide ids are single digit only so it got the last character from the subtopic id. Eg: For subtopic_id: abcd-10 originally we would have gotten study guide id as 0. This PR fixes the logic so we get an id 10.
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->


[Screencast from 2025-12-12 20-19-54.webm](https://github.com/user-attachments/assets/eafdc6b9-0f73-40c9-a418-1d7b5ff63c4c)



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
