### PR TITLE
Fix part of #21970: Refactor UserEmailPreferences to use domain object

### DIFF
--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -558,6 +558,9 @@ class UserGroupDict(TypedDict):
     user_group_id: str
     name: str
     member_usernames: List[str]
+    
+class UserEmailPreferences:
+    """Domain object for a user's email preferences."""
 
 
 class UserGroup:

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -561,6 +561,21 @@ class UserGroupDict(TypedDict):
     
 class UserEmailPreferences:
     """Domain object for a user's email preferences."""
+        def __init__(
+        self,
+        user_id: str,
+        site_updates: Optional[bool],
+        editor_role_notifications: bool,
+        feedback_message_notifications: bool,
+        subscription_notifications: bool,
+    ) -> None:
+        self.user_id = user_id
+        self.site_updates = site_updates
+        self.editor_role_notifications = editor_role_notifications
+        self.feedback_message_notifications = feedback_message_notifications
+        self.subscription_notifications = subscription_notifications
+
+    
 
 
 class UserGroup:

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -26,6 +26,10 @@ from core.constants import constants
 
 from typing import Dict, List, Optional, TypedDict
 
+from typing import Optional
+from core import utils
+
+
 
 # TODO(#15105): Refactor UserSettings to limit the number of Optional
 # fields used in UserSettingsDict.
@@ -574,6 +578,38 @@ class UserEmailPreferences:
         self.editor_role_notifications = editor_role_notifications
         self.feedback_message_notifications = feedback_message_notifications
         self.subscription_notifications = subscription_notifications
+          
+        def validate(self) -> None:
+        """Validates the properties of this UserEmailPreferences object."""
+        if not isinstance(self.user_id, str):
+            raise utils.ValidationError('user_id must be a string.')
+        if not self.user_id:
+            raise utils.ValidationError('user_id must be non-empty.')
+
+        if self.site_updates is not None and not isinstance(
+            self.site_updates, bool
+        ):
+            raise utils.ValidationError(
+                'site_updates must be a boolean or None.'
+            )
+
+        if not isinstance(self.editor_role_notifications, bool):
+            raise utils.ValidationError(
+                'editor_role_notifications must be a boolean.'
+            )
+
+        if not isinstance(self.feedback_message_notifications, bool):
+            raise utils.ValidationError(
+                'feedback_message_notifications must be a boolean.'
+            )
+
+        if not isinstance(self.subscription_notifications, bool):
+            raise utils.ValidationError(
+                'subscription_notifications must be a boolean.'
+            )
+
+
+
 
     
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1913,20 +1913,40 @@ def update_email_preferences(
     email_preferences_model = user_models.UserEmailPreferencesModel.get(
         user_id, strict=False
     )
-    if email_preferences_model is None:
-        email_preferences_model = user_models.UserEmailPreferencesModel(
-            id=user_id
-        )
-
-    email_preferences_model.editor_role_notifications = (
+   if email_preferences_model is None:
+        email_preferences = user_domain.UserEmailPreferences(
+            user_id=user_id,
+            site_updates=can_receive_email_updates,
+            editor_role_notifications=can_receive_editor_role_email,
+            feedback_message_notifications=can_receive_feedback_email,
+            subscription_notifications=can_receive_subscription_email,
+    )
+    else:
+        email_preferences = (
+            email_preferences_model.to_domain_object()
+                )
+    email_preferences.site_updates = can_receive_email_updates
+    email_preferences.editor_role_notifications = (
         can_receive_editor_role_email
     )
-    email_preferences_model.feedback_message_notifications = (
+    email_preferences.feedback_message_notifications = (
         can_receive_feedback_email
     )
-    email_preferences_model.subscription_notifications = (
+    email_preferences.subscription_notifications = (
         can_receive_subscription_email
     )
+    email_preferences.validate()
+    if email_preferences_model is None:
+         email_preferences_model = user_models.UserEmailPreferencesModel(
+                id=user_id
+            )
+        
+    email_preferences_model.update_from_domain_object(
+        email_preferences
+    )
+    email_preferences_model.put()
+
+
     email = get_email_from_user_id(user_id)
     # Mailchimp database should not be updated in servers where sending
     # emails is not allowed.
@@ -1935,6 +1955,7 @@ def update_email_preferences(
             platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
         )
     )
+    user_creation_successful= True
     if not bulk_email_db_already_updated and server_can_send_emails:
         user_creation_successful = (
             bulk_email_services.add_or_update_user_status(
@@ -1944,14 +1965,15 @@ def update_email_preferences(
                 can_receive_email_updates=can_receive_email_updates,
             )
         )
-        if not user_creation_successful:
-            email_preferences_model.site_updates = False
-            email_preferences_model.update_timestamps()
-            email_preferences_model.put()
-            return True
-    email_preferences_model.site_updates = can_receive_email_updates
-    email_preferences_model.update_timestamps()
-    email_preferences_model.put()
+    if not user_creation_successful:
+        email_preferences.site_updates = False
+        email_preferences.validate()
+        email_preferences_model.update_from_domain_object(
+            email_preferences
+        )
+        email_preferences_model.put()
+        return True
+ 
     return False
 
 
@@ -1970,13 +1992,21 @@ def get_email_preferences(user_id: str) -> user_domain.UserGlobalPrefs:
     )
     if email_preferences_model is None:
         return user_domain.UserGlobalPrefs.create_default_prefs()
+        
     else:
-        return user_domain.UserGlobalPrefs(
-            email_preferences_model.site_updates,
-            email_preferences_model.editor_role_notifications,
-            email_preferences_model.feedback_message_notifications,
-            email_preferences_model.subscription_notifications,
-        )
+    email_preferences = (
+        email_preferences_model.to_domain_object()
+    )
+    email_preferences.validate()
+
+    return user_domain.UserGlobalPrefs(
+        email_preferences.site_updates,
+        email_preferences.editor_role_notifications,
+        email_preferences.feedback_message_notifications,
+        email_preferences.subscription_notifications,
+    )
+
+  )
 
 
 def get_users_email_preferences(
@@ -2001,12 +2031,18 @@ def get_users_email_preferences(
         if email_preferences_model is None:
             result.append(user_domain.UserGlobalPrefs.create_default_prefs())
         else:
-            result.append(
-                user_domain.UserGlobalPrefs(
-                    email_preferences_model.site_updates,
-                    email_preferences_model.editor_role_notifications,
-                    email_preferences_model.feedback_message_notifications,
-                    email_preferences_model.subscription_notifications,
+           email_preferences = (
+            email_preferences_model.to_domain_object()
+            )
+            email_preferences.validate()
+
+        result.append(
+            user_domain.UserGlobalPrefs(
+                email_preferences.site_updates,
+                email_preferences.editor_role_notifications,
+                email_preferences.feedback_message_notifications,
+                email_preferences.subscription_notifications,
+            
                 )
             )
 

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -25,6 +25,8 @@ import string
 from core import feconf, utils
 from core.constants import constants
 from core.platform import models
+from core.domain import user_domain
+
 
 from typing import (
     Dict,
@@ -1064,6 +1066,31 @@ class UserEmailPreferencesModel(base_models.BaseModel):
     subscription_notifications = datastore_services.BooleanProperty(
         indexed=True, default=feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE
     )
+    
+        def to_domain_object(self) -> user_domain.UserEmailPreferences:
+        """Returns the domain object representation of this model."""
+        return user_domain.UserEmailPreferences(
+            user_id=self.id,
+            site_updates=self.site_updates,
+            editor_role_notifications=self.editor_role_notifications,
+            feedback_message_notifications=self.feedback_message_notifications,
+            subscription_notifications=self.subscription_notifications,
+        )
+        def update_from_domain_object(
+        self, domain_object: user_domain.UserEmailPreferences
+    ) -> None:
+        """Updates this model from the given domain object."""
+        self.site_updates = domain_object.site_updates
+        self.editor_role_notifications = (
+            domain_object.editor_role_notifications
+        )
+        self.feedback_message_notifications = (
+            domain_object.feedback_message_notifications
+        )
+        self.subscription_notifications = (
+            domain_object.subscription_notifications
+        )
+
 
     @staticmethod
     def get_deletion_policy() -> base_models.DELETION_POLICY:
@@ -1122,6 +1149,7 @@ class UserEmailPreferencesModel(base_models.BaseModel):
                 'feedback_message_notifications': user_email_preferences.feedback_message_notifications,
                 'subscription_notifications': user_email_preferences.subscription_notifications,
             }
+    
         else:
             return {}
 


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21970.
2. This PR introduces the UserEmailPreferences domain object and refactors
   user_services to ensure business logic operates on the domain object
   instead of directly accessing UserEmailPreferencesModel.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix part of #21970: ", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

No proof of changes needed because this PR refactors backend domain logic
and does not affect user-facing behavior.
