### PR TITLE
Fix part of #24131: Remove unused i18n key from en.json

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -13,7 +13,6 @@
     "I18N_ABOUT_FOUNDATION_PAGE_SECTION_SIX": "There's a role for you to play",
     "I18N_ABOUT_FOUNDATION_PAGE_SECTION_SIX_PART_1": "Are you a part of a school, NGO, or other organization who shares our passion for educational inequality? <a href=\"/partnerships\" class=\"inline-links\">Consider becoming a partner today!</a>",
     "I18N_ABOUT_FOUNDATION_PAGE_SECTION_SIX_PART_2": "Do you have time, skills, or other resources you’d like to share to help advance our mission? <a href=\"/volunteer\" class=\"inline-links\">Join our large volunteer community!</a>",
-    "I18N_ABOUT_FOUNDATION_PAGE_SECTION_SIX_PART_3": "If neither of those apply to you, we always appreciate <a href=\"/donate\" class=\"inline-links\">donations</a> too!",
     "I18N_ABOUT_FOUNDATION_PAGE_TITLE": "About the Oppia Foundation | Oppia",
     "I18N_ABOUT_FOUNDATION_PAGE_WE_CANNOT": "We cannot ignore the potential quality education has to improve people's lives.",
     "I18N_ABOUT_FOUNDATION_PAGE_WE_CANNOT_CONTENT": "Researchers have shown again and again that education has the power to rejuvenate communities, increase economic growth, and disrupt the cycle of poverty. UNESCO predicts that if we achieve universal primary and secondary completion, we could lift more than <a href=\"http://uis.unesco.org/en/news/world-poverty-could-be-cut-half-if-all-adults-completed-secondary-education\" class=\"inline-links\">420 million</a> people out of poverty.",


### PR DESCRIPTION
## Overview

1. This PR fixes part of #24131.
2. This PR removes an unused i18n key from assets/i18n/en.json to reduce unnecessary translation and maintenance burden.
3. N/A (This is not a bug-fixing PR; it is a cleanup change.)

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (Not applicable for i18n key cleanup)
- [ ] The *PR title* starts with "Fix part of #24131: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with "@{{reviewer_username}} PTAL").

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A — This PR does not affect production server data.

## Proof that changes are correct

No proof of changes needed because this PR only removes an unused i18n key and does not affect any user-facing or developer-facing functionality.