### PR TITLE
Fix #23619: Resolve Topic Intro to C Programming Language not found in classroom.

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -2444,6 +2444,28 @@ export class CurriculumAdmin extends TopicManager {
     await this.clickOnElementWithSelector(topicSelector);
     await this.page.waitForSelector(openTopicDropdownButton);
 
+    // Wait for the topic to appear in the classroom before adding prerequisites.
+    await this.page.waitForFunction(
+      (
+        topicBoxSelector: string,
+        topicNameSelector: string,
+        expectedTopicName: string
+      ) => {
+        const topicBoxElements = document.querySelectorAll(topicBoxSelector);
+        for (const element of topicBoxElements) {
+          const topicNameElement = element.querySelector(topicNameSelector);
+          if (topicNameElement?.textContent?.trim() === expectedTopicName) {
+            return true;
+          }
+        }
+        return false;
+      },
+      {},
+      classroomTopicBoxSelector,
+      classroomTopicNameSelector,
+      topicName
+    );
+
     for (const prerequisiteTopic of prerequisiteTopics) {
       await this.addPrerequisiteTopicForATopicInClassroom(
         topicName,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #23619 .
2. This PR does the following: Fixes a flaky E2E test in the `curriculum-admin/create-edit-and-delete-a-classroom`
   CI step by resolving a race condition when adding a topic to a classroom. The
   test now explicitly waits for the selected topic box to appear in the DOM before
   proceeding to add prerequisites, ensuring stable and deterministic behavior.
3. (For bug-fixing PRs only) The original bug occurred because: After selecting a topic from the dropdown, the test did not wait for the topic
   box to be rendered in the DOM. As a result, `expectClassroomToContainTopic` was
   sometimes called before the topic was actually added, leading to the error:
   "Topic Intro to C Programming Language not found in classroom."


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).


- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #23619: " followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@oppia/ci-reviewers PTAL" if I can't assign them directly).


## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct
      
 Proof showing that the test passes even after 3–4 consecutive executions.

<img width="1761" height="444" alt="ci 1" src="https://github.com/user-attachments/assets/74d19537-6030-47ff-9a1b-b7f5565aa5f2" />

<img width="977" height="203" alt="ci3" src="https://github.com/user-attachments/assets/4d02fdc4-2f19-457f-97bd-ffb79b777d82" />

<img width="1919" height="496" alt="ci2" src="https://github.com/user-attachments/assets/4caf4b35-6817-475b-89d3-48d5eab11ff9" />



<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

