### PR TITLE
Fix #24206: fix typos in blog services and creator dashboard test files

### DIFF
--- a/core/domain/blog_services.py
+++ b/core/domain/blog_services.py
@@ -459,7 +459,7 @@ def does_blog_post_with_url_fragment_exist(url_fragment: str) -> bool:
         url_fragment: str. The url fragment for the blog post.
 
     Returns:
-        bool. Whether the the url fragment for the blog post exists.
+        bool. Whether the url fragment for the blog post exists.
 
     Raises:
         Exception. Blog Post URL fragment is not a string.

--- a/core/domain/blog_services_test.py
+++ b/core/domain/blog_services_test.py
@@ -414,7 +414,7 @@ class BlogServicesUnitTests(test_utils.GenericTestBase):
         assert blog_post is not None
         self.assertEqual(blog_post.to_dict(), expected_blog_post.to_dict())
 
-    def test_get_blog_posy_by_invalid_url(self) -> None:
+    def test_get_blog_post_by_invalid_url(self) -> None:
         # TODO(#13059): Here we use MyPy ignore because after we fully type the
         # codebase we plan to get rid of the tests that intentionally test wrong
         # inputs that we can normally catch by typing.

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.spec.ts
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.spec.ts
@@ -148,7 +148,7 @@ describe('Creator Dashboard Page Component', () => {
   });
 
   it(
-    'should get complete thumbail icon path corresponding to a given' +
+    'should get complete thumbnail icon path corresponding to a given' +
       ' relative path',
     () => {
       expect(component.getCompleteThumbnailIconUrl('/path/to/icon.png')).toBe(


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #24206.
2. This PR does the following: It corrects minor typos across three files to improve code clarity and consistency. Specifically, it removes a duplicate word in a docstring in `blog_services.py`, renames a test function with a typo in `blog_services_test.py`, and corrects a spelling error in a test description within `creator-dashboard-page.component.spec.ts`.

3. (For bug-fixing PRs only) The original bug occurred because: these files contained small typographical errors that were overlooked during initial development and review. No functional logic was affected.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

No proof of changes needed because this PR only fixes spelling and wording in docstrings and test descriptions and does not affect user-facing behavior or functionality.
<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
N/A
#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->
N/A
#### Proof of changes in Arabic language
N/A
<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
