### PR TITLE
Fix #23011: Resolve issue where skill search required filters to work

### DIFF
--- a/core/templates/components/skill-selector/skill-selector.component.html
+++ b/core/templates/components/skill-selector/skill-selector.component.html
@@ -4,7 +4,7 @@
       <mat-card class="list-view-item e2e-test-skill-select-header">
         Search By Skill
         <input type="text" class="form-control e2e-test-skill-name-input" placeholder="Enter a skill name"
-          [(ngModel)]="skillFilterText" autofocus>
+          [(ngModel)]="skillFilterText" (ngModelChange)="updateSkillsListOnSubtopicFilterChange()" autofocus>
       </mat-card>
       <div class="skill-list-box">
         <mat-radio-group [(ngModel)]="selectedSkill" (change)="setSelectedSkillId()">
@@ -25,11 +25,11 @@
               </div>
             </mat-card>
           </div>
-          <mat-card *ngIf="untriagedSkillSummaries && untriagedSkillSummaries.length" class="list-view-item">
+          <mat-card *ngIf="untriagedSkillSummaries && untriagedSkillSummaries.length && searchInUntriagedSkillSummaries(skillFilterText).length > 0" class="list-view-item">
             <mat-card class="list-view-item">
               <h2><label class="oppia-heading-text">Untriaged Skills</label></h2>
             </mat-card>
-            <div *ngIf="!checkIfEmpty(untriagedSkillSummaries)" class="list-view-item ">
+            <div *ngIf="searchInUntriagedSkillSummaries(skillFilterText).length > 0" class="list-view-item ">
               <mat-card class="list-view-item">
                 <label>
                   <mat-radio-button class="oppia-skills-list-item e2e-test-skills-list-item e2e-test-skill-selection-item" *ngFor="let skill of searchInUntriagedSkillSummaries(skillFilterText)" [value]="skill.id" [disabled]="!userCanEditSkills" attr.aria-label="{{ skill.description }}"><span class="oppia-mat-radio-button-label">{{ skill.description }}</span>

--- a/core/templates/components/skill-selector/skill-selector.component.html
+++ b/core/templates/components/skill-selector/skill-selector.component.html
@@ -29,7 +29,7 @@
             <mat-card class="list-view-item">
               <h2><label class="oppia-heading-text">Untriaged Skills</label></h2>
             </mat-card>
-            <div *ngIf="!checkIfEmpty(untriagedSkillSummaries)" class="list-view-item ">
+            <div *ngIf="searchInUntriagedSkillSummaries(skillFilterText).length > 0" class="list-view-item ">
               <mat-card class="list-view-item">
                 <label>
                   <mat-radio-button class="oppia-skills-list-item e2e-test-skills-list-item e2e-test-skill-selection-item" *ngFor="let skill of searchInUntriagedSkillSummaries(skillFilterText)" [value]="skill.id" [disabled]="!userCanEditSkills" attr.aria-label="{{ skill.description }}"><span class="oppia-mat-radio-button-label">{{ skill.description }}</span>

--- a/core/templates/components/skill-selector/skill-selector.component.html
+++ b/core/templates/components/skill-selector/skill-selector.component.html
@@ -29,7 +29,7 @@
             <mat-card class="list-view-item">
               <h2><label class="oppia-heading-text">Untriaged Skills</label></h2>
             </mat-card>
-            <div *ngIf="searchInUntriagedSkillSummaries(skillFilterText).length > 0" class="list-view-item ">
+            <div *ngIf="!checkIfEmpty(untriagedSkillSummaries)" class="list-view-item ">
               <mat-card class="list-view-item">
                 <label>
                   <mat-radio-button class="oppia-skills-list-item e2e-test-skills-list-item e2e-test-skill-selection-item" *ngFor="let skill of searchInUntriagedSkillSummaries(skillFilterText)" [value]="skill.id" [disabled]="!userCanEditSkills" attr.aria-label="{{ skill.description }}"><span class="oppia-mat-radio-button-label">{{ skill.description }}</span>

--- a/core/templates/components/skill-selector/skill-selector.component.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.ts
@@ -89,13 +89,18 @@ export class SkillSelectorComponent implements OnInit {
       });
   }
 
-  checkIfEmpty(skills: Object[]): boolean {
-    return skills.length === 0;
+  checkIfEmpty(skills: ShortSkillSummary[]): boolean {
+    return (
+      this.searchInSubtopicSkills(skills, this.skillFilterText).length === 0
+    );
   }
 
   checkTopicIsNotEmpty(topicName: string): boolean {
-    for (let key in this.currCategorizedSkills[topicName]) {
-      if (Object.keys(this.currCategorizedSkills[topicName][key]).length) {
+    for (let subtopicName in this.currCategorizedSkills[topicName]) {
+      let skills = this.currCategorizedSkills[topicName][subtopicName];
+      if (
+        this.searchInSubtopicSkills(skills, this.skillFilterText).length > 0
+      ) {
         return true;
       }
     }

--- a/core/templates/components/skill-selector/skill-selector.component.ts
+++ b/core/templates/components/skill-selector/skill-selector.component.ts
@@ -90,12 +90,18 @@ export class SkillSelectorComponent implements OnInit {
   }
 
   checkIfEmpty(skills: ShortSkillSummary[]): boolean {
+    // This method now depends on the search query (skillFilterText).
+    // If a skill matches the search query, it will be displayed.
+    // Otherwise, it will be hidden.
     return (
       this.searchInSubtopicSkills(skills, this.skillFilterText).length === 0
     );
   }
 
   checkTopicIsNotEmpty(topicName: string): boolean {
+    // This method now depends on the search query (skillFilterText).
+    // If a topic has at least one skill that matches the search query,
+    // it will be displayed. Otherwise, it will be hidden.
     for (let subtopicName in this.currCategorizedSkills[topicName]) {
       let skills = this.currCategorizedSkills[topicName][subtopicName];
       if (


### PR DESCRIPTION

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #23011.
2. This PR does the following: This PR ensures that Search by Skill works immediately when the user types, without requiring topic or subtopic filters to be selected first. It improves usability while keeping the fix minimal and consistent with existing Angular patterns.
3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because the filtering logic was only triggered when topic or subtopic filters changed. Updates to the skill search input (skillFilterText) did not trigger the filtering logic, so results were not refreshed unless another filter event occurred.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.  
- [x] The **PR title** starts with "Fix #23011: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or have left a comment with the phrase `@{{reviewer_username}} PTAL`).

## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

code change - 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/156a6cc6-f190-4371-bfea-fd7c9dfe2648" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/78ecc1f7-b81d-4e96-a041-57bcbf07afce" />

 Video Proof- 
 

https://github.com/user-attachments/assets/fd1ba056-a825-4541-81fe-781357f355ca

 

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
