### PR TITLE
Fix learner dashboard story progress calculation

### DIFF
--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
@@ -59,7 +59,7 @@ export class GoalListComponent implements OnInit {
   }
 
   getStoryProgress(story: StorySummary): number {
-    const nodes = story.getStoryNodes();
+    const nodes = story.getAllNodes();
     if (nodes.length === 0) {
       return 0;
     }

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
@@ -59,10 +59,16 @@ export class GoalListComponent implements OnInit {
   }
 
   getStoryProgress(story: StorySummary): number {
-    return (
-      (story.getCompletedNodeTitles().length / story.getNodeTitles().length) *
-      100
-    );
+    const nodes = story.getStoryNodes();
+    if (nodes.length === 0) {
+      return 0;
+    }
+
+    const totalProgress = nodes.reduce((sum, node) => {
+      return sum + this.getChapterProgress(node);
+    }, 0);
+
+    return Math.round(totalProgress / nodes.length);
   }
 
   getChapterProgress(storyNode: StoryNode): number {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #24178.
2. This PR does the following: This PR updates the Learner Dashboard to compute story progress using
per-chapter lesson progress instead of only completed chapters, allowing
partial progress to be reflected accurately.

3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because story progress was calculated solely
from the number of completed story nodes, ignoring existing chapter-level
lesson progress data.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).




## Proof that changes are correct
No proof of changes needed because this PR updates internal progress
calculation logic and does not change UI structure. End-to-end UI testing
requires publishing explorations and stories, which was blocked locally
due to Elasticsearch flood-stage (read-only index) issues.

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
