### PR TITLE
Fix #24005:  fix ffmpeg installation

### DIFF
--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -104,8 +104,10 @@ jobs:
         uses: ./.github/actions/install-chrome
       - name: Install ffmpeg for wdio videos
         run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt install ffmpeg
+          sudo apt install -y ffmpeg
       - name: Generate modified suite name for artifacts
         id: generate_suite_name_for_artifacts
         # Replace slashes in the filename with hyphens.
@@ -266,14 +268,14 @@ jobs:
 
       # Upload other essential files.
       - name: Upload generated test to angular module mapping
-        if: ${{ failure() && (steps.desktop-test-attempt-1.outcome == 'failure' || steps.mobile-test-attempt-1.outcome == 'failure') }}
+        if: ${{ failure() && (steps.desktop-test.outcome == 'failure' || steps.mobile-test.outcome == 'failure') }}
         uses: actions/upload-artifact@v4
         with:
           name: generated-test-to-angular-module-mapping-${{steps.generate_suite_name_for_artifacts.outputs.MODIFIED_SUITE_NAME}}
           path: /home/runner/work/oppia/oppia/core/tests/test-modules-mappings/acceptance/${{ steps.generate_suite_name_for_artifacts.outputs.MODIFIED_SUITE_NAME }}.txt
 
       - name: Upload webpack bundles
-        if: ${{ failure() && (steps.desktop-test-attempt-1.outcome == 'failure' || steps.mobile-test-attempt-1.outcome == 'failure') }}
+        if: ${{ failure() && (steps.desktop-test.outcome == 'failure' || steps.mobile-test.outcome == 'failure') }}
         uses: actions/upload-artifact@v4
         with:
           name: webpack-bundles-${{steps.generate_suite_name_for_artifacts.outputs.MODIFIED_SUITE_NAME}}
@@ -421,10 +423,12 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           repository: oppia/release-scripts
           event-type: develop-commit
-          client-payload: '{
-            "version": "${{ env.VERSION }}",
-            "app_name": "oppiatestserver",
-            "maintenance_mode": false,
-            "sha": "${{ github.sha }}",
-            "repo_owner": "${{ github.repository_owner }}"
-          }'
+          client-payload: >-
+            {
+              "version": "${{ env.VERSION }}",
+              "app_name": "oppiatestserver",
+              "maintenance_mode": false,
+              "sha": "${{ github.sha }}",
+              "repo_owner": "${{ github.repository_owner }}"
+            }
+              


### PR DESCRIPTION
### Overview

Fixes #24005

Explanation

The E2E learner CI workflow is currently failing due to an upstream outage in the Microsoft package repositories. Specifically, the sudo apt-get update step throws a 403 Forbidden error when attempting to fetch data from packages.microsoft.com. This prevents the package lists from updating correctly and blocks the installation of ffmpeg, causing the build to fail.

To address this, I have modified the full_stack_tests.yml workflow to explicitly remove the unstable Azure and Microsoft source lists (azure-cli.list and microsoft-prod.list) from the runner before executing the update command. This ensures that the apt-get update step proceeds without errors and allows ffmpeg to be installed successfully.

### Essential Checklist
Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

 I have linked the issue that this PR fixes in the "Development" section of the sidebar.
 I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
 I have written tests for my code.
 The PR title starts with "Fix https://github.com/oppia/oppia/issues/24005: " followed by a short, clear summary of the changes.
 I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
Testing doc (for PRs with Beam jobs that modify production server data)

###  A testing doc has been written: ... (ADD LINK) ...
 (To be confirmed by the server admin) All jobs in this PR have been verified on a live server, and the PR is safe to merge.
Proof that changes are correct

### PR Pointers
Never force push! If you do, your PR will be closed.
To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.