### PR TITLE
Fix : Add test for empty image data in check_image_png_or_webp

### DIFF
--- a/core/tests/test_utils_test.py
+++ b/core/tests/test_utils_test.py
@@ -885,6 +885,10 @@ class CheckImagePngOrWebpTests(test_utils.GenericTestBase):
     def test_jpeg_image_yields_false(self) -> None:
         self.assertFalse(test_utils.check_image_png_or_webp('data:image/jpeg'))
 
+    def test_empty_string_yields_false(self) -> None:
+        """Tests that empty image data returns False."""
+        self.assertFalse(test_utils.check_image_png_or_webp(''))
+
 
 class ElasticSearchStubTests(test_utils.GenericTestBase):
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR adds a unit test to ensure `check_image_png_or_webp` returns False when given empty image data.
3. N/A (This is not a bug-fixing PR).

## Essential Checklist

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...". (N/A – test-only change)
- [ ] I have assigned the correct reviewers to this PR. (Will be assigned by maintainers)

## Proof that changes are correct

No proof of changes needed because this PR only adds a backend unit test and does not modify runtime behavior.
