### PR TITLE
Fix #24423: Story Viewer should show ready to publish chapter as grayed out and should not show draft chapters at all when in serialized story editor mode.

### DIFF
--- a/core/templates/domain/story_viewer/read-only-story-node.model.spec.ts
+++ b/core/templates/domain/story_viewer/read-only-story-node.model.spec.ts
@@ -60,6 +60,7 @@ describe('Read only story node model', () => {
       completed: true,
       thumbnail_bg_color: '#a33f40',
       thumbnail_filename: 'image.png',
+      status: 'Published',
     };
     _sampleStoryNode = ReadOnlyStoryNode.createFromBackendDict(
       sampleReadOnlyStoryNodeBackendDict
@@ -103,5 +104,6 @@ describe('Read only story node model', () => {
     expect(_sampleStoryNode.getOutlineStatus()).toEqual(false);
     expect(_sampleStoryNode.getThumbnailFilename()).toEqual('image.png');
     expect(_sampleStoryNode.getThumbnailBgColor()).toEqual('#a33f40');
+    expect(_sampleStoryNode.getStatus()).toEqual('Published');
   });
 });

--- a/core/templates/domain/story_viewer/read-only-story-node.model.ts
+++ b/core/templates/domain/story_viewer/read-only-story-node.model.ts
@@ -36,6 +36,7 @@ export interface StoryNodeBackendDict {
   completed: boolean;
   thumbnail_bg_color: string;
   thumbnail_filename: string;
+  status: string;
 }
 
 export class ReadOnlyStoryNode {
@@ -52,6 +53,7 @@ export class ReadOnlyStoryNode {
   completed: boolean;
   thumbnailBgColor: string;
   thumbnailFilename: string;
+  status: string;
 
   constructor(
     id: string,
@@ -66,7 +68,8 @@ export class ReadOnlyStoryNode {
     explorationSummary: LearnerExplorationSummary,
     completed: boolean,
     thumbnailBgColor: string,
-    thumbnailFilename: string
+    thumbnailFilename: string,
+    status: string
   ) {
     this.id = id;
     this.title = title;
@@ -81,6 +84,7 @@ export class ReadOnlyStoryNode {
     this.completed = completed;
     this.thumbnailBgColor = thumbnailBgColor;
     this.thumbnailFilename = thumbnailFilename;
+    this.status = status;
   }
 
   static createFromBackendDict(
@@ -103,7 +107,8 @@ export class ReadOnlyStoryNode {
       explorationSummary,
       storyNodeBackendDict.completed,
       storyNodeBackendDict.thumbnail_bg_color,
-      storyNodeBackendDict.thumbnail_filename
+      storyNodeBackendDict.thumbnail_filename,
+      storyNodeBackendDict.status
     );
   }
 
@@ -145,5 +150,9 @@ export class ReadOnlyStoryNode {
 
   getThumbnailBgColor(): string {
     return this.thumbnailBgColor;
+  }
+
+  getStatus(): string {
+    return this.status;
   }
 }

--- a/core/templates/domain/story_viewer/story-playthrough.model.spec.ts
+++ b/core/templates/domain/story_viewer/story-playthrough.model.spec.ts
@@ -59,6 +59,7 @@ describe('Story playthrough model', () => {
       completed: true,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: 'filename',
+      status: 'Published',
     };
     var secondSampleReadOnlyStoryNodeBackendDict = {
       id: 'node_2',
@@ -97,6 +98,7 @@ describe('Story playthrough model', () => {
       completed: false,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: 'filename',
+      status: 'Published',
     };
     var storyPlaythroughBackendObject = {
       story_id: 'qwerty',

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.css
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.css
@@ -94,7 +94,6 @@ oppia-story-viewer-page.oppia-login-or-signup-text {
 
 oppia-story-viewer-page .oppia-chapter-coming-soon {
   cursor: not-allowed;
-  pointer-events: none;
 }
 
 oppia-story-viewer-page .oppia-story-viewer-card-coming-soon {
@@ -103,11 +102,4 @@ oppia-story-viewer-page .oppia-story-viewer-card-coming-soon {
 
 oppia-story-viewer-page .oppia-lesson-icon-coming-soon {
   background-color: #ccc;
-}
-
-oppia-story-viewer-page .oppia-coming-soon-label {
-  color: #888;
-  font-size: 14px;
-  font-style: italic;
-  margin-left: 8px;
 }

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.css
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.css
@@ -94,6 +94,7 @@ oppia-story-viewer-page.oppia-login-or-signup-text {
 
 oppia-story-viewer-page .oppia-chapter-coming-soon {
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 oppia-story-viewer-page .oppia-story-viewer-card-coming-soon {
@@ -102,4 +103,11 @@ oppia-story-viewer-page .oppia-story-viewer-card-coming-soon {
 
 oppia-story-viewer-page .oppia-lesson-icon-coming-soon {
   background-color: #ccc;
+}
+
+oppia-story-viewer-page .oppia-coming-soon-label {
+  color: #888;
+  font-size: 14px;
+  font-style: italic;
+  margin-left: 8px;
 }

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.css
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.css
@@ -91,3 +91,24 @@ oppia-story-viewer-page.oppia-login-or-signup-text {
     display: block;
   }
 }
+
+/* Styles for "Coming Soon" chapters (Ready To Publish status). */
+oppia-story-viewer-page .oppia-chapter-coming-soon {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+oppia-story-viewer-page .oppia-story-viewer-card-coming-soon {
+  opacity: 0.5;
+}
+
+oppia-story-viewer-page .oppia-lesson-icon-coming-soon {
+  background-color: #ccc;
+}
+
+oppia-story-viewer-page .oppia-coming-soon-label {
+  color: #888;
+  font-size: 14px;
+  font-style: italic;
+  margin-left: 8px;
+}

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.css
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.css
@@ -92,7 +92,6 @@ oppia-story-viewer-page.oppia-login-or-signup-text {
   }
 }
 
-/* Styles for "Coming Soon" chapters (Ready To Publish status). */
 oppia-story-viewer-page .oppia-chapter-coming-soon {
   cursor: not-allowed;
   pointer-events: none;

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.html
@@ -24,7 +24,6 @@
              [href]="getChapterExplorationUrl(node)"
              [class.oppia-chapter-coming-soon]="isChapterDisplayedAsComingSoon(node)"
              [attr.title]="isChapterDisplayedAsComingSoon(node) ? ('I18N_LEARNER_STORY_TILE_COMING_SOON_TOOLTIP' | translate) : null"
-             (click)="isChapterDisplayedAsComingSoon(node) && $event.preventDefault()"
              tabindex="0">
 
             <div>
@@ -65,6 +64,9 @@
                     </span>
                     <span *ngIf="isHackyStoryNodeTitleTranslationDisplayed(index)">
                       {{index + 1}}: {{ storyNodesTitleTranslationKeys[index] | translate }}
+                    </span>
+                    <span *ngIf="isChapterDisplayedAsComingSoon(node)" class="oppia-coming-soon-label">
+                      ({{ 'I18N_LEARNER_STORY_TILE_COMING_SOON' | translate }})
                     </span>
                   </span>
 

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.html
@@ -21,7 +21,10 @@
 
         <div *ngIf="showChapters()" class="d-md-block oppia-story-viewer-card-container">
           <a *ngFor="let node of storyPlaythroughObject.getStoryNodes();let last = isLast;let index = index"
-             [href]="getExplorationUrl(node)" tabindex="0">
+             [href]="getChapterExplorationUrl(node)"
+             [class.oppia-chapter-coming-soon]="isChapterDisplayedAsComingSoon(node)"
+             [attr.title]="isChapterDisplayedAsComingSoon(node) ? ('I18N_LEARNER_STORY_TILE_COMING_SOON_TOOLTIP' | translate) : null"
+             tabindex="0">
 
             <div>
               <div class="fx-row">
@@ -42,15 +45,18 @@
                   <img class="oppia-lesson-icon-completed e2e-test-lesson-icon-completed"
                        [src]="getStaticImageUrl('/general/collection_paw.svg')"
                        *ngIf="node.isCompleted()">
-                  <div *ngIf="!node.isCompleted() && (node.getId() === storyPlaythroughObject.getNextPendingNodeId())"
+                  <div *ngIf="!node.isCompleted() && !isChapterDisplayedAsComingSoon(node) && (node.getId() === storyPlaythroughObject.getNextPendingNodeId())"
                        class="oppia-lesson-icon-uncompleted e2e-test-lesson-icon-uncompleted">
                   </div>
-                  <div *ngIf="!node.isCompleted() && (node.getId() !== storyPlaythroughObject.getNextPendingNodeId())"
+                  <div *ngIf="!node.isCompleted() && !isChapterDisplayedAsComingSoon(node) && (node.getId() !== storyPlaythroughObject.getNextPendingNodeId())"
                        class="oppia-lesson-icon-uncompleted oppia-lesson-icon-unavailable e2e-test-lesson-icon-uncompleted">
+                  </div>
+                  <div *ngIf="isChapterDisplayedAsComingSoon(node)"
+                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-coming-soon e2e-test-lesson-icon-coming-soon">
                   </div>
                 </div>
 
-                <div class="oppia-story-viewer-card">
+                <div class="oppia-story-viewer-card" [class.oppia-story-viewer-card-coming-soon]="isChapterDisplayedAsComingSoon(node)">
                   <span class="oppia-chapter-title e2e-test-chapter-title" aria-live="assertive">
                     <span [innerHTML]="'I18N_TOPIC_VIEWER_CHAPTER' | translate"></span>
                     <span *ngIf="!isHackyStoryNodeTitleTranslationDisplayed(index)">
@@ -58,6 +64,9 @@
                     </span>
                     <span *ngIf="isHackyStoryNodeTitleTranslationDisplayed(index)">
                       {{index + 1}}: {{ storyNodesTitleTranslationKeys[index] | translate }}
+                    </span>
+                    <span *ngIf="isChapterDisplayedAsComingSoon(node)" class="oppia-coming-soon-label">
+                      ({{ 'I18N_LEARNER_STORY_TILE_COMING_SOON' | translate }})
                     </span>
                   </span>
 

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.html
@@ -21,10 +21,11 @@
 
         <div *ngIf="showChapters()" class="d-md-block oppia-story-viewer-card-container">
           <a *ngFor="let node of storyPlaythroughObject.getStoryNodes();let last = isLast;let index = index"
-             [href]="getChapterExplorationUrl(node)"
+             [attr.href]="getChapterExplorationUrl(node)"
              [class.oppia-chapter-coming-soon]="isChapterDisplayedAsComingSoon(node)"
              [attr.title]="isChapterDisplayedAsComingSoon(node) ? ('I18N_LEARNER_STORY_TILE_COMING_SOON_TOOLTIP' | translate) : null"
-             tabindex="0">
+             [attr.aria-disabled]="isChapterDisplayedAsComingSoon(node) ? 'true' : null"
+             [attr.tabindex]="isChapterDisplayedAsComingSoon(node) ? '-1' : '0'">
 
             <div>
               <div class="fx-row">
@@ -49,6 +50,24 @@
                        class="oppia-lesson-icon-uncompleted e2e-test-lesson-icon-uncompleted">
                   </div>
                   <div *ngIf="!node.isCompleted() && !isChapterDisplayedAsComingSoon(node) && (node.getId() !== storyPlaythroughObject.getNextPendingNodeId())"
+                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-unavailable e2e-test-lesson-icon-uncompleted">
+                  </div>
+                  <div *ngIf="isChapterDisplayedAsComingSoon(node)"
+                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-coming-soon e2e-test-lesson-icon-coming-soon">
+                  </div>
+                </div>
+
+                <div class="oppia-story-viewer-card" [class.oppia-story-viewer-card-coming-soon]="isChapterDisplayedAsComingSoon(node)">
+playedAsComingSoon(node) && (node.getId() !== storyPlaythroughObject.getNextPendingNodeId())"
+                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-unavailable e2e-test-lesson-icon-uncompleted">
+                  </div>
+                  <div *ngIf="isChapterDisplayedAsComingSoon(node)"
+                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-coming-soon e2e-test-lesson-icon-coming-soon">
+                  </div>
+                </div>
+
+                <div class="oppia-story-viewer-card" [class.oppia-story-viewer-card-coming-soon]="isChapterDisplayedAsComingSoon(node)">
+playedAsComingSoon(node) && (node.getId() !== storyPlaythroughObject.getNextPendingNodeId())"
                        class="oppia-lesson-icon-uncompleted oppia-lesson-icon-unavailable e2e-test-lesson-icon-uncompleted">
                   </div>
                   <div *ngIf="isChapterDisplayedAsComingSoon(node)"

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.html
@@ -24,7 +24,6 @@
              [href]="getChapterExplorationUrl(node)"
              [class.oppia-chapter-coming-soon]="isChapterDisplayedAsComingSoon(node)"
              [attr.title]="isChapterDisplayedAsComingSoon(node) ? ('I18N_LEARNER_STORY_TILE_COMING_SOON_TOOLTIP' | translate) : null"
-             (click)="isChapterDisplayedAsComingSoon(node) && $event.preventDefault()"
              tabindex="0">
 
             <div>

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.html
@@ -24,6 +24,7 @@
              [href]="getChapterExplorationUrl(node)"
              [class.oppia-chapter-coming-soon]="isChapterDisplayedAsComingSoon(node)"
              [attr.title]="isChapterDisplayedAsComingSoon(node) ? ('I18N_LEARNER_STORY_TILE_COMING_SOON_TOOLTIP' | translate) : null"
+             (click)="isChapterDisplayedAsComingSoon(node) && $event.preventDefault()"
              tabindex="0">
 
             <div>
@@ -64,9 +65,6 @@
                     </span>
                     <span *ngIf="isHackyStoryNodeTitleTranslationDisplayed(index)">
                       {{index + 1}}: {{ storyNodesTitleTranslationKeys[index] | translate }}
-                    </span>
-                    <span *ngIf="isChapterDisplayedAsComingSoon(node)" class="oppia-coming-soon-label">
-                      ({{ 'I18N_LEARNER_STORY_TILE_COMING_SOON' | translate }})
                     </span>
                   </span>
 

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.html
@@ -58,24 +58,6 @@
                 </div>
 
                 <div class="oppia-story-viewer-card" [class.oppia-story-viewer-card-coming-soon]="isChapterDisplayedAsComingSoon(node)">
-playedAsComingSoon(node) && (node.getId() !== storyPlaythroughObject.getNextPendingNodeId())"
-                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-unavailable e2e-test-lesson-icon-uncompleted">
-                  </div>
-                  <div *ngIf="isChapterDisplayedAsComingSoon(node)"
-                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-coming-soon e2e-test-lesson-icon-coming-soon">
-                  </div>
-                </div>
-
-                <div class="oppia-story-viewer-card" [class.oppia-story-viewer-card-coming-soon]="isChapterDisplayedAsComingSoon(node)">
-playedAsComingSoon(node) && (node.getId() !== storyPlaythroughObject.getNextPendingNodeId())"
-                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-unavailable e2e-test-lesson-icon-uncompleted">
-                  </div>
-                  <div *ngIf="isChapterDisplayedAsComingSoon(node)"
-                       class="oppia-lesson-icon-uncompleted oppia-lesson-icon-coming-soon e2e-test-lesson-icon-coming-soon">
-                  </div>
-                </div>
-
-                <div class="oppia-story-viewer-card" [class.oppia-story-viewer-card-coming-soon]="isChapterDisplayedAsComingSoon(node)">
                   <span class="oppia-chapter-title e2e-test-chapter-title" aria-live="assertive">
                     <span [innerHTML]="'I18N_TOPIC_VIEWER_CHAPTER' | translate"></span>
                     <span *ngIf="!isHackyStoryNodeTitleTranslationDisplayed(index)">

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
@@ -38,6 +38,7 @@ import {WindowRef} from 'services/contextual/window-ref.service';
 import {MockTranslatePipe} from 'tests/unit-test-utils';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {ReadOnlyStoryNode} from 'domain/story_viewer/read-only-story-node.model';
+import {PlatformFeatureService} from 'services/platform-feature.service';
 
 class MockAssetsBackendApiService {
   getThumbnailUrlForPreview() {
@@ -52,6 +53,14 @@ class MockTranslateService {
   }
 }
 
+class MockPlatformFeatureService {
+  status = {
+    SerialChapterLaunchLearnerView: {
+      isEnabled: false,
+    },
+  };
+}
+
 describe('Story Viewer Page component', () => {
   let httpTestingController: HttpTestingController;
   let component: StoryViewerPageComponent;
@@ -64,6 +73,7 @@ describe('Story Viewer Page component', () => {
   let windowRef: WindowRef;
   let i18nLanguageCodeService: I18nLanguageCodeService;
   let translateService: TranslateService;
+  let mockPlatformFeatureService: MockPlatformFeatureService;
   let _samplePlaythroughObject: StoryPlaythrough;
   const UserInfoObject = {
     roles: ['USER_ROLE'],
@@ -79,6 +89,7 @@ describe('Story Viewer Page component', () => {
   };
 
   beforeEach(fakeAsync(() => {
+    mockPlatformFeatureService = new MockPlatformFeatureService();
     TestBed.configureTestingModule({
       declarations: [StoryViewerPageComponent, MockTranslatePipe],
       imports: [HttpClientTestingModule],
@@ -90,6 +101,10 @@ describe('Story Viewer Page component', () => {
         {
           provide: TranslateService,
           useClass: MockTranslateService,
+        },
+        {
+          provide: PlatformFeatureService,
+          useValue: mockPlatformFeatureService,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -117,7 +132,6 @@ describe('Story Viewer Page component', () => {
       },
     } as Window);
   }));
-
   beforeEach(() => {
     spyOn(assetsBackendApiService, 'getThumbnailUrlForPreview').and.returnValue(
       'thumbnail-url'
@@ -165,6 +179,7 @@ describe('Story Viewer Page component', () => {
       completed: true,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: 'filename',
+      status: 'Published',
     };
     var secondSampleReadOnlyStoryNodeBackendDict = {
       id: 'node_2',
@@ -203,6 +218,7 @@ describe('Story Viewer Page component', () => {
       completed: false,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: 'filename',
+      status: 'Published',
     };
     var storyPlaythroughBackendObject = {
       story_id: 'qwerty',
@@ -670,5 +686,287 @@ describe('Story Viewer Page component', () => {
     let hackyStoryNodeDescTranslationIsDisplayed =
       component.isHackyStoryNodeDescTranslationDisplayed(0);
     expect(hackyStoryNodeDescTranslationIsDisplayed).toBe(true);
+  });
+
+  it('should get status of Serial Chapter Launch Learner Feature flag', () => {
+    mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+      false;
+    expect(component.isSerialChapterFeatureLearnerFlagEnabled()).toBe(false);
+
+    mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+      true;
+    expect(component.isSerialChapterFeatureLearnerFlagEnabled()).toBe(true);
+  });
+
+  it('should correctly identify published chapters', () => {
+    const publishedNode = ReadOnlyStoryNode.createFromBackendDict({
+      id: 'node_1',
+      description: 'description',
+      title: 'Title 1',
+      prerequisite_skill_ids: [],
+      acquired_skill_ids: [],
+      destination_node_ids: [],
+      outline: 'Outline',
+      exploration_id: 'exp_id',
+      outline_is_finalized: false,
+      exp_summary_dict: {
+        title: 'Title',
+        status: 'private',
+        last_updated_msec: 1591296737470.528,
+        community_owned: false,
+        objective: 'Test Objective',
+        id: '44LKoKLlIbGe',
+        num_views: 0,
+        thumbnail_icon_url: '/subjects/Algebra.svg',
+        human_readable_contributors_summary: {},
+        language_code: 'en',
+        thumbnail_bg_color: '#cc4b00',
+        created_on_msec: 1591296635736.666,
+        ratings: {1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+        tags: [],
+        activity_type: 'exploration',
+        category: 'Algebra',
+      },
+      completed: false,
+      thumbnail_bg_color: '#927117',
+      thumbnail_filename: 'filename',
+      status: 'Published',
+    });
+
+    expect(component.isChapterPublished(publishedNode)).toBe(true);
+    expect(component.isChapterReadyToPublish(publishedNode)).toBe(false);
+  });
+
+  it('should correctly identify ready to publish chapters', () => {
+    const readyToPublishNode = ReadOnlyStoryNode.createFromBackendDict({
+      id: 'node_1',
+      description: 'description',
+      title: 'Title 1',
+      prerequisite_skill_ids: [],
+      acquired_skill_ids: [],
+      destination_node_ids: [],
+      outline: 'Outline',
+      exploration_id: 'exp_id',
+      outline_is_finalized: false,
+      exp_summary_dict: {
+        title: 'Title',
+        status: 'private',
+        last_updated_msec: 1591296737470.528,
+        community_owned: false,
+        objective: 'Test Objective',
+        id: '44LKoKLlIbGe',
+        num_views: 0,
+        thumbnail_icon_url: '/subjects/Algebra.svg',
+        human_readable_contributors_summary: {},
+        language_code: 'en',
+        thumbnail_bg_color: '#cc4b00',
+        created_on_msec: 1591296635736.666,
+        ratings: {1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+        tags: [],
+        activity_type: 'exploration',
+        category: 'Algebra',
+      },
+      completed: false,
+      thumbnail_bg_color: '#927117',
+      thumbnail_filename: 'filename',
+      status: 'Ready To Publish',
+    });
+
+    expect(component.isChapterPublished(readyToPublishNode)).toBe(false);
+    expect(component.isChapterReadyToPublish(readyToPublishNode)).toBe(true);
+  });
+
+  it('should display chapter as coming soon when feature flag is enabled and chapter is ready to publish', () => {
+    const readyToPublishNode = ReadOnlyStoryNode.createFromBackendDict({
+      id: 'node_1',
+      description: 'description',
+      title: 'Title 1',
+      prerequisite_skill_ids: [],
+      acquired_skill_ids: [],
+      destination_node_ids: [],
+      outline: 'Outline',
+      exploration_id: 'exp_id',
+      outline_is_finalized: false,
+      exp_summary_dict: {
+        title: 'Title',
+        status: 'private',
+        last_updated_msec: 1591296737470.528,
+        community_owned: false,
+        objective: 'Test Objective',
+        id: '44LKoKLlIbGe',
+        num_views: 0,
+        thumbnail_icon_url: '/subjects/Algebra.svg',
+        human_readable_contributors_summary: {},
+        language_code: 'en',
+        thumbnail_bg_color: '#cc4b00',
+        created_on_msec: 1591296635736.666,
+        ratings: {1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+        tags: [],
+        activity_type: 'exploration',
+        category: 'Algebra',
+      },
+      completed: false,
+      thumbnail_bg_color: '#927117',
+      thumbnail_filename: 'filename',
+      status: 'Ready To Publish',
+    });
+
+    // Feature flag disabled - should not show as coming soon.
+    mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+      false;
+    expect(component.isChapterDisplayedAsComingSoon(readyToPublishNode)).toBe(
+      false
+    );
+
+    // Feature flag enabled - should show as coming soon.
+    mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+      true;
+    expect(component.isChapterDisplayedAsComingSoon(readyToPublishNode)).toBe(
+      true
+    );
+  });
+
+  it('should not display published chapter as coming soon', () => {
+    const publishedNode = ReadOnlyStoryNode.createFromBackendDict({
+      id: 'node_1',
+      description: 'description',
+      title: 'Title 1',
+      prerequisite_skill_ids: [],
+      acquired_skill_ids: [],
+      destination_node_ids: [],
+      outline: 'Outline',
+      exploration_id: 'exp_id',
+      outline_is_finalized: false,
+      exp_summary_dict: {
+        title: 'Title',
+        status: 'private',
+        last_updated_msec: 1591296737470.528,
+        community_owned: false,
+        objective: 'Test Objective',
+        id: '44LKoKLlIbGe',
+        num_views: 0,
+        thumbnail_icon_url: '/subjects/Algebra.svg',
+        human_readable_contributors_summary: {},
+        language_code: 'en',
+        thumbnail_bg_color: '#cc4b00',
+        created_on_msec: 1591296635736.666,
+        ratings: {1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+        tags: [],
+        activity_type: 'exploration',
+        category: 'Algebra',
+      },
+      completed: false,
+      thumbnail_bg_color: '#927117',
+      thumbnail_filename: 'filename',
+      status: 'Published',
+    });
+
+    mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+      true;
+    expect(component.isChapterDisplayedAsComingSoon(publishedNode)).toBe(false);
+  });
+
+  it('should return null for chapter URL when chapter is displayed as coming soon', () => {
+    spyOn(urlService, 'getTopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'topic'
+    );
+    spyOn(urlService, 'getClassroomUrlFragmentFromLearnerUrl').and.returnValue(
+      'math'
+    );
+    spyOn(urlService, 'getStoryUrlFragmentFromLearnerUrl').and.returnValue(
+      'story'
+    );
+
+    const readyToPublishNode = ReadOnlyStoryNode.createFromBackendDict({
+      id: 'node_1',
+      description: 'description',
+      title: 'Title 1',
+      prerequisite_skill_ids: [],
+      acquired_skill_ids: [],
+      destination_node_ids: [],
+      outline: 'Outline',
+      exploration_id: 'exp_id',
+      outline_is_finalized: false,
+      exp_summary_dict: {
+        title: 'Title',
+        status: 'private',
+        last_updated_msec: 1591296737470.528,
+        community_owned: false,
+        objective: 'Test Objective',
+        id: '44LKoKLlIbGe',
+        num_views: 0,
+        thumbnail_icon_url: '/subjects/Algebra.svg',
+        human_readable_contributors_summary: {},
+        language_code: 'en',
+        thumbnail_bg_color: '#cc4b00',
+        created_on_msec: 1591296635736.666,
+        ratings: {1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+        tags: [],
+        activity_type: 'exploration',
+        category: 'Algebra',
+      },
+      completed: false,
+      thumbnail_bg_color: '#927117',
+      thumbnail_filename: 'filename',
+      status: 'Ready To Publish',
+    });
+
+    mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+      true;
+    expect(component.getChapterExplorationUrl(readyToPublishNode)).toBeNull();
+  });
+
+  it('should return exploration URL for published chapters', () => {
+    spyOn(urlService, 'getTopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'topic'
+    );
+    spyOn(urlService, 'getClassroomUrlFragmentFromLearnerUrl').and.returnValue(
+      'math'
+    );
+    spyOn(urlService, 'getStoryUrlFragmentFromLearnerUrl').and.returnValue(
+      'story'
+    );
+
+    const publishedNode = ReadOnlyStoryNode.createFromBackendDict({
+      id: 'node_1',
+      description: 'description',
+      title: 'Title 1',
+      prerequisite_skill_ids: [],
+      acquired_skill_ids: [],
+      destination_node_ids: [],
+      outline: 'Outline',
+      exploration_id: 'exp_id',
+      outline_is_finalized: false,
+      exp_summary_dict: {
+        title: 'Title',
+        status: 'private',
+        last_updated_msec: 1591296737470.528,
+        community_owned: false,
+        objective: 'Test Objective',
+        id: '44LKoKLlIbGe',
+        num_views: 0,
+        thumbnail_icon_url: '/subjects/Algebra.svg',
+        human_readable_contributors_summary: {},
+        language_code: 'en',
+        thumbnail_bg_color: '#cc4b00',
+        created_on_msec: 1591296635736.666,
+        ratings: {1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
+        tags: [],
+        activity_type: 'exploration',
+        category: 'Algebra',
+      },
+      completed: false,
+      thumbnail_bg_color: '#927117',
+      thumbnail_filename: 'filename',
+      status: 'Published',
+    });
+
+    mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
+      true;
+    expect(component.getChapterExplorationUrl(publishedNode)).toBe(
+      '/explore/exp_id?topic_url_fragment=topic&' +
+        'classroom_url_fragment=math&story_url_fragment=story&' +
+        'node_id=node_1'
+    );
   });
 });

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
@@ -294,7 +294,7 @@ describe('Story Viewer Page component', () => {
 
     component.ngOnInit();
 
-    expect(component.showChapters()).toBeFalse();
+    expect(component.showChapters()).toBe(false);
   });
 
   it('should throw error if story url fragment is not present', () => {
@@ -393,7 +393,7 @@ describe('Story Viewer Page component', () => {
       'node_2'
     );
 
-    expect(component.showChapters()).toBeTrue();
+    expect(component.showChapters()).toBe(true);
   });
 
   it('should sign in correctly', fakeAsync(() => {
@@ -551,6 +551,7 @@ describe('Story Viewer Page component', () => {
       completed: true,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: '',
+      status: 'not_started',
     };
     var secondSampleReadOnlyStoryNodeBackendDict = {
       id: 'node_2',
@@ -589,6 +590,7 @@ describe('Story Viewer Page component', () => {
       completed: false,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: '',
+      status: 'not_started',
     };
 
     var storyPlaythroughBackendObject = {

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
@@ -915,7 +915,9 @@ describe('Story Viewer Page component', () => {
 
     mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
       true;
-    expect(component.getChapterExplorationUrl(readyToPublishNode)).toBeNull();
+    expect(component.getChapterExplorationUrl(readyToPublishNode)).toBe(
+      'javascript:void(0)'
+    );
   });
 
   it('should return exploration URL for published chapters', () => {

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
@@ -551,7 +551,7 @@ describe('Story Viewer Page component', () => {
       completed: true,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: '',
-      status: 'not_started',
+      status: 'Published',
     };
     var secondSampleReadOnlyStoryNodeBackendDict = {
       id: 'node_2',
@@ -590,7 +590,7 @@ describe('Story Viewer Page component', () => {
       completed: false,
       thumbnail_bg_color: '#927117',
       thumbnail_filename: '',
-      status: 'not_started',
+      status: 'Published',
     };
 
     var storyPlaythroughBackendObject = {

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
@@ -915,9 +915,7 @@ describe('Story Viewer Page component', () => {
 
     mockPlatformFeatureService.status.SerialChapterLaunchLearnerView.isEnabled =
       true;
-    expect(component.getChapterExplorationUrl(readyToPublishNode)).toBe(
-      'javascript:void(0)'
-    );
+    expect(component.getChapterExplorationUrl(readyToPublishNode)).toBeNull();
   });
 
   it('should return exploration URL for published chapters', () => {

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
@@ -344,11 +344,11 @@ export class StoryViewerPageComponent implements OnInit, OnDestroy {
     );
   }
 
-  getChapterExplorationUrl(node: ReadOnlyStoryNode): string | null {
+  getChapterExplorationUrl(node: ReadOnlyStoryNode): string {
     // When serial chapter feature is enabled, "Ready To Publish" chapters
     // should not be accessible.
     if (this.isChapterDisplayedAsComingSoon(node)) {
-      return null;
+      return 'javascript:void(0)';
     }
     return this.getExplorationUrl(node as unknown as StoryNode);
   }

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
@@ -42,9 +42,11 @@ import {
   I18nLanguageCodeService,
   TranslationKeyType,
 } from 'services/i18n-language-code.service';
+import {PlatformFeatureService} from 'services/platform-feature.service';
 
 import './story-viewer-page.component.css';
 import {StoryNode} from 'domain/story/story-node.model';
+import constants from 'assets/constants';
 
 interface IconParametersArray {
   thumbnailIconUrl: string;
@@ -96,7 +98,8 @@ export class StoryViewerPageComponent implements OnInit, OnDestroy {
     private storyViewerBackendApiService: StoryViewerBackendApiService,
     private pageTitleService: PageTitleService,
     private alertsService: AlertsService,
-    private translateService: TranslateService
+    private translateService: TranslateService,
+    private platformFeatureService: PlatformFeatureService
   ) {}
 
   focusSkipButton(eventTarget: Element, isLoggedIn: boolean): void {
@@ -319,5 +322,34 @@ export class StoryViewerPageComponent implements OnInit, OnDestroy {
         this.storyNodesDescTranslationKeys[index]
       ) && !this.i18nLanguageCodeService.isCurrentLanguageEnglish()
     );
+  }
+
+  isSerialChapterFeatureLearnerFlagEnabled(): boolean {
+    return this.platformFeatureService.status.SerialChapterLaunchLearnerView
+      .isEnabled;
+  }
+
+  isChapterPublished(node: ReadOnlyStoryNode): boolean {
+    return node.getStatus() === constants.STORY_NODE_STATUS_PUBLISHED;
+  }
+
+  isChapterReadyToPublish(node: ReadOnlyStoryNode): boolean {
+    return node.getStatus() === constants.STORY_NODE_STATUS_READY_TO_PUBLISH;
+  }
+
+  isChapterDisplayedAsComingSoon(node: ReadOnlyStoryNode): boolean {
+    return (
+      this.isSerialChapterFeatureLearnerFlagEnabled() &&
+      this.isChapterReadyToPublish(node)
+    );
+  }
+
+  getChapterExplorationUrl(node: ReadOnlyStoryNode): string | null {
+    // When serial chapter feature is enabled, "Ready To Publish" chapters
+    // should not be accessible.
+    if (this.isChapterDisplayedAsComingSoon(node)) {
+      return null;
+    }
+    return this.getExplorationUrl(node as unknown as StoryNode);
   }
 }

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
@@ -344,11 +344,9 @@ export class StoryViewerPageComponent implements OnInit, OnDestroy {
     );
   }
 
-  getChapterExplorationUrl(node: ReadOnlyStoryNode): string {
-    // When serial chapter feature is enabled, "Ready To Publish" chapters
-    // should not be accessible.
+  getChapterExplorationUrl(node: ReadOnlyStoryNode): string | null {
     if (this.isChapterDisplayedAsComingSoon(node)) {
-      return 'javascript:void(0)';
+      return null;
     }
     return this.getExplorationUrl(node as unknown as StoryNode);
   }


### PR DESCRIPTION
## Overview

1. This PR fixes **#24423**.

2. This PR does the following:
- Adds the `status` field to the frontend `StoryNodeBackendDict` and `ReadOnlyStoryNode` model so
  the frontend is aware of each chapter’s publication state.
- Updates the story viewer frontend logic to correctly interpret chapter status.
- Ensures **Draft** chapters are completely hidden from the learner view.
- Displays **Ready To Publish** chapters as **grayed out and non-clickable**, making them visible
  but inaccessible to learners.
- Keeps **Published** chapters fully accessible as before
3. The original bug occurred because:
- The backend already filters out **Draft** nodes when constructing the story viewer data.
- However, **Ready To Publish** nodes are still included and sent to the frontend via `node.to_dict()`,
  along with their `status` field.
- The frontend `StoryNodeBackendDict` interface did **not** include the `status` field, so the
  frontend was unaware of a chapter’s publication state.
- As a result, the story viewer treated **Ready To Publish** chapters as fully accessible,
  allowing learners to click and open unpublished content.
- This issue surfaced when a previously published chapter was unpublished (moved to Draft or
  Ready To Publish), but remained reachable through already published chapters.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [] I have linked the issue that this PR fixes in the **Development** section of the sidebar.
- [x] I have checked the **Files Changed** tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with **"Story Viewer should show ready to publish chapter as grayed out and should not show draft chapter's at all when in serialized story editor mode . #24423"**.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase `@{reviewer_username} PTAL` if I can't assign them directly).

## Proof that changes are correct

Before:

https://github.com/user-attachments/assets/6185d4d5-3276-423e-8fbf-bb56a02e675f


After: 

https://github.com/user-attachments/assets/ec14e3d1-4eca-4445-b593-5a32280ead26



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
