### PR TITLE
Fix #22892: Prevent volunteer tab reset on mobile 

### DIFF
--- a/core/templates/pages/volunteer-page/volunteer-page.component.ts
+++ b/core/templates/pages/volunteer-page/volunteer-page.component.ts
@@ -383,16 +383,22 @@ export class VolunteerPageComponent implements OnInit, OnDestroy {
 
   setScreenType(): void {
     const width = this.windowDimensionsService.getWidth();
+    let newScreenType: 'desktop' | 'tablet' | 'mobile' | 'smallMobile';
+
     if (width < 440) {
-      this.screenType = 'smallMobile';
+      newScreenType = 'smallMobile';
     } else if (width < 641) {
-      this.screenType = 'mobile';
+      newScreenType = 'mobile';
     } else if (width < 769) {
-      this.screenType = 'tablet';
+      newScreenType = 'tablet';
     } else {
-      this.screenType = 'desktop';
+      newScreenType = 'desktop';
     }
-    this.activeTabGroupIndex = 0;
+
+    if (this.screenType !== newScreenType) {
+      this.screenType = newScreenType;
+      this.activeTabGroupIndex = 0;
+    }
   }
 
   incrementTabGroupIndex(): void {


### PR DESCRIPTION
## Overview

1. This PR fixes #22892.
2. This PR prevents the active volunteer tab from resetting on mobile devices during normal scrolling.
   On mobile browsers, scrolling causes the address bar to hide/show, which triggers `window.resize`
   events even though the actual screen layout (mobile/tablet/desktop) has not changed.
   Previously, the `setScreenType()` method unconditionally reset `activeTabGroupIndex` to `0`
   on every resize event, causing the UI to switch back to the default "Outreach" tab.
   This PR updates the logic to reset the tab index **only when the screen layout category actually changes**.
3. (For bug-fixing PRs only) The original bug occurred because `setScreenType()` was triggered on every
   resize event and always reset `activeTabGroupIndex` to `0`, even for minor viewport height changes
   caused by mobile browser UI behavior.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.  
      _(No existing tests cover this mobile resize behavior; adding tests will be handled in a follow-up PR if required.)_
- [x] The **PR title** starts with "Fix #22892: Prevent volunteer tab reset on mobile ".
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase
      "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

### Proof of changes on mobile phone

**Before fix**
- Selecting any volunteer category other than "Outreach" causes the page to automatically switch
  back to "Outreach" within a second while scrolling.

**After fix**
- Selected volunteer category remains stable during scrolling.
- Tab index resets only when switching between layout categories (mobile ↔ tablet ↔ desktop).

https://github.com/user-attachments/assets/c4a3224c-206d-4c44-9a40-5e9440b23043


## Additional Notes

- The change is limited to `core/templates/pages/volunteer-page/volunteer-page.component.ts`.
- No public APIs were modified.
- This fix improves mobile usability without affecting desktop behavior.
