### PR TITLE
Fix classroom thumbnail visibility by truncating long titles

### DIFF
--- a/core/templates/pages/classroom-page/classroom-page.component.css
+++ b/core/templates/pages/classroom-page/classroom-page.component.css
@@ -135,7 +135,7 @@
 
 .oppia-classroom-page-container .classroom-top .classroom-admin-banner {
   align-items: center;
-  background-color: #015f9c ;
+  background-color: #015f9c;
   color: white;
   display: flex;
   justify-content: center;
@@ -190,34 +190,34 @@
 
 .breadcrumbs-container .classroom-information-container .classroom-text-container span {
   color: #00645c;
+  display: block;
   font-family: 'Capriola', 'Roboto', Arial, sans-serif;
   font-size: 22.6045px;
   font-style: normal;
   font-weight: 400;
   line-height: 28px;
   margin: 0;
-  padding-right: 10px;
-  white-space: nowrap;
+  max-width: 600px;
   overflow: hidden;
+  padding-right: 10px;
   text-overflow: ellipsis;
-  display: block;
-  max-width: 600px; 
+  white-space: nowrap;
 }
 
 .breadcrumbs-container .classroom-information-container .classroom-text-container h1 {
   color: #00645c;
+  display: block;
   font-family: 'Capriola', 'Roboto', Arial, sans-serif;
   font-size: 54px;
   font-style: normal;
   font-weight: 400;
   line-height: 68px;
-  padding-right: 10px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: block;
   margin: 0;
   max-width: 520px;
+  overflow: hidden;
+  padding-right: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .breadcrumbs-container .classroom-breadcrumbs .desktop-breadcrumbs {
@@ -364,23 +364,23 @@
     font-size: 18px;
     font-style: normal;
     line-height: 22px;
-    padding-right: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     max-width: 160px;
+    overflow: hidden;
+    padding-right: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
-  
+
   .breadcrumbs-container .classroom-information-container .classroom-text-container h1 {
     font-size: 28px;
     letter-spacing: -0.02em;
     line-height: 36px;
     margin-top: 10px;
-    padding-right: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     max-width: 200px;
+    overflow: hidden;
+    padding-right: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .breadcrumbs-container .classroom-information-container .classroom-thumbnail-container .classroom-thumbnail {
@@ -401,7 +401,7 @@
   .oppia-classroom-search-container {
     height: 220px;
   }
-  
+
   .oppia-classroom-search-container .search-box-text-container {
     align-items: center;
   }

--- a/core/templates/pages/classroom-page/classroom-page.component.css
+++ b/core/templates/pages/classroom-page/classroom-page.component.css
@@ -162,6 +162,11 @@
   width: 686px;
 }
 
+.breadcrumbs-container .classroom-information-container .classroom-text-container {
+  flex-grow: 1;
+  min-width: 0;
+}
+
 .breadcrumbs-container .classroom-information-container {
   align-items: start;
   display: flex;
@@ -193,6 +198,10 @@
   margin: 0;
   padding-right: 10px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  max-width: 600px; 
 }
 
 .breadcrumbs-container .classroom-information-container .classroom-text-container h1 {
@@ -204,6 +213,11 @@
   line-height: 68px;
   padding-right: 10px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  margin: 0;
+  max-width: 520px;
 }
 
 .breadcrumbs-container .classroom-breadcrumbs .desktop-breadcrumbs {
@@ -265,6 +279,10 @@
   font-weight: 400;
   letter-spacing: -0.02em;
   text-align: center;
+}
+
+.breadcrumbs-container .classroom-information-container .classroom-thumbnail-container {
+  flex-shrink: 0;
 }
 
 .breadcrumbs-container .classroom-information-container .classroom-thumbnail-container .classroom-thumbnail {
@@ -347,17 +365,22 @@
     font-style: normal;
     line-height: 22px;
     padding-right: 0;
-    white-space: pre-wrap;
-    
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 160px;
   }
+  
   .breadcrumbs-container .classroom-information-container .classroom-text-container h1 {
     font-size: 28px;
     letter-spacing: -0.02em;
     line-height: 36px;
     margin-top: 10px;
     padding-right: 0;
-    white-space: pre-wrap;
-
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
   }
 
   .breadcrumbs-container .classroom-information-container .classroom-thumbnail-container .classroom-thumbnail {
@@ -386,5 +409,4 @@
   .oppia-classroom-search-container .oppia-classrooms-search-section .search-box-text-container {
     align-items: center;
   }
-
 }


### PR DESCRIPTION
## Overview

1. This PR fixes issue #24428.
2. This PR does the following:

Adds flex-shrink: 0 to the .classroom-thumbnail-container to prevent the thumbnail from being squeezed or disappearing when the classroom name is long.

Implements text-overflow: ellipsis, white-space: nowrap, and overflow: hidden on the classroom title elements (span and h1) to ensure they truncate gracefully.

Sets max-width constraints (600px for the span and 520px for the h1) to allow names to display as many characters as possible without interfering with the thumbnail layout.
3. The original bug occurred because the classroom header layout was unconstrained. When the classroom name became long, the text container expanded indefinitely, causing the thumbnail’s flex item to shrink to zero width due to default flex-shrink behavior.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
## Proof that changes are correct


https://github.com/user-attachments/assets/58f2be2c-a72a-4eeb-a6b0-d05a7a28afca



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
