### PR TITLE
Fix #24159: Gates Review Test page redirection logic with a new feature flag

### DIFF
--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -339,8 +339,8 @@ class StoryProgressHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
 
         # Gated Review Test redirection.
         if feature_flag_services.is_feature_flag_enabled(
-            self.user_id,
             feature_flag_list.FeatureNames.ENABLE_READY_FOR_REVIEW_TEST.value,
+            self.user_id,
         ) and (
             questions_available
             and (learner_at_review_point_in_story or learner_completed_story)

--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 
 import logging
 
-from core import feconf, utils
+from core import feature_flag_list, feconf, utils
 from core.constants import constants
 from core.controllers import acl_decorators, base
 from core.domain import (
+    feature_flag_services,
     learner_progress_services,
     question_services,
     skill_fetchers,
@@ -335,8 +336,14 @@ class StoryProgressHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
             len(completed_node_ids) & constants.NUM_EXPLORATIONS_PER_REVIEW_TEST
             == 0
         )
-        if questions_available and (
-            learner_at_review_point_in_story or learner_completed_story
+
+        # Gated Review Test redirection
+        if feature_flag_services.is_feature_flag_enabled(
+            self.user_id,
+            feature_flag_list.FeatureNames.ENABLE_READY_FOR_REVIEW_TEST.value,
+        ) and (
+            questions_available
+            and (learner_at_review_point_in_story or learner_completed_story)
         ):
             ready_for_review_test = True
 

--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -337,7 +337,7 @@ class StoryProgressHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
             == 0
         )
 
-        # Gated Review Test redirection
+        # Gated Review Test redirection.
         if feature_flag_services.is_feature_flag_enabled(
             self.user_id,
             feature_flag_list.FeatureNames.ENABLE_READY_FOR_REVIEW_TEST.value,

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 
-from core import feconf
+from core import feature_flag_list, feconf
 from core.constants import constants
 from core.domain import (
     learner_goals_services,
@@ -628,7 +628,66 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
         self.assertIsNone(json_response['next_node_id'])
         self.assertFalse(json_response['ready_for_review_test'])
 
-    def test_post_returns_ready_for_review_when_acquired_skills_exist(
+    def test_post_returns_ready_for_review_false_when_acquired_skills_exist_and_enable_ready_for_review_test_is_disabled(
+        self,
+    ) -> None:
+        csrf_token = self.get_new_csrf_token()
+        self.save_new_skill(
+            'skill_1', self.admin_id, description='Skill Description'
+        )
+        content_id_generator = translation_domain.ContentIdGenerator()
+        self.save_new_question(
+            'question_1',
+            self.admin_id,
+            self._create_valid_question_data('ABC', content_id_generator),
+            ['skill_1'],
+            content_id_generator.next_content_id_index,
+        )
+        question_services.create_new_question_skill_link(
+            self.admin_id, 'question_1', 'skill_1', 0.3
+        )
+        old_value: List[str] = []
+        changelist = [
+            story_domain.StoryChange(
+                {
+                    'cmd': story_domain.CMD_UPDATE_STORY_NODE_PROPERTY,
+                    'property_name': (
+                        story_domain.STORY_NODE_PROPERTY_ACQUIRED_SKILL_IDS
+                    ),
+                    'node_id': self.NODE_ID_1,
+                    'old_value': old_value,
+                    'new_value': ['skill_1'],
+                }
+            )
+        ]
+        story_services.update_story(
+            self.admin_id, self.STORY_ID, changelist, 'Added acquired skill.'
+        )
+
+        story_services.record_completed_node_in_story_context(
+            self.viewer_id, self.STORY_ID, self.NODE_ID_2
+        )
+        story_services.record_completed_node_in_story_context(
+            self.viewer_id, self.STORY_ID, self.NODE_ID_1
+        )
+        json_response = self.post_json(
+            '%s/staging/topic/%s/%s'
+            % (
+                feconf.STORY_PROGRESS_URL_PREFIX,
+                self.STORY_URL_FRAGMENT,
+                self.NODE_ID_3,
+            ),
+            {},
+            csrf_token=csrf_token,
+        )
+        self.assertEqual(len(json_response['summaries']), 0)
+        self.assertIsNone(json_response['next_node_id'])
+        self.assertFalse(json_response['ready_for_review_test'])
+
+    @test_utils.enable_feature_flags(
+        [feature_flag_list.FeatureNames.ENABLE_READY_FOR_REVIEW_TEST]
+    )
+    def test_post_returns_ready_for_review_when_acquired_skills_exist_and_enable_ready_for_review_test_is_enabled(
         self,
     ) -> None:
         csrf_token = self.get_new_csrf_token()

--- a/core/feature_flag_list.py
+++ b/core/feature_flag_list.py
@@ -82,6 +82,7 @@ class FeatureNames(enum.Enum):
     ENABLE_BACKGROUND_VOICEOVER_SYNTHESIS = (
         'enable_background_voiceover_synthesis'
     )
+    ENABLE_READY_FOR_REVIEW_TEST = 'enable_ready_for_review_test'
 
 
 # Names of feature objects defined in FeatureNames should be added
@@ -108,6 +109,7 @@ DEV_FEATURES_LIST = [
     FeatureNames.SHOW_TRANSLATION_SIZE,
     FeatureNames.REDESIGNED_TOPIC_VIEWER_PAGE,
     FeatureNames.ENABLE_TRANSLATION_OPPORTUNITIES_WITH_NEW_OPP_MODELS,
+    FeatureNames.ENABLE_READY_FOR_REVIEW_TEST,
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must
@@ -302,6 +304,12 @@ FEATURE_FLAG_NAME_TO_DESCRIPTION_AND_FEATURE_STAGE = {
             'The flag enables the asynchronous voiceover synthesis for the '
             'curated exploration contents.',
             feature_flag_domain.ServerMode.TEST,
+        )
+    ),
+    FeatureNames.ENABLE_READY_FOR_REVIEW_TEST.value: (
+        (
+            'This flag enables ready_for_review_test, which controls the learner’s redirection to the Review Test upon lesson completion.',
+            feature_flag_domain.ServerMode.DEV,
         )
     ),
 }

--- a/core/templates/domain/feature-flag/feature-status-summary.model.ts
+++ b/core/templates/domain/feature-flag/feature-status-summary.model.ts
@@ -45,6 +45,7 @@ export enum FeatureNames {
   EnableWorkedExamplesRteComponent = 'enable_worked_examples_rte_component',
   ShowRegeneratedVoiceoversToLearners = 'show_regenerated_voiceovers_to_learners',
   EnableBackgroundVoiceoverSynthesis = 'enable_background_voiceover_synthesis',
+  EnableReadyForReviewTest = 'enable_ready_for_review_test',
 }
 
 export interface FeatureStatusSummaryBackendDict {

--- a/core/templates/pages/review-test-page/review-test-auth.guard.spec.ts
+++ b/core/templates/pages/review-test-page/review-test-auth.guard.spec.ts
@@ -22,19 +22,30 @@ import {
   ActivatedRouteSnapshot,
   RouterStateSnapshot,
   Router,
+  ParamMap,
+  convertToParamMap,
 } from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {AppConstants} from 'app.constants';
 import {ReviewTestAuthGuard} from './review-test-auth.guard';
 import {AccessValidationBackendApiService} from 'pages/oppia-root/routing/access-validation-backend-api.service';
+import {PlatformFeatureService} from 'services/platform-feature.service';
+
+class MockPlatformFeatureService {
+  get status() {
+    return {
+      EnableReadyForReviewTest: {isEnabled: true},
+    };
+  }
+}
 
 class MockAccessValidationBackendApiService {
   validateAccessToReviewTestPage(
     classroomUrlFragment: string,
     topicUrlFragment: string,
     storyUrlFragment: string
-  ) {
+  ): Promise<void> {
     return Promise.resolve();
   }
 }
@@ -45,10 +56,42 @@ class MockRouter {
   }
 }
 
+class MockLocation {
+  replaceState(url: string): void {}
+}
+
 describe('ReviewTestAuthGuard', () => {
   let guard: ReviewTestAuthGuard;
   let accessValidationBackendApiService: AccessValidationBackendApiService;
+  let platformFeatureService: PlatformFeatureService;
   let router: Router;
+  let location: Location;
+
+  const createMockRoute = (
+    classroomUrlFragment: string = 'math',
+    topicUrlFragment: string = 'algebra',
+    storyUrlFragment: string = 'story-1'
+  ): ActivatedRouteSnapshot => {
+    const route = new ActivatedRouteSnapshot();
+    const paramMap: ParamMap = convertToParamMap({
+      classroom_url_fragment: classroomUrlFragment,
+      topic_url_fragment: topicUrlFragment,
+      story_url_fragment: storyUrlFragment,
+    });
+
+    Object.defineProperty(route, 'paramMap', {
+      get: () => paramMap,
+    });
+
+    return route;
+  };
+
+  const createMockState = (url: string): RouterStateSnapshot => {
+    return {
+      url: url,
+      root: new ActivatedRouteSnapshot(),
+    } as RouterStateSnapshot;
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -59,8 +102,12 @@ describe('ReviewTestAuthGuard', () => {
           provide: AccessValidationBackendApiService,
           useClass: MockAccessValidationBackendApiService,
         },
+        {
+          provide: PlatformFeatureService,
+          useClass: MockPlatformFeatureService,
+        },
         {provide: Router, useClass: MockRouter},
-        Location,
+        {provide: Location, useClass: MockLocation},
       ],
     });
 
@@ -68,8 +115,42 @@ describe('ReviewTestAuthGuard', () => {
     accessValidationBackendApiService = TestBed.inject(
       AccessValidationBackendApiService
     );
+    platformFeatureService = TestBed.inject(PlatformFeatureService);
     router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
   });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should redirect to 404 when flag is disabled', fakeAsync(() => {
+    spyOnProperty(platformFeatureService, 'status', 'get').and.returnValue({
+      EnableReadyForReviewTest: {isEnabled: false},
+    });
+
+    const navigateSpy = spyOn(router, 'navigate').and.returnValue(
+      Promise.resolve(true)
+    );
+    const locationSpy = spyOn(location, 'replaceState');
+
+    const route = createMockRoute();
+    const state = createMockState('/review-test/math/algebra/story-1');
+
+    let canActivateResult: boolean | null = null;
+
+    guard.canActivate(route, state).then(result => {
+      canActivateResult = result;
+    });
+
+    tick();
+
+    expect(canActivateResult).toBeFalse();
+    expect(navigateSpy).toHaveBeenCalledWith([
+      `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
+    ]);
+    expect(locationSpy).toHaveBeenCalledWith(state.url);
+  }));
 
   it('should allow access if validation succeeds', fakeAsync(() => {
     const validateAccessSpy = spyOn(
@@ -80,18 +161,23 @@ describe('ReviewTestAuthGuard', () => {
       Promise.resolve(true)
     );
 
+    const route = createMockRoute('math', 'algebra', 'story-1');
+    const state = createMockState('/review-test/math/algebra/story-1');
+
     let canActivateResult: boolean | null = null;
 
-    guard
-      .canActivate(new ActivatedRouteSnapshot(), {} as RouterStateSnapshot)
-      .then(result => {
-        canActivateResult = result;
-      });
+    guard.canActivate(route, state).then(result => {
+      canActivateResult = result;
+    });
 
     tick();
 
     expect(canActivateResult).toBeTrue();
-    expect(validateAccessSpy).toHaveBeenCalled();
+    expect(validateAccessSpy).toHaveBeenCalledWith(
+      'math',
+      'algebra',
+      'story-1'
+    );
     expect(navigateSpy).not.toHaveBeenCalled();
   }));
 
@@ -99,18 +185,20 @@ describe('ReviewTestAuthGuard', () => {
     spyOn(
       accessValidationBackendApiService,
       'validateAccessToReviewTestPage'
-    ).and.returnValue(Promise.reject());
+    ).and.returnValue(Promise.reject(new Error('Validation failed')));
     const navigateSpy = spyOn(router, 'navigate').and.returnValue(
       Promise.resolve(true)
     );
+    const locationSpy = spyOn(location, 'replaceState');
+
+    const route = createMockRoute('math', 'algebra', 'story-1');
+    const state = createMockState('/review-test/math/algebra/story-1');
 
     let canActivateResult: boolean | null = null;
 
-    guard
-      .canActivate(new ActivatedRouteSnapshot(), {} as RouterStateSnapshot)
-      .then(result => {
-        canActivateResult = result;
-      });
+    guard.canActivate(route, state).then(result => {
+      canActivateResult = result;
+    });
 
     tick();
 
@@ -118,5 +206,6 @@ describe('ReviewTestAuthGuard', () => {
     expect(navigateSpy).toHaveBeenCalledWith([
       `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
     ]);
+    expect(locationSpy).toHaveBeenCalledWith(state.url);
   }));
 });

--- a/core/templates/pages/review-test-page/review-test-auth.guard.ts
+++ b/core/templates/pages/review-test-page/review-test-auth.guard.ts
@@ -27,6 +27,7 @@ import {
 } from '@angular/router';
 
 import {AppConstants} from 'app.constants';
+import {PlatformFeatureService} from 'services/platform-feature.service';
 import {AccessValidationBackendApiService} from 'pages/oppia-root/routing/access-validation-backend-api.service';
 
 @Injectable({
@@ -34,6 +35,7 @@ import {AccessValidationBackendApiService} from 'pages/oppia-root/routing/access
 })
 export class ReviewTestAuthGuard implements CanActivate {
   constructor(
+    private platformFeatureService: PlatformFeatureService,
     private accessValidationBackendApiService: AccessValidationBackendApiService,
     private router: Router,
     private location: Location
@@ -46,16 +48,23 @@ export class ReviewTestAuthGuard implements CanActivate {
       route.paramMap.get('classroom_url_fragment') || '';
     const topicUrlFragment = route.paramMap.get('topic_url_fragment') || '';
     const storyUrlFragment = route.paramMap.get('story_url_fragment') || '';
+    if (this.platformFeatureService.status.EnableReadyForReviewTest.isEnabled) {
+      try {
+        await this.accessValidationBackendApiService.validateAccessToReviewTestPage(
+          classroomUrlFragment,
+          topicUrlFragment,
+          storyUrlFragment
+        );
 
-    try {
-      await this.accessValidationBackendApiService.validateAccessToReviewTestPage(
-        classroomUrlFragment,
-        topicUrlFragment,
-        storyUrlFragment
-      );
-
-      return true;
-    } catch (_) {
+        return true;
+      } catch (_) {
+        await this.router.navigate([
+          `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
+        ]);
+        this.location.replaceState(state.url);
+        return false;
+      }
+    } else {
       await this.router.navigate([
         `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
       ]);


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/24159 and fixes https://github.com/oppia/oppia/issues/24072 and fixes https://github.com/oppia/oppia/issues/21235.
2. This PR does the following: Gates the Logic where ready_for_review_test is turned True.
3. (For bug-fixing PRs only) The original bug occurred because: This occurred because of being not gated by any feature flag. If ready_for_review_test is True, Learners are redirected to the review test page.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).



## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

[Screencast from 2025-12-15 04-07-13.webm](https://github.com/user-attachments/assets/d7ecc155-bd4c-4b37-a43b-f79f2eb79168)

## Can't be accessed from URL
<img width="3056" height="1525" alt="image" src="https://github.com/user-attachments/assets/f5694579-e28c-48ed-88bf-3216bf047e09" />

[Screencast from 2025-12-20 00-03-33.webm](https://github.com/user-attachments/assets/3cac9a5d-ad11-477b-9ceb-f0b1123f4413)



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
