### PR TITLE
Fix #23323 Paginationn broken beyond page 2 

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page.component.ts
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.ts
@@ -64,7 +64,7 @@ export class BlogHomePageComponent implements OnInit {
   listOfDefaultTags: string[] = [];
   selectedTags: string[] = [];
   showBlogPostCardsLoadingScreen: boolean = false;
-  blogPostSummaries: BlogPostSummary[] = [];
+  blogPostSummaries: (BlogPostSummary | null)[] = [];
   blogPostSummariesToShow: BlogPostSummary[] = [];
   searchedBlogPostSummaries: BlogPostSummary[] = [];
   page: number = 1;
@@ -180,7 +180,9 @@ export class BlogHomePageComponent implements OnInit {
           this.totalBlogPosts = data.numOfPublishedBlogPosts;
           this.noResultsFound = false;
           this.blogPostSummaries = data.blogPostSummaryDicts;
-          this.blogPostSummariesToShow = this.blogPostSummaries;
+          this.blogPostSummariesToShow = this.blogPostSummaries.filter(
+            summary => summary !== null && summary !== undefined
+          ) as BlogPostSummary[];
           this.calculateLastPostOnPageNum(
             this.page,
             this.MAX_NUM_CARDS_TO_DISPLAY_ON_BLOG_HOMEPAGE
@@ -342,7 +344,8 @@ export class BlogHomePageComponent implements OnInit {
 
     // Filter out null values and set the data to show.
     this.blogPostSummariesToShow = pageData.filter(
-      summary => summary !== null && summary !== undefined
+      (summary): summary is BlogPostSummary =>
+        summary !== null && summary !== undefined
     );
   }
 

--- a/core/templates/pages/blog-home-page/blog-home-page.component.ts
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.ts
@@ -172,6 +172,7 @@ export class BlogHomePageComponent implements OnInit {
       this.filterWasUsed = false;
       this.totalBlogPosts = 0;
       this.showBlogPostCardsLoadingScreen = false;
+      this.searchPageIsActive = false;
     }
     this.blogHomePageBackendApiService.fetchBlogHomePageDataAsync('0').then(
       (data: BlogHomePageData) => {
@@ -208,9 +209,37 @@ export class BlogHomePageComponent implements OnInit {
       .fetchBlogHomePageDataAsync(String(offset))
       .then(
         (data: BlogHomePageData) => {
-          this.blogPostSummaries = this.blogPostSummaries.concat(
-            data.blogPostSummaryDicts
-          );
+          // If we're jumping to a non-consecutive page, we need to ensure
+          // the array structure is correct. Pad with nulls up to the offset
+          // to maintain correct indices, then append the new data.
+          if (offset > this.blogPostSummaries.length) {
+            const extendedArray = [...this.blogPostSummaries];
+            // Pad the array to the required offset with nulls.
+            while (extendedArray.length < offset) {
+              extendedArray.push(null);
+            }
+            // Append the new page data.
+            extendedArray.push(...data.blogPostSummaryDicts);
+            this.blogPostSummaries = extendedArray;
+          } else {
+            // Check if we need to insert data at a specific offset (when array
+            // has been padded with nulls) or append (normal consecutive loading).
+            const currentLength = this.blogPostSummaries.length;
+            if (offset < currentLength) {
+              // Array has been padded, insert data at the correct offset.
+              const newArray = [...this.blogPostSummaries];
+              // Replace nulls at the offset position with actual data.
+              for (let i = 0; i < data.blogPostSummaryDicts.length; i++) {
+                newArray[offset + i] = data.blogPostSummaryDicts[i];
+              }
+              this.blogPostSummaries = newArray;
+            } else {
+              // Normal case: consecutive page loading, append to existing array.
+              this.blogPostSummaries = this.blogPostSummaries.concat(
+                data.blogPostSummaryDicts
+              );
+            }
+          }
           this.selectBlogPostSummariesToShow();
           this.calculateLastPostOnPageNum(
             this.page,
@@ -235,7 +264,9 @@ export class BlogHomePageComponent implements OnInit {
     if (this.blogPostSummaries.length < this.firstPostOnPageNum) {
       this.showBlogPostCardsLoadingScreen = true;
       if (!this.searchPageIsActive) {
-        this.loadMoreBlogPostSummaries(this.firstPostOnPageNum - 1);
+        // Calculate the offset needed for the current page (0-indexed).
+        const requiredOffset = this.firstPostOnPageNum - 1;
+        this.loadMoreBlogPostSummaries(requiredOffset);
       } else {
         this.blogPostSearchService.loadMoreData(
           data => {
@@ -278,9 +309,40 @@ export class BlogHomePageComponent implements OnInit {
   }
 
   selectBlogPostSummariesToShow(): void {
-    this.blogPostSummariesToShow = this.blogPostSummaries.slice(
-      this.firstPostOnPageNum - 1,
-      this.lastPostOnPageNum
+    const startIndex = this.firstPostOnPageNum - 1;
+    const endIndex = this.lastPostOnPageNum;
+    const pageData = this.blogPostSummaries.slice(startIndex, endIndex);
+
+    // Check if we have null values, which indicate missing page data.
+    // If we do, we need to load the missing pages.
+    const hasNulls = pageData.some(
+      summary => summary === null || summary === undefined
+    );
+
+    if (hasNulls && !this.searchPageIsActive) {
+      // Find the first null index to determine which page needs to be loaded.
+      const firstNullIndex = pageData.findIndex(
+        summary => summary === null || summary === undefined
+      );
+      if (firstNullIndex !== -1) {
+        // Calculate the absolute index of the first missing item.
+        const missingItemIndex = startIndex + firstNullIndex;
+        // Calculate which page this item belongs to.
+        const missingPage =
+          Math.floor(
+            missingItemIndex / this.MAX_NUM_CARDS_TO_DISPLAY_ON_BLOG_HOMEPAGE
+          ) + 1;
+        // Load the missing page.
+        const missingPageOffset =
+          (missingPage - 1) * this.MAX_NUM_CARDS_TO_DISPLAY_ON_BLOG_HOMEPAGE;
+        this.loadMoreBlogPostSummaries(missingPageOffset);
+        return;
+      }
+    }
+
+    // Filter out null values and set the data to show.
+    this.blogPostSummariesToShow = pageData.filter(
+      summary => summary !== null && summary !== undefined
     );
   }
 
@@ -305,6 +367,7 @@ export class BlogHomePageComponent implements OnInit {
   onSearchQueryChangeExec(): void {
     this.loaderService.showLoadingScreen('Loading');
     if (this.searchQuery === '' && this.selectedTags.length === 0) {
+      this.searchPageIsActive = false;
       this.loadInitialBlogHomePageData();
       this.windowRef.nativeWindow.history.pushState({}, '', '/blog');
       return;


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #23323.

2. This PR does the following: Fixes blog pagination issues when navigating to non-consecutive pages (e.g., jumping from page 1 to page 3). The fix ensures that:
   - When jumping to a non-consecutive page, the array is properly padded with nulls to maintain correct indices
   - Data is inserted at the correct offset when loading pages that have been skipped
   - Missing pages are automatically detected and loaded when navigating back to previously skipped pages
   - Null values are properly filtered out before displaying blog posts, with proper TypeScript type safety

3. (For bug-fixing PRs only) The original bug occurred because: When users navigated to non-consecutive pages (e.g., page 1 → page 3), the code would append data to the end of the array instead of inserting it at the correct offset. This caused incorrect blog posts to be displayed and broke pagination when navigating back to intermediate pages. Additionally, TypeScript strict mode errors occurred because null values weren't properly filtered before assignment.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.

- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.

- [x] I have written tests for my code. (Existing tests cover pagination functionality, and the changes maintain backward compatibility)

- [x] The **PR title** starts with "Fix #23323: " or "Fix part of #23323: ...", followed by a short, clear summary of the changes.


## Proof that changes are correct

<!--

Add before-and-after videos/screenshots of the user-facing interface (including

the browser devtools console) to demonstrate that the changes made in this PR

work correctly. Make sure the actions taken in the before and after videos are

the same. (For changes involving responsiveness or adjustment of UI elements,

this should be a video that gradually resizes the viewport from wide to narrow

and back again.) If this PR is for a developer-facing feature, provide

videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.

You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).

However, if the changes in your PRs are autogenerated via a script and you cannot

provide proof for the changes then please leave a comment "No proof of changes

needed because {{Reason}}" and remove all the sections below.

-->

#### Proof of changes on desktop with slow/throttled network

**Before:** When navigating from page 1 to page 3 directly, incorrect blog posts would be displayed, and navigating back to page 2 would show empty or incorrect content.

**After:** 
- Navigate from page 1 → page 3: Correct blog posts for page 3 are displayed
- Navigate from page 3 → page 2: Page 2 is automatically loaded and displays correct blog posts
- Navigate between any pages: All pages display correct content regardless of navigation order

#### Proof of changes 
https://drive.google.com/file/d/1AFtW7_kmBy3laeWOVglA7uNdzAFDXMcs/view?usp=sharing