### PR TITLE
Fixes UI issues related to voiceovers

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.html
@@ -30,13 +30,11 @@
         </mat-progress-bar>
 
         <span class="voiceover-timer">
-          {{manualVoiceoverCurrentDuration | formatTime}} / {{manualVoiceoverTotalDuration | formatTime}}
+          {{roundedManualVoiceoverCurrentDuration | formatTime}} / {{manualVoiceoverTotalDuration | formatTime}}
         </span>
 
         <div class="voiceover-action-buttons">
           <button (click)="toggleAudioNeedsUpdate()"
-                  mat-icon-button
-                  mat-button
                   class="e2e-test-audio-status-update-button"
                   [ngClass]="manualVoiceover.needsUpdate == true ? 'needs-update-button-icon' : 'does-not-needs-update-button-icon'">
             <mat-icon matTooltip="Audio needs update"
@@ -51,8 +49,6 @@
           </button>
 
           <button (click)="deleteManualVoiceover()"
-                  mat-icon-button
-                  mat-button
                   class="delete-manual-voiceover-icon e2e-test-delete-voiceover-button">
             <mat-icon matTooltip="Delete voiceover">delete</mat-icon>
           </button>
@@ -87,12 +83,10 @@
                             class="voiceover-progress">
           </mat-progress-bar>
           <span class="voiceover-timer">
-            {{automaticVoiceoverCurrentDuration | formatTime}} / {{automaticVoiceoverTotalDuration | formatTime}}
+            {{roundedAutomaticVoiceoverCurrentDuration | formatTime}} / {{automaticVoiceoverTotalDuration | formatTime}}
           </span>
           <div class="voiceover-action-buttons">
             <button (click)="generateVoiceover()"
-                    mat-icon-button
-                    mat-button
                     [disabled]="!isGenerateAutomaticVoiceoverOptionEnabled || !contentAvailableForVoiceovers"
                     class="regenerate-voiceover-button">
               <mat-icon matTooltip="Regenerate voiceover" *ngIf="!isAutomaticVoiceoverGenerating">
@@ -161,11 +155,19 @@
   }
   .needs-update-button-icon {
     background-color: #e9b330;
+    border: none;
+    border-radius: 20px;
     color: #fff;
+    height: 40px;
+    width: 40px;
   }
   .does-not-needs-update-button-icon {
     background-color: #009688;
+    border: none;
+    border-radius: 20px;
     color: #fff;
+    height: 40px;
+    width: 40px;
   }
   .language-accent-selector {
     width: 350px;
@@ -223,11 +225,19 @@
   }
   .delete-manual-voiceover-icon {
     background-color: #d14836;
+    border: none;
+    border-radius: 20px;
     color: #fff;
+    height: 40px;
+    width: 40px;
   }
   .regenerate-voiceover-button {
     background-color: #009688;
+    border: none;
+    border-radius: 20px;
     color: #fff;
+    height: 40px;
+    width: 40px;
   }
   .regenerate-voiceover-button:disabled {
     background-color: #a1c5c3;

--- a/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.ts
@@ -74,12 +74,14 @@ export class VoiceoverCardComponent implements OnInit, AfterViewChecked {
 
   manualVoiceover!: Voiceover | undefined;
   manualVoiceoverCurrentDuration: number = 0;
+  roundedManualVoiceoverCurrentDuration: number = 0;
   manualVoiceoverTotalDuration!: number;
   manualVoiceoverProgress: number = 0;
   isManualVoiceoverPlaying: boolean = false;
 
   automaticVoiceover!: Voiceover | undefined;
   automaticVoiceoverCurrentDuration: number = 0;
+  roundedAutomaticVoiceoverCurrentDuration: number = 0;
   automaticVoiceoverTotalDuration!: number;
   automaticVoiceoverProgress: number = 0;
   isAutomaticVoiceoverPlaying: boolean = false;
@@ -200,6 +202,9 @@ export class VoiceoverCardComponent implements OnInit, AfterViewChecked {
         if (this.isManualVoiceoverPlaying) {
           this.manualVoiceoverCurrentDuration =
             this.audioPlayerService.getCurrentTimeInSecs();
+          this.roundedManualVoiceoverCurrentDuration = Math.round(
+            this.manualVoiceoverCurrentDuration
+          );
           this.manualVoiceoverProgress = Math.round(
             (this.manualVoiceoverCurrentDuration /
               this.manualVoiceoverTotalDuration) *
@@ -209,6 +214,9 @@ export class VoiceoverCardComponent implements OnInit, AfterViewChecked {
         if (this.isAutomaticVoiceoverPlaying) {
           this.automaticVoiceoverCurrentDuration =
             this.audioPlayerService.getCurrentTimeInSecs();
+          this.roundedAutomaticVoiceoverCurrentDuration = Math.round(
+            this.automaticVoiceoverCurrentDuration
+          );
           this.automaticVoiceoverProgress = Math.round(
             (this.automaticVoiceoverCurrentDuration /
               this.automaticVoiceoverTotalDuration) *
@@ -218,8 +226,10 @@ export class VoiceoverCardComponent implements OnInit, AfterViewChecked {
       } else if (!this.audioPlayerService.isTrackLoaded()) {
         this.automaticVoiceoverProgress = 0;
         this.automaticVoiceoverCurrentDuration = 0;
+        this.roundedAutomaticVoiceoverCurrentDuration = 0;
         this.manualVoiceoverCurrentDuration = 0;
         this.manualVoiceoverProgress = 0;
+        this.roundedManualVoiceoverCurrentDuration = 0;
       }
 
       if (!this.audioPlayerService.isPlaying()) {

--- a/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.html
@@ -26,10 +26,7 @@
           </a>
         </div>
         <div class="slider-section" *ngIf="progressBarIsShown">
-          <div *ngIf="audioLoadingIndicatorIsShown">
-            <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-          </div>
-          <div *ngIf="!audioLoadingIndicatorIsShown">
+          <div>
             <oppia-audio-slider [value]="this.currentVoiceoverTime"
                                 [dir]="isLanguageRTL() ? 'rtl' : 'ltr'"
                                 [max]="this.totalVoiceoverDurationSecs"

--- a/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.html
@@ -15,7 +15,7 @@
              [ngbTooltip]="!isAudioAvailableInCurrentLanguageAccent() ? ('I18N_PLAYER_AUDIO_NOT_AVAILABLE_IN' | translate:{languageDescription:selectedLanguageAccentDescription}) : ''"
              placement="right">
             <i class="fas oppia-audio-controls-button-icon" tabindex="0" aria-label="Press enter to Listen to the Lesson"
-               [ngClass]="{'fa-ellipsis-h': audioLoadingIndicatorIsShown, 'fa-play-circle e2e-test-play-circle': !isAudioPlaying(), 'fa-pause-circle e2e-test-pause-circle': isAudioPlaying(), 'audio-controls-audio-not-available': !isAudioAvailableInCurrentLanguageAccent() || audioIsLoading}">
+               [ngClass]="{'fa-ellipsis-h': audioLoadingIndicatorIsShown, 'fa-play-circle e2e-test-play-circle': !isAudioPlaying(), 'fa-pause-circle e2e-test-pause-circle': isAudioPlaying(), 'audio-controls-audio-not-available': !isAudioAvailableInCurrentLanguageAccent() || audioLoadingIndicatorIsShown}">
             </i>
           </a>
           <a (click)="onForwardButtonClicked()">

--- a/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.spec.ts
@@ -326,6 +326,15 @@ describe('Audio Bar Component', () => {
       }
     );
 
+    it('should not play voiceover if new audio is loading', () => {
+      component.audioLoadingIndicatorIsShown = true;
+      component.isPaused = true;
+
+      component.onPlayButtonClicked();
+      // Voiceover is still paused.
+      expect(component.isPaused).toBeTrue();
+    });
+
     it('should load audio track and play audio when play button is clicked', () => {
       component.voiceoverToBePlayed = Voiceover.createFromBackendDict({
         filename: 'audio-en.mp3',

--- a/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/layout-directives/audio-bar.component.ts
@@ -273,6 +273,9 @@ export class AudioBarComponent {
   }
 
   onPlayButtonClicked(): void {
+    if (this.audioLoadingIndicatorIsShown) {
+      return;
+    }
     this.isPaused = !this.isPaused;
     this.progressBarIsShown = true;
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

This PR does the following:
- Fixes CSS in the voiceover card after Bootstrap 5 migration ref comment: https://github.com/oppia/oppia/pull/23068#issuecomment-3616627658
- Rounds off the voiceover duration to prevent width changes during voiceover playback (see the second video below for reference).
- Fixes audio bar flicker while changing language accent in the exploration player/preview page. Ref issue https://github.com/oppia/oppia/issues/23842. (See the first video for reference)



## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

**Image description**: Updated the UI of the voiceover card to reflect the first change mentioned above.

<img width="1089" height="352" alt="Screenshot from 2025-12-15 18-41-04" src="https://github.com/user-attachments/assets/028c3ac5-a0d4-4f1a-9187-876c2fb3c982" />

**Video description**: When changing the language accent and replaying the voiceover, the text “Loading audio…” appears briefly and then disappears. This happens because the voiceover is played locally; however, if network latency is high, this text will be clearly visible while the voiceover is being fetched from the backend.


https://github.com/user-attachments/assets/4e539670-283b-4fea-a303-a0f5d6e16c4d


**Video description**: During voiceover playback, notice that the width of the time duration used to change when the value rounded off to seconds; after the update, the width remains consistent.


https://github.com/user-attachments/assets/eae928ca-af9e-4472-bc57-13e67ec42c8e


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
