### PR TITLE
Fix deprecated CSS rules and improve standards compliance

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -57,22 +57,6 @@
   100% { opacity: 1; }
 }
 
-@-webkit-viewport {
-  width: device-width;
-}
-
-@-moz-viewport {
-  width: device-width;
-}
-
-@-ms-viewport {
-  width: device-width;
-}
-
-@-o-viewport {
-  width: device-width;
-}
-
 @viewport {
   width: device-width;
 }
@@ -322,6 +306,7 @@ html {
 }
 button.btn-close {
   -webkit-appearance: none;
+  appearance: none;
   border: 0;
   cursor: pointer;
   padding: 5px;
@@ -1864,6 +1849,7 @@ pre.oppia-pre-wrapped-text {
   -moz-user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;
+  user-select: none;
 }
 
 .oppia-save-state-item-button {
@@ -2572,7 +2558,6 @@ div#ng-curtain {
 }
 .oppia-option-list {
   display: block;
-  vertical-align: initial;
 }
 .oppia-navbar-dropdown-toggle,
 .oppia-navbar-tab {
@@ -3230,6 +3215,7 @@ oppia-noninteractive-link {
   font-size: 0.85em;
   height: 70px;
   -webkit-line-clamp: 3; /* Truncating to 3 lines. */
+  line-clamp: 3;
   line-height: 1.26;
   /* `max-height` is calculated as: 1.26 (line-height) * 3 (lines) / 0.85
   (font-size). An additional (1.26 (line-height) * 0.85 (font-size) * 0.25) is added
@@ -3259,7 +3245,7 @@ oppia-noninteractive-link {
 
 .oppia-activity-summary-tile [section="right-section"],
 .oppia-activity-summary-tile-mobile [section="right-section"] {
-  display: inline-block;
+  display: block;
   float: left;
   height: 80px;
   position: relative;
@@ -3942,6 +3928,7 @@ div.oppia-issues-learner-action {
   justify-content: space-around;
 }
 
+/* TODO: Deprecated typo, use .fx-main-space-between instead */
 .fx-main-pace-between {
   justify-content: space-between;
 }


### PR DESCRIPTION
## Overview

This PR fixes #N/A by cleaning up deprecated and ineffective CSS rules and adds missing standard property declarations to improve standards compliance.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof (standards-based):

- Only @viewport is defined in the CSS Device Adaptation spec

- Vendor-prefixed variants are deprecated and ignored by modern browsers

- Oppia does not support browsers that require these prefixes

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
