### PR TITLE
Fix #24100: Stabilize E2E test by handling overlapping offline and online toast messages

### DIFF
--- a/core/tests/webdriverio_utils/ExplorationEditorPage.js
+++ b/core/tests/webdriverio_utils/ExplorationEditorPage.js
@@ -66,7 +66,6 @@ var ExplorationEditorPage = function () {
     '.e2e-test-exploration-category-dropdown'
   );
   var sharePublishModalElement = $('.e2e-test-share-publish-modal');
-  var toastMessage = $('.e2e-test-toast-message');
 
   /*
    * Non-Interactive elements
@@ -510,6 +509,15 @@ var ExplorationEditorPage = function () {
   // ---- INTERNET CONNECTION ----
 
   this.waitForOnlineAlert = async function () {
+    const toastContainer = $('.toast-success');
+
+    await waitFor.presenceOf(
+      toastContainer,
+      'Online success toast container taking too long to appear.'
+    );
+
+    const toastMessage = toastContainer.$('.e2e-test-toast-message');
+
     await waitFor.visibilityOf(
       toastMessage,
       'Online info toast message taking too long to appear.'
@@ -517,13 +525,18 @@ var ExplorationEditorPage = function () {
     expect(await action.getText('Toast Message', toastMessage)).toMatch(
       'Reconnected. Checking whether your changes are mergeable.'
     );
-    await waitFor.invisibilityOf(
-      toastMessage,
-      'Online info toast message taking too long to disappear.'
-    );
   };
 
   this.waitForOfflineAlert = async function () {
+    const toastContainer = $('.toast-info');
+
+    await waitFor.presenceOf(
+      toastContainer,
+      'Offline info toast container taking too long to appear.'
+    );
+
+    const toastMessage = toastContainer.$('.e2e-test-toast-message');
+
     await waitFor.visibilityOf(
       toastMessage,
       'Offline warning toast message taking too long to appear.'
@@ -531,10 +544,6 @@ var ExplorationEditorPage = function () {
     expect(await action.getText('Toast Message', toastMessage)).toMatch(
       'Looks like you are offline. You can continue working, and can save ' +
         'your changes once reconnected.'
-    );
-    await waitFor.invisibilityOf(
-      toastMessage,
-      'Offline warning toast message taking too long to disappear.'
     );
   };
 };

--- a/core/tests/webdriverio_utils/ExplorationEditorPage.js
+++ b/core/tests/webdriverio_utils/ExplorationEditorPage.js
@@ -509,39 +509,39 @@ var ExplorationEditorPage = function () {
   // ---- INTERNET CONNECTION ----
 
   this.waitForOnlineAlert = async function () {
-    const toastContainer = $('.toast-success');
+    const TOAST_CONTAINER = $('.toast-success');
 
     await waitFor.presenceOf(
-      toastContainer,
+      TOAST_CONTAINER,
       'Online success toast container taking too long to appear.'
     );
 
-    const toastMessage = toastContainer.$('.e2e-test-toast-message');
+    const TOAST_MESSAGE = TOAST_CONTAINER.$('.e2e-test-toast-message');
 
     await waitFor.visibilityOf(
-      toastMessage,
+      TOAST_MESSAGE,
       'Online info toast message taking too long to appear.'
     );
-    expect(await action.getText('Toast Message', toastMessage)).toMatch(
+    expect(await action.getText('Toast Message', TOAST_MESSAGE)).toMatch(
       'Reconnected. Checking whether your changes are mergeable.'
     );
   };
 
   this.waitForOfflineAlert = async function () {
-    const toastContainer = $('.toast-info');
+    const TOAST_CONTAINER = $('.toast-info');
 
     await waitFor.presenceOf(
-      toastContainer,
+      TOAST_CONTAINER,
       'Offline info toast container taking too long to appear.'
     );
 
-    const toastMessage = toastContainer.$('.e2e-test-toast-message');
+    const TOAST_MESSAGE = TOAST_CONTAINER.$('.e2e-test-toast-message');
 
     await waitFor.visibilityOf(
-      toastMessage,
+      TOAST_MESSAGE,
       'Offline warning toast message taking too long to appear.'
     );
-    expect(await action.getText('Toast Message', toastMessage)).toMatch(
+    expect(await action.getText('Toast Message', TOAST_MESSAGE)).toMatch(
       'Looks like you are offline. You can continue working, and can save ' +
         'your changes once reconnected.'
     );


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes  #24100.
2. This PR does the following: This PR makes the exploration editor E2E test for offline/online behavior deterministic by fixing how toast notifications are asserted. Specifically, it updates the E2E helper methods to correctly handle cases where offline and online toast notifications briefly overlap in CI, ensuring that the correct toast message is verified without relying on fragile timing assumptions.
3. The original bug occurred because: The original bug occurred because the E2E test assumed that only one toast notification would be visible at a time. In CI, goOffline() and goOnline() can trigger very close together, causing both offline (info) and online (success) toast notifications to be present in the DOM simultaneously. The test used a generic .e2e-test-toast-message selector and strict invisibility checks, which led to race conditions where the online toast was matched against the offline expectation, causing flaky failures.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
I have created the following changes in the test code to create an overlap between the toast messages, which caused the original flake.

Since reliably recreating the race condition locally is difficult, and the root cause was an overlap triggered by a race between `waitForOfflineAlert `and `goOnline`, I explicitly simulated this overlap scenario in the test.
Following is the before code:

<img width="668" height="357" alt="image" src="https://github.com/user-attachments/assets/e6afd3ad-64b6-4f54-9cc4-33137174368a" /> <img width="715" height="575" alt="image" src="https://github.com/user-attachments/assets/9f1c3851-b51c-4e0e-a029-19a018d1a5cc" />

And this is the case I created to force the overlap and reproduce the error:

<img width="648" height="329" alt="image" src="https://github.com/user-attachments/assets/29108f70-23d8-495a-84e7-baaa4517c65e" />


The following is proof that I was able to recreate the error with the previous helper functions (`waitForOnlineAlert` and `waitForOfflineAlert`).
<img width="1482" height="471" alt="image" src="https://github.com/user-attachments/assets/6a30852b-e165-49a9-80dc-752935cbc8d4" />

Finally, the following is proof that the test passes once the changes were made to the helper functions for the same overlap condtion.
<img width="1328" height="310" alt="image" src="https://github.com/user-attachments/assets/a3078997-9ef6-4f9a-abbc-a48ece1a536d" />

Note: The reason i have removed `waitFor.invisibilityOf` from helper fucntions is because the test waited for the toast message to disappear because the selector was generic and could match different toasts over time. With the updated implementation, the selector is now scoped to the specific toast container (.toast-success for online and .toast-info for offline), ensuring that the correct toast message is always selected.

Once the expected message text is verified, waiting for the toast to disappear is no longer necessary. Removing this wait also avoids CI flakiness caused by timing and animation differences, while keeping the original intent of the test intact.
## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
