### PR TITLE
Fix part of #23496: Enable strict checks for Group 17 and dependent Player Services

### DIFF
--- a/core/templates/base-components/footer-donate-volunteer.component.spec.ts
+++ b/core/templates/base-components/footer-donate-volunteer.component.spec.ts
@@ -125,7 +125,9 @@ describe('FooterDonateVolunteerComponent', () => {
   it('should prevent default navigation for Donate link', fakeAsync(() => {
     const donateLink = document.createElement('a');
     donateLink.setAttribute('href', '/donate');
-    component.el.nativeElement.appendChild(donateLink);
+    (component as unknown as {el: ElementRef}).el.nativeElement.appendChild(
+      donateLink
+    );
     component.ngAfterViewInit();
     tick();
     const event = new MouseEvent('click', {
@@ -143,7 +145,9 @@ describe('FooterDonateVolunteerComponent', () => {
   it('should prevent default navigation for Volunteer link', fakeAsync(() => {
     const volunteerLink = document.createElement('a');
     volunteerLink.setAttribute('href', '/volunteer');
-    component.el.nativeElement.appendChild(volunteerLink);
+    (component as unknown as {el: ElementRef}).el.nativeElement.appendChild(
+      volunteerLink
+    );
     component.ngAfterViewInit();
     tick();
     const event = new MouseEvent('click', {
@@ -163,10 +167,14 @@ describe('FooterDonateVolunteerComponent', () => {
     donateLink.setAttribute('href', '/donate');
     const volunteerLink = document.createElement('a');
     volunteerLink.setAttribute('href', '/volunteer');
-    component.el.nativeElement.appendChild(donateLink);
-    component.el.nativeElement.appendChild(volunteerLink);
+    (component as unknown as {el: ElementRef}).el.nativeElement.appendChild(
+      donateLink
+    );
+    (component as unknown as {el: ElementRef}).el.nativeElement.appendChild(
+      volunteerLink
+    );
     const rendererListenSpy = spyOn(
-      component.renderer,
+      (component as unknown as {renderer: Renderer2}).renderer,
       'listen'
     ).and.callThrough();
     component.ngAfterViewInit();

--- a/core/templates/base-components/oppia-footer.component.spec.ts
+++ b/core/templates/base-components/oppia-footer.component.spec.ts
@@ -117,40 +117,40 @@ describe('OppiaFooterComponent', () => {
 
   it('should validate email address correctly', () => {
     component.emailAddress = 'invalidEmail';
-    expect(component.validateEmailAddress()).toBeFalse();
+    expect(component.validateEmailAddress()).toBe(false);
 
     component.emailAddress = 'validEmail@example.com';
-    expect(component.validateEmailAddress()).toBeTrue();
+    expect(component.validateEmailAddress()).toBe(true);
   });
 
   it('should return false when email address is null', () => {
     component.emailAddress = null;
-    expect(component.validateEmailAddress()).toBeFalse();
+    expect(component.validateEmailAddress()).toBe(false);
   });
 
   it('should return true if not processing subscription and email address is invalid', () => {
     component.subscriptionProcessing = false;
     component.emailAddress = 'invalidEmail';
-    expect(component.disableNewsletterSubscription()).toBeTrue();
+    expect(component.disableNewsletterSubscription()).toBe(true);
 
     component.emailAddress = 'validEmail@example.com';
-    expect(component.disableNewsletterSubscription()).toBeFalse();
+    expect(component.disableNewsletterSubscription()).toBe(false);
   });
 
   it('should return true if processing subscription regardless of email address validity', () => {
     component.subscriptionProcessing = true;
     component.emailAddress = 'invalidEmail';
-    expect(component.disableNewsletterSubscription()).toBeTrue();
+    expect(component.disableNewsletterSubscription()).toBe(true);
 
     component.emailAddress = 'validEmail@example.com';
-    expect(component.disableNewsletterSubscription()).toBeTrue();
+    expect(component.disableNewsletterSubscription()).toBe(true);
   });
 
   it('should return whether the email address is present or not in the set of subscribed emails', () => {
-    expect(component.isAlreadySubscribed('validEmail@example.com')).toBeFalse();
+    expect(component.isAlreadySubscribed('validEmail@example.com')).toBe(false);
 
     component.emailsSubscribed.add('validEmail@example.com');
-    expect(component.isAlreadySubscribed('validEmail@example.com')).toBeTrue();
+    expect(component.isAlreadySubscribed('validEmail@example.com')).toBe(true);
   });
 
   it('should clear newsletter warning when email address input changes', fakeAsync(() => {
@@ -159,14 +159,13 @@ describe('OppiaFooterComponent', () => {
     component.emailsSubscribed.add(component.emailAddress);
     fixture.detectChanges();
 
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.emailDuplicated).toBe(false);
 
     component.subscribeToMailingList();
 
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.emailDuplicated).toBeTrue();
-
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.emailDuplicated).toBe(true);
     const input: HTMLInputElement =
       fixture.nativeElement.querySelector('input');
     input.value = 'anotherEmail@example.com';
@@ -174,7 +173,7 @@ describe('OppiaFooterComponent', () => {
     tick();
     fixture.detectChanges();
 
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.emailDuplicated).toBe(false);
   }));
 
   it('should not subscribe when email is invalid', () => {
@@ -183,7 +182,7 @@ describe('OppiaFooterComponent', () => {
 
     component.subscribeToMailingList();
 
-    expect(component.newsletterTouched).toBeTrue();
+    expect(component.newsletterTouched).toBe(true);
     expect(
       mailingListBackendApiService.subscribeUserToMailingList
     ).not.toHaveBeenCalled();
@@ -200,7 +199,7 @@ describe('OppiaFooterComponent', () => {
 
     component.subscribeToMailingList();
 
-    expect(component.subscriptionProcessing).toBeTrue();
+    expect(component.subscriptionProcessing).toBe(true);
 
     flushMicrotasks();
 
@@ -211,7 +210,7 @@ describe('OppiaFooterComponent', () => {
       null,
       AppConstants.MAILING_LIST_WEB_TAG
     );
-    expect(component.subscriptionProcessing).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
   }));
 
   it('should add user to mailing list and return status', fakeAsync(() => {
@@ -224,12 +223,11 @@ describe('OppiaFooterComponent', () => {
       'subscribeUserToMailingList'
     ).and.returnValue(Promise.resolve(true));
 
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.emailDuplicated).toBe(false);
 
     component.subscribeToMailingList();
-
-    expect(component.subscriptionProcessing).toBeTrue();
+    expect(component.subscriptionProcessing).toBe(true);
 
     flushMicrotasks();
 
@@ -238,9 +236,9 @@ describe('OppiaFooterComponent', () => {
       ThanksForSubscribingModalComponent,
       {backdrop: 'static', size: 'xl'}
     );
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.isAlreadySubscribed(component.emailAddress)).toBeTrue();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.isAlreadySubscribed(component.emailAddress)).toBe(true);
+    expect(component.emailDuplicated).toBe(false);
   }));
 
   it('should fail to add user to mailing list and return status', fakeAsync(() => {
@@ -253,12 +251,12 @@ describe('OppiaFooterComponent', () => {
       'subscribeUserToMailingList'
     ).and.returnValue(Promise.resolve(false));
 
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.emailDuplicated).toBe(false);
 
     component.subscribeToMailingList();
 
-    expect(component.subscriptionProcessing).toBeTrue();
+    expect(component.subscriptionProcessing).toBe(true);
 
     flushMicrotasks();
 
@@ -266,9 +264,9 @@ describe('OppiaFooterComponent', () => {
       AppConstants.MAILING_LIST_UNEXPECTED_ERROR_MESSAGE,
       10000
     );
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.isAlreadySubscribed(component.emailAddress)).toBeTrue();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.isAlreadySubscribed(component.emailAddress)).toBe(true);
+    expect(component.emailDuplicated).toBe(false);
   }));
 
   it('should reject request to the mailing list correctly', fakeAsync(() => {
@@ -281,12 +279,12 @@ describe('OppiaFooterComponent', () => {
       'subscribeUserToMailingList'
     ).and.returnValue(Promise.reject(false));
 
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.emailDuplicated).toBe(false);
 
     component.subscribeToMailingList();
 
-    expect(component.subscriptionProcessing).toBeTrue();
+    expect(component.subscriptionProcessing).toBe(true);
 
     flushMicrotasks();
 
@@ -294,9 +292,9 @@ describe('OppiaFooterComponent', () => {
       AppConstants.MAILING_LIST_UNEXPECTED_ERROR_MESSAGE,
       10000
     );
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.isAlreadySubscribed(component.emailAddress)).toBeTrue();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.isAlreadySubscribed(component.emailAddress)).toBe(true);
+    expect(component.emailDuplicated).toBe(false);
   }));
 
   it('should show newsletter warning if user tries to subscribe to newsletter with already used email address', fakeAsync(() => {
@@ -307,23 +305,22 @@ describe('OppiaFooterComponent', () => {
       'subscribeUserToMailingList'
     ).and.returnValue(Promise.resolve(true));
 
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.emailDuplicated).toBe(false);
 
     component.subscribeToMailingList();
 
-    expect(component.subscriptionProcessing).toBeTrue();
+    expect(component.subscriptionProcessing).toBe(true);
 
     flushMicrotasks();
-
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.isAlreadySubscribed(component.emailAddress)).toBeTrue();
-    expect(component.emailDuplicated).toBeFalse();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.isAlreadySubscribed(component.emailAddress)).toBe(true);
+    expect(component.emailDuplicated).toBe(false);
 
     component.subscribeToMailingList();
 
-    expect(component.subscriptionProcessing).toBeFalse();
-    expect(component.emailDuplicated).toBeTrue();
+    expect(component.subscriptionProcessing).toBe(false);
+    expect(component.emailDuplicated).toBe(true);
   }));
   it('should register About footer link click event', () => {
     spyOn(siteAnalyticsService, 'registerClickFooterButtonEvent');

--- a/core/templates/components/button-directives/exploration-embed-button-modal.component.spec.ts
+++ b/core/templates/components/button-directives/exploration-embed-button-modal.component.spec.ts
@@ -20,7 +20,7 @@ import {
   ComponentFixture,
   fakeAsync,
   TestBed,
-  async,
+  waitForAsync,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
@@ -45,7 +45,8 @@ describe('ExplorationEmbedButtonModalComponent', () => {
   let fixture: ComponentFixture<ExplorationEmbedButtonModalComponent>;
   let siteAnalyticsService: SiteAnalyticsService;
   let ngbActiveModal: NgbActiveModal;
-  beforeEach(async(() => {
+
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ExplorationEmbedButtonModalComponent],
       providers: [
@@ -64,8 +65,8 @@ describe('ExplorationEmbedButtonModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ExplorationEmbedButtonModalComponent);
     component = fixture.componentInstance;
-    siteAnalyticsService = TestBed.get(SiteAnalyticsService);
-    ngbActiveModal = TestBed.get(NgbActiveModal);
+    siteAnalyticsService = TestBed.inject(SiteAnalyticsService);
+    ngbActiveModal = TestBed.inject(NgbActiveModal);
     component.explorationId = '3f6cD869';
     component.serverName = 'https://oppia.org';
     fixture.detectChanges();
@@ -93,18 +94,10 @@ describe('ExplorationEmbedButtonModalComponent', () => {
   it('should select the embed url', fakeAsync(() => {
     const removeAllRanges = jasmine.createSpy('removeAllRanges');
     const addRange = jasmine.createSpy('addRange');
-    // This throws "Argument of type '{ removeAllRanges:
-    // jasmine.Spy<jasmine.Func>; addRange: jasmine.Spy<jasmine.Func>; }'
-    // is not assignable to parameter of type 'Selection'." This is because
-    // the type of the actual 'getSelection' function doesn't match the type
-    // of function we've mocked it to. We need to suppress this error because
-    // we need to mock 'getSelection' function to our function for testing
-    // purposes.
-    // @ts-expect-error
     spyOn(window, 'getSelection').and.returnValue({
       removeAllRanges: removeAllRanges,
       addRange: addRange,
-    });
+    } as unknown as Selection);
 
     let embedUrlDiv = fixture.debugElement.query(
       By.css('.oppia-embed-modal-code')
@@ -121,12 +114,7 @@ describe('ExplorationEmbedButtonModalComponent', () => {
       currentTarget: null,
     };
     expect(() => {
-      // This throws "Argument of type '{ type: string; currentTarget:
-      // () => any; }' is not assignable to parameter of type 'MouseEvent'."
-      // We need to suppress this error because we need to test selectText
-      // function.
-      // @ts-expect-error
-      component.selectText(event);
+      component.selectText(event as unknown as MouseEvent);
     }).toThrowError('No CodeDiv was found!');
   });
 

--- a/core/templates/components/button-directives/hint-and-solution-buttons.component.spec.ts
+++ b/core/templates/components/button-directives/hint-and-solution-buttons.component.spec.ts
@@ -29,7 +29,6 @@ import {NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {TranslateService} from '@ngx-translate/core';
 import {MockTranslateService} from 'components/forms/schema-based-editors/integration-tests/schema-based-editors.integration.spec';
 import {Interaction} from 'domain/exploration/interaction.model';
-import {RecordedVoiceovers} from 'domain/exploration/recorded-voiceovers.model';
 import {StateCard} from 'domain/state_card/state-card.model';
 import {ExplorationModeService} from 'pages/exploration-player-page/services/exploration-mode.service';
 import {HintAndSolutionModalService} from 'pages/exploration-player-page/services/hint-and-solution-modal.service';
@@ -159,7 +158,6 @@ describe('HintAndSolutionButtonsComponent', () => {
       '<p>Content</p>',
       '<interaction></interaction>',
       Interaction.createFromBackendDict(defaultInteractionBackendDict),
-      RecordedVoiceovers.createEmpty(),
       'content'
     );
   });
@@ -175,7 +173,6 @@ describe('HintAndSolutionButtonsComponent', () => {
       'Content html',
       'Interaction html',
       interaction,
-      RecordedVoiceovers.createEmpty(),
       'content'
     );
     spyOn(component, 'resetLocalHintsArray');
@@ -195,7 +192,6 @@ describe('HintAndSolutionButtonsComponent', () => {
       'Content html',
       'Interaction html',
       interaction,
-      RecordedVoiceovers.createEmpty(),
       'content'
     );
     spyOn(component, 'resetLocalHintsArray');
@@ -237,7 +233,6 @@ describe('HintAndSolutionButtonsComponent', () => {
         '<p>Content</p>',
         '<interaction></interaction>',
         {} as Interaction,
-        RecordedVoiceovers.createEmpty(),
         'content'
       );
       spyOn(hintsAndSolutionManagerService, 'getNumHints').and.returnValue(1);
@@ -253,7 +248,7 @@ describe('HintAndSolutionButtonsComponent', () => {
   );
 
   it('should get RTL language status correctly', () => {
-    expect(component.isLanguageRTL()).toBeTrue();
+    expect(component.isLanguageRTL()).toBe(true);
   });
 
   it(
@@ -346,7 +341,6 @@ describe('HintAndSolutionButtonsComponent', () => {
           hints: [],
           solution: null,
         }),
-        RecordedVoiceovers.createEmpty(),
         'content'
       );
 

--- a/core/templates/components/checkpoint-celebration-modal/checkpoint-celebration-modal.component.spec.ts
+++ b/core/templates/components/checkpoint-celebration-modal/checkpoint-celebration-modal.component.spec.ts
@@ -36,11 +36,9 @@ import {UrlInterpolationService} from 'domain/utilities/url-interpolation.servic
 import {PlayerPositionService} from 'pages/exploration-player-page/services/player-position.service';
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
 import {StateCard} from 'domain/state_card/state-card.model';
-import {RecordedVoiceovers} from 'domain/exploration/recorded-voiceovers.model';
 import {Interaction} from 'domain/exploration/interaction.model';
 import {StateObjectsBackendDict} from 'domain/exploration/states.model';
 import {ExplorationModeService} from 'pages/exploration-player-page/services/exploration-mode.service';
-
 class MockCheckpointCelebrationUtilityService {
   isOnCheckpointedState = false;
   openLessonInformationModalEmitter = new EventEmitter<void>();
@@ -304,7 +302,6 @@ describe('Checkpoint celebration modal component', function () {
           },
         },
       }),
-      RecordedVoiceovers.createEmpty(),
       'content'
     );
   });
@@ -646,20 +643,12 @@ describe('Checkpoint celebration modal component', function () {
   it('should reset timer', () => {
     component.checkpointTimerTemplateRef = {
       nativeElement: {
-        // This throws "Type
-        // '{ strokeDasharray: string; strokeDashoffset: string; }' is missing
-        // the following properties from type 'CSSStyleDeclaration':
-        // accentColor, alignContent, alignItems, alignSelf, and 457 more.".
-        // We need to suppress this error because only these values are
-        // needed for testing and providing a value for every single property is
-        // unnecessary.
-        // @ts-expect-error
         style: {
           strokeDashoffset: '',
           transitionDuration: '',
         },
       },
-    };
+    } as unknown as HTMLElement;
     const rtlSpy = spyOn(
       i18nLanguageCodeService,
       'isLanguageRTL'

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -117,7 +117,7 @@ export class CkEditor4RteComponent
     private renderer: Renderer2
   ) {
     this.rteHelperService =
-      OppiaAngularRootComponent.rteHelperService as RteHelperService;
+      OppiaAngularRootComponent.rteHelperService as unknown as RteHelperService;
     this.subscriptions = new Subscription();
   }
 

--- a/core/templates/components/code-mirror/codemirror-mergeview.component.spec.ts
+++ b/core/templates/components/code-mirror/codemirror-mergeview.component.spec.ts
@@ -18,7 +18,7 @@
 
 import {NgZone, SimpleChanges} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
-import CodeMirror from '@types/codemirror';
+import CodeMirror from 'codemirror';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {CodemirrorMergeviewComponent} from './codemirror-mergeview.component';
 

--- a/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.spec.ts
@@ -116,28 +116,28 @@ describe('ClassroomNavigationLinksComponent', () => {
   });
 
   it('should set component properties on initialization', fakeAsync(() => {
-    classroomBackendApiService.getAllClassroomsSummaryAsync.and.returnValue(
-      Promise.resolve(dummyClassroomSummaries)
-    );
+    (
+      classroomBackendApiService.getAllClassroomsSummaryAsync as jasmine.Spy
+    ).and.returnValue(Promise.resolve(dummyClassroomSummaries));
 
     expect(component.classroomSummaries.length).toEqual(0);
-    expect(component.isLoading).toBeTrue();
+    expect(component.isLoading).toBe(true);
 
     component.ngOnInit();
     tick();
 
     // It should store all public classrooms.
     expect(component.classroomSummaries.length).toEqual(3);
-    expect(component.isLoading).toBeFalse();
+    expect(component.isLoading).toBe(false);
   }));
 
   it('should get classroom thumbnail', () => {
     const classroomId = 'math';
     const thumbnailFilename = 'thumbnail.svg';
 
-    assetsBackendApiService.getThumbnailUrlForPreview.and.returnValue(
-      '/thumbnail/thumbnail.svg'
-    );
+    (
+      assetsBackendApiService.getThumbnailUrlForPreview as jasmine.Spy
+    ).and.returnValue('/thumbnail/thumbnail.svg');
 
     const result = component.getClassroomThumbnail(
       classroomId,
@@ -175,7 +175,7 @@ describe('ClassroomNavigationLinksComponent', () => {
     const result =
       component.isHackyClassroomNameTranslationDisplayed(classroomName);
 
-    expect(result).toBeTrue();
+    expect(result).toBe(true);
     expect(
       i18nLanguageCodeService.isClassroomnNameTranslationAvailable
     ).toHaveBeenCalledWith(classroomName);
@@ -204,7 +204,7 @@ describe('ClassroomNavigationLinksComponent', () => {
       classroomBackendApiService.getAllClassroomsSummaryAsync
     ).not.toHaveBeenCalled();
     expect(component.classroomSummaries).toEqual([]);
-    expect(component.isLoading).toBeTrue();
+    expect(component.isLoading).toBe(true);
   }));
 
   it('should return the correct number of classrooms from getClassroomCount', () => {

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
@@ -475,11 +475,6 @@ describe('TopNavigationBarComponent', () => {
       .and.returnValues(
         [
           {
-            // This throws "Type '{ innerText: string; }' is not assignable to
-            // type 'Element'.". We need to suppress this error because if i18n
-            // has not run, then the tabs will not have text content and so
-            // their innerText.length value will be 0.
-            // @ts-expect-error
             innerText: '',
           },
         ],
@@ -547,13 +542,6 @@ describe('TopNavigationBarComponent', () => {
     spyOn(wds, 'isWindowNarrow').and.returnValues(false, true);
     spyOn(document, 'querySelector')
       .withArgs('div.collapse.navbar-collapse')
-      // This throws "Type '{ clientWidth: number; }' is missing the following
-      // properties from type 'Element': assignedSlot, attributes, classList,
-      // className, and 122 more.". We need to suppress this error because
-      // typescript expects around 120 more properties than just one
-      // (clientWidth). We need only one 'clientWidth' for
-      // testing purposes.
-      // @ts-expect-error
       .and.returnValue({
         clientHeight: 61,
       });
@@ -904,14 +892,14 @@ describe('TopNavigationBarComponent', () => {
     () => {
       expect(
         component.isShowFeedbackUpdatesInProfilepicDropdownFeatureFlagEnable()
-      ).toBeFalse();
+      ).toBe(false);
 
       mockPlatformFeatureService.status.ShowFeedbackUpdatesInProfilePicDropdownMenu.isEnabled =
         true;
 
       expect(
         component.isShowFeedbackUpdatesInProfilepicDropdownFeatureFlagEnable()
-      ).toBeTrue();
+      ).toBe(true);
     }
   );
 
@@ -927,21 +915,21 @@ describe('TopNavigationBarComponent', () => {
     tick();
 
     expect(learnerGroupSpy).not.toHaveBeenCalled();
-    expect(component.LEARNER_GROUPS_FEATURE_IS_ENABLED).toBeFalse();
+    expect(component.LEARNER_GROUPS_FEATURE_IS_ENABLED).toBe(false);
   }));
 
   it('should hide menu icon when page contains a back button', () => {
     spyOn(urlService, 'getPathname').and.returnValue('/blog/post123');
     component.PAGES_WITH_BACK_STATE = ['/blog/'];
     component.ngOnInit();
-    expect(component.menuIconIsShown).toBeFalse();
+    expect(component.menuIconIsShown).toBe(false);
   });
 
   it('should show menu icon when page does not contain a back button', () => {
     spyOn(urlService, 'getPathname').and.returnValue('/classroom/math');
     component.PAGES_WITH_BACK_STATE = ['/blog/', '/learner-dashboard/'];
     component.ngOnInit();
-    expect(component.menuIconIsShown).toBeTrue();
+    expect(component.menuIconIsShown).toBe(true);
   });
 
   it('should set classroomSummariesLength from DOM data attribute', () => {

--- a/core/templates/components/forms/custom-forms-directives/apply-validation.directive.ts
+++ b/core/templates/components/forms/custom-forms-directives/apply-validation.directive.ts
@@ -22,6 +22,7 @@ import {
   Validator,
   AbstractControl,
   ValidationErrors,
+  ValidatorFn,
 } from '@angular/forms';
 import {UnderscoresToCamelCasePipe} from 'filters/string-utility-filters/underscores-to-camel-case.pipe';
 import {Validator as OppiaValidator} from 'interactions/TextInput/directives/text-input-validation.service';
@@ -39,8 +40,9 @@ import {SchemaValidators} from '../validators/schema-validators';
   ],
 })
 export class ApplyValidationDirective implements Validator {
-  @Input() validators: OppiaValidator[];
+  @Input() validators!: OppiaValidator[];
   underscoresToCamelCasePipe = new UnderscoresToCamelCasePipe();
+
   validate(control: AbstractControl): ValidationErrors | null {
     if (!this.validators || this.validators.length === 0) {
       return null;
@@ -51,15 +53,23 @@ export class ApplyValidationDirective implements Validator {
       const validatorName = this.underscoresToCamelCasePipe.transform(
         validatorSpec.id
       );
-      const filterArgs = {};
+      const filterArgs: Record<string, unknown> = {};
       for (let key in validatorSpec) {
         if (key !== 'id') {
           filterArgs[this.underscoresToCamelCasePipe.transform(key)] =
-            cloneDeep(validatorSpec[key]);
+            cloneDeep(
+              (validatorSpec as unknown as Record<string, unknown>)[key]
+            );
         }
       }
-      if (SchemaValidators[validatorName]) {
-        const error = SchemaValidators[validatorName](filterArgs)(control);
+
+      const validatorsMap = SchemaValidators as unknown as Record<
+        string,
+        (args: Record<string, unknown>) => ValidatorFn
+      >;
+
+      if (validatorsMap[validatorName]) {
+        const error = validatorsMap[validatorName](filterArgs)(control);
         if (error !== null) {
           errorsPresent = true;
           allValidationErrors = {...allValidationErrors, ...error};

--- a/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.spec.ts
@@ -102,18 +102,12 @@ describe('Edit Thumbnail Modal Component', () => {
     svgSanitizerService = TestBed.inject(SvgSanitizerService);
     closeSpy = spyOn(ngbActiveModal, 'close').and.callThrough();
     dismissSpy = spyOn(ngbActiveModal, 'dismiss').and.callThrough();
-    // This throws "Argument of type 'mockImageObject' is not assignable to
-    // parameter of type 'HTMLImageElement'.". We need to suppress this
-    // error because 'HTMLImageElement' has around 250 more properties.
-    // We have only defined the properties we need in 'mockImageObject'.
-    // @ts-expect-error
-    spyOn(window, 'Image').and.returnValue(new MockImageObject());
-    // This throws "Argument of type 'mockReaderObject' is not assignable to
-    // parameter of type 'HTMLImageElement'.". We need to suppress this
-    // error because 'HTMLImageElement' has around 250 more properties.
-    // We have only defined the properties we need in 'mockReaderObject'.
-    // @ts-expect-error
-    spyOn(window, 'FileReader').and.returnValue(new MockReaderObject());
+    spyOn(window, 'Image').and.returnValue(
+      new MockImageObject() as unknown as HTMLImageElement
+    );
+    spyOn(window, 'FileReader').and.returnValue(
+      new MockReaderObject() as unknown as FileReader
+    );
     spyOn(component, 'updateBackgroundColor').and.callThrough();
     spyOn(component, 'setImageDimensions').and.callThrough();
   }));
@@ -160,8 +154,8 @@ describe('Edit Thumbnail Modal Component', () => {
     component.onFileChanged(file);
 
     expect(component.uploadedImage).toBeNull();
-    expect(component.invalidFilenameWarningIsShown).toBeFalse();
-    expect(component.invalidImageWarningIsShown).toBeTrue();
+    expect(component.invalidFilenameWarningIsShown).toBe(false);
+    expect(component.invalidImageWarningIsShown).toBe(true);
   });
 
   it('should not load file if it does not have a proper filename', () => {
@@ -178,20 +172,20 @@ describe('Edit Thumbnail Modal Component', () => {
     var file = new File([arrayBuffer], 'thumb..nail.svg');
     component.onFileChanged(file);
     expect(component.uploadedImage).toBeNull();
-    expect(component.invalidFilenameWarningIsShown).toBeTrue();
-    expect(component.invalidImageWarningIsShown).toBeFalse();
+    expect(component.invalidFilenameWarningIsShown).toBe(true);
+    expect(component.invalidImageWarningIsShown).toBe(false);
 
     file = new File([arrayBuffer], 'thumb/nail.svg');
     component.onFileChanged(file);
     expect(component.uploadedImage).toBeNull();
-    expect(component.invalidFilenameWarningIsShown).toBeTrue();
-    expect(component.invalidImageWarningIsShown).toBeFalse();
+    expect(component.invalidFilenameWarningIsShown).toBe(true);
+    expect(component.invalidImageWarningIsShown).toBe(false);
 
     file = new File([arrayBuffer], '.thumbnail.svg');
     component.onFileChanged(file);
     expect(component.uploadedImage).toBeNull();
-    expect(component.invalidFilenameWarningIsShown).toBeTrue();
-    expect(component.invalidImageWarningIsShown).toBeFalse();
+    expect(component.invalidFilenameWarningIsShown).toBe(true);
+    expect(component.invalidImageWarningIsShown).toBe(false);
   });
 
   it('should update bgColor on changing background color', () => {
@@ -201,13 +195,13 @@ describe('Edit Thumbnail Modal Component', () => {
     component.updateBackgroundColor('#B3D8F1');
 
     expect(component.bgColor).toBe('#B3D8F1');
-    expect(component.thumbnailHasChanged).toBeTrue();
+    expect(component.thumbnailHasChanged).toBe(true);
   });
 
   it('should check for uploaded image to be svg', () => {
     component.uploadedImageMimeType = 'image/svg+xml';
     let result = component.isUploadedImageSvg();
-    expect(result).toBeTrue();
+    expect(result).toBe(true);
   });
 
   it('should check for uploaded image to have correct filename', () => {
@@ -217,7 +211,7 @@ describe('Edit Thumbnail Modal Component', () => {
     );
     const file = new File([arrayBuffer], 'thumbnail.svg');
     let result = component.isValidFilename(file);
-    expect(result).toBeTrue();
+    expect(result).toBe(true);
   });
 
   it('should set image dimensions', () => {
@@ -232,13 +226,13 @@ describe('Edit Thumbnail Modal Component', () => {
   it('should reset the uploaded image on clicking reset button', () => {
     component.reset();
     expect(component.uploadedImage).toBeNull();
-    expect(component.openInUploadMode).toBeTrue();
+    expect(component.openInUploadMode).toBe(true);
   });
 
   it('should reset the uploaded Image and show a warning', () => {
     component.onInvalidImageLoaded();
     expect(component.uploadedImage).toBeNull();
-    expect(component.invalidImageWarningIsShown).toBeTrue();
+    expect(component.invalidImageWarningIsShown).toBe(true);
   });
 
   it('should close the modal when clicking on Add Thumbnail Button', () => {
@@ -251,7 +245,7 @@ describe('Edit Thumbnail Modal Component', () => {
       width: 180,
     };
     component.confirm();
-    expect(component.thumbnailHasChanged).toBeFalse();
+    expect(component.thumbnailHasChanged).toBe(false);
     expect(closeSpy).toHaveBeenCalledWith({
       newThumbnailDataUrl: 'uploaded_img.svg',
       newBgColor: '#fff',
@@ -283,9 +277,9 @@ describe('Edit Thumbnail Modal Component', () => {
       ).and.returnValue(fileContent);
       let file = new File([fileContent], 'triangle.svg', {type: 'image/svg'});
       component.uploadedImageMimeType = 'image/svg+xml';
-      expect(component.thumbnailHasChanged).toBeFalse();
+      expect(component.thumbnailHasChanged).toBe(false);
       component.onFileChanged(file);
-      expect(component.thumbnailHasChanged).toBeTrue();
+      expect(component.thumbnailHasChanged).toBe(true);
     }
   );
 });

--- a/core/templates/components/forms/custom-forms-directives/image-receiver.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-receiver.component.spec.ts
@@ -190,9 +190,7 @@ describe('ImageReceiverComponent', () => {
 
   it('should return correct format string when there is one allowed image format', () => {
     component.allowedImageFormats = ['jpeg'];
-    const formatString = component.getAllowedImageFormatsString(
-      component.allowedImageFormats
-    );
+    const formatString = component.getAllowedImageFormatsString();
     expect(formatString).toBe('Is in .jpeg format');
   });
 


### PR DESCRIPTION
### Overview

This PR fixes or fixes part of : Enable strict type checking https://github.com/oppia/oppia/issues/23496

enforces TypeScript Strict Type Checking (strict: true) for the following file scopes and their associated unit tests:

Group 17 Files (Base Components): (e.g., oppia-footer.component.spec.ts, edit-thumbnail-modal.component.spec.ts).
Interaction Components: (ImageClickInput.component.ts, companion Music Notes components).
Player Services: (exploration-engine.service.ts, question-player-engine.service.ts).
The PR resolves numerous type errors (TS2564, TS2345, TS7053) by implementing:

Definite Assignment Assertion (!) for late-initialized properties.
Null Checks and appropriate casting (| null).
Index Signature fixes (as any or as Record<string, any>) for dynamic object access.
Test Mock Fixes for argument count mismatches

### Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

I have linked the issue that this PR fixes in the "Development" section of the sidebar.
I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
I have written tests for my code.
The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

### Testing doc (for PRs with Beam jobs that modify production server data)

A testing doc has been written: ... (ADD LINK) ...
(To be confirmed by the server admin) All jobs in this PR have been verified on a live server, and the PR is safe to merge.

### proofs that changes are correct
<img width="421" height="80" alt="gg" src="https://github.com/user-attachments/assets/0fcd0e48-870c-4381-b8ba-e0615f928182" />

prooof I have fixed the strict type errors in the files and verified that the typescript checks pass.

### pr pointers

Never force push! If you do, your PR will be closed.
To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).

Part of a larger PR? No
and-checks-to-be-carried-out-by-developers) for what code owners will expect.