### PR TITLE
Fix #23677: Mirror menu bar dropdowns in RTL (Arabic)

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -644,4 +644,3 @@
 :lang(ar) .get-involved-dropdown .d-flex {
   direction: rtl;
 }
-

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -616,3 +616,32 @@
     }
   }
 }
+:lang(ar) .get-involved-dropdown .des {
+  padding-left: 0;
+  padding-right: 36px;
+}
+
+:lang(ar) .top-section .heading-text,
+:lang(ar) .bottom-section .heading-text {
+  margin-left: 0;
+  margin-right: 7px;
+}
+
+:lang(ar) .bottom-section .heading-text {
+  margin-right: 9px;
+}
+
+:lang(ar) .oppia-navbar-arrow-right {
+  padding-left: 0;
+  padding-right: 8px;
+  transform: scaleX(-1);
+}
+
+:lang(ar) .learn-dropdown-menu .nav-item-main {
+  direction: rtl;
+}
+
+:lang(ar) .get-involved-dropdown .d-flex {
+  direction: rtl;
+}
+

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -98,9 +98,9 @@
             </span>
           </a>
           <ul ngbDropdownMenu
-              [ngStyle]="{'left.px': learnDropdownOffset}"
               [ngClass]="{
                 'dropdown-menu oppia-navbar-dropdown learn-dropdown-menu classroom-enabled': true,
+                'dropdown-menu-end': isLanguageRTL(),
                 'two-columns': classroomSummariesLength == 2,
                 'three-columns': classroomSummariesLength >= 3
               }"
@@ -247,7 +247,6 @@
             </span>
           </a>
           <ul ngbDropdownMenu
-              [ngStyle]="{'left.px': getInvolvedMenuOffset}"
               class="dropdown-menu oppia-navbar-dropdown get-involved-dropdown"
               (mouseover)="openSubmenu($event, 'getInvolvedMenu')"
               (mouseleave)="closeSubmenuIfNotMobile($event)">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #23677.
3. This PR does the following: This PR updates the menu bar dropdown alignment so that the “learn-dashboard” and “creator-dashboard” dropdowns are correctly mirrored when the site is viewed in an RTL language (Arabic). The dropdown positioning and alignment now respect the document direction, ensuring a consistent and accessible user experience for RTL users.
4. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because the dropdown menu styles were hardcoded for LTR layouts (for example, using left-based positioning) and did not account for RTL direction. As a result, the dropdowns were not mirrored correctly when the language was set to Arabic.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #23677: " followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

Problem -
<img width="2003" height="1020" alt="problem 1" src="https://github.com/user-attachments/assets/2423bfdb-48a3-42ae-8926-4e139d8207e3" />

<img width="1920" height="1020" alt="problem 2" src="https://github.com/user-attachments/assets/16238612-1dc1-4132-8dde-c768d45a758f" />

Proof of Solution-
Learner Dashboard-
https://drive.google.com/file/d/1YVQsoIscRVdhli95XJ2UZKxOz9EpygFY/view?usp=sharing

Creator Dashboard-
https://drive.google.com/file/d/1OI2SjLFu7aSNBt7JTCm0HZurby4A8t96/view?usp=sharing
<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
