### PR TITLE
Fix #23309, Fix #23312: Fix dropdown appearing on save/publish button hover

### DIFF
--- a/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.component.html
+++ b/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.component.html
@@ -1,9 +1,9 @@
 <ul class="nav navbar-nav oppia-navbar-nav float-right"
     id="skill-editor-navbar-desktop"
     *ngIf="!isLoadingSkill()">
-  <li class="oppia-publish-button-container"
+  <li class="oppia-publish-button-container d-inline-flex align-items-center"
       *ngIf="getActiveTabName() !== 'questions'">
-    <div ngbDropdown>
+    <div class="d-inline-block position-relative">
       <button class="btn btn-light oppia-save-changes-button oppia-save-publish-changes-button e2e-test-save-or-publish-skill"
               [ngClass]="{'btn-success': isSkillSaveable()}"
               (click)="saveChanges()"
@@ -25,23 +25,25 @@
           <loading-dots></loading-dots>
         </span>
       </button>
-      <button type="button"
-              class="btn btn-light dropdown-toggle oppia-dropdown-toggle oppia-dropdown-toggle-icon"
-              [disabled]="!getChangeListCount()"
-              aria-label="Dropdown toggle"
-              ngbDropdownToggle>
-      </button>
-      <ul ngbDropdownMenu
-          class="oppia-discard-draft-button-container"
-          [ngStyle]="{ width: getChangeListCount() ? '150px' : '120px' }">
-        <li title="Discard all pending changes">
-          <a (click)="discardChanges()"
-             [ngClass]="{'oppia-disabled-link': !getChangeListCount()}"
-             class="dropdown-item">
-             Discard Draft
-          </a>
-        </li>
-      </ul>
+      <div ngbDropdown class="d-inline-block ml-1">
+        <button type="button"
+                class="btn btn-light dropdown-toggle oppia-dropdown-toggle oppia-dropdown-toggle-icon"
+                [disabled]="!getChangeListCount()"
+                aria-label="Dropdown toggle"
+                ngbDropdownToggle>
+        </button>
+        <ul ngbDropdownMenu
+            class="oppia-discard-draft-button-container"
+            [ngStyle]="{ 'width': getChangeListCount() ? '150px' : '120px' }">
+          <li title="Discard all pending changes">
+            <a (click)="discardChanges()"
+               [ngClass]="{'oppia-disabled-link': !getChangeListCount()}"
+               class="dropdown-item">
+              Discard Draft
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </li>
 </ul>
@@ -124,8 +126,9 @@
     height: 34px;
   }
   .oppia-discard-draft-button-container {
+    left: auto;
     min-width: 125px;
-    right: inherit;
+    right: 0;
   }
   .oppia-save-publish-changes-button {
     float: left;

--- a/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.component.html
+++ b/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.component.html
@@ -1,7 +1,7 @@
 <ul class="oppia-navbar-desktop nav navbar-nav oppina-navbar-nav float-right"
     *ngIf="topic && topicRights.canEditTopic()">
-  <li class="oppia-navbar-dropdown-menu">
-    <div ngbDropdown>
+  <li class="oppia-navbar-dropdown-menu d-inline-flex align-items-center">
+    <div class="d-inline-block position-relative">
       <span [matTooltip]="getAllTopicWarnings()"
             matTooltipClass="oppia-mat-tooltip-list"
             [matTooltipDisabled]="isWarningTooltipDisabled()"
@@ -28,24 +28,25 @@
           </span>
         </button>
       </span>
-
-      <button type="button"
-              class="btn btn-light dropdown-toggle dropdown-toggle oppia-dropdown-toggle-button"
-              [disabled]="!changeListLength"
-              aria-label="Dropdown toggle"
-              ngbDropdownToggle>
-      </button>
-      <ul ngbDropdownMenu role="menu"
-          class="oppia-dropdown-menu"
-          [ngStyle]="{ width: changeListLength && topicRights.isPublished() ? '150px' : '120px' }">
-        <li title="Discard all pending changes">
-          <a (click)="discardChanges()"
-             [ngClass]="{'oppia-disabled-link': !changeListLength}"
-             class="dropdown-item">
-            Discard Draft
-          </a>
-        </li>
-      </ul>
+      <div ngbDropdown class="d-inline-block">
+        <button type="button"
+                class="btn btn-light dropdown-toggle dropdown-toggle oppia-dropdown-toggle-button"
+                [disabled]="!changeListLength"
+                aria-label="Dropdown toggle"
+                ngbDropdownToggle>
+        </button>
+        <ul ngbDropdownMenu role="menu"
+            class="oppia-dropdown-menu"
+            [ngStyle]="{ width: changeListLength && topicRights.isPublished() ? '150px' : '120px' }">
+          <li title="Discard all pending changes">
+            <a (click)="discardChanges()"
+               [ngClass]="{'oppia-disabled-link': !changeListLength}"
+               class="dropdown-item">
+              Discard Draft
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </li>
   <li class="oppia-editor-publish-button-container">
@@ -188,10 +189,12 @@
   .oppia-dropdown-toggle-button {
     height: 34px;
     margin-left: 5px !important;
+
   }
   .oppia-dropdown-menu {
+    left: auto;
     min-width: 125px;
-    right: inherit;
+    right: 0;
   }
   .oppia-editor-publish-button-container {
     margin-right: 20px;


### PR DESCRIPTION
## Overview

1. This PR fixes #23309 and fixes #23312.
2. This PR does the following: Fixes the issue where the "Discard Draft" label/dropdown was appearing incorrectly when hovering or clicking the "Save Changes" button (in Topic Editor) and "Publish Changes" button (in Skill Editor). It restructures the button layout using nested `btn-group` divs to properly isolate the `ngbDropdown` directive to the toggle arrow only, while maintaining the split-button visual appearance.
3. The original bug occurred because: The `ngbDropdown` directive was applied to a parent container that included both the main Save/Publish button and the dropdown toggle arrow. This caused hover or click events on the main button to propagate and trigger the dropdown logic.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Topic Editor:**
* Hovering/Clicking "Save Changes" no longer triggers "Discard Draft".
* Dropdown arrow still functions correctly.

https://github.com/user-attachments/assets/3d0a11fc-0238-43d7-a48d-582a6fc04a00




**Skill Editor:**
* Hovering/Clicking "Publish Changes" no longer triggers "Discard Draft".
* Dropdown arrow still functions correctly.


https://github.com/user-attachments/assets/bd313302-0822-4234-b2a1-f9da2524d71a


#### Proof of changes on mobile phone
No proof of changes needed because this feature is not present on mobile views.

#### Proof of changes in Arabic language

<img width="1896" height="863" alt="image" src="https://github.com/user-attachments/assets/499afeba-d9bd-4cee-a107-e1c3730281fc" />
<img width="1899" height="868" alt="image" src="https://github.com/user-attachments/assets/a4077f4a-bd44-4991-ac7e-dc0d48026ce9" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.