### PR TITLE
Add deletion logic for TranslationCoordinatorsModel

### DIFF
--- a/core/domain/wipeout_service.py
+++ b/core/domain/wipeout_service.py
@@ -477,6 +477,33 @@ def _delete_profile_picture(
         )
 
 
+def remove_user_from_translation_coordinators(user_id: str) -> None:
+    """Removes the user from all translation coordinator models.
+
+    Args:
+        user_id: str. The ID of the user to remove from translation
+            coordinator models.
+    """
+    translation_coordinator_models: Sequence[
+        suggestion_models.TranslationCoordinatorsModel
+    ] = suggestion_models.TranslationCoordinatorsModel.get_by_user(user_id)
+
+    models_to_update: List[suggestion_models.TranslationCoordinatorsModel] = []
+    for coordinator_model in translation_coordinator_models:
+        if user_id in coordinator_model.coordinator_ids:
+            coordinator_model.coordinator_ids.remove(user_id)
+            coordinator_model.coordinators_count = len(
+                coordinator_model.coordinator_ids
+            )
+            models_to_update.append(coordinator_model)
+
+    if models_to_update:
+        suggestion_models.TranslationCoordinatorsModel.update_timestamps_multi(
+            models_to_update
+        )
+        datastore_services.put_multi(models_to_update)
+
+
 def remove_user_from_user_groups(user_id: str) -> None:
     """Removes the user from all user groups they are a member of.
 
@@ -534,6 +561,7 @@ def delete_user(
     _delete_models(user_id, models.Names.FEEDBACK)
     _delete_models(user_id, models.Names.SUGGESTION)
     remove_user_from_user_groups(user_id)
+    remove_user_from_translation_coordinators(user_id)
 
     # Explicitly handle the case where the user settings model is deleted.
     if (

--- a/core/domain/wipeout_service.py
+++ b/core/domain/wipeout_service.py
@@ -612,6 +612,13 @@ def delete_user(
             subtopic_models.SubtopicPageCommitLogEntryModel,
             'subtopic_page_id',
         )
+        _pseudonymize_activity_models_without_associated_rights_models(
+            pending_deletion_request,
+            models.Names.SUBTOPIC,
+            subtopic_models.StudyGuideSnapshotMetadataModel,
+            subtopic_models.StudyGuideCommitLogEntryModel,
+            'study_guide_id',
+        )
         _pseudonymize_activity_models_with_associated_rights_models(
             pending_deletion_request,
             models.Names.EXPLORATION,

--- a/core/domain/wipeout_service_test.py
+++ b/core/domain/wipeout_service_test.py
@@ -1454,6 +1454,33 @@ class WipeoutServiceDeleteConfigModelsTests(test_utils.GenericTestBase):
         )
         self.assertNotIn(self.user_1_id, updated_user_group_model.user_ids)
 
+    def test_remove_user_from_translation_coordinators(self) -> None:
+        translation_coordinator_model = (
+            suggestion_models.TranslationCoordinatorsModel(
+                id='hi',
+                coordinator_ids=[self.user_1_id, self.user_2_id],
+                coordinators_count=2,
+            )
+        )
+        translation_coordinator_model.put()
+
+        existing_model = (
+            suggestion_models.TranslationCoordinatorsModel.get_by_id('hi')
+        )
+        self.assertIn(self.user_1_id, existing_model.coordinator_ids)
+        self.assertEqual(existing_model.coordinators_count, 2)
+
+        wipeout_service.delete_user(
+            wipeout_service.get_pending_deletion_request(self.user_1_id)
+        )
+
+        updated_model = (
+            suggestion_models.TranslationCoordinatorsModel.get_by_id('hi')
+        )
+        self.assertNotIn(self.user_1_id, updated_model.coordinator_ids)
+        self.assertIn(self.user_2_id, updated_model.coordinator_ids)
+        self.assertEqual(updated_model.coordinators_count, 1)
+
     def test_one_config_property_when_the_deletion_is_repeated_is_pseudonymized(
         self,
     ) -> None:

--- a/core/storage/storage_models_test.py
+++ b/core/storage/storage_models_test.py
@@ -161,3 +161,106 @@ class StorageModelsTest(test_utils.GenericTestBase):
                     }
                 )
             )
+
+    def test_locally_pseudonymize_models_have_wipeout_handling(self) -> None:
+        """Ensure all models with LOCALLY_PSEUDONYMIZE policy are explicitly
+        handled in the wipeout service.
+
+        When adding a new model with LOCALLY_PSEUDONYMIZE deletion policy, you
+        must also add corresponding wipeout logic in core/domain/wipeout_service
+        to handle user deletion for that model. After doing so, add the model
+        class name to the MODELS_WITH_WIPEOUT_HANDLING set below.
+
+        This test prevents issues where a model with LOCALLY_PSEUDONYMIZE policy
+        is added but the wipeout service is not updated, which would cause user
+        deletion to fail verification.
+        """
+        # This set contains all model class names that have LOCALLY_PSEUDONYMIZE
+        # deletion policy and have been verified to have corresponding wipeout
+        # handling in core/domain/wipeout_service.py.
+        #
+        # Base classes that are inherited from but not directly instantiated
+        # are included here as they don't need direct wipeout handling.
+        #
+        # When adding a new model with LOCALLY_PSEUDONYMIZE policy, follow
+        # these steps:
+        # 1. Add wipeout handling in wipeout_service.py.
+        # 2. Add tests for the wipeout handling.
+        # 3. Add the model class name to this set.
+        models_with_wipeout_handling = {
+            # Base classes (inherited from, not directly instantiated).
+            'BaseCommitLogEntryModel',
+            'BaseSnapshotMetadataModel',
+            # Improvements models.
+            'ExplorationStatsTaskEntryModel',
+            # Suggestion models.
+            'GeneralSuggestionModel',
+            'TranslationCoordinatorsModel',
+            # Exploration models.
+            'ExplorationSnapshotMetadataModel',
+            'ExplorationRightsSnapshotMetadataModel',
+            'ExplorationRightsSnapshotContentModel',
+            'ExplorationVersionHistoryModel',
+            # Collection models.
+            'CollectionSnapshotMetadataModel',
+            'CollectionRightsSnapshotMetadataModel',
+            'CollectionRightsSnapshotContentModel',
+            # Feedback models.
+            'GeneralFeedbackThreadModel',
+            'GeneralFeedbackMessageModel',
+            # Blog models.
+            'BlogPostModel',
+            'BlogPostSummaryModel',
+            'BlogAuthorDetailsModel',
+            # Topic models.
+            'TopicSnapshotMetadataModel',
+            'TopicCommitLogEntryModel',
+            'TopicRightsSnapshotMetadataModel',
+            'TopicRightsSnapshotContentModel',
+            'TopicRightsModel',
+            # Story models.
+            'StorySnapshotMetadataModel',
+            'StoryCommitLogEntryModel',
+            # Skill models.
+            'SkillSnapshotMetadataModel',
+            'SkillCommitLogEntryModel',
+            # Question models.
+            'QuestionSnapshotMetadataModel',
+            'QuestionCommitLogEntryModel',
+            # Subtopic models.
+            'SubtopicPageSnapshotMetadataModel',
+            'SubtopicPageCommitLogEntryModel',
+            'StudyGuideSnapshotMetadataModel',
+            'StudyGuideCommitLogEntryModel',
+            # Config models.
+            'PlatformParameterSnapshotMetadataModel',
+            # User models.
+            'UserGroupModel',
+            # App feedback report models.
+            'AppFeedbackReportModel',
+        }
+
+        locally_pseudonymize_models = [
+            clazz.__name__
+            for clazz in test_utils.get_storage_model_classes()
+            if (
+                clazz.__name__
+                not in test_utils.BASE_MODEL_CLASSES_WITHOUT_DATA_POLICIES
+                and clazz.get_deletion_policy()
+                == base_models.DELETION_POLICY.LOCALLY_PSEUDONYMIZE
+            )
+        ]
+
+        models_missing_wipeout_handling = set(locally_pseudonymize_models) - (
+            models_with_wipeout_handling
+        )
+
+        self.assertEqual(
+            models_missing_wipeout_handling,
+            set(),
+            'The following models have LOCALLY_PSEUDONYMIZE deletion policy '
+            'but are not listed as having wipeout handling. Please add wipeout '
+            'logic in core/domain/wipeout_service.py and then add the model '
+            'name to the models_with_wipeout_handling set in this test: %s'
+            % sorted(models_missing_wipeout_handling),
+        )


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: Add deletion logic in wipeout_service.py for TranslationCoordinatorsModel. This was missing and should be included in order to ensure the wipeout system is not buggy.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

The added backend tests should verify this.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
