### PR TITLE
Fix #22375: Persist Not Applicable misconception status in questions

### DIFF
--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -1140,6 +1140,7 @@ class UpdateQuestionSuggestionHandlerNormalizedPayloadDict(TypedDict):
     skill_difficulty: float
     question_state_data: state_domain.StateDict
     next_content_id_index: int
+    inapplicable_skill_misconception_ids: List[str]
 
 
 class UpdateQuestionSuggestionHandler(
@@ -1177,6 +1178,10 @@ class UpdateQuestionSuggestionHandler(
                 }
             },
             'next_content_id_index': {'schema': {'type': 'int'}},
+            'inapplicable_skill_misconception_ids': {
+                'schema': {'type': 'list', 'items': {'type': 'basestring'}},
+                'default_value': None,
+            },
         }
     }
 
@@ -1200,6 +1205,7 @@ class UpdateQuestionSuggestionHandler(
             self.normalized_payload['skill_difficulty'],
             self.normalized_payload['question_state_data'],
             self.normalized_payload['next_content_id_index'],
+            self.normalized_payload.get('inapplicable_skill_misconception_ids'),
         )
 
         self.render_json(self.values)

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -2577,6 +2577,7 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
 class QuestionSuggestionTests(test_utils.GenericTestBase):
 
     AUTHOR_EMAIL: Final = 'author@example.com'
+    REVIEWER_EMAIL: Final = 'reviewer@example.com'
 
     # Needs to be 12 characters long.
     SKILL_ID: Final = 'skill1234567'
@@ -2587,8 +2588,10 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
         super().setUp()
         self.signup(self.CURRICULUM_ADMIN_EMAIL, self.CURRICULUM_ADMIN_USERNAME)
         self.signup(self.AUTHOR_EMAIL, 'author')
+        self.signup(self.REVIEWER_EMAIL, 'reviewer')
         self.admin_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
         self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
+        self.reviewer_id = self.get_user_id_from_email(self.REVIEWER_EMAIL)
         self.set_curriculum_admins([self.CURRICULUM_ADMIN_USERNAME])
         self.save_new_skill(
             self.SKILL_ID, self.admin_id, description=self.SKILL_DESCRIPTION
@@ -2994,6 +2997,56 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
             },
             csrf_token=csrf_token,
         )
+        self.logout()
+
+    def test_update_question_suggestion_with_misconception_changes(
+        self,
+    ) -> None:
+        self.login(self.AUTHOR_EMAIL)
+        suggestions = self.get_json(
+            '%s?author_id=%s'
+            % (feconf.SUGGESTION_LIST_URL_PREFIX, self.author_id)
+        )['suggestions']
+        suggestion_id = suggestions[0]['suggestion_id']
+        suggestion = suggestion_services.get_suggestion_by_id(suggestion_id)
+        assert isinstance(suggestion, suggestion_registry.SuggestionAddQuestion)
+        self.logout()
+
+        self.login(self.REVIEWER_EMAIL)
+        # Give reviewer permission to review questions (if not already done in setUp, ensuring it here)
+        user_services.allow_user_to_review_question(self.reviewer_id)
+
+        new_inapplicable_ids = ['skillid12345-2']
+        question_dict = suggestion.change_cmd.question_dict
+        question_state_data = question_dict['question_state_data']
+        next_content_id_index = question_dict['next_content_id_index']
+
+        csrf_token = self.get_new_csrf_token()
+        self.post_json(
+            '%s/%s'
+            % (feconf.UPDATE_QUESTION_SUGGESTION_URL_PREFIX, suggestion_id),
+            {
+                'skill_difficulty': 0.3,
+                'question_state_data': question_state_data,
+                'next_content_id_index': next_content_id_index,
+                'inapplicable_skill_misconception_ids': new_inapplicable_ids,
+            },
+            csrf_token=csrf_token,
+        )
+
+        updated_suggestion = suggestion_services.get_suggestion_by_id(
+            suggestion_id
+        )
+        assert isinstance(
+            updated_suggestion, suggestion_registry.SuggestionAddQuestion
+        )
+        self.assertEqual(
+            updated_suggestion.change_cmd.question_dict[
+                'inapplicable_skill_misconception_ids'
+            ],
+            new_inapplicable_ids,
+        )
+
         self.logout()
 
 

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -2468,6 +2468,7 @@ def update_question_suggestion(
     skill_difficulty: float,
     question_state_data: state_domain.StateDict,
     next_content_id_index: int,
+    inapplicable_skill_misconception_ids: Optional[List[str]] = None,
 ) -> Optional[suggestion_registry.BaseSuggestion]:
     """Updates skill_difficulty and question_state_data of a suggestion with
     the given suggestion_id.
@@ -2478,6 +2479,8 @@ def update_question_suggestion(
         question_state_data: obj. Details of the question.
         next_content_id_index: int. The next content Id index for the question's
             content.
+        inapplicable_skill_misconception_ids: list(str)|None. The list of
+            inapplicable skill misconception ids for the question.
 
     Returns:
         Suggestion|None. The corresponding suggestion, or None if no suggestion
@@ -2493,7 +2496,16 @@ def update_question_suggestion(
             'Expected SuggestionAddQuestion suggestion but found: %s.'
             % type(suggestion).__name__
         )
+
+    if inapplicable_skill_misconception_ids is None:
+        inapplicable_skill_misconception_ids = []
+
     question_dict = suggestion.change_cmd.question_dict
+    question_dict['question_state_data'] = question_state_data
+    question_dict['next_content_id_index'] = next_content_id_index
+    question_dict['inapplicable_skill_misconception_ids'] = (
+        inapplicable_skill_misconception_ids
+    )
     new_change_obj = (
         question_domain.CreateNewFullySpecifiedQuestionSuggestionCmd(
             {

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -2518,9 +2518,7 @@ def update_question_suggestion(
                     ),
                     'linked_skill_ids': question_dict['linked_skill_ids'],
                     'inapplicable_skill_misconception_ids': (
-                        suggestion.change_cmd.question_dict[
-                            'inapplicable_skill_misconception_ids'
-                        ]
+                        inapplicable_skill_misconception_ids
                     ),
                     'next_content_id_index': next_content_id_index,
                 },

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -2501,11 +2501,6 @@ def update_question_suggestion(
         inapplicable_skill_misconception_ids = []
 
     question_dict = suggestion.change_cmd.question_dict
-    question_dict['question_state_data'] = question_state_data
-    question_dict['next_content_id_index'] = next_content_id_index
-    question_dict['inapplicable_skill_misconception_ids'] = (
-        inapplicable_skill_misconception_ids
-    )
     new_change_obj = (
         question_domain.CreateNewFullySpecifiedQuestionSuggestionCmd(
             {
@@ -2520,6 +2515,7 @@ def update_question_suggestion(
                     'inapplicable_skill_misconception_ids': (
                         inapplicable_skill_misconception_ids
                     ),
+                    'version': question_dict['version'],
                     'next_content_id_index': next_content_id_index,
                 },
                 'skill_id': suggestion.change_cmd.skill_id,

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -487,13 +487,14 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
   ): boolean {
     let skillId = this.selectedSkillId;
     let expectedMisconceptionIds = this.misconceptionIdsForSelectedSkill;
-    let actualMisconceptionIds = skillMisconceptionIds.map(
-      skillMisconceptionId => {
+    let actualMisconceptionIds = skillMisconceptionIds
+      .map(skillMisconceptionId => {
         if (skillMisconceptionId.startsWith(skillId)) {
           return parseInt(skillMisconceptionId.split('-')[1]);
         }
-      }
-    );
+        return null;
+      })
+      .filter(id => id !== null);
     return this.utilsService.isEquivalent(
       actualMisconceptionIds.sort(),
       expectedMisconceptionIds.sort()

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-editor-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-editor-modal.component.spec.ts
@@ -65,13 +65,14 @@ class MockContributionAndReviewService {
     suggestionId: string,
     skillDifficulty: string,
     questionStateData: string,
-    imagesData: File[]
+    nextContentIdIndex: string,
+    inapplicableSkillMisconceptionIds: string[],
+    imagesData: File[],
+    onSuccess: (suggestionId: string) => void,
+    onFailure: (suggestionId: string) => void
   ) {
-    return {
-      then: (successCallback: () => void, errorCallback: () => void) => {
-        successCallback();
-      },
-    };
+    onSuccess(suggestionId);
+    return Promise.resolve();
   }
 }
 
@@ -336,6 +337,7 @@ describe('Question Suggestion Editor Modal Component', () => {
         skillDifficulty,
         questionStateData,
         nextContentIdIndex,
+        inapplicableSkillMisconceptionIds,
         imagesData,
         successCallback,
         errorCallback

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-editor-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-editor-modal.component.ts
@@ -27,7 +27,7 @@ import {AppConstants} from 'app.constants';
 import {MisconceptionSkillMap} from 'domain/skill/misconception.model';
 import {Question} from 'domain/question/question.model';
 import {QuestionUndoRedoService} from 'domain/editor/undo_redo/question-undo-redo.service';
-import {Skill} from 'domain/skill/skill.model.ts';
+import {Skill} from 'domain/skill/skill.model';
 import {State} from 'domain/state/state.model';
 import {ConfirmOrCancelModal} from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
 import {ConfirmQuestionExitModalComponent} from 'components/question-directives/modal-templates/confirm-question-exit-modal.component';
@@ -172,6 +172,7 @@ export class QuestionSuggestionEditorModalComponent
         this.skillDifficulty,
         questionDict.question_state_data,
         questionDict.next_content_id_index,
+        questionDict.inapplicable_skill_misconception_ids,
         imagesData,
         () => {
           this.alertsService.addSuccessMessage('Updated question.');

--- a/core/templates/pages/contributor-dashboard-page/services/contribution-and-review.service.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/contribution-and-review.service.spec.ts
@@ -966,6 +966,8 @@ describe('Contribution and review service', () => {
     const payload = {
       skill_difficulty: 'easy',
       question_state_data: questionStateData,
+      next_content_id_index: 10,
+      inapplicable_skill_misconception_ids: ['skillid-1'],
     };
 
     const imagesData = [
@@ -1004,6 +1006,7 @@ describe('Contribution and review service', () => {
           2,
           questionStateData,
           10,
+          ['skillid-1'],
           imagesData,
           onSuccess,
           onFailure
@@ -1032,6 +1035,7 @@ describe('Contribution and review service', () => {
           2,
           questionStateData,
           10,
+          ['skillid-1'],
           imagesData,
           onSuccess,
           onFailure

--- a/core/templates/pages/contributor-dashboard-page/services/contribution-and-review.service.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/contribution-and-review.service.ts
@@ -469,6 +469,7 @@ export class ContributionAndReviewService {
     skillDifficulty: number,
     questionStateData: StateBackendDict,
     nextContentIdIndex: number,
+    inapplicableSkillMisconceptionIds: string[],
     imagesData: ImagesData[],
     onSuccess: (suggestionId: string) => void,
     onFailure: (suggestionId: string) => void
@@ -477,6 +478,7 @@ export class ContributionAndReviewService {
       skill_difficulty: skillDifficulty,
       question_state_data: questionStateData,
       next_content_id_index: nextContentIdIndex,
+      inapplicable_skill_misconception_ids: inapplicableSkillMisconceptionIds,
     };
     const requestBody = new FormData();
     requestBody.append('payload', JSON.stringify(payload));


### PR DESCRIPTION
## Overview

1. This PR fixes #22375.
2. This PR does the following: Ensures that the "Not Applicable" status for skill misconceptions (`inapplicable_skill_misconception_ids`) is correctly persisted when a question suggestion is edited.
3. (For bug-fixing PRs only) The original bug occurred because: The `inapplicable_skill_misconception_ids` field was not included in the payload sent from the frontend to the `UpdateQuestionSuggestionHandler`, preventing the backend from persisting this field on save.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Before fix:**
- Effect: After a reviewer marked a misconception as “Not Applicable” and accepted the question, the Skill Editor did not reflect this change. The Question List continued to show the “Unaddressed misconception” warning.

![skill editor not marked not applicable bug](https://github.com/user-attachments/assets/ad8e8d04-d94e-4817-afaf-be8616a9ec8e)
![question list warning bug](https://github.com/user-attachments/assets/eb0b704c-c4c6-479e-b600-95b60542bc9a)

**After fix:**
- Effect: The misconception remains correctly marked as “Not Applicable” in the Skill Editor after the question is accepted. The Question List no longer shows the warning.

![misconception not applicable now fixed](https://github.com/user-attachments/assets/b05578c9-c84a-404e-90ec-74cebd5bcfac)
![question list fixed](https://github.com/user-attachments/assets/eb4e2471-1ab6-4e09-8eb6-570ad2ca21b3)

#### Proof of changes on mobile phone
N/A (This PR focuses on backend persistence and frontend data flow, with no mobile-specific UI changes.)

#### Proof of changes in Arabic language
N/A (No UI text or layout changes.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.