### PR TITLE
Fix #24156: Draft Lessons should not be shown on the Learner Dashboard

### DIFF
--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -80,8 +80,8 @@ class StoryPageDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         # are adding new keys that are not defined on the 'StoryNodeDict'.
         ordered_node_dicts: List[FrontendStoryNodeDict] = [
             node.to_dict()
-            for node in story.story_contents.get_ordered_nodes()  # type: ignore[misc]
-            if node.status != constants.STORY_NODE_STATUS_DRAFT
+            for node in story.story_contents.get_ordered_nodes()
+            if node.status != constants.STORY_NODE_STATUS_DRAFT  # type: ignore[misc]
         ]
         for node in ordered_node_dicts:
             node['completed'] = False

--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -79,7 +79,9 @@ class StoryPageDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         # 'FrontendStoryNodeDict', and this is done because below we
         # are adding new keys that are not defined on the 'StoryNodeDict'.
         ordered_node_dicts: List[FrontendStoryNodeDict] = [
-            node.to_dict() for node in story.story_contents.get_ordered_nodes()  # type: ignore[misc]
+            node.to_dict()
+            for node in story.story_contents.get_ordered_nodes()  # type: ignore[misc]
+            if node.status != constants.STORY_NODE_STATUS_DRAFT
         ]
         for node in ordered_node_dicts:
             node['completed'] = False

--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -79,9 +79,9 @@ class StoryPageDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         # 'FrontendStoryNodeDict', and this is done because below we
         # are adding new keys that are not defined on the 'StoryNodeDict'.
         ordered_node_dicts: List[FrontendStoryNodeDict] = [
-            node.to_dict()
+            node.to_dict()  # type: ignore[misc]
             for node in story.story_contents.get_ordered_nodes()
-            if node.status != constants.STORY_NODE_STATUS_DRAFT  # type: ignore[misc]
+            if node.status != constants.STORY_NODE_STATUS_DRAFT
         ]
         for node in ordered_node_dicts:
             node['completed'] = False

--- a/core/domain/story_fetchers.py
+++ b/core/domain/story_fetchers.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 import copy
 import itertools
 
-from core.constants import constants
 from core import feconf
+from core.constants import constants
 from core.domain import (
     caching_services,
     classroom_config_services,

--- a/core/domain/story_fetchers.py
+++ b/core/domain/story_fetchers.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import copy
 import itertools
 
+from core.constants import constants
 from core import feconf
 from core.domain import (
     caching_services,
@@ -708,9 +709,13 @@ def get_pending_and_all_nodes_in_story(
     for node in story.story_contents.nodes:
         if node.id not in completed_node_ids:
             pending_nodes.append(node)
+    all_nodes = []
 
+    for node in story.story_contents.nodes:
+        if node.status != constants.STORY_NODE_STATUS_DRAFT:
+            all_nodes.append(node)
     return {
-        'all_nodes': story.story_contents.nodes,
+        'all_nodes': all_nodes,
         'pending_nodes': pending_nodes,
     }
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #24156.
2. This PR does the following: Change backend logic to not include draft nodes.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

[Screencast from 2026-01-11 13-16-10.webm](https://github.com/user-attachments/assets/a306b76f-bb7c-41ec-bcc3-8888bb19d516)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
