### PR TITLE
Fix part of #23677: Learn dropdown RTL layout

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -644,4 +644,3 @@
 :lang(ar) .get-involved-dropdown .d-flex {
   direction: rtl;
 }
-

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -616,3 +616,32 @@
     }
   }
 }
+:lang(ar) .get-involved-dropdown .des {
+  padding-left: 0;
+  padding-right: 36px;
+}
+
+:lang(ar) .top-section .heading-text,
+:lang(ar) .bottom-section .heading-text {
+  margin-left: 0;
+  margin-right: 7px;
+}
+
+:lang(ar) .bottom-section .heading-text {
+  margin-right: 9px;
+}
+
+:lang(ar) .oppia-navbar-arrow-right {
+  padding-left: 0;
+  padding-right: 8px;
+  transform: scaleX(-1);
+}
+
+:lang(ar) .learn-dropdown-menu .nav-item-main {
+  direction: rtl;
+}
+
+:lang(ar) .get-involved-dropdown .d-flex {
+  direction: rtl;
+}
+

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -98,9 +98,9 @@
             </span>
           </a>
           <ul ngbDropdownMenu
-              [ngStyle]="{'left.px': learnDropdownOffset}"
               [ngClass]="{
                 'dropdown-menu oppia-navbar-dropdown learn-dropdown-menu classroom-enabled': true,
+                'dropdown-menu-end': isLanguageRTL(),
                 'two-columns': classroomSummariesLength == 2,
                 'three-columns': classroomSummariesLength >= 3
               }"
@@ -247,7 +247,6 @@
             </span>
           </a>
           <ul ngbDropdownMenu
-              [ngStyle]="{'left.px': getInvolvedMenuOffset}"
               class="dropdown-menu oppia-navbar-dropdown get-involved-dropdown"
               (mouseover)="openSubmenu($event, 'getInvolvedMenu')"
               (mouseleave)="closeSubmenuIfNotMobile($event)">


### PR DESCRIPTION
## Overview
This PR fixes or fixes part of #23677.

This PR fixes an RTL (Arabic) layout issue where the tabs dropdown in the menu bar was not mirrored correctly on the Learn page and the Creator Dashboard. The dropdown alignment and arrow direction did not respect RTL block ordering, leading to a broken UI in Arabic.

(For bug-fixing PRs only) The original bug occurred because the Learn dropdown layout did not explicitly handle RTL block ordering and arrow direction, causing incorrect alignment in RTL languages.

## Essential Checklist
Please follow the instructions for making a code change.

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix part of #23677: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)
N/A

## Proof that changes are correct

### Proof of changes on desktop with slow/throttled network
Verified the Learn dropdown layout on desktop with the network throttled to 3G.  
No UI regressions or layout issues were observed.

### Proof of changes on mobile phone
Verified using browser responsive mode.  
The Learn dropdown layout behaves correctly on smaller screen sizes.

### Proof of changes in Arabic language
Problem screenshots:

<img width="2003" height="1020" alt="problem 1" src="https://github.com/user-attachments/assets/2423bfdb-48a3-42ae-8926-4e139d8207e3" />
<img width="1920" height="1020" alt="problem 2" src="https://github.com/user-attachments/assets/16238612-1dc1-4132-8dde-c768d45a758f" />

The dropdown layout is now correctly mirrored in RTL mode, with proper alignment and arrow direction on both dashboards.

Screen recordings demonstrating the fix in Arabic (RTL):

**Learner Dashboard:**  
https://drive.google.com/file/d/1YVQsoIscRVdhli95XJ2UZKxOz9EpygFY/view?usp=sharing

**Creator Dashboard:**  
https://drive.google.com/file/d/1OI2SjLFu7aSNBt7JTCm0HZurby4A8t96/view?usp=sharing

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions:  
  https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky and can fail for reasons unrelated to your PR.
- See the Code Owner's wiki page for what code owners will expect.
