### PR TITLE
Fix #16535: Exclude draft chapters from learner dashboard chapter count

### DIFF
--- a/core/templates/components/summary-tile/learner-topic-goals-summary-tile.component.spec.ts
+++ b/core/templates/components/summary-tile/learner-topic-goals-summary-tile.component.spec.ts
@@ -211,4 +211,288 @@ describe('Learner Topic Goals Summary Tile Component', () => {
 
     expect(mockEvent.preventDefault).not.toHaveBeenCalled();
   });
+
+  describe('getPublishedNodesCount', () => {
+    it('should return all nodes count when serial chapter feature is disabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        false;
+      component.ngOnInit();
+      const story = component.storySummaryToDisplay;
+
+      const count = component.getPublishedNodesCount(story);
+      expect(count).toEqual(2);
+    });
+
+    it('should return only published nodes count when serial chapter feature is enabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        true;
+      const draftNode = {
+        id: 'node_draft',
+        thumbnail_filename: 'image3.png',
+        title: 'Draft Chapter',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_3',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const learnerTopicSummaryBackendDictWithDraft = {
+        id: 'sample_topic_id_2',
+        name: 'Topic Name',
+        language_code: 'en',
+        description: 'description',
+        version: 1,
+        story_titles: ['Story 1'],
+        total_published_node_count: 2,
+        thumbnail_filename: 'image.svg',
+        thumbnail_bg_color: '#C6DCDA',
+        classroom_name: 'math',
+        classroom_url_fragment: 'math',
+        practice_tab_is_displayed: false,
+        canonical_story_summary_dict: [
+          {
+            id: '0',
+            title: 'Story Title',
+            description: 'Story Description',
+            node_titles: ['Chapter 1', 'Chapter 2', 'Draft Chapter'],
+            thumbnail_filename: 'image.svg',
+            thumbnail_bg_color: '#F8BF74',
+            story_is_published: true,
+            completed_node_titles: ['Chapter 2'],
+            all_node_dicts: [
+              {
+                id: 'node_1',
+                thumbnail_filename: 'image1.png',
+                title: 'Chapter 1',
+                description: 'Description 1',
+                prerequisite_skill_ids: ['skill_1'],
+                acquired_skill_ids: ['skill_2'],
+                destination_node_ids: ['node_2'],
+                outline: 'Outline',
+                exploration_id: 'exp_1',
+                outline_is_finalized: false,
+                thumbnail_bg_color: '#a33f40',
+                status: 'Published',
+                planned_publication_date_msecs: 100,
+                last_modified_msecs: 100,
+                first_publication_date_msecs: 200,
+                unpublishing_reason: null,
+              },
+              {
+                id: 'node_2',
+                thumbnail_filename: 'image2.png',
+                title: 'Chapter 2',
+                description: 'Description 1',
+                prerequisite_skill_ids: ['skill_1'],
+                acquired_skill_ids: ['skill_2'],
+                destination_node_ids: ['node_3'],
+                outline: 'Outline',
+                exploration_id: 'exp_2',
+                outline_is_finalized: false,
+                thumbnail_bg_color: '#a33f40',
+                status: 'Published',
+                planned_publication_date_msecs: 100,
+                last_modified_msecs: 100,
+                first_publication_date_msecs: 200,
+                unpublishing_reason: null,
+              },
+              draftNode,
+            ],
+            url_fragment: 'story-title',
+            topic_name: 'Topic Name',
+            classroom_url_fragment: 'math',
+            topic_url_fragment: 'topic-name',
+          },
+        ],
+        url_fragment: 'topic-name',
+        subtopics: [],
+        degrees_of_mastery: {},
+        skill_descriptions: {},
+      };
+      component.topicSummary = LearnerTopicSummary.createFromBackendDict(
+        learnerTopicSummaryBackendDictWithDraft
+      );
+      component.ngOnInit();
+      const story = component.storySummaryToDisplay;
+
+      const count = component.getPublishedNodesCount(story);
+      expect(count).toEqual(2);
+    });
+  });
+
+  describe('Story progress calculation with serial chapter feature', () => {
+    it('should calculate storyProgress using published nodes only when feature enabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        true;
+      const draftNode = {
+        id: 'node_draft',
+        thumbnail_filename: 'image3.png',
+        title: 'Draft Chapter',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_3',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const learnerTopicSummaryBackendDictWithDraft = {
+        id: 'sample_topic_id_3',
+        name: 'Topic Name',
+        language_code: 'en',
+        description: 'description',
+        version: 1,
+        story_titles: ['Story 1'],
+        total_published_node_count: 2,
+        thumbnail_filename: 'image.svg',
+        thumbnail_bg_color: '#C6DCDA',
+        classroom_name: 'math',
+        classroom_url_fragment: 'math',
+        practice_tab_is_displayed: false,
+        canonical_story_summary_dict: [
+          {
+            id: '0',
+            title: 'Story Title',
+            description: 'Story Description',
+            node_titles: ['Chapter 1', 'Chapter 2', 'Draft Chapter'],
+            thumbnail_filename: 'image.svg',
+            thumbnail_bg_color: '#F8BF74',
+            story_is_published: true,
+            completed_node_titles: ['Chapter 1'],
+            all_node_dicts: [
+              {
+                id: 'node_1',
+                thumbnail_filename: 'image1.png',
+                title: 'Chapter 1',
+                description: 'Description 1',
+                prerequisite_skill_ids: ['skill_1'],
+                acquired_skill_ids: ['skill_2'],
+                destination_node_ids: ['node_2'],
+                outline: 'Outline',
+                exploration_id: 'exp_1',
+                outline_is_finalized: false,
+                thumbnail_bg_color: '#a33f40',
+                status: 'Published',
+                planned_publication_date_msecs: 100,
+                last_modified_msecs: 100,
+                first_publication_date_msecs: 200,
+                unpublishing_reason: null,
+              },
+              {
+                id: 'node_2',
+                thumbnail_filename: 'image2.png',
+                title: 'Chapter 2',
+                description: 'Description 1',
+                prerequisite_skill_ids: ['skill_1'],
+                acquired_skill_ids: ['skill_2'],
+                destination_node_ids: ['node_3'],
+                outline: 'Outline',
+                exploration_id: 'exp_2',
+                outline_is_finalized: false,
+                thumbnail_bg_color: '#a33f40',
+                status: 'Published',
+                planned_publication_date_msecs: 100,
+                last_modified_msecs: 100,
+                first_publication_date_msecs: 200,
+                unpublishing_reason: null,
+              },
+              draftNode,
+            ],
+            url_fragment: 'story-title',
+            topic_name: 'Topic Name',
+            classroom_url_fragment: 'math',
+            topic_url_fragment: 'topic-name',
+          },
+        ],
+        url_fragment: 'topic-name',
+        subtopics: [],
+        degrees_of_mastery: {},
+        skill_descriptions: {},
+      };
+      component.topicSummary = LearnerTopicSummary.createFromBackendDict(
+        learnerTopicSummaryBackendDictWithDraft
+      );
+      component.ngOnInit();
+
+      expect(component.storyProgress).toEqual(50);
+    });
+
+    it('should return 0 progress when no published nodes exist', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        true;
+      const draftNode = {
+        id: 'node_draft',
+        thumbnail_filename: 'image3.png',
+        title: 'Draft Chapter',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_3',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const learnerTopicSummaryBackendDictAllDraft = {
+        id: 'sample_topic_id_4',
+        name: 'Topic Name',
+        language_code: 'en',
+        description: 'description',
+        version: 1,
+        story_titles: ['Story 1'],
+        total_published_node_count: 0,
+        thumbnail_filename: 'image.svg',
+        thumbnail_bg_color: '#C6DCDA',
+        classroom_name: 'math',
+        classroom_url_fragment: 'math',
+        practice_tab_is_displayed: false,
+        canonical_story_summary_dict: [
+          {
+            id: '0',
+            title: 'Story Title',
+            description: 'Story Description',
+            node_titles: ['Draft Chapter'],
+            thumbnail_filename: 'image.svg',
+            thumbnail_bg_color: '#F8BF74',
+            story_is_published: true,
+            completed_node_titles: [],
+            all_node_dicts: [draftNode],
+            url_fragment: 'story-title',
+            topic_name: 'Topic Name',
+            classroom_url_fragment: 'math',
+            topic_url_fragment: 'topic-name',
+          },
+        ],
+        url_fragment: 'topic-name',
+        subtopics: [],
+        degrees_of_mastery: {},
+        skill_descriptions: {},
+      };
+      component.topicSummary = LearnerTopicSummary.createFromBackendDict(
+        learnerTopicSummaryBackendDictAllDraft
+      );
+      component.ngOnInit();
+
+      expect(component.storyProgress).toEqual(0);
+    });
+  });
 });

--- a/core/templates/components/summary-tile/learner-topic-goals-summary-tile.component.ts
+++ b/core/templates/components/summary-tile/learner-topic-goals-summary-tile.component.ts
@@ -143,8 +143,9 @@ export class LearnerTopicGoalsSummaryTileComponent implements OnInit {
       this.storyName = this.storySummaryToDisplay.getTitle();
 
       this.storyNodeLink = this.getStoryNodeLink();
-      let totalStoryNodesCount =
-        this.storySummaryToDisplay.getAllNodes().length;
+      let totalStoryNodesCount = this.getPublishedNodesCount(
+        this.storySummaryToDisplay
+      );
       let completedNodesCount =
         this.storySummaryToDisplay.getCompletedNodeTitles().length;
       const allNodes = this.storySummaryToDisplay.getAllNodes();
@@ -153,9 +154,13 @@ export class LearnerTopicGoalsSummaryTileComponent implements OnInit {
       }
 
       this.statusIsPublished = this.storyNode?.getPublishedStatus();
-      this.storyProgress = Math.floor(
-        (completedNodesCount / totalStoryNodesCount) * 100
-      );
+      if (totalStoryNodesCount === 0) {
+        this.storyProgress = 0;
+      } else {
+        this.storyProgress = Math.floor(
+          (completedNodesCount / totalStoryNodesCount) * 100
+        );
+      }
     }
   }
 
@@ -169,6 +174,14 @@ export class LearnerTopicGoalsSummaryTileComponent implements OnInit {
   isSerialChapterFeatureLearnerFlagEnabled(): boolean {
     return this.platformFeatureService.status.SerialChapterLaunchLearnerView
       .isEnabled;
+  }
+
+  getPublishedNodesCount(story: StorySummary): number {
+    if (this.isSerialChapterFeatureLearnerFlagEnabled()) {
+      return story.getAllNodes().filter(node => node.getPublishedStatus())
+        .length;
+    }
+    return story.getAllNodes().length;
   }
 
   isNewChapterLabelVisible(): boolean {

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.html
@@ -10,7 +10,7 @@
             </p>
             <div class="goal-list-center">
               <p class="goal-list-progress-text">
-                {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_STORY_PROGRESS' | translate: {current: story.getCompletedNodeTitles().length, total: story.getNodeTitles().length} }}
+                {{ 'I18N_LEARNER_DASHBOARD_GOALS_SECTION_LIST_STORY_PROGRESS' | translate: {current: story.getCompletedNodeTitles().length, total: getPublishedNodesCount(story)} }}
               </p>
               <div class="goal-list-progress-bar">
                 <div [ngStyle]="{'width': getStoryProgress(story) + '%'}"> </div>
@@ -23,7 +23,7 @@
               <oppia-content-toggle-button (contentToggleEmitter)="handleToggleState($event, story.getId())"> </oppia-content-toggle-button>
             </div>
               <!--TODO(#18384): Resume state, can only check if node is completed or not.-->
-            <a *ngIf="story.getAllNodes().length !== story.getCompletedNodeTitles().length && !isExpanded(story.getId())"
+            <a *ngIf="getPublishedNodesCount(story) !== story.getCompletedNodeTitles().length && !isExpanded(story.getId())"
                class="oppia-learner-dash-button-sm oppia-learner-dash-button--goals-list align-self-end e2e-test-start-lesson-button"
                [ngClass]="getStartButtonClass(story, allCurrentNodes[i])"
                [attr.href]="getStartButtonHref(story, allCurrentNodes[i])"

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.spec.ts
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.spec.ts
@@ -236,6 +236,214 @@ describe('GoalListComponent', () => {
     expect(progress).toEqual(100);
   });
 
+  describe('getPublishedNodesCount', () => {
+    it('should return all nodes count when serial chapter feature is disabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        false;
+      const story = StorySummary.createFromBackendDict(sampleStorySummary);
+
+      const count = component.getPublishedNodesCount(story);
+      expect(count).toEqual(3);
+    });
+
+    it('should return only published nodes count when serial chapter feature is enabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        true;
+      const draftNode = {
+        id: 'node_draft',
+        thumbnail_filename: 'image.png',
+        title: 'Draft Chapter',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_draft',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const storyWithDraft = {
+        id: '3',
+        title: 'Story Title',
+        description: 'Story Description',
+        node_titles: ['Title 1', 'Title 2', 'Draft Chapter'],
+        thumbnail_filename: 'image.svg',
+        thumbnail_bg_color: '#F8BF74',
+        story_is_published: true,
+        completed_node_titles: ['Title 1'],
+        url_fragment: 'story-title',
+        all_node_dicts: [sampleStoryNode, sampleStoryNode2, draftNode],
+        topic_name: 'Topic',
+        classroom_url_fragment: 'math',
+        topic_url_fragment: 'topic',
+      };
+      const story = StorySummary.createFromBackendDict(storyWithDraft);
+
+      const count = component.getPublishedNodesCount(story);
+      expect(count).toEqual(2);
+    });
+
+    it('should return 0 when all nodes are draft and feature flag is enabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        true;
+      const draftNode1 = {
+        id: 'node_draft1',
+        thumbnail_filename: 'image.png',
+        title: 'Draft Chapter 1',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_draft1',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const draftNode2 = {
+        id: 'node_draft2',
+        thumbnail_filename: 'image.png',
+        title: 'Draft Chapter 2',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_draft2',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const storyWithAllDraft = {
+        id: '4',
+        title: 'Story Title',
+        description: 'Story Description',
+        node_titles: ['Draft Chapter 1', 'Draft Chapter 2'],
+        thumbnail_filename: 'image.svg',
+        thumbnail_bg_color: '#F8BF74',
+        story_is_published: true,
+        completed_node_titles: [],
+        url_fragment: 'story-title',
+        all_node_dicts: [draftNode1, draftNode2],
+        topic_name: 'Topic',
+        classroom_url_fragment: 'math',
+        topic_url_fragment: 'topic',
+      };
+      const story = StorySummary.createFromBackendDict(storyWithAllDraft);
+
+      const count = component.getPublishedNodesCount(story);
+      expect(count).toEqual(0);
+    });
+  });
+
+  describe('getStoryProgress with serial chapter feature', () => {
+    it('should calculate progress using only published nodes when feature enabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        true;
+      const draftNode = {
+        id: 'node_draft',
+        thumbnail_filename: 'image.png',
+        title: 'Draft Chapter',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_draft',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const storyWithMixed = {
+        id: '5',
+        title: 'Story Title',
+        description: 'Story Description',
+        node_titles: ['Title 1', 'Title 2', 'Draft Chapter'],
+        thumbnail_filename: 'image.svg',
+        thumbnail_bg_color: '#F8BF74',
+        story_is_published: true,
+        completed_node_titles: ['Title 1', 'Title 2'],
+        url_fragment: 'story-title',
+        all_node_dicts: [sampleStoryNode, sampleStoryNode2, draftNode],
+        topic_name: 'Topic',
+        classroom_url_fragment: 'math',
+        topic_url_fragment: 'topic',
+      };
+      const story = StorySummary.createFromBackendDict(storyWithMixed);
+
+      const progress = component.getStoryProgress(story);
+      expect(progress).toEqual(100);
+    });
+
+    it('should calculate progress using all nodes when feature disabled', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        false;
+      const story = StorySummary.createFromBackendDict(incompleteStorySummary);
+
+      const progress = component.getStoryProgress(story);
+      expect(progress).toBeCloseTo(66.67, 1);
+    });
+
+    it('should return 0 when no published nodes exist', () => {
+      mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+        true;
+      const draftNode = {
+        id: 'node_draft',
+        thumbnail_filename: 'image.png',
+        title: 'Draft Chapter',
+        description: 'Description',
+        prerequisite_skill_ids: [],
+        acquired_skill_ids: [],
+        destination_node_ids: [],
+        outline: 'Outline',
+        exploration_id: 'exp_draft',
+        outline_is_finalized: false,
+        thumbnail_bg_color: '#a33f40',
+        status: 'Draft',
+        planned_publication_date_msecs: 100,
+        last_modified_msecs: 100,
+        first_publication_date_msecs: null,
+        unpublishing_reason: null,
+      };
+      const storyWithAllDraft = {
+        id: '6',
+        title: 'Story Title',
+        description: 'Story Description',
+        node_titles: ['Draft Chapter'],
+        thumbnail_filename: 'image.svg',
+        thumbnail_bg_color: '#F8BF74',
+        story_is_published: true,
+        completed_node_titles: [],
+        url_fragment: 'story-title',
+        all_node_dicts: [draftNode],
+        topic_name: 'Topic',
+        classroom_url_fragment: 'math',
+        topic_url_fragment: 'topic',
+      };
+      const story = StorySummary.createFromBackendDict(storyWithAllDraft);
+
+      const progress = component.getStoryProgress(story);
+      expect(progress).toEqual(0);
+    });
+  });
+
   it('should return the correct lesson url with getNodeLessonUrl', () => {
     const story = StorySummary.createFromBackendDict(sampleStorySummary);
     const node = StoryNode.createFromBackendDict(sampleStoryNode);

--- a/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
+++ b/core/templates/pages/learner-dashboard-page/goal-list/goal-list.component.ts
@@ -58,13 +58,6 @@ export class GoalListComponent implements OnInit {
       .map(story => this.getMostRecentCompletedNode(story));
   }
 
-  getStoryProgress(story: StorySummary): number {
-    return (
-      (story.getCompletedNodeTitles().length / story.getNodeTitles().length) *
-      100
-    );
-  }
-
   getChapterProgress(storyNode: StoryNode): number {
     const explorationId = storyNode.getExplorationId();
     if (!explorationId) {
@@ -156,6 +149,22 @@ export class GoalListComponent implements OnInit {
   isSerialChapterFeatureLearnerFlagEnabled(): boolean {
     return this.platformFeatureService.status.SerialChapterLaunchLearnerView
       .isEnabled;
+  }
+
+  getPublishedNodesCount(story: StorySummary): number {
+    if (this.isSerialChapterFeatureLearnerFlagEnabled()) {
+      return story.getAllNodes().filter(node => node.getPublishedStatus())
+        .length;
+    }
+    return story.getAllNodes().length;
+  }
+
+  getStoryProgress(story: StorySummary): number {
+    const totalNodes = this.getPublishedNodesCount(story);
+    if (totalNodes === 0) {
+      return 0;
+    }
+    return (story.getCompletedNodeTitles().length / totalNodes) * 100;
   }
 
   getStartButtonClass(story: StorySummary, nodeIndex: number): string {


### PR DESCRIPTION
## Overview

1. This PR fixes #24470.
2. This PR does the following: Fixes the bug where draft chapters were incorrectly included in the total chapter count displayed to learners on the Goals tab of the learner dashboard. When the `serial_chapter_launch_learner_view` feature flag is enabled, the code now filters out draft nodes and only counts published chapters when calculating the "X of Y completed" progress display.
3. (For bug-fixing PRs only) The original bug occurred because: The `getStoryProgress()` method in `goal-list.component.ts` and the story progress calculation in `learner-topic-goals-summary-tile.component.ts` were using `story.getAllNodes().length` to get the total chapter count, which included both published and draft nodes. This caused draft chapters to be displayed in the total count shown to learners, which should only show published chapters.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Before:**
- With `serial_chapter_launch_learner_view` flag enabled, a story with 3 published chapters and 2 draft chapters would show "X of 5 completed" to learners.

**After:**
- With `serial_chapter_launch_learner_view` flag enabled, the same story now correctly shows "X of 3 completed" to learners, excluding the 2 draft chapters.
<img width="2560" height="1440" alt="Screenshot 2026-01-12 at 9 46 43 PM" src="https://github.com/user-attachments/assets/d26008de-ea16-49c7-bbf2-9f7564292650" />
<img width="2560" height="1440" alt="Screenshot 2026-01-12 at 9 47 01 PM" src="https://github.com/user-attachments/assets/d4340054-b059-4a93-b044-a93cc1194e21" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.