### PR TITLE
Fix #24441: Prevent double unpublish modal in Serial Chapter Mode

### DIFF
--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.spec.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.spec.ts
@@ -911,6 +911,14 @@ describe('Story editor navbar component', () => {
       storyUpdateService,
       'setStoryNodeUnpublishingReason'
     );
+    let changeStoryStatusSpy = spyOn(
+      storyEditorStateService,
+      'changeStoryPublicationStatus'
+    ).and.callFake((newStatus, callback) => {
+      if (callback) {
+        callback();
+      }
+    });
     let unpublishStorySpy = spyOn(component, 'unpublishStory');
     let loadStorySpy = spyOn(
       storyEditorStateService,
@@ -981,7 +989,8 @@ describe('Story editor navbar component', () => {
     expect(modalSpy).toHaveBeenCalled();
     expect(storyNodeStatusSpy).toHaveBeenCalledTimes(4);
     expect(storyNodeUnpublishingReasonSpy).toHaveBeenCalledTimes(4);
-    expect(unpublishStorySpy).toHaveBeenCalled();
+    expect(changeStoryStatusSpy).toHaveBeenCalled();
+    expect(unpublishStorySpy).not.toHaveBeenCalled();
     expect(storyNodePlannedPublicationDateSpy).toHaveBeenCalledTimes(2);
     expect(chapterStatusChangingSpy).toHaveBeenCalledTimes(6);
     expect(saveStorySpy).toHaveBeenCalled();

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
@@ -343,7 +343,15 @@ export class StoryEditorNavbarComponent implements OnInit {
               }
             }
             if (Number(selectedChapterIndexInPublishUptoDropdown) === -1) {
-              this.unpublishStory();
+              this.storyEditorStateService.changeStoryPublicationStatus(
+                false,
+                () => {
+                  this.storyIsPublished =
+                    this.storyEditorStateService.isStoryPublished();
+                  this.forceValidateExplorations = true;
+                  this._validateStory();
+                }
+              );
             }
             this.storyEditorStateService.saveStory(
               'Unpublished chapters',


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #24441.
2. This PR does the following:
   This PR updates the logic in `StoryEditorNavbarComponent.changeChapterStatus`. When a user chooses to unpublish all chapters in Serial Chapter Mode, the code now directly calls `storyEditorStateService.changeStoryPublicationStatus(...)` instead of invoking the component’s `unpublishStory()` method.

   This ensures that the unpublish action is handled within the context of the existing confirmation modal, preventing a redundant second confirmation popup from appearing.

   Frontend unit tests have been updated to:
   * Verify that the service method is called directly.
   * Ensure that the component method responsible for opening the second confirmation modal is not triggered.

3. (For bug-fixing PRs only) The original bug occurred because:
   The `changeChapterStatus` method—which is already triggered from a confirmation modal—was calling `this.unpublishStory()` when the user selected "Unpublish All Chapters". Since `unpublishStory()` is designed to open its own confirmation modal, this resulted in two consecutive confirmation dialogs, forcing the user to confirm the same action twice.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

#### Proof of changes on mobile phone

#### Proof of changes in Arabic language