### PR TITLE
Fix issue 24510

### DIFF
--- a/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
+++ b/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
@@ -45,6 +45,7 @@
   .oppia-learner-dash-goals-checkbox {
     font-size: 16px;
     gap: 0 12px;
+    min-width: 0;
     overflow: hidden;
   }
 
@@ -62,9 +63,11 @@
     box-sizing: border-box;
     display: grid;
     gap: 0 4px;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     grid-template-rows: auto;
     height: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
     padding-top: 12px;
     width: 100%;
   }

--- a/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
+++ b/core/templates/pages/learner-dashboard-page/add-goals-modal/add-goals-modal.component.html
@@ -71,6 +71,7 @@
     padding-top: 12px;
     width: 100%;
   }
+  
 
   .oppia-learner-dash-goals-modal-actions {
     display: flex;


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #24510.

2. This PR fixes a UI layout issue in the Learner Dashboard where the skills box in the Progress → Place Values section    overflows horizontally from its parent container on smaller screen sizes. The fix ensures that the content remains properly constrained within the container and responsive across different viewport widths.

3. (For bug-fixing PRs only) The original bug occurred because:  the skills container used a fixed multi-column CSS grid layout that did not properly constrain its width or allow content to shrink, causing horizontal overflow on narrower viewports. The PR that introduced this issue has not yet been identified.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.(Not applicable — this PR contains UI-only CSS changes and does not modify application logic.)
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<img width="525" height="804" alt="Screenshot 2026-01-19 at 8 29 48 PM" src="https://github.com/user-attachments/assets/d29e6dab-ec66-4044-a90b-038ad6037bcd" />


#### Proof of changes on desktop with slow/throttled network


Verified locally on desktop by resizing the viewport from wide to narrow.

Confirmed that the skills box no longer overflows from the right side of the parent container.

No horizontal scrollbar appears, and all content remains visible.

Tested with network throttling enabled (3G) and observed no UI regressions.


#### Proof of changes on mobile phone

<img width="525" height="804" alt="Screenshot 2026-01-19 at 8 29 48 PM" src="https://github.com/user-attachments/assets/c6df8acd-6a32-4ee1-92e7-aa0e58126706" />



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
