### PR TITLE
Fix #24358: lesson card title wrapping and alignment on library page

### DIFF
--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -736,3 +736,18 @@ oppia-library-page .oppia-exp-summary-tiles-container {
     max-width: 96vw;
   }
 }
+
+/* Fix */
+.e2e-test-exp-summary-tile,
+.e2e-test-collection-summary-tile {
+  display: flex;
+  flex-direction: column;
+}
+
+.e2e-test-exp-summary-tile .title,
+.e2e-test-collection-summary-tile .title {
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.4;
+  text-align: left;
+}


### PR DESCRIPTION
Overview
This PR fixes #24358.

This PR does the following:
- Updates CSS styles for library lesson cards to improve text wrapping.
- Ensures consistent alignment across cards with long lesson titles.

The original bug occurred because the lesson card title container did not handle long text wrapping correctly, which caused misalignment across cards.

Essential Checklist
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (Not applicable — CSS-only UI change)
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@HardikGoyal2003 PTAL" if I can't assign them directly).

Proof that changes are correct
- Manually verified UI changes on the Library page.
- Confirmed correct behavior for both long and short lesson titles.

PR Pointers
N/A
