### PR TITLE
Fix #23746: Fix skeleton card ghosting 

### DIFF
--- a/core/templates/components/summary-tile/lesson-card.component.html
+++ b/core/templates/components/summary-tile/lesson-card.component.html
@@ -18,7 +18,7 @@
       <div class="lesson-card-title-container mt-1 e2e-test-lesson-title">
         <p class="e2e-test-lesson-card-title lesson-card-title mb-0"> {{ title }} </p>
       </div>
-      <p class="lesson-card-topic mb-0"> {{ 'I18N_LEARNER_DASHBOARD_CARD_TOPIC' | translate: {cardTopic: lessonTopic} }} </p>
+      <p class="lesson-card-topic mb-0" *ngIf="lessonTopic"> {{ 'I18N_LEARNER_DASHBOARD_CARD_TOPIC' | translate: {cardTopic: lessonTopic} }} </p>
       <p class="lesson-card-desc mb-0"> {{ desc.charAt(0).toUpperCase() + desc.slice(1) }} </p>
     </div>
     <div class="align-items-center d-flex justify-content-between mt-2">

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -366,7 +366,6 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
         setTimeout(() => {
           this.loaderService.hideLoadingScreen();
           this.loadingIndicatorIsShown = false;
-          this.loadingIndicatorIsShown = false;
           // So that focus is applied after the loading screen has dissapeared.
           this.communityLessonsDataLoaded = true;
           this.focusManagerService.setFocusWithoutScroll('ourLessonsBtn');

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.ts
@@ -242,6 +242,7 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.loadingIndicatorIsShown = true;
     this.loaderService.showLoadingScreen('Loading');
 
     let userInfoPromise = this.userService.getUserInfoAsync();
@@ -364,6 +365,8 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
         ];
         setTimeout(() => {
           this.loaderService.hideLoadingScreen();
+          this.loadingIndicatorIsShown = false;
+          this.loadingIndicatorIsShown = false;
           // So that focus is applied after the loading screen has dissapeared.
           this.communityLessonsDataLoaded = true;
           this.focusManagerService.setFocusWithoutScroll('ourLessonsBtn');
@@ -418,6 +421,7 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
       LearnerDashboardPageConstants.LEARNER_DASHBOARD_SECTION_I18N_IDS
         .COMMUNITY_LESSONS
     ) {
+      this.loadingIndicatorIsShown = true;
       this.loaderService.showLoadingScreen('Loading');
       let dashboardCollectionsDataPromise =
         this.learnerDashboardBackendApiService.fetchLearnerDashboardCollectionsDataAsync();
@@ -464,6 +468,7 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
         .then(() => {
           setTimeout(() => {
             this.loaderService.hideLoadingScreen();
+            this.loadingIndicatorIsShown = false;
             this.communityLessonsDataLoaded = true;
             // So that focus is applied after the loading screen has dissapeared.
             this.focusManagerService.setFocusWithoutScroll('ourLessonsBtn');
@@ -482,6 +487,7 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
       LearnerDashboardPageConstants.LEARNER_DASHBOARD_SUBSECTION_I18N_IDS
         .LESSONS
     ) {
+      this.loadingIndicatorIsShown = true;
       this.loaderService.showLoadingScreen('Loading');
       let dashboardCollectionsDataPromise =
         this.learnerDashboardBackendApiService.fetchLearnerDashboardCollectionsDataAsync();
@@ -528,6 +534,7 @@ export class LearnerDashboardPageComponent implements OnInit, OnDestroy {
         .then(() => {
           setTimeout(() => {
             this.loaderService.hideLoadingScreen();
+            this.loadingIndicatorIsShown = false;
             this.communityLessonsDataLoaded = true;
             // So that focus is applied after the loading screen has dissapeared.
             this.focusManagerService.setFocusWithoutScroll('ourLessonsBtn');


### PR DESCRIPTION
## Overview



1. Fixes https://github.com/oppia/oppia/issues/23746: Resolves the delay in the dashboard appearance (including the learner greeting). The issue was caused by the loading spinner waiting for "ghost" lesson cards in sections that were not actually rendered.
2. This PR does the following:Root Cause Resolution: Added an *ngIf check to the lesson card component template.

Behavior: This ensures the card elements are physically removed from the DOM until the data is truthy. By preventing the element from existing during the "undefined" state, the translation pipe never executes on empty data, and the raw placeholders never appear.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

https://github.com/user-attachments/assets/143a93b9-a5cf-4277-910b-0d58aad7190f



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
