### PR TITLE
Fix #23944: Added missing unpublishCollection function to collection editor navbar

### DIFF
--- a/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.spec.ts
+++ b/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.spec.ts
@@ -160,6 +160,24 @@ describe('Collection editor navbar component', () => {
     expect(collectionEditorStateService.getCollectionRights).toHaveBeenCalled();
   }));
 
+  it('should unpublish the collection', fakeAsync(() => {
+    const unpublishSpy = spyOn(
+      collectionRightsBackendApiService,
+      'setCollectionPrivateAsync'
+    ).and.returnValue(Promise.resolve());
+    const setRightsSpy = spyOn(
+      collectionEditorStateService,
+      'setCollectionRights'
+    );
+    componentInstance.collectionId = collectionId;
+    componentInstance.collection = mockCollection;
+    componentInstance.collectionRights = mockPrivateCollectionRights;
+    componentInstance.unpublishCollection();
+    tick();
+    expect(unpublishSpy).toHaveBeenCalled();
+    expect(setRightsSpy).toHaveBeenCalled();
+  }));
+
   it('should validate public collection', fakeAsync(() => {
     let mockPublicCollectionRights = new CollectionRights({
       collection_id: collectionId,

--- a/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.ts
+++ b/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.ts
@@ -188,6 +188,20 @@ export class CollectionEditorNavbarComponent {
     }
   }
 
+  unpublishCollection(): void {
+    this.collectionRightsBackendApiService
+      .setCollectionPrivateAsync(
+        this.collectionId,
+        this.collection.getVersion()
+      )
+      .then(() => {
+        this.collectionRights.setPrivate();
+        this.collectionEditorStateService.setCollectionRights(
+          this.collectionRights
+        );
+      });
+  }
+
   isLoadingCollection(): boolean {
     return this.collectionEditorStateService.isLoadingCollection();
   }

--- a/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.ts
+++ b/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.ts
@@ -192,7 +192,7 @@ export class CollectionEditorNavbarComponent {
     this.collectionRightsBackendApiService
       .setCollectionPrivateAsync(
         this.collectionId,
-        this.collection.getVersion()
+        this.collection.getVersion() as number
       )
       .then(() => {
         this.collectionRights.setPrivate();


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes issue #23944
2. This PR does the following: Adds the missing unpublishCollection() function to the CollectionEditorNavbarComponent. This ensures that when a Moderator or Collection Editor clicks the "Unpublish" button, the request is correctly sent to the backend and the UI state is updated to reflect that the collection is now private.
3.The original bug occurred because: The collection-editor-navbar.component.html template was attempting to call unpublishCollection() on click, but this method was never defined in the corresponding .ts file. This resulted in a _co.unpublishCollection is not a function error in the frontend console.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

https://github.com/user-attachments/assets/fe24d6af-c3e1-4a54-97da-d5c125d59aa1


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
