### PR TITLE
docs: add link to Installing Oppia setup guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ and platform integration. The Oppia project documentation and installation
 instructions are maintained on the project wiki — treat
 https://github.com/oppia/oppia/wiki as the source-of-truth for setup steps and
 environment choices.
+For local setup instructions (Windows/macOS/Linux), see: https://github.com/oppia/oppia/wiki/Installing-Oppia
 
 Key directories to inspect:
 


### PR DESCRIPTION
## Overview

This PR is a small documentation improvement.

1. This PR fixes or fixes part of #N/A
2. This PR does the following:
   - Adds a direct link in `AGENTS.md` to the "Installing Oppia" wiki page so contributors can quickly find local setup instructions (Windows/macOS/Linux).

## Proof that changes are correct

- Verified that the added link points to the official Oppia wiki page and opens correctly:
  https://github.com/oppia/oppia/wiki/Installing-Oppia
- This is a documentation-only change; no code behavior is modified.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I confirm this change is documentation-only and does not require tests.
- [x] I verified the link works as expected.

