### PR TITLE
Fix  #24470: Learner dashboard goals counting draft chapters

### DIFF
--- a/core/domain/topic_fetchers.py
+++ b/core/domain/topic_fetchers.py
@@ -799,6 +799,7 @@ def get_canonical_story_dicts(
         story_summary_dict: CannonicalStoryDict = (
             story_summary.to_human_readable_dict()  # type: ignore[assignment]
         )
+        story_summary_dict['node_titles'] = [node.title for node in all_nodes]
         story_summary_dict['topic_url_fragment'] = topic.url_fragment
         story_summary_dict['classroom_url_fragment'] = (
             classroom_config_services.get_classroom_url_fragment_for_topic_id(


### PR DESCRIPTION
## Overview

1. This PR fixes #24470
2. This PR does the following: It modifies the topic fetcher logic to ensure that the Learner Dashboard "Goals" tab only counts **published** chapters in the progress bar. Previously, it incorrectly included draft chapters in the total count (e.g., showing "0/3" when only 1 chapter was published).
3. The original bug occurred because: The `get_canonical_story_dicts` function in `topic_fetchers.py` was populating `node_titles` using the raw story nodes (which include drafts), rather than filtering for published nodes only.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Before Fix (Bug):**
The progress bar incorrectly counts the draft chapter (showing 0 of 3 items).
https://github.com/user-attachments/assets/ec2a61c5-832c-4767-a855-558215ca6160

**After Fix (Solved):**
The progress bar correctly ignores the draft chapter (showing 0 of 2 items).
https://github.com/user-attachments/assets/a3653599-c7c5-4100-aac1-32a67b0a6b51

#### Proof of changes on mobile phone

*N/A: This is a backend logic fix that affects data fetching. The UI responsiveness on mobile remains unchanged from the desktop behavior shown above.*

#### Proof of changes in Arabic language

*N/A: This change only affects the backend logic for counting chapters. It does not introduce new UI text strings or modify layout directions.*

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.