### PR TITLE
Fix #23683: Align learning progress checkpoint numbers

### DIFF
--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/checkpoint-bar.component.css
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/checkpoint-bar.component.css
@@ -28,6 +28,7 @@
 }
 
 .completed-checkpoint-node {
+  align-items: center;
   background-color: #00645c;
   border-radius: 50%;
   cursor: pointer;
@@ -36,7 +37,6 @@
   justify-content: center;
   width: 25px;
   z-index: 0;
-  align-items: center;
 }
 
 .in-progress-checkpoint-node {

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/checkpoint-bar.component.css
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/checkpoint-bar.component.css
@@ -32,32 +32,33 @@
   border-radius: 50%;
   cursor: pointer;
   display: flex;
-  height: 12px;
+  height: 25px;
   justify-content: center;
-  width: 12px;
+  width: 25px;
   z-index: 0;
+  align-items: center;
 }
 
 .in-progress-checkpoint-node {
-  align-items: flex-start;
+  align-items: center;
   background-color: #fff;
   border: 2px solid #00645c;
   border-radius: 50%;
   display: flex;
-  height: 20px;
+  height: 25px;
   justify-content: center;
-  width: 20px;
+  width: 25px;
   z-index: 0;
 }
 
 .incomplete-checkpoint-node {
-  align-items: flex-end;
+  align-items: center;
   background-color: #fff;
   border: 1px solid #c0c0c0;
   border-radius: 50%;
   display: flex;
-  height: 12px;
+  height: 25px;
   justify-content: center;
-  width: 12px;
+  width: 25px;
   z-index: 111;
 }


### PR DESCRIPTION
## Overview

1. This PR fixes #23683.
2. This PR fixes the misalignment of numbered checkpoint indicators in the Learning Progress section by ensuring the checkpoint numbers are consistently centered within their circular containers across all states.
3. The original bug occurred because the checkpoint numbers had inconsistent sizing and alignment styles, causing the text to appear vertically misaligned within the circular indicators in certain states.

**Files Changed**
- `core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/checkpoint-bar.component.css`

**Changes Made**
- Updated the `.completed-checkpoint-node`, `.in-progress-checkpoint-node`, and `.incomplete-checkpoint-node` styles to use consistent dimensions and center alignment.
- Standardised `height` and `width` to `25px` and applied `align-items: center` to ensure the checkpoint numbers are visually centered.
- The sizing aligns with existing checkpoint styles used in `lesson-information-card-modal.component.css` to maintain UI consistency across the lesson player.

---

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

---

## Testing doc (for PRs with Beam jobs that modify production server data)

Not applicable - this PR only contains frontend CSS styling changes and does not affect production server data.

---

## Proof that changes are correct

### Proof of changes on desktop with slow/throttled network

**Before Changes**
<img width="1919" height="946" alt="image" src="https://github.com/user-attachments/assets/402ca145-ba62-40f3-8b21-592d48cea926" />


**After Changes**

https://github.com/user-attachments/assets/baaa9e3a-cbeb-4efd-bb40-ace1685691c5

### Proof of changes on mobile phone

Verified using responsive mode in browser developer tools; checkpoint numbers remain properly centered across viewport sizes.

### Proof of changes in Arabic language

Not applicable - this change affects numeric alignment only and is language-agnostic.

---

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
