### PR TITLE
Fix #15986: Animate loading dots while response is loading

### DIFF
--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
@@ -74,10 +74,10 @@ oppia-input-response-pair .oppia-loading-dot-three {
   background-color: #666;
   border-radius: 50%;
   display: inline-block;
-  font-size: 0;    
-  height: 5px; 
+  font-size: 0;
+  height: 5px;
   margin-right: 4px;
-  width: 5px;  
+  width: 5px;
 }
 
 oppia-input-response-pair .oppia-loading-dot-one {
@@ -101,13 +101,13 @@ oppia-input-response-pair .oppia-loading-dot-two {
 }
 
 oppia-input-response-pair .oppia-loading-dot-three {
-  -webkit-animation: dot 1.0s infinite;
-   margin-right: 0;
   -moz-animation: dot 1.0s infinite;
+  -webkit-animation: dot 1.0s infinite;
   animation: dot 1.0s infinite;
-  -webkit-animation-delay: 0.4s;
-  -moz-animation-delay: 0.4s;
   animation-delay: 0.4s;
+  -moz-animation-delay: 0.4s;
+  -webkit-animation-delay: 0.4s;
+  margin-right: 0;
   opacity: 0;
 }
 

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
@@ -68,16 +68,23 @@ oppia-input-response-pair .oppia-popover {
   max-width: 300px;
 }
 
-oppia-input-response-pair .conversation-skin-feedback-dot-one,
-oppia-input-response-pair .conversation-skin-feedback-dot-two,
-oppia-input-response-pair .conversation-skin-feedback-dot-three {
+oppia-input-response-pair .oppia-loading-dot-one,
+oppia-input-response-pair .oppia-loading-dot-two,
+oppia-input-response-pair .oppia-loading-dot-three {
   background-color: #666;
   display: inline-block;
-  height: 2px;
-  width: 2px;
+  height: 5px; 
+  width: 5px;       
+  margin-right: 4px;
+  border-radius: 50%;
+  font-size: 0;    
 }
 
-oppia-input-response-pair .conversation-skin-feedback-dot-one {
+oppia-input-response-pair .oppia-loading-dot-three {
+  margin-right: 0;
+}
+
+oppia-input-response-pair .oppia-loading-dot-one {
   -webkit-animation: dot 1.0s infinite;
   -moz-animation: dot 1.0s infinite;
   animation: dot 1.0s infinite;
@@ -87,7 +94,7 @@ oppia-input-response-pair .conversation-skin-feedback-dot-one {
   opacity: 0;
 }
 
-oppia-input-response-pair .conversation-skin-feedback-dot-two {
+oppia-input-response-pair .oppia-loading-dot-two {
   -webkit-animation: dot 1.0s infinite;
   -moz-animation: dot 1.0s infinite;
   animation: dot 1.0s infinite;
@@ -97,7 +104,7 @@ oppia-input-response-pair .conversation-skin-feedback-dot-two {
   opacity: 0;
 }
 
-oppia-input-response-pair .conversation-skin-feedback-dot-three {
+oppia-input-response-pair .oppia-loading-dot-three {
   -webkit-animation: dot 1.0s infinite;
   -moz-animation: dot 1.0s infinite;
   animation: dot 1.0s infinite;

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
@@ -104,8 +104,8 @@ oppia-input-response-pair .oppia-loading-dot-three {
   -moz-animation: dot 1.0s infinite;
   -webkit-animation: dot 1.0s infinite;
   animation: dot 1.0s infinite;
-  animation-delay: 0.4s;
   -moz-animation-delay: 0.4s;
+  animation-delay: 0.4s;
   -webkit-animation-delay: 0.4s;
   margin-right: 0;
   opacity: 0;

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
@@ -105,8 +105,8 @@ oppia-input-response-pair .oppia-loading-dot-three {
   -webkit-animation: dot 1.0s infinite;
   animation: dot 1.0s infinite;
   -moz-animation-delay: 0.4s;
-  animation-delay: 0.4s;
   -webkit-animation-delay: 0.4s;
+  animation-delay: 0.4s;
   margin-right: 0;
   opacity: 0;
 }

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.css
@@ -72,16 +72,12 @@ oppia-input-response-pair .oppia-loading-dot-one,
 oppia-input-response-pair .oppia-loading-dot-two,
 oppia-input-response-pair .oppia-loading-dot-three {
   background-color: #666;
-  display: inline-block;
-  height: 5px; 
-  width: 5px;       
-  margin-right: 4px;
   border-radius: 50%;
+  display: inline-block;
   font-size: 0;    
-}
-
-oppia-input-response-pair .oppia-loading-dot-three {
-  margin-right: 0;
+  height: 5px; 
+  margin-right: 4px;
+  width: 5px;  
 }
 
 oppia-input-response-pair .oppia-loading-dot-one {
@@ -106,6 +102,7 @@ oppia-input-response-pair .oppia-loading-dot-two {
 
 oppia-input-response-pair .oppia-loading-dot-three {
   -webkit-animation: dot 1.0s infinite;
+   margin-right: 0;
   -moz-animation: dot 1.0s infinite;
   animation: dot 1.0s infinite;
   -webkit-animation-delay: 0.4s;

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
@@ -41,8 +41,10 @@
   <img class="conversation-skin-oppia-avatar rounded-circle"
        [src]="oppiaAvatarImageUrl"
        alt="">
-   <div *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()"
-       class="e2e-test-input-response-loading-dots" dir="auto">
+  <div
+    *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()"
+    class="e2e-test-input-response-loading-dots"
+    dir="auto">
     <div class="oppia-rte-viewer conversation-skin-oppia-feedback-content">
       <loading-dots></loading-dots>
     </div>

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
@@ -41,10 +41,9 @@
   <img class="conversation-skin-oppia-avatar rounded-circle"
        [src]="oppiaAvatarImageUrl"
        alt="">
-  <div
-    *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()"
-    class="e2e-test-input-response-loading-dots"
-    dir="auto">
+  <div *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()"
+       class="e2e-test-input-response-loading-dots"
+       dir="auto">
     <div class="oppia-rte-viewer conversation-skin-oppia-feedback-content">
       <loading-dots></loading-dots>
     </div>

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
@@ -41,7 +41,8 @@
   <img class="conversation-skin-oppia-avatar rounded-circle"
        [src]="oppiaAvatarImageUrl"
        alt="">
-  <div *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()" dir="auto">
+   <div *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()"
+       class="e2e-test-input-response-loading-dots" dir="auto">
     <div class="oppia-rte-viewer conversation-skin-oppia-feedback-content">
       <loading-dots></loading-dots>
     </div>

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/input-response-pair.component.html
@@ -36,15 +36,15 @@
   </div>
 </div>
 
-<div class="conversation-skin-oppia-feedback-container" *ngIf="data.oppiaResponse !== '' && feedbackIsEnabled">
+<div class="conversation-skin-oppia-feedback-container"
+     *ngIf="data.oppiaResponse !== '' && feedbackIsEnabled">
   <img class="conversation-skin-oppia-avatar rounded-circle"
        [src]="oppiaAvatarImageUrl"
        alt="">
-  <div *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()"
-       class="e2e-test-input-response-loading-dots">
-    <div class="conversation-skin-feedback-dot-one"></div>
-    <div class="conversation-skin-feedback-dot-two"></div>
-    <div class="conversation-skin-feedback-dot-three"></div>
+  <div *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()" dir="auto">
+    <div class="oppia-rte-viewer conversation-skin-oppia-feedback-content">
+      <loading-dots></loading-dots>
+    </div>
   </div>
   <span id="getInputResponsePairId()"></span>
   <div dir="auto">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #15986 .
2. This PR does the following: This PR fixes the issue where the three loading dots shown after a learner submits an answer do not animate properly while the response is loading. The dots now animate sequentially, providing clear visual feedback to the learner during the loading state.
3. (For bug-fixing PRs only) The original bug occurred because: The issue was caused by incorrect CSS structure and animation-related styles for the loading dots, which prevented the animation from functioning as intended in the input-response pair component.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix #15986: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)


- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

The three dots animate sequentially while the response is loading, providing clear visual feedback to the learner.


https://github.com/user-attachments/assets/52eb75db-97ec-439e-be2a-1ebdb2f1a093


<!--




-->

#### Proof of changes on desktop with slow/throttled network
Properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. 
The network was throttled to 3G using the browser Developer Tools. While the network was slow, the three loading dots animated smoothly without any UI glitches or performance issues. The behavior remained consistent until the response was fully loaded.
<!--

-->

#### Proof of changes on mobile phone
Verified using the browser developer tools mobile device emulator.
The loading dots animate correctly while the response is loading, and no layout or alignment issues were observed on smaller screen sizes.
<!--

-->

#### Proof of changes in Arabic language
Verified the fix with the site language set to Arabic (RTL).
The loading dots animate correctly while the response is loading, and the UI layout and alignment remain correct in the RTL view.
<!--

-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
