### PR TITLE
Fix #22725: Username overflow in contributor dashboard

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.css
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.css
@@ -1,0 +1,16 @@
+/* Fix username overlapping in contributor dashboard */
+
+.oppia-short-contributor-username-container,
+.oppia-long-contributor-username-container {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.e2e-test-username {
+  display: block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+}


### PR DESCRIPTION
## Overview

This PR fixes the issue of username overflow in the contributor dashboard.

### Issue
Fixes #22725

### What this PR does
- Adds CSS constraints to username containers
- Prevents long usernames from overflowing or overlapping
- Truncates long usernames gracefully using ellipsis

### Root cause
The username containers did not restrict width or handle overflow properly, which caused long usernames to overlap adjacent UI elements.

## Essential Checklist

- [x] I have linked the issue that this PR fixes.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are correct.
- [ ] I have written tests for my code (Not applicable – CSS-only change).

