### PR TITLE
Fix #<23598>: Prevent navbar flicker during async auth resolution

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -62,7 +62,7 @@
       <ul *ngIf="!windowIsNarrow && !pageIsIframed"
           class="nav oppia-navbar-tabs">
         <li [ngClass]="{'show' : activeMenuName === 'homeMenu'}"
-            *ngIf="!userIsLoggedIn"
+            *ngIf="authStatusResolved && !userIsLoggedIn"
             [hidden]="!navElementsVisibilityStatus.I18N_TOPNAV_HOME"
             aria-hidden="false"
             class="nav-item  oppia-navbar-clickable-dropdown e2e-test-home-oppia-list-item">
@@ -351,7 +351,7 @@
       </div>
       <ul ngbDropdownMenu class="dropdown-menu oppia-navbar-dropdown language-dropdown"
           [ngClass]="{'oppia-embedded-navbar-dropdown': pageIsIframed}"
-          [style.margin-top]="userIsLoggedIn ? '-10px': '0'"
+          [style.margin-top]="authStatusResolved && userIsLoggedIn ? '-10px': '0'"
           (mouseover)="openSubmenu($event, 'languageMenu')"
           (mouseleave)="closeSubmenuIfNotMobile($event)">
         <li class="nav-item" [ngClass]="'e2e-test-i18n-language-' + language.id" *ngFor="let language of supportedSiteLanguages; let last = last">
@@ -372,7 +372,7 @@
     <li [ngClass]="{'show' : activeMenuName === 'profileMenu'}"
         ngbDropdown
         #profileDropdown="ngbDropdown"
-        *ngIf="userIsLoggedIn && !pageIsIframed"
+        *ngIf="authStatusResolved && userIsLoggedIn&& !pageIsIframed"
         class="nav-item e2e-test-profile-dropdown oppia-navbar-clickable-dropdown profile-dropdown pfl">
       <a [attr.aria-expanded]="profileDropdown.isOpen() ? 'true' : 'false'"
          (click)="profileDropdown.isOpen() ? profileDropdown.close() : profileDropdown.open();"
@@ -525,7 +525,7 @@
     </li>
 
     <li ngbDropdown
-        *ngIf="!userIsLoggedIn && username !== '' && !pageIsIframed"
+        *ngIf="authStatusResolved && !userIsLoggedIn && username !== '' && !pageIsIframed"
         class="nav-item oppia-navbar-clickable-dropdown dropdown">
       <div class="oppia-navbar-button-container dropdown oppia-navbar-button-container-extra-info sinin">
         <button ngbDropdownToggle

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -103,6 +103,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   isBlogAdmin: boolean = false;
   isBlogPostEditor: boolean = false;
   userIsLoggedIn: boolean = false;
+  authStatusResolved: boolean = false;
   currentUrl!: string;
   userMenuIsShown: boolean = false;
   inClassroomPage: boolean = false;
@@ -275,6 +276,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
       this.isBlogAdmin = userInfo.isBlogAdmin();
       this.isBlogPostEditor = userInfo.isBlogPostEditor();
       this.userIsLoggedIn = userInfo.isLoggedIn();
+      this.authStatusResolved = true;
       let usernameFromUserInfo = userInfo.getUsername();
       if (this.userIsLoggedIn) {
         let feedbackUpdatesDataPromise =


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #23598.
2. This PR fixes a brief navbar flicker caused by asynchronous authentication resolution by explicitly distinguishing the unresolved auth state from the resolved logged-in/logged-out states. The navbar now waits for auth resolution before rendering auth-dependent UI.
Although the issue was initially reported on a specific page, the underlying behavior was observed during general page navigation, and this fix addresses the shared navbar logic without expanding scope.
3. (For bug-fixing PRs only) The original bug occurred because the auth state was treated as a binary value (logged in / logged out), causing the UI to temporarily assume a logged-out state while the async auth check was still in progress.

## Essential Checklist

Please follow the instructions for making a code change.

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
(Tests were not added because this is a UI-only change that affects async rendering behavior, which is not currently covered by existing unit test patterns.)
- [x] The **PR title** starts with "Fix #23598 :" followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Proof Video added below : 
### Proof of changes on desktop with slow/throttled network

**Before: 

https://github.com/user-attachments/assets/92f12802-58de-40e5-bc5e-b678bedcc897

**After: 

https://github.com/user-attachments/assets/11c46985-8e4f-4303-9c6f-78b3af0c9d31

Proof of changes is provided above via before-and-after videos recorded under slow (3G) network throttling.

---

### Proof of changes on mobile phone

Not provided because this change affects shared navbar logic and does not introduce any mobile-specific UI changes. The behavior remains consistent across responsive layouts.

---

### Proof of changes in Arabic language

Not provided because this change does not affect layout, text direction, or any language-dependent UI elements.

---

## Files Changed

- `./core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts`
- `./core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html`

## PR Pointers

- I will not force push to this PR.
- I will follow Oppia’s guidelines when responding to review comments.
- I understand that some CI failures may be unrelated to this PR and will follow the CI failure guide if needed.
