### PR TITLE
Fix #20564: Consolidate image upload components by migrating to unified image-uploader

### DIFF
--- a/core/templates/components/entity-creation-services/topic-creation.service.spec.ts
+++ b/core/templates/components/entity-creation-services/topic-creation.service.spec.ts
@@ -28,17 +28,13 @@ import {NewlyCreatedTopic} from 'domain/topics_and_skills_dashboard/newly-create
 import {TopicsAndSkillsDashboardBackendApiService} from 'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-backend-api.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {AlertsService} from 'services/alerts.service';
-import {PageContextService} from 'services/page-context.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {TopicCreationService} from './topic-creation.service';
 
 describe('Topic creation service', () => {
   let topicCreationService: TopicCreationService;
-  let pageContextService: PageContextService;
   let ngbModal: NgbModal;
   let alertsService: AlertsService;
-  let imageLocalStorageService: ImageLocalStorageService;
   let topicCreationBackendApiService: TopicCreationBackendApiService;
   let topicsAndSkillsDashboardBackendApiService: TopicsAndSkillsDashboardBackendApiService;
   let urlInterpolationService: UrlInterpolationService;
@@ -65,8 +61,6 @@ describe('Topic creation service', () => {
           useClass: MockWindowRef,
         },
         AlertsService,
-        PageContextService,
-        ImageLocalStorageService,
         TopicCreationBackendApiService,
         TopicsAndSkillsDashboardBackendApiService,
         UrlInterpolationService,
@@ -76,10 +70,8 @@ describe('Topic creation service', () => {
 
   beforeEach(() => {
     topicCreationService = TestBed.inject(TopicCreationService);
-    pageContextService = TestBed.inject(PageContextService);
     ngbModal = TestBed.inject(NgbModal);
     alertsService = TestBed.inject(AlertsService);
-    imageLocalStorageService = TestBed.inject(ImageLocalStorageService);
     topicCreationBackendApiService = TestBed.inject(
       TopicCreationBackendApiService
     );
@@ -91,18 +83,18 @@ describe('Topic creation service', () => {
 
   it('should create new topic', fakeAsync(() => {
     topicCreationService.topicCreationInProgress = false;
-    spyOn(pageContextService, 'setImageSaveDestinationToLocalStorage');
+    const mockImageData = {
+      filename: 'test.svg',
+      image_data: new Blob(),
+      bg_color: '#000000',
+    };
     spyOn(ngbModal, 'open').and.returnValue({
-      result: Promise.resolve(
-        new NewlyCreatedTopic('valid', 'valid', 'valid', 'valid')
-      ),
+      result: Promise.resolve({
+        topic: new NewlyCreatedTopic('valid', 'valid', 'valid', 'valid'),
+        imageData: mockImageData,
+      }),
     } as NgbModalRef);
     spyOn(alertsService, 'clearWarnings');
-    spyOn(imageLocalStorageService, 'getStoredImagesData').and.returnValue([]);
-    spyOn(imageLocalStorageService, 'getThumbnailBgColor').and.returnValue(
-      'bgColor'
-    );
-    spyOn(imageLocalStorageService, 'flushStoredImagesData');
     spyOn(topicCreationBackendApiService, 'createTopicAsync').and.returnValue(
       Promise.resolve({topicId: 'topicId'})
     );
@@ -110,96 +102,79 @@ describe('Topic creation service', () => {
       topicsAndSkillsDashboardBackendApiService.onTopicsAndSkillsDashboardReinitialized,
       'emit'
     );
-    spyOn(pageContextService, 'resetImageSaveDestination');
     spyOn(urlInterpolationService, 'interpolateUrl').and.returnValue('');
     topicCreationService.createNewTopic();
     tick();
     tick();
-    expect(
-      pageContextService.setImageSaveDestinationToLocalStorage
-    ).toHaveBeenCalled();
     expect(ngbModal.open).toHaveBeenCalled();
     expect(alertsService.clearWarnings).toHaveBeenCalled();
-    expect(imageLocalStorageService.getStoredImagesData).toHaveBeenCalled();
-    expect(imageLocalStorageService.getThumbnailBgColor).toHaveBeenCalled();
-    expect(imageLocalStorageService.flushStoredImagesData).toHaveBeenCalled();
     expect(topicCreationBackendApiService.createTopicAsync).toHaveBeenCalled();
-    expect(pageContextService.resetImageSaveDestination).toHaveBeenCalled();
     expect(urlInterpolationService.interpolateUrl).toHaveBeenCalled();
   }));
 
   it('should not create topic if creation is already in process', () => {
     topicCreationService.topicCreationInProgress = true;
-    spyOn(pageContextService, 'setImageSaveDestinationToLocalStorage');
+    spyOn(ngbModal, 'open');
     topicCreationService.createNewTopic();
-    expect(
-      pageContextService.setImageSaveDestinationToLocalStorage
-    ).not.toHaveBeenCalled();
+    expect(ngbModal.open).not.toHaveBeenCalled();
   });
 
   it('should throw error if topic fields are empty', fakeAsync(() => {
     topicCreationService.topicCreationInProgress = false;
-    spyOn(pageContextService, 'setImageSaveDestinationToLocalStorage');
+    const mockImageData = {
+      filename: 'test.svg',
+      image_data: new Blob(),
+      bg_color: '#000000',
+    };
+    const mockTopic = {
+      isValid: () => false,
+    };
     spyOn(ngbModal, 'open').and.returnValue({
-      result: {
-        then: (successCallback: (arg1: {}) => void, errorCallback) => {
-          successCallback({
-            isValid: () => {
-              return false;
-            },
-          });
-        },
-      },
+      result: Promise.resolve({
+        topic: mockTopic,
+        imageData: mockImageData,
+      }),
     } as NgbModalRef);
     expect(() => {
       topicCreationService.createNewTopic();
       tick();
     }).toThrowError('Topic fields cannot be empty');
-    expect(
-      pageContextService.setImageSaveDestinationToLocalStorage
-    ).toHaveBeenCalled();
     expect(ngbModal.open).toHaveBeenCalled();
   }));
 
-  it('should throw error if new topic is invalid', fakeAsync(() => {
+  it('should throw error if image data is missing', fakeAsync(() => {
     topicCreationService.topicCreationInProgress = false;
-    spyOn(pageContextService, 'setImageSaveDestinationToLocalStorage');
+    const mockTopic = {
+      isValid: () => true,
+    };
     spyOn(ngbModal, 'open').and.returnValue({
-      result: {
-        then: (successCallback: (arg1: {}) => void, errorCallback) => {
-          successCallback({
-            isValid: () => {
-              return true;
-            },
-          });
-        },
-      },
+      result: Promise.resolve({
+        topic: mockTopic,
+        imageData: null,
+      }),
     } as NgbModalRef);
-    spyOn(imageLocalStorageService, 'getThumbnailBgColor').and.returnValue(
-      null
-    );
     expect(() => {
       topicCreationService.createNewTopic();
       tick();
-    }).toThrowError('Background color not found.');
+    }).toThrowError('Image data is required');
   }));
 
   it('should handle error if topic creation fails', fakeAsync(() => {
     let error = 'promise rejected';
     topicCreationService.topicCreationInProgress = false;
-    spyOn(pageContextService, 'setImageSaveDestinationToLocalStorage');
+    const mockImageData = {
+      filename: 'test.svg',
+      image_data: new Blob(),
+      bg_color: '#000000',
+    };
     spyOn(ngbModal, 'open').and.returnValue({
-      result: Promise.resolve(
-        new NewlyCreatedTopic('valid', 'valid', 'valid', 'valid')
-      ),
+      result: Promise.resolve({
+        topic: new NewlyCreatedTopic('valid', 'valid', 'valid', 'valid'),
+        imageData: mockImageData,
+      }),
     } as NgbModalRef);
     spyOn(alertsService, 'clearWarnings');
     spyOn(alertsService, 'addWarning');
-    spyOn(imageLocalStorageService, 'getStoredImagesData').and.returnValue([]);
-    spyOn(imageLocalStorageService, 'getThumbnailBgColor').and.returnValue(
-      'bgColor'
-    );
-    spyOn(imageLocalStorageService, 'flushStoredImagesData');
     spyOn(topicCreationBackendApiService, 'createTopicAsync').and.returnValue(
       Promise.reject({error})
     );
@@ -212,16 +187,12 @@ describe('Topic creation service', () => {
 
   it('should do nothing when user cancels the topic creation modal', fakeAsync(() => {
     topicCreationService.topicCreationInProgress = false;
-    spyOn(pageContextService, 'setImageSaveDestinationToLocalStorage');
     spyOn(ngbModal, 'open').and.returnValue({
       result: Promise.reject(),
     } as NgbModalRef);
     spyOn(alertsService, 'clearWarnings');
     topicCreationService.createNewTopic();
     tick();
-    expect(
-      pageContextService.setImageSaveDestinationToLocalStorage
-    ).toHaveBeenCalled();
     expect(ngbModal.open).toHaveBeenCalled();
   }));
 });

--- a/core/templates/components/entity-creation-services/topic-creation.service.spec.ts
+++ b/core/templates/components/entity-creation-services/topic-creation.service.spec.ts
@@ -135,8 +135,8 @@ describe('Topic creation service', () => {
         imageData: mockImageData,
       }),
     } as NgbModalRef);
+    topicCreationService.createNewTopic();
     expect(() => {
-      topicCreationService.createNewTopic();
       tick();
     }).toThrowError('Topic fields cannot be empty');
     expect(ngbModal.open).toHaveBeenCalled();
@@ -153,8 +153,8 @@ describe('Topic creation service', () => {
         imageData: null,
       }),
     } as NgbModalRef);
+    topicCreationService.createNewTopic();
     expect(() => {
-      topicCreationService.createNewTopic();
       tick();
     }).toThrowError('Image data is required');
   }));

--- a/core/templates/components/entity-creation-services/topic-creation.service.ts
+++ b/core/templates/components/entity-creation-services/topic-creation.service.ts
@@ -23,9 +23,8 @@ import {TopicsAndSkillsDashboardBackendApiService} from 'domain/topics_and_skill
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {CreateNewTopicModalComponent} from 'pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component';
 import {AlertsService} from 'services/alerts.service';
-import {PageContextService} from 'services/page-context.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {ImageLocalStorageService} from 'services/image-local-storage.service';
+import {ImageData} from 'domain/skill/skill-creation-backend-api.service';
 
 @Injectable({
   providedIn: 'root',
@@ -38,8 +37,6 @@ export class TopicCreationService {
     private ngbModal: NgbModal,
     private windowRef: WindowRef,
     private alertsService: AlertsService,
-    private pageContextService: PageContextService,
-    private imageLocalStorageService: ImageLocalStorageService,
     private topicCreationBackendApiService: TopicCreationBackendApiService,
     private topicsAndSkillsDashboardBackendApiService: TopicsAndSkillsDashboardBackendApiService,
     private urlInterpolationService: UrlInterpolationService
@@ -49,16 +46,21 @@ export class TopicCreationService {
     if (this.topicCreationInProgress) {
       return;
     }
-    this.pageContextService.setImageSaveDestinationToLocalStorage();
     let modalRef = this.ngbModal.open(CreateNewTopicModalComponent, {
       backdrop: 'static',
       windowClass: 'create-new-topic',
     });
 
     modalRef.result.then(
-      newlyCreatedTopic => {
+      result => {
+        const newlyCreatedTopic = result.topic;
+        const imageData = result.imageData;
+
         if (!newlyCreatedTopic.isValid()) {
           throw new Error('Topic fields cannot be empty');
+        }
+        if (!imageData) {
+          throw new Error('Image data is required');
         }
         this.topicCreationInProgress = true;
         this.alertsService.clearWarnings();
@@ -69,19 +71,22 @@ export class TopicCreationService {
         // new tab is created as soon as the user clicks the 'Create' button
         // and filled with URL once the details are fetched from the backend.
         let newTab = this.windowRef.nativeWindow.open() as Window;
-        let imagesData = this.imageLocalStorageService.getStoredImagesData();
-        let bgColor = this.imageLocalStorageService.getThumbnailBgColor();
-        if (bgColor === null) {
-          throw new Error('Background color not found.');
-        }
+
+        // Convert ImageUploaderData to ImageData format expected by backend.
+        const imagesData: ImageData[] = [
+          {
+            filename: imageData.filename,
+            imageBlob: imageData.image_data,
+          },
+        ];
+        const bgColor = imageData.bg_color;
+
         this.topicCreationBackendApiService
           .createTopicAsync(newlyCreatedTopic, imagesData, bgColor)
           .then(
             response => {
               this.topicsAndSkillsDashboardBackendApiService.onTopicsAndSkillsDashboardReinitialized.emit();
               this.topicCreationInProgress = false;
-              this.imageLocalStorageService.flushStoredImagesData();
-              this.pageContextService.resetImageSaveDestination();
               newTab.location.href =
                 this.urlInterpolationService.interpolateUrl(
                   this.TOPIC_EDITOR_URL_TEMPLATE,

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -73,8 +73,8 @@ export class ImageUploaderComponent implements OnInit {
   ngOnInit(): void {
     this.placeholderImageUrl = this.urlInterpolationService.getStaticImageUrl(
       this.isImageInPortraitMode()
-        ? '/icons/story-image-icon.png'
-        : '/icons/story-image-icon-landscape.png'
+        ? '/icons/story-image-icon.svg'
+        : '/icons/story-image-icon-landscape.svg'
     );
 
     if (this.imageUploaderParameters.filename) {

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.html
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.html
@@ -134,18 +134,9 @@
               </span>
             </div>
             <label class="form-heading">Thumbnail</label>
-            <oppia-thumbnail-uploader [disabled]="!topicRights.canEditTopic()"
-                                      [useLocalStorage]="false"
-                                      [filename]="topic.getThumbnailFilename()"
-                                      (updateFilename)="updateTopicThumbnailFilename($event)"
-                                      [bgColor]="topic.getThumbnailBgColor()"
-                                      (updateBgColor)="updateTopicThumbnailBgColor($event)"
-                                      [allowedBgColors]="allowedBgColors"
-                                      [aspectRatio]="'4:3'"
-                                      [previewTitle]="editableName"
-                                      previewDescriptionBgColor="#2F6687"
-                                      [previewFooter]="topic.getCanonicalStoryIds().length + ' Lessons'">
-            </oppia-thumbnail-uploader>
+            <oppia-image-uploader [imageUploaderParameters]="imageUploaderParameters"
+                                  (imageSave)="handleThumbnailImageSave($event)">
+            </oppia-image-uploader>
             <div class="topic-classroom-container">
               <label>Classroom</label>
               <span *ngIf="isAssignedToAClassroom()">
@@ -506,10 +497,6 @@
   </div>
 </div>
 <style>
-  .topic-editor thumbnail-uploader {
-    margin-bottom: 15px;
-  }
-
   .topic-editor textarea {
     resize: vertical;
   }

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
@@ -209,8 +209,7 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
       filename: this.topic.getThumbnailFilename(),
       previewTitle: this.editableName,
       previewDescriptionBgColor: '#2F6687',
-      previewFooter:
-        this.topic.getCanonicalStoryIds().length + ' Lessons',
+      previewFooter: this.topic.getCanonicalStoryIds().length + ' Lessons',
     };
   }
 
@@ -450,13 +449,18 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
     }
 
     this.assetsBackendApiService
-      .postThumbnailFile(imageData.image_data, imageData.filename, entityType, entityId)
+      .postThumbnailFile(
+        imageData.image_data,
+        imageData.filename,
+        entityType,
+        entityId
+      )
       .toPromise()
       .then(response => {
         // Update the topic with the new thumbnail filename and background color.
         this.updateTopicThumbnailFilename(response.filename);
         this.updateTopicThumbnailBgColor(imageData.bg_color);
-        
+
         // Update the thumbnail preview URL.
         this.editableThumbnailDataUrl =
           this.imageUploadHelperService.getTrustedResourceUrlForThumbnailFilename(

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
@@ -204,7 +204,7 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
       orientation: 'landscape',
       bgColor: this.topic.getThumbnailBgColor() || this.allowedBgColors[0],
       allowedBgColors: this.allowedBgColors,
-      allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+      allowedImageFormats: ['svg'],
       aspectRatio: '4:3',
       filename: this.topic.getThumbnailFilename(),
       previewTitle: this.editableName,

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
@@ -45,6 +45,11 @@ import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 import {Topic} from 'domain/topic/topic-object.model';
 import {TopicRights} from 'domain/topic/topic-rights.model';
 import {RearrangeSkillsInSubtopicsModalComponent} from '../modal-templates/rearrange-skills-in-subtopics-modal.component';
+import {
+  ImageUploaderParameters,
+  ImageUploaderData,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
+import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 
 @Component({
   selector: 'oppia-topic-editor-tab',
@@ -102,6 +107,7 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
   classroomName: string | null = null;
   curriculumAdminUsernames: string[] = [];
   generatedUrlPrefix: string;
+  imageUploaderParameters!: ImageUploaderParameters;
 
   constructor(
     private pageContextService: PageContextService,
@@ -118,7 +124,8 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
     private undoRedoService: UndoRedoService,
     private urlInterpolationService: UrlInterpolationService,
     private windowDimensionsService: WindowDimensionsService,
-    private windowRef: WindowRef
+    private windowRef: WindowRef,
+    private assetsBackendApiService: AssetsBackendApiService
   ) {}
 
   directiveSubscriptions = new Subscription();
@@ -188,6 +195,23 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
         this.pageContextService.getEntityId()
       );
     this.generatedUrlPrefix = `${this.hostname}/learn/${this.classroomUrlFragment}`;
+
+    // Initialize image uploader parameters for topic thumbnail.
+    this.imageUploaderParameters = {
+      disabled: !this.topicRights.canEditTopic(),
+      maxImageSizeInKB: 1024,
+      imageName: 'Thumbnail',
+      orientation: 'landscape',
+      bgColor: this.topic.getThumbnailBgColor() || this.allowedBgColors[0],
+      allowedBgColors: this.allowedBgColors,
+      allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+      aspectRatio: '4:3',
+      filename: this.topic.getThumbnailFilename(),
+      previewTitle: this.editableName,
+      previewDescriptionBgColor: '#2F6687',
+      previewFooter:
+        this.topic.getCanonicalStoryIds().length + ' Lessons',
+    };
   }
 
   getEligibleSkillSummariesForDiagnosticTest(): ShortSkillSummary[] {
@@ -414,6 +438,36 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
       this.topic,
       newThumbnailBgColor
     );
+  }
+
+  handleThumbnailImageSave(imageData: ImageUploaderData): void {
+    // Upload the image to the backend.
+    const entityType = this.pageContextService.getEntityType();
+    const entityId = this.pageContextService.getEntityId();
+
+    if (!entityType || !entityId) {
+      throw new Error('Entity type and ID are required for image upload');
+    }
+
+    this.assetsBackendApiService
+      .postThumbnailFile(imageData.image_data, imageData.filename, entityType, entityId)
+      .toPromise()
+      .then(response => {
+        // Update the topic with the new thumbnail filename and background color.
+        this.updateTopicThumbnailFilename(response.filename);
+        this.updateTopicThumbnailBgColor(imageData.bg_color);
+        
+        // Update the thumbnail preview URL.
+        this.editableThumbnailDataUrl =
+          this.imageUploadHelperService.getTrustedResourceUrlForThumbnailFilename(
+            response.filename,
+            entityType,
+            entityId
+          );
+      })
+      .catch(error => {
+        throw new Error('Failed to upload thumbnail: ' + error);
+      });
   }
 
   updateTopicDescription(newDescription: string): void {

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.html
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.html
@@ -89,15 +89,9 @@
 
       <div class="thumbnail-editor e2e-test-subtopic-thumbnail e2e-test-photo-button create-new-subtopic-input-field">
         <strong>Thumbnail Image*</strong>
-        <oppia-thumbnail-uploader (updateFilename)="updateSubtopicThumbnailFilename($event)"
-                                  [useLocalStorage]="false"
-                                  [bgColor]="editableThumbnailBgColor"
-                                  (updateBgColor)="updateSubtopicThumbnailBgColor($event)"
-                                  [allowedBgColors]="allowedBgColors"
-                                  [aspectRatio]="'4:3'"
-                                  [previewTitle]="subtopicTitle"
-                                  previewDescriptionBgColor="#BE563C">
-        </oppia-thumbnail-uploader>
+        <oppia-image-uploader [imageUploaderParameters]="imageUploaderParameters"
+                              (imageSave)="handleImageSave($event)">
+        </oppia-image-uploader>
       </div>
     </div>
   </div>

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.html
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.html
@@ -87,7 +87,7 @@
         </div>
       </div>
 
-      <div class="thumbnail-editor e2e-test-subtopic-thumbnail e2e-test-photo-button create-new-subtopic-input-field">
+      <div class="thumbnail-editor e2e-test-subtopic-thumbnail create-new-subtopic-input-field">
         <strong>Thumbnail Image*</strong>
         <oppia-image-uploader [imageUploaderParameters]="imageUploaderParameters"
                               (imageSave)="handleImageSave($event)">

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
@@ -327,7 +327,10 @@ export class CreateNewSubtopicModalComponent
       this.subtopicId,
       this.subtopicTitle
     );
-    this.ngbActiveModal.close(this.subtopicId);
+    this.ngbActiveModal.close({
+      subtopicId: this.subtopicId,
+      imageData: this.uploadedImageData,
+    });
   }
 
   localValueChange(event: string): void {

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
@@ -128,7 +128,7 @@ export class CreateNewSubtopicModalComponent
       orientation: 'landscape',
       bgColor: this.allowedBgColors[0],
       allowedBgColors: this.allowedBgColors,
-      allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+      allowedImageFormats: ['svg'],
       aspectRatio: '4:3',
       previewDescriptionBgColor: '#BE563C',
     };

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
@@ -127,7 +127,7 @@ export class CreateNewSubtopicModalComponent
       imageName: 'Thumbnail',
       orientation: 'landscape',
       bgColor: this.allowedBgColors[0],
-      allowedBgColors: this.allowedBgColors,
+      allowedBgColors: this.allowedBgColors as string[],
       allowedImageFormats: ['svg'],
       aspectRatio: '4:3',
       previewDescriptionBgColor: '#BE563C',
@@ -210,19 +210,19 @@ export class CreateNewSubtopicModalComponent
     if (this.isShowRestructuredStudyGuidesFeatureEnabled()) {
       return Boolean(
         this.editableThumbnailFilename &&
-          this.subtopicTitle &&
-          this.sectionHeadingPlaintext &&
-          this.sectionContentHtml &&
-          this.editableUrlFragment &&
-          this.isUrlFragmentValid()
+        this.subtopicTitle &&
+        this.sectionHeadingPlaintext &&
+        this.sectionContentHtml &&
+        this.editableUrlFragment &&
+        this.isUrlFragmentValid()
       );
     } else {
       return Boolean(
         this.editableThumbnailFilename &&
-          this.subtopicTitle &&
-          this.htmlData &&
-          this.editableUrlFragment &&
-          this.isUrlFragmentValid()
+        this.subtopicTitle &&
+        this.htmlData &&
+        this.editableUrlFragment &&
+        this.isUrlFragmentValid()
       );
     }
   }

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
@@ -210,19 +210,19 @@ export class CreateNewSubtopicModalComponent
     if (this.isShowRestructuredStudyGuidesFeatureEnabled()) {
       return Boolean(
         this.editableThumbnailFilename &&
-        this.subtopicTitle &&
-        this.sectionHeadingPlaintext &&
-        this.sectionContentHtml &&
-        this.editableUrlFragment &&
-        this.isUrlFragmentValid()
+          this.subtopicTitle &&
+          this.sectionHeadingPlaintext &&
+          this.sectionContentHtml &&
+          this.editableUrlFragment &&
+          this.isUrlFragmentValid()
       );
     } else {
       return Boolean(
         this.editableThumbnailFilename &&
-        this.subtopicTitle &&
-        this.htmlData &&
-        this.editableUrlFragment &&
-        this.isUrlFragmentValid()
+          this.subtopicTitle &&
+          this.htmlData &&
+          this.editableUrlFragment &&
+          this.isUrlFragmentValid()
       );
     }
   }

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
@@ -33,6 +33,10 @@ import {
   CALCULATION_TYPE_CHARACTER,
   HtmlLengthService,
 } from 'services/html-length.service';
+import {
+  ImageUploaderParameters,
+  ImageUploaderData,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 @Component({
   selector: 'oppia-create-new-subtopic-modal',
@@ -70,6 +74,8 @@ export class CreateNewSubtopicModalComponent
   generatedUrlPrefix!: string;
   studyGuideSectionCharacterLimit: number =
     AppConstants.STUDY_GUIDE_SECTION_CHARACTER_LIMIT;
+  imageUploaderParameters!: ImageUploaderParameters;
+  uploadedImageData: ImageUploaderData | null = null;
 
   constructor(
     private ngbActiveModal: NgbActiveModal,
@@ -113,6 +119,19 @@ export class CreateNewSubtopicModalComponent
     this.errorMsg = null;
     this.subtopicUrlFragmentExists = false;
     this.generatedUrlPrefix = `${this.hostname}/learn/${this.classroomUrlFragment} /${this.topic.getUrlFragment()}/studyguide`;
+
+    // Initialize image uploader parameters for subtopic thumbnail.
+    this.imageUploaderParameters = {
+      disabled: false,
+      maxImageSizeInKB: 1024,
+      imageName: 'Thumbnail',
+      orientation: 'landscape',
+      bgColor: this.allowedBgColors[0],
+      allowedBgColors: this.allowedBgColors,
+      allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+      aspectRatio: '4:3',
+      previewDescriptionBgColor: '#BE563C',
+    };
   }
 
   getSchema(): object {
@@ -154,10 +173,24 @@ export class CreateNewSubtopicModalComponent
 
   updateSubtopicThumbnailFilename(newThumbnailFilename: string): void {
     this.editableThumbnailFilename = newThumbnailFilename;
+    // Update the preview title when subtopic title changes.
+    if (this.imageUploaderParameters) {
+      this.imageUploaderParameters.previewTitle = this.subtopicTitle;
+    }
   }
 
   updateSubtopicThumbnailBgColor(newThumbnailBgColor: string): void {
     this.editableThumbnailBgColor = newThumbnailBgColor;
+  }
+
+  handleImageSave(imageData: ImageUploaderData): void {
+    this.uploadedImageData = imageData;
+    this.editableThumbnailFilename = imageData.filename;
+    this.editableThumbnailBgColor = imageData.bg_color;
+    // Update the preview title when subtopic title changes.
+    if (this.imageUploaderParameters) {
+      this.imageUploaderParameters.previewTitle = this.subtopicTitle;
+    }
   }
 
   resetErrorMsg(): void {

--- a/core/templates/pages/topic-editor-page/services/entity-creation.service.ts
+++ b/core/templates/pages/topic-editor-page/services/entity-creation.service.ts
@@ -24,6 +24,9 @@ import {CreateNewSubtopicModalComponent} from 'pages/topic-editor-page/modal-tem
 import {CreateNewSkillModalService} from './create-new-skill-modal.service';
 import {TopicEditorRoutingService} from './topic-editor-routing.service';
 import {TopicEditorStateService} from './topic-editor-state.service';
+import {PageContextService} from 'services/page-context.service';
+import {AssetsBackendApiService} from 'services/assets-backend-api.service';
+import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 @Injectable({
   providedIn: 'root',
@@ -33,7 +36,9 @@ export class EntityCreationService {
     private createNewSkillModalService: CreateNewSkillModalService,
     private ngbModal: NgbModal,
     private topicEditorRoutingService: TopicEditorRoutingService,
-    private topicEditorStateService: TopicEditorStateService
+    private topicEditorStateService: TopicEditorStateService,
+    private pageContextService: PageContextService,
+    private assetsBackendApiService: AssetsBackendApiService
   ) {}
 
   createSubtopic(): void {
@@ -43,10 +48,46 @@ export class EntityCreationService {
         windowClass: 'create-new-subtopic',
       })
       .result.then(
-        subtopicId => {
-          this.topicEditorRoutingService.navigateToSubtopicEditorWithId(
-            subtopicId
-          );
+        result => {
+          const subtopicId = result.subtopicId;
+          const imageData: ImageUploaderData | null = result.imageData;
+
+          // Upload the image if provided.
+          if (imageData) {
+            const entityType = this.pageContextService.getEntityType();
+            const entityId = this.pageContextService.getEntityId();
+
+            if (!entityType || !entityId) {
+              throw new Error(
+                'Entity type and ID are required for image upload'
+              );
+            }
+
+            this.assetsBackendApiService
+              .postThumbnailFile(
+                imageData.image_data,
+                imageData.filename,
+                entityType,
+                entityId
+              )
+              .toPromise()
+              .then(() => {
+                // Navigate to subtopic editor after successful image upload.
+                this.topicEditorRoutingService.navigateToSubtopicEditorWithId(
+                  subtopicId
+                );
+              })
+              .catch(error => {
+                throw new Error(
+                  'Failed to upload subtopic thumbnail: ' + error
+                );
+              });
+          } else {
+            // Navigate directly if no image.
+            this.topicEditorRoutingService.navigateToSubtopicEditorWithId(
+              subtopicId
+            );
+          }
         },
         () => {
           // Note to developers:

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.html
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.html
@@ -116,16 +116,9 @@
             <p>
               <strong>Thumbnail Image*</strong>
             </p>
-            <oppia-thumbnail-uploader [filename]="subtopic?.getThumbnailFilename()"
-                                      [useLocalStorage]="false"
-                                      (updateFilename)="updateSubtopicThumbnailFilename($event)"
-                                      [bgColor]="subtopic?.getThumbnailBgColor()"
-                                      (updateBgColor)="updateSubtopicThumbnailBgColor($event)"
-                                      [allowedBgColors]="allowedBgColors"
-                                      [aspectRatio]="'4:3'"
-                                      [previewTitle]="editableTitle"
-                                      previewDescriptionBgColor="#BE563C">
-            </oppia-thumbnail-uploader>
+            <oppia-image-uploader [imageUploaderParameters]="imageUploaderParameters"
+                                  (imageSave)="handleThumbnailImageSave($event)">
+            </oppia-image-uploader>
           </div>
         </div>
         <div *ngIf="editableThumbnailFilename && subtopicEditorCardIsShown">

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
@@ -297,7 +297,12 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
     }
 
     this.assetsBackendApiService
-      .postThumbnailFile(imageData.image_data, imageData.filename, entityType, entityId)
+      .postThumbnailFile(
+        imageData.image_data,
+        imageData.filename,
+        entityType,
+        entityId
+      )
       .toPromise()
       .then(response => {
         // Update the subtopic with the new thumbnail filename and background color.

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
@@ -186,7 +186,7 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
         orientation: 'landscape',
         bgColor: this.subtopic.getThumbnailBgColor() || this.allowedBgColors[0],
         allowedBgColors: this.allowedBgColors,
-        allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+        allowedImageFormats: ['svg'],
         aspectRatio: '4:3',
         filename: this.subtopic.getThumbnailFilename(),
         previewTitle: this.editableTitle,

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
@@ -39,6 +39,13 @@ import {StudyGuideSection} from 'domain/topic/study-guide-sections.model';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {DeleteStudyGuideSectionComponent} from 'pages/topic-editor-page/subtopic-editor/delete-study-guide-section-modal.component';
 import {AddStudyGuideSectionModalComponent} from 'pages/topic-editor-page/subtopic-editor/add-study-guide-section.component';
+import {
+  ImageUploaderParameters,
+  ImageUploaderData,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
+import {AssetsBackendApiService} from 'services/assets-backend-api.service';
+import {PageContextService} from 'services/page-context.service';
+import {ImageUploadHelperService} from 'services/image-upload-helper.service';
 
 @Component({
   selector: 'oppia-subtopic-editor-tab',
@@ -88,6 +95,7 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
     };
   };
   generatedUrlPrefix: string;
+  imageUploaderParameters!: ImageUploaderParameters;
 
   constructor(
     private questionBackendApiService: QuestionBackendApiService,
@@ -99,7 +107,10 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
     private urlInterpolationService: UrlInterpolationService,
     private windowDimensionsService: WindowDimensionsService,
     private platformFeatureService: PlatformFeatureService,
-    private windowRef: WindowRef
+    private windowRef: WindowRef,
+    private assetsBackendApiService: AssetsBackendApiService,
+    private pageContextService: PageContextService,
+    private imageUploadHelperService: ImageUploadHelperService
   ) {}
 
   directiveSubscriptions = new Subscription();
@@ -166,6 +177,21 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
         this.subtopicValidationService.isUrlFragmentValid(
           this.editableUrlFragment
         );
+
+      // Initialize image uploader parameters for subtopic thumbnail.
+      this.imageUploaderParameters = {
+        disabled: false,
+        maxImageSizeInKB: 1024,
+        imageName: 'Thumbnail',
+        orientation: 'landscape',
+        bgColor: this.subtopic.getThumbnailBgColor() || this.allowedBgColors[0],
+        allowedBgColors: this.allowedBgColors,
+        allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+        aspectRatio: '4:3',
+        filename: this.subtopic.getThumbnailFilename(),
+        previewTitle: this.editableTitle,
+        previewDescriptionBgColor: '#BE563C',
+      };
     }
   }
 
@@ -259,6 +285,28 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
       newThumbnailBgColor
     );
     this.editableThumbnailBgColor = newThumbnailBgColor;
+  }
+
+  handleThumbnailImageSave(imageData: ImageUploaderData): void {
+    // Upload the image to the backend.
+    const entityType = this.pageContextService.getEntityType();
+    const entityId = this.pageContextService.getEntityId();
+
+    if (!entityType || !entityId) {
+      throw new Error('Entity type and ID are required for image upload');
+    }
+
+    this.assetsBackendApiService
+      .postThumbnailFile(imageData.image_data, imageData.filename, entityType, entityId)
+      .toPromise()
+      .then(response => {
+        // Update the subtopic with the new thumbnail filename and background color.
+        this.updateSubtopicThumbnailFilename(response.filename);
+        this.updateSubtopicThumbnailBgColor(imageData.bg_color);
+      })
+      .catch(error => {
+        throw new Error('Failed to upload subtopic thumbnail: ' + error);
+      });
   }
 
   resetErrorMsg(): void {

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.html
@@ -67,13 +67,9 @@
     </div>
     <div class="create-new-topic-input-field">
       <label class="create-new-topic-input-label">Topic Thumbnail*</label>
-      <oppia-thumbnail-uploader [previewTitle]="newlyCreatedTopic.name"
-                                [aspectRatio]="'4:3'"
-                                [disabled]="false"
-                                [useLocalStorage]="true"
-                                [allowedBgColors]="allowedBgColors"
-                                previewDescriptionBgColor="#2F6687">
-      </oppia-thumbnail-uploader>
+      <oppia-image-uploader [imageUploaderParameters]="imageUploaderParameters"
+                            (imageSave)="handleImageSave($event)">
+      </oppia-image-uploader>
     </div>
   </div>
 

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
@@ -22,9 +22,7 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
 import {TopicEditorStateService} from 'pages/topic-editor-page/services/topic-editor-state.service';
-import {PageContextService} from 'services/page-context.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {CreateNewTopicModalComponent} from './create-new-topic-modal.component';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
@@ -32,9 +30,7 @@ import {By} from '@angular/platform-browser';
 describe('Create new topic modal', () => {
   let fixture: ComponentFixture<CreateNewTopicModalComponent>;
   let componentInstance: CreateNewTopicModalComponent;
-  let pageContextService: PageContextService;
   let ngbActiveModal: NgbActiveModal;
-  let imageLocalStorageService: ImageLocalStorageService;
   let topicEditorStateService: TopicEditorStateService;
 
   class MockWindowRef {
@@ -51,7 +47,6 @@ describe('Create new topic modal', () => {
       declarations: [CreateNewTopicModalComponent, UrlFragmentEditorComponent],
       providers: [
         NgbActiveModal,
-        ImageLocalStorageService,
         TopicEditorStateService,
         {
           provide: WindowRef,
@@ -65,9 +60,7 @@ describe('Create new topic modal', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateNewTopicModalComponent);
     componentInstance = fixture.componentInstance;
-    pageContextService = TestBed.inject(PageContextService);
     ngbActiveModal = TestBed.inject(NgbActiveModal);
-    imageLocalStorageService = TestBed.inject(ImageLocalStorageService);
     topicEditorStateService = TestBed.inject(TopicEditorStateService);
   });
 
@@ -76,17 +69,23 @@ describe('Create new topic modal', () => {
   });
 
   it('should intialize', () => {
-    spyOn(pageContextService, 'setImageSaveDestinationToLocalStorage');
     componentInstance.ngOnInit();
-    expect(
-      pageContextService.setImageSaveDestinationToLocalStorage
-    ).toHaveBeenCalled();
+    expect(componentInstance.imageUploaderParameters).toBeDefined();
+    expect(componentInstance.uploadedImageData).toBeNull();
   });
 
   it('should save new topic', () => {
     spyOn(ngbActiveModal, 'close');
+    componentInstance.uploadedImageData = {
+      filename: 'test.svg',
+      image_data: new Blob(),
+      bg_color: '#000000',
+    };
     componentInstance.save();
-    expect(ngbActiveModal.close).toHaveBeenCalled();
+    expect(ngbActiveModal.close).toHaveBeenCalledWith({
+      topic: componentInstance.newlyCreatedTopic,
+      imageData: componentInstance.uploadedImageData,
+    });
   });
 
   it('should cancel', () => {
@@ -97,13 +96,32 @@ describe('Create new topic modal', () => {
 
   it('should validate newly created topic', () => {
     spyOn(componentInstance.newlyCreatedTopic, 'isValid').and.returnValue(true);
-    spyOn(imageLocalStorageService, 'getStoredImagesData').and.returnValue([
-      {
-        filename: '',
-        imageBlob: null,
-      },
-    ]);
+    componentInstance.uploadedImageData = {
+      filename: 'test.svg',
+      image_data: new Blob(),
+      bg_color: '#000000',
+    };
     expect(componentInstance.isValid()).toBeTrue();
+  });
+
+  it('should not be valid without uploaded image', () => {
+    spyOn(componentInstance.newlyCreatedTopic, 'isValid').and.returnValue(true);
+    componentInstance.uploadedImageData = null;
+    expect(componentInstance.isValid()).toBeFalse();
+  });
+
+  it('should handle image save', () => {
+    const mockImageData = {
+      filename: 'test.svg',
+      image_data: new Blob(),
+      bg_color: '#000000',
+    };
+    componentInstance.newlyCreatedTopic.name = 'Test Topic';
+    componentInstance.handleImageSave(mockImageData);
+    expect(componentInstance.uploadedImageData).toEqual(mockImageData);
+    expect(componentInstance.imageUploaderParameters.previewTitle).toBe(
+      'Test Topic'
+    );
   });
 
   it('should update topic url framgent', () => {

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
@@ -111,6 +111,7 @@ describe('Create new topic modal', () => {
   });
 
   it('should handle image save', () => {
+    componentInstance.ngOnInit();
     const mockImageData = {
       filename: 'test.svg',
       image_data: new Blob(),

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
@@ -69,7 +69,7 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
       orientation: 'landscape',
       bgColor: this.allowedBgColors[0],
       allowedBgColors: this.allowedBgColors,
-      allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+      allowedImageFormats: ['svg'],
       aspectRatio: '4:3',
       previewDescriptionBgColor: '#2F6687',
     };

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
@@ -33,7 +33,8 @@ import {WindowRef} from 'services/contextual/window-ref.service';
   templateUrl: './create-new-topic-modal.component.html',
 })
 export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
-  allowedBgColors: string[] = AppConstants.ALLOWED_THUMBNAIL_BG_COLORS.topic;
+  allowedBgColors: readonly string[] =
+    AppConstants.ALLOWED_THUMBNAIL_BG_COLORS.topic;
   validUrlFragmentRegex = new RegExp(AppConstants.VALID_URL_FRAGMENT_REGEX);
   newlyCreatedTopic: NewlyCreatedTopic = NewlyCreatedTopic.createDefault();
   hostname: string = this.windowRef.nativeWindow.location.hostname;
@@ -68,7 +69,7 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
       imageName: 'Thumbnail',
       orientation: 'landscape',
       bgColor: this.allowedBgColors[0],
-      allowedBgColors: this.allowedBgColors,
+      allowedBgColors: this.allowedBgColors as string[],
       allowedImageFormats: ['svg'],
       aspectRatio: '4:3',
       previewDescriptionBgColor: '#2F6687',

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
@@ -20,18 +20,20 @@ import {Component} from '@angular/core';
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
 import {AppConstants} from 'app.constants';
 import {ConfirmOrCancelModal} from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
+import {
+  ImageUploaderParameters,
+  ImageUploaderData,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
 import {NewlyCreatedTopic} from 'domain/topics_and_skills_dashboard/newly-created-topic.model';
 import {TopicEditorStateService} from 'pages/topic-editor-page/services/topic-editor-state.service';
-import {PageContextService} from 'services/page-context.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {ImageLocalStorageService} from 'services/image-local-storage.service';
 
 @Component({
   selector: 'oppia-create-new-topic-modal',
   templateUrl: './create-new-topic-modal.component.html',
 })
 export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
-  allowedBgColors: object = AppConstants.ALLOWED_THUMBNAIL_BG_COLORS.topic;
+  allowedBgColors: string[] = AppConstants.ALLOWED_THUMBNAIL_BG_COLORS.topic;
   validUrlFragmentRegex = new RegExp(AppConstants.VALID_URL_FRAGMENT_REGEX);
   newlyCreatedTopic: NewlyCreatedTopic = NewlyCreatedTopic.createDefault();
   hostname: string = this.windowRef.nativeWindow.location.hostname;
@@ -47,11 +49,11 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
   maxWebTitleFrag = AppConstants.MAX_CHARS_IN_PAGE_TITLE_FRAGMENT_FOR_WEB;
   minWebTitleFrag = AppConstants.MIN_CHARS_IN_PAGE_TITLE_FRAGMENT_FOR_WEB;
   generatedUrlPrefix = `${this.hostname}/learn/staging`;
+  imageUploaderParameters!: ImageUploaderParameters;
+  uploadedImageData: ImageUploaderData | null = null;
 
   constructor(
-    private pageContextService: PageContextService,
     private ngbActiveModal: NgbActiveModal,
-    private imageLocalStorageService: ImageLocalStorageService,
     private windowRef: WindowRef,
     private topicEditorStateService: TopicEditorStateService
   ) {
@@ -59,11 +61,35 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
   }
 
   ngOnInit(): void {
-    this.pageContextService.setImageSaveDestinationToLocalStorage();
+    // Initialize image uploader parameters for the topic thumbnail.
+    this.imageUploaderParameters = {
+      disabled: false,
+      maxImageSizeInKB: 1024,
+      imageName: 'Thumbnail',
+      orientation: 'landscape',
+      bgColor: this.allowedBgColors[0],
+      allowedBgColors: this.allowedBgColors,
+      allowedImageFormats: ['svg', 'png', 'jpeg', 'jpg'],
+      aspectRatio: '4:3',
+      previewDescriptionBgColor: '#2F6687',
+    };
+  }
+
+  handleImageSave(imageData: ImageUploaderData): void {
+    this.uploadedImageData = imageData;
+    // Update the preview title when topic name changes.
+    this.imageUploaderParameters.previewTitle = this.newlyCreatedTopic.name;
+  }
+
+  getImageData(): ImageUploaderData | null {
+    return this.uploadedImageData;
   }
 
   save(): void {
-    this.ngbActiveModal.close(this.newlyCreatedTopic);
+    this.ngbActiveModal.close({
+      topic: this.newlyCreatedTopic,
+      imageData: this.uploadedImageData,
+    });
   }
 
   cancel(): void {
@@ -72,8 +98,7 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
 
   isValid(): boolean {
     return Boolean(
-      this.newlyCreatedTopic.isValid() &&
-        this.imageLocalStorageService.getStoredImagesData().length > 0
+      this.newlyCreatedTopic.isValid() && this.uploadedImageData !== null
     );
   }
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -39,7 +39,7 @@ const photoBoxButton = 'div.e2e-test-photo-button';
 const subtopicPhotoBoxButton =
   '.e2e-test-subtopic-thumbnail .e2e-test-photo-button';
 const uploadPhotoButton = 'button.e2e-test-photo-upload-submit';
-const photoUploadModal = 'edit-thumbnail-modal';
+const photoUploadModal = '.e2e-test-image-uploader-modal';
 const removeQuestionConfirmationButton =
   '.e2e-test-remove-question-confirmation-button';
 


### PR DESCRIPTION
## Overview

1. This PR fixes: #20564 
2. This PR does the following: It changes multiple thumbnail/image upload implementations into the standardized `oppia-image-uploader` component. Previously, various components across the codebase used the deprecated `oppia-thumbnail-uploader`, leading to code duplication and maintenance overhead.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

### Changes Made

**Migrated 4 components from `oppia-thumbnail-uploader` to `oppia-image-uploader`:**
1. **Create New Topic Modal** - Topic creation with thumbnail upload
2. **Topic Editor Tab** - Direct thumbnail editing in topic editor
3. **Create New Subtopic Modal** - Subtopic creation with thumbnail upload  
4. **Subtopic Editor Tab** - Direct thumbnail editing in subtopic editor

**Key Implementation Changes:**

- **Component Updates**: All 4 components now use `ImageUploaderParameters` interface with standardized configuration:
  - `allowedImageFormats`: `['svg']`
  - Consistent aspect ratio (`4:3`)
  - Proper orientation and size limits (1024KB max)
  - Background color customization support

- **Service Layer**: Updated `topic-creation.service.ts` to handle the new image data structure returned by the unified uploader:
  - Changed from storing data in `ImageLocalStorageService` to directly handling `ImageUploaderData`
  - Modal now returns `{topic, imageData}` structure
  - Service converts `ImageUploaderData` to `ImageData[]` for backend compatibility

- **Cleanup**: Removed deprecated CSS rule `.topic-editor thumbnail-uploader` (lines 500-502 in topic-editor-tab.component.html)

### Files Changed (11 files)

**Component TypeScript files (4):**
- `core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts`
- `core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts`
- `core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts`
- `core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts`

**Component HTML templates (4):**
- `core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.html`
- `core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.html`
- `core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.html`
- `core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.html`

**Service & Test files (3):**
- `core/templates/components/entity-creation-services/topic-creation.service.ts`
- `core/templates/components/entity-creation-services/topic-creation.service.spec.ts`
- `core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts`

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

https://github.com/user-attachments/assets/4067c0f2-ce68-4199-a667-5335bce59213


#### Proof of changes on desktop with slow/throttled network
<img width="1919" height="969" alt="Screenshot 2026-01-25 180542" src="https://github.com/user-attachments/assets/550d30a2-c6e8-4a56-ac3f-8cdb670700a2" />


#### Proof of changes on mobile phone
<img width="1919" height="978" alt="Screenshot 2026-01-25 180951" src="https://github.com/user-attachments/assets/e5836033-5f93-4d52-a578-d130c077165b" />
<img width="1919" height="980" alt="Screenshot 2026-01-25 181047" src="https://github.com/user-attachments/assets/2f48471a-5b63-4c05-a7d1-061291c5684a" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
