### PR TITLE
Fix #12844: Sort translation contribution cards and add verification tests

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
@@ -2844,6 +2844,22 @@ describe('Contributions and review component', () => {
             chapter_title: 'Chapter',
           },
         },
+        suggestion_4: {
+          suggestion: {
+            suggestion_id: 'suggestion_4',
+            status: 'accepted',
+            change_cmd: {
+              content_html: 'Content 4',
+              translation_html: 'Translation 4',
+            },
+            exploration_content_html: null,
+          },
+          details: {
+            topic_name: 'Topic',
+            story_title: 'Story',
+            chapter_title: 'Chapter',
+          },
+        },
       } as unknown as Record<string, SuggestionDetails>;
 
       const summaryList = component.getTranslationContributionsSummary(
@@ -2858,6 +2874,9 @@ describe('Contributions and review component', () => {
 
       expect(summaryList[2].id).toBe('suggestion_3');
       expect(summaryList[2].labelText).toBe('Accepted');
+
+      expect(summaryList[3].id).toBe('suggestion_4');
+      expect(summaryList[3].labelText).toBe('Obsolete');
     }));
   });
 });

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
@@ -2793,5 +2793,71 @@ describe('Contributions and review component', () => {
 
       expect(commitQueuedSuggestionSpy).toHaveBeenCalled();
     });
+
+    it('should sort translation contributions by status', fakeAsync(() => {
+      const suggestionIdToSuggestions = {
+        suggestion_1: {
+          suggestion: {
+            suggestion_id: 'suggestion_1',
+            status: 'review',
+            change_cmd: {
+              content_html: 'Content 1',
+              translation_html: 'Translation 1',
+            },
+            exploration_content_html: 'Content 1',
+          },
+          details: {
+            topic_name: 'Topic',
+            story_title: 'Story',
+            chapter_title: 'Chapter',
+          },
+        },
+        suggestion_2: {
+          suggestion: {
+            suggestion_id: 'suggestion_2',
+            status: 'rejected',
+            change_cmd: {
+              content_html: 'Content 2',
+              translation_html: 'Translation 2',
+            },
+            exploration_content_html: 'Content 2',
+          },
+          details: {
+            topic_name: 'Topic',
+            story_title: 'Story',
+            chapter_title: 'Chapter',
+          },
+        },
+        suggestion_3: {
+          suggestion: {
+            suggestion_id: 'suggestion_3',
+            status: 'accepted',
+            change_cmd: {
+              content_html: 'Content 3',
+              translation_html: 'Translation 3',
+            },
+            exploration_content_html: 'Content 3',
+          },
+          details: {
+            topic_name: 'Topic',
+            story_title: 'Story',
+            chapter_title: 'Chapter',
+          },
+        },
+      } as unknown as Record<string, SuggestionDetails>;
+
+      const summaryList = component.getTranslationContributionsSummary(
+        suggestionIdToSuggestions
+      );
+
+      expect(summaryList[0].id).toBe('suggestion_2');
+      expect(summaryList[0].labelText).toBe('Revisions Requested');
+
+      expect(summaryList[1].id).toBe('suggestion_3');
+      expect(summaryList[1].labelText).toBe('Accepted');
+
+      expect(summaryList[2].id).toBe('suggestion_1');
+      expect(summaryList[2].labelText).toBe('Awaiting review');
+    }));
   });
 });

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
@@ -2853,11 +2853,11 @@ describe('Contributions and review component', () => {
       expect(summaryList[0].id).toBe('suggestion_2');
       expect(summaryList[0].labelText).toBe('Revisions Requested');
 
-      expect(summaryList[1].id).toBe('suggestion_3');
-      expect(summaryList[1].labelText).toBe('Accepted');
+      expect(summaryList[1].id).toBe('suggestion_1');
+      expect(summaryList[1].labelText).toBe('Awaiting review');
 
-      expect(summaryList[2].id).toBe('suggestion_1');
-      expect(summaryList[2].labelText).toBe('Awaiting review');
+      expect(summaryList[2].id).toBe('suggestion_3');
+      expect(summaryList[2].labelText).toBe('Accepted');
     }));
   });
 });

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
@@ -290,9 +290,9 @@ export class ContributionsAndReview implements OnInit, OnDestroy {
       const getPriority = (statusLabel: string) => {
         if (statusLabel === this.SUGGESTION_LABELS.rejected.text) {
           return 0;
-        } else if (statusLabel === this.SUGGESTION_LABELS.accepted.text) {
-          return 1;
         } else if (statusLabel === this.SUGGESTION_LABELS.review.text) {
+          return 1;
+        } else if (statusLabel === this.SUGGESTION_LABELS.accepted.text) {
           return 2;
         }
         return 3;

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
@@ -285,6 +285,25 @@ export class ContributionsAndReview implements OnInit, OnDestroy {
 
       translationContributionsSummaryList.push(requiredData);
     });
+
+    translationContributionsSummaryList.sort((a, b) => {
+      const getPriority = (statusLabel: string) => {
+        if (statusLabel === this.SUGGESTION_LABELS.rejected.text) {
+          return 0;
+        } else if (statusLabel === this.SUGGESTION_LABELS.accepted.text) {
+          return 1;
+        } else if (statusLabel === this.SUGGESTION_LABELS.review.text) {
+          return 2;
+        }
+        return 3;
+      };
+
+      const priorityA = getPriority(a.labelText);
+      const priorityB = getPriority(b.labelText);
+
+      return priorityA - priorityB;
+    });
+
     return translationContributionsSummaryList;
   }
 


### PR DESCRIPTION
## Overview

1. This PR fixes #12844.
2. This PR does the following: Implements client-side sorting for translation contribution cards to prioritize them in the order: **Revisions Requested** > **Accepted** > **Awaiting Review**. This ensures that items needing attention (rejected) or recently completed (accepted) are seen first. It also adds a unit test to verify this sorting logic.
3. (For bug-fixing PRs only) The original bug occurred because: The contribution cards were not receiving any specific sorting based on status, causing "Revisions Requested" items to be buried in the list.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network
![fix translations](https://github.com/user-attachments/assets/82c3f6fd-0603-4d18-8c91-b9a32247a346)

#### Proof of changes on mobile phone
N/A (Sorting logic applies generally; no specific mobile UI changes)

#### Proof of changes in Arabic language
N/A (No translation or layout direction changes)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.