### PR TITLE
Fix #24204: Prevent text overflow and layout break in classroom page

### DIFF
--- a/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.html
+++ b/core/templates/components/common-layout-directives/common-elements/classroom-navigation-links.component.html
@@ -82,13 +82,17 @@
 
   .classroom-item .classroom-text-container .classroom-name {
     color: #000;
+    display: block;
     font-family: 'Inter', 'Roboto', sans-serif;
     font-size: 15px;
     font-style: normal;
     font-weight: 700;
     line-height: 18px;
     margin: 0;
+    min-width: 0;
+    overflow-wrap: anywhere;
     text-decoration: none;
+    word-break: break-word;
   }
 
   .classroom-item .classroom-text-container .classroom-name:hover,

--- a/core/templates/pages/classroom-page/classroom-page.component.css
+++ b/core/templates/pages/classroom-page/classroom-page.component.css
@@ -47,7 +47,7 @@
 }
 
 .classroom-content-container .classroom-content .diagnostic-test-container {
-  align-items: start;
+  align-items: stretch;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -62,7 +62,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  height: 115px;
+  height: auto;
+  min-height: 115px;
   padding: 12px 36px;
   width: 338px;
 }
@@ -74,9 +75,12 @@
   font-style: normal;
   font-weight: 700;
   height: fit-content;
+  hyphens: auto;
   letter-spacing: -0.02em;
   line-height: 20px;
+  overflow-wrap: anywhere;
   width: 266px;
+  word-break: break-word;
 }
 
 .diagnostic-test-container .diagnostic-test-box .diagnostic-test-info p {
@@ -131,6 +135,8 @@
   font-weight: 400;
   letter-spacing: -0.02em;
   line-height: 20px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .oppia-classroom-page-container .classroom-top .classroom-admin-banner {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[[24204]](https://github.com/oppia/oppia/issues/24204).
2. This PR improves text wrapping and prevents overflow issues in the classroom page and learn navigation popup.
3. (For bug-fixing PRs only) The original bug occurred because fixed heights and aggressive word-breaking caused text to overflow for longer translations.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

**Before:**
<img width="1916" height="910" alt="old1" src="https://github.com/user-attachments/assets/2e6d646c-a653-47bb-b99d-bdaa0fb805d3" />
<img width="1213" height="360" alt="image" src="https://github.com/user-attachments/assets/008228a7-c62f-4751-a623-b239f39a8363" />

**After:**
<img width="1907" height="965" alt="image" src="https://github.com/user-attachments/assets/a713e48a-55af-4b16-bd72-e9b7fe9c4eb7" />
<img width="1918" height="959" alt="image" src="https://github.com/user-attachments/assets/5a9daa3d-686f-42d0-98d3-5629c03c7ed8" />


#### Proof of changes on desktop with slow/throttled network
- Verified with Chrome DevTools network throttling (Slow 3G).
- No UI regressions or layout issues observed.
- Text wrapping and diagnostic card layout remain correct.
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
<img width="1265" height="953" alt="image" src="https://github.com/user-attachments/assets/57e0a8e3-f648-46d5-a3e2-25c0b6253572" />
<img width="1264" height="960" alt="image" src="https://github.com/user-attachments/assets/17744cdb-6b1d-4e58-a00a-902a701fee63" />

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language
<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/f0cd76fc-2b73-4a5e-b771-0bd56195668b" />

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
