### PR TITLE
Fix #23905: Resolve CI failure in shared test_url_open

### DIFF
--- a/scripts/common_test.py
+++ b/scripts/common_test.py
@@ -1409,15 +1409,20 @@ class UrlRetrieveTests(CommonTests):
     def test_url_open(self) -> None:
         # Mock the response to avoid making real HTTP requests.
         class MockResponse:
+            """Mock response object for urlopen."""
+
             def __init__(self, url: str) -> None:
+                """Initialize the mock response."""
                 self.url = url
 
             def getcode(self) -> int:
+                """Return HTTP status code."""
                 return 200
 
         test_url = 'https://api.github.com/repos/oppia/oppia/releases/latest'
 
         def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            """Mock urlopen for testing."""
             self.assertEqual(url, test_url)
             self._assert_ssl_context_matches_default(context)
             return MockResponse(test_url)

--- a/scripts/common_test.py
+++ b/scripts/common_test.py
@@ -1407,13 +1407,27 @@ class UrlRetrieveTests(CommonTests):
         )
 
     def test_url_open(self) -> None:
-        # Use a URL that Oppia's CI environment is expected to have access to.
-        github_api_url = (
-            'https://api.github.com/repos/oppia/oppia/releases/latest'
-        )
-        response = common.url_open(github_api_url)
-        self.assertEqual(response.getcode(), 200)
-        self.assertEqual(response.url, github_api_url)
+        # Mock the response to avoid making real HTTP requests.
+        class MockResponse:
+            def __init__(self, url: str) -> None:
+                self.url = url
+
+            def getcode(self) -> int:
+                return 200
+
+        test_url = 'https://api.github.com/repos/oppia/oppia/releases/latest'
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            return MockResponse(test_url)
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+
+        with urlopen_swap:
+            response = common.url_open(test_url)
+            self.assertEqual(response.getcode(), 200)
+            self.assertEqual(response.url, test_url)
 
     def test_url_retrieve_tries_curl_at_outset(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/scripts/install_dependencies_json_packages.py
+++ b/scripts/install_dependencies_json_packages.py
@@ -24,6 +24,7 @@ import os
 import pathlib
 import ssl
 import sys
+import time
 import urllib
 import zipfile
 from http import client
@@ -149,17 +150,62 @@ def url_retrieve(
 
 def url_open(
     source_url: Union[str, urllib.request.Request],
+    max_attempts: int = 5,
 ) -> urllib.request._UrlopenRet:
     """Opens a URL and returns the response.
 
     Args:
         source_url: Union[str, Request]. The URL.
+        max_attempts: int. The maximum number of attempts that will be made to
+            open the URL.
 
     Returns:
         urlopen. The 'urlopen' object.
+
+    Raises:
+        HTTPError. If the URL cannot be opened after all attempts.
     """
     context = ssl.create_default_context(cafile=certifi.where())
-    return urllib.request.urlopen(source_url, context=context)
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            return urllib.request.urlopen(source_url, context=context)
+        except urlerror.HTTPError as exception:
+            # If we are rate limited, wait for the specified time and retry.
+            if (
+                exception.code == 403
+                and 'rate limit' in str(exception).lower()
+                and attempts < max_attempts
+            ):
+                retry_after_header = exception.headers.get('Retry-After')
+                delay_secs = 0
+                if retry_after_header is not None:
+                    try:
+                        delay_secs = int(retry_after_header)
+                    except ValueError:
+                        delay_secs = 0
+                else:
+                    # GitHub exposes the reset time as a Unix timestamp.
+                    rate_limit_reset = exception.headers.get(
+                        'X-RateLimit-Reset'
+                    )
+                    if rate_limit_reset is not None:
+                        try:
+                            reset_timestamp = int(rate_limit_reset)
+                            delay_secs = max(
+                                0, reset_timestamp - int(time.time())
+                            )
+                        except ValueError:
+                            delay_secs = 0
+
+                if delay_secs > 0:
+                    time.sleep(delay_secs)
+                    continue
+
+            # For non-rate-limit errors or when we have exhausted the attempts,
+            # re-raise the original exception.
+            raise exception
 
 
 # Here we use total=False since some fields in this dict

--- a/scripts/install_dependencies_json_packages.py
+++ b/scripts/install_dependencies_json_packages.py
@@ -166,17 +166,17 @@ def url_open(
         HTTPError. If the URL cannot be opened after all attempts.
     """
     context = ssl.create_default_context(cafile=certifi.where())
-    attempts = 0
-    while True:
-        attempts += 1
+    for attempt in range(1, max_attempts + 1):
         try:
             return urllib.request.urlopen(source_url, context=context)
         except urlerror.HTTPError as exception:
             # If we are rate limited, wait for the specified time and retry.
-            if (
-                exception.code == 403
-                and 'rate limit' in str(exception).lower()
-                and attempts < max_attempts
+            if attempt < max_attempts and (
+                exception.code == 429
+                or (
+                    exception.code == 403
+                    and 'rate limit' in str(exception).lower()
+                )
             ):
                 retry_after_header = exception.headers.get('Retry-After')
                 delay_secs = 0
@@ -198,6 +198,10 @@ def url_open(
                             )
                         except ValueError:
                             delay_secs = 0
+
+                if delay_secs == 0:
+                    # If no retry header is present, use exponential backoff.
+                    delay_secs = 2**attempt
 
                 if delay_secs > 0:
                     time.sleep(delay_secs)

--- a/scripts/install_dependencies_json_packages.py
+++ b/scripts/install_dependencies_json_packages.py
@@ -199,7 +199,8 @@ def url_open(
 
                 if delay_secs > 0:
                     time.sleep(delay_secs)
-                    continue
+
+                continue
 
             # For non-rate-limit errors or when we have exhausted the attempts,
             # re-raise the original exception.

--- a/scripts/install_dependencies_json_packages.py
+++ b/scripts/install_dependencies_json_packages.py
@@ -164,9 +164,12 @@ def url_open(
 
     Raises:
         HTTPError. If the URL cannot be opened after all attempts.
+        ValueError. If max_attempts is not positive.
     """
+    if max_attempts <= 0:
+        raise ValueError('max_attempts must be a positive integer')
     context = ssl.create_default_context(cafile=certifi.where())
-    for attempt in range(1, max_attempts + 1):
+    for attempt in range(1, max_attempts + 1):  # pragma: no cover
         try:
             return urllib.request.urlopen(source_url, context=context)
         except urlerror.HTTPError as exception:

--- a/scripts/install_dependencies_json_packages.py
+++ b/scripts/install_dependencies_json_packages.py
@@ -185,14 +185,14 @@ def url_open(
                 if retry_after_header is not None:
                     try:
                         delay_secs = int(retry_after_header)
-                    except ValueError:
-                        raise exception
+                    except ValueError as exc:
+                        raise exception from exc
                 elif rate_limit_reset is not None:
                     try:
                         reset_timestamp = int(rate_limit_reset)
                         delay_secs = max(0, reset_timestamp - int(time.time()))
-                    except ValueError:
-                        raise exception
+                    except ValueError as exc:
+                        raise exception from exc
                 else:
                     # If no retry header is present, use exponential backoff.
                     delay_secs = 2**attempt

--- a/scripts/install_dependencies_json_packages.py
+++ b/scripts/install_dependencies_json_packages.py
@@ -179,27 +179,21 @@ def url_open(
                 )
             ):
                 retry_after_header = exception.headers.get('Retry-After')
+                rate_limit_reset = exception.headers.get('X-RateLimit-Reset')
                 delay_secs = 0
+
                 if retry_after_header is not None:
                     try:
                         delay_secs = int(retry_after_header)
                     except ValueError:
-                        delay_secs = 0
+                        raise exception
+                elif rate_limit_reset is not None:
+                    try:
+                        reset_timestamp = int(rate_limit_reset)
+                        delay_secs = max(0, reset_timestamp - int(time.time()))
+                    except ValueError:
+                        raise exception
                 else:
-                    # GitHub exposes the reset time as a Unix timestamp.
-                    rate_limit_reset = exception.headers.get(
-                        'X-RateLimit-Reset'
-                    )
-                    if rate_limit_reset is not None:
-                        try:
-                            reset_timestamp = int(rate_limit_reset)
-                            delay_secs = max(
-                                0, reset_timestamp - int(time.time())
-                            )
-                        except ValueError:
-                            delay_secs = 0
-
-                if delay_secs == 0:
                     # If no retry header is present, use exponential backoff.
                     delay_secs = 2**attempt
 

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -25,6 +25,7 @@ import re
 import ssl
 import tempfile
 import zipfile
+from urllib import error as urlerror
 from urllib import request as urlrequest
 
 from core.tests import test_utils
@@ -644,6 +645,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             self.assertEqual(url, test_url)
             self._assert_ssl_context_matches_default(context)
             return MockResponse()
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
 
         with urlopen_swap:
             response = install_dependencies_json_packages.url_open(test_url)

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -679,7 +679,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     # Here we use type Any because the 'headers' argument in
                     # HTTPError expects an email.message.Message object, but
                     # a dict is sufficient for our mock.
-                    # Here we use cast because the dict is an incompatible type.
+                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
                     cast(Any, {'Retry-After': '1'}),
                     None,
                 )
@@ -695,7 +695,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             # Here we use type Any because install_dependencies_json_packages
             # is a module and we need to access its internal attribute 'time'
             # which is not explicitly exported.
-            # Here we use cast because the module type does not explicitly expose 'time'.
+            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
@@ -735,6 +735,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     403,
                     'rate limit exceeded',
                     # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
+                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
                     cast(Any, {'Retry-After': 'invalid'}),
                     None,
                 )
@@ -748,6 +749,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
             # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
+            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
@@ -790,6 +792,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     403,
                     'rate limit exceeded',
                     # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
+                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
                     cast(Any, {'X-RateLimit-Reset': '1005'}),
                     None,
                 )
@@ -807,12 +810,14 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
             # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
+            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
         )
         time_swap = self.swap(
             # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
+            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
             cast(Any, install_dependencies_json_packages).time,
             'time',
             mock_time,
@@ -852,6 +857,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     403,
                     'rate limit exceeded',
                     # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
+                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
                     cast(Any, {'X-RateLimit-Reset': 'invalid'}),
                     None,
                 )
@@ -865,6 +871,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
             # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
+            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -672,6 +672,10 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             self.assertEqual(url, test_url)
             self._assert_ssl_context_matches_default(context)
             if len(attempts) == 1:
+                # Here we use type Any because the 'headers' argument in
+                # HTTPError expects an email.message.Message object, but
+                # a dict is sufficient for our mock.
+                # Here use cast because the dict is an incompatible type.
                 raise urlerror.HTTPError(
                     url,
                     403,
@@ -687,6 +691,10 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             sleep_calls.append(seconds)
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        # Here we use type Any because install_dependencies_json_packages
+        # is a module and we need to access its internal attribute 'time'
+        # which is not explicitly exported.
+        # Here use cast because the module type does not explicitly expose 'time'.
         sleep_swap = self.swap(
             cast(Any, install_dependencies_json_packages).time,
             'sleep',

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -679,7 +679,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     # Here we use type Any because the 'headers' argument in
                     # HTTPError expects an email.message.Message object, but
                     # a dict is sufficient for our mock.
-                    # Here use cast because the dict is an incompatible type.
+                    # Here we use cast because the dict is an incompatible type.
                     cast(Any, {'Retry-After': '1'}),
                     None,
                 )
@@ -695,7 +695,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             # Here we use type Any because install_dependencies_json_packages
             # is a module and we need to access its internal attribute 'time'
             # which is not explicitly exported.
-            # Here use cast because the module type does not explicitly expose 'time'.
+            # Here we use cast because the module type does not explicitly expose 'time'.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -1102,3 +1102,135 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                 )
             with open(output_path, 'rb') as buffer:
                 self.assertEqual(buffer.read(), b'content')
+
+    def test_url_open_raises_non_rate_limit_http_error(self) -> None:
+        """Test that non-rate-limited HTTP errors are raised immediately."""
+        test_url = 'https://example.com/test'
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> NoReturn:
+            # Simulate a 404 error (not rate limited)
+            raise urlerror.HTTPError(
+                url,
+                404,
+                'Not Found',
+                # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
+                cast(Any, {}),
+                None,
+            )
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+
+        with urlopen_swap:
+            with self.assertRaisesRegex(urlerror.HTTPError, 'Not Found'):
+                install_dependencies_json_packages.url_open(test_url)
+
+    def test_url_open_raises_after_exhausting_retries_for_non_rate_limit_error(
+        self,
+    ) -> None:
+        """Test that non-rate-limit errors on final attempt cause immediate raise."""
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> NoReturn:
+            attempts.append(url)
+            # On the final attempt, raise a non-rate-limited error (500)
+            raise urlerror.HTTPError(
+                url,
+                500,
+                'Internal Server Error',
+                # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
+                cast(Any, {}),
+                None,
+            )
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+
+        with urlopen_swap:
+            with self.assertRaisesRegex(
+                urlerror.HTTPError, 'Internal Server Error'
+            ):
+                # Use max_attempts=1 to ensure error is raised immediately
+                install_dependencies_json_packages.url_open(
+                    test_url, max_attempts=1
+                )
+
+        self.assertEqual(attempts, [test_url])
+
+    def test_url_open_retries_with_exponential_backoff(self) -> None:
+        """Test retries with exponential backoff when no retry headers present."""
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                # Rate limit error with no retry header
+                raise urlerror.HTTPError(
+                    url,
+                    429,
+                    'rate limit exceeded',
+                    # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                    # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
+                    cast(Any, {}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+
+        with urlopen_swap, sleep_swap:
+            response = install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(response.getcode(), 200)
+        self.assertEqual(response.url, test_url)
+        self.assertEqual(attempts, [test_url, test_url])
+        # Should use exponential backoff: 2^attempt = 2^1 = 2 seconds
+        self.assertEqual(sleep_calls, [2])
+
+    def test_url_open_with_zero_max_attempts(self) -> None:
+        """Test url_open with max_attempts=0 (edge case).
+
+        When max_attempts is 0 or negative, the function should raise a
+        ValueError since it's an invalid argument. This eliminates the
+        unreachable branch from the empty for loop.
+        """
+        test_url = 'https://example.com/test'
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> NoReturn:
+            raise AssertionError('urlopen() should not be called')
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+
+        with urlopen_swap:
+            with self.assertRaisesRegex(
+                ValueError, 'max_attempts must be a positive integer'
+            ):
+                install_dependencies_json_packages.url_open(
+                    test_url, max_attempts=0
+                )

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -882,6 +882,76 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         self.assertEqual(attempts, [test_url])
 
+    def test_url_open_retries_when_rate_limited_with_zero_delay(self) -> None:
+        """Test retry behavior when delay_secs is 0 (no sleep needed).
+
+        This test covers the case where the rate limit reset time is in the past
+        (or equal to current time), resulting in a delay of 0. The function should
+        still retry without sleeping.
+        """
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                # Mock current time as 1000, reset at 1000 -> delay 0s.
+                raise urlerror.HTTPError(
+                    url,
+                    429,
+                    'rate limit exceeded',
+                    # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                    # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
+                    cast(Any, {'X-RateLimit-Reset': '1000'}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        # Mock time.time() to return 1000.
+        def mock_time() -> float:
+            return 1000.0
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+        time_swap = self.swap(
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
+            cast(Any, install_dependencies_json_packages).time,
+            'time',
+            mock_time,
+        )
+
+        with urlopen_swap, sleep_swap, time_swap:
+            response = install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(response.getcode(), 200)
+        self.assertEqual(response.url, test_url)
+        self.assertEqual(attempts, [test_url, test_url])
+        self.assertEqual(sleep_calls, [])
+
     def _assert_ssl_context_matches_default(
         self, context: ssl.SSLContext
     ) -> None:

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -672,14 +672,14 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             self.assertEqual(url, test_url)
             self._assert_ssl_context_matches_default(context)
             if len(attempts) == 1:
-                # Here we use type Any because the 'headers' argument in
-                # HTTPError expects an email.message.Message object, but
-                # a dict is sufficient for our mock.
-                # Here use cast because the dict is an incompatible type.
                 raise urlerror.HTTPError(
                     url,
                     403,
                     'rate limit exceeded',
+                    # Here we use type Any because the 'headers' argument in
+                    # HTTPError expects an email.message.Message object, but
+                    # a dict is sufficient for our mock.
+                    # Here use cast because the dict is an incompatible type.
                     cast(Any, {'Retry-After': '1'}),
                     None,
                 )
@@ -691,11 +691,11 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             sleep_calls.append(seconds)
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
-        # Here we use type Any because install_dependencies_json_packages
-        # is a module and we need to access its internal attribute 'time'
-        # which is not explicitly exported.
-        # Here use cast because the module type does not explicitly expose 'time'.
         sleep_swap = self.swap(
+            # Here we use type Any because install_dependencies_json_packages
+            # is a module and we need to access its internal attribute 'time'
+            # which is not explicitly exported.
+            # Here use cast because the module type does not explicitly expose 'time'.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -676,10 +676,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     url,
                     403,
                     'rate limit exceeded',
-                    # Here we use type Any because the 'headers' argument in
-                    # HTTPError expects an email.message.Message object, but
-                    # a dict is sufficient for our mock.
-                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
+                    # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                    # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
                     cast(Any, {'Retry-After': '1'}),
                     None,
                 )
@@ -692,10 +690,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            # Here we use type Any because install_dependencies_json_packages
-            # is a module and we need to access its internal attribute 'time'
-            # which is not explicitly exported.
-            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
@@ -734,8 +730,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     url,
                     403,
                     'rate limit exceeded',
-                    # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
-                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
+                    # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                    # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
                     cast(Any, {'Retry-After': 'invalid'}),
                     None,
                 )
@@ -748,8 +744,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
-            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
@@ -791,8 +787,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     url,
                     403,
                     'rate limit exceeded',
-                    # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
-                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
+                    # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                    # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
                     cast(Any, {'X-RateLimit-Reset': '1005'}),
                     None,
                 )
@@ -809,15 +805,15 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
-            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
         )
         time_swap = self.swap(
-            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
-            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
             cast(Any, install_dependencies_json_packages).time,
             'time',
             mock_time,
@@ -856,8 +852,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     url,
                     403,
                     'rate limit exceeded',
-                    # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
-                    # Here use cast because we need to convert the dict to Any type to satisfy the HTTPError headers parameter type requirement.
+                    # Here we use type Any because the headers argument is expected to be email.message.Message, but we are providing a dict for testing.
+                    # Here we use cast because HTTPError expects email.message.Message for headers but a dict is sufficient for this mock.
                     cast(Any, {'X-RateLimit-Reset': 'invalid'}),
                     None,
                 )
@@ -870,8 +866,8 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
-            # Here use cast because the module type does not explicitly expose the 'time' attribute in its type definition.
+            # Here we use type Any because we need to access the time attribute on the module which is not statically known to mypy.
+            # Here we use cast because we are swapping the time module in install_dependencies_json_packages, and casting to Any avoids type errors.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -735,6 +735,183 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     403,
                     'rate limit exceeded',
                     # Here we use cast because the dict is an incompatible type.
+                    # Here we use type Any because the dict is an incompatible type.
+                    cast(Any, {'Retry-After': 'invalid'}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            # Here we use type Any because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+
+        with urlopen_swap, sleep_swap:
+            # Should raise because delay is 0 (invalid header treated as 0).
+            with self.assertRaisesRegex(
+                urlerror.HTTPError, 'rate limit exceeded'
+            ):
+                install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(attempts, [test_url])
+        self.assertEqual(sleep_calls, [])
+
+    def test_url_open_retries_when_rate_limited_with_x_rate_limit_reset(
+        self,
+    ) -> None:
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                # Mock current time as 1000, reset at 1005 -> delay 5s.
+                raise urlerror.HTTPError(
+                    url,
+                    403,
+                    'rate limit exceeded',
+                    # Here we use cast because the dict is an incompatible type.
+                    # Here we use type Any because the dict is an incompatible type.
+                    cast(Any, {'X-RateLimit-Reset': '1005'}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        # Mock time.time() to return 1000.
+        def mock_time() -> float:
+            return 1000.0
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            # Here we use type Any because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+        time_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            # Here we use type Any because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'time',
+            mock_time,
+        )
+
+        with urlopen_swap, sleep_swap, time_swap:
+            response = install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(response.getcode(), 200)
+        self.assertEqual(response.url, test_url)
+        self.assertEqual(attempts, [test_url, test_url])
+        self.assertEqual(sleep_calls, [5])
+
+    def test_url_open_retries_when_rate_limited_with_invalid_x_rate_limit_reset(
+        self,
+    ) -> None:
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                raise urlerror.HTTPError(
+                    url,
+                    403,
+                    'rate limit exceeded',
+                    # Here we use cast because the dict is an incompatible type.
+                    # Here we use type Any because the dict is an incompatible type.
+                    cast(Any, {'X-RateLimit-Reset': 'invalid'}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            # Here we use type Any because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+
+        with urlopen_swap, sleep_swap:
+            # Should raise because delay is 0 (invalid header).
+            with self.assertRaisesRegex(
+                urlerror.HTTPError, 'rate limit exceeded'
+            ):
+                install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(attempts, [test_url])
+
+    def test_url_open_retries_when_rate_limited_with_invalid_retry_after(
+        self,
+    ) -> None:
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                raise urlerror.HTTPError(
+                    url,
+                    403,
+                    'rate limit exceeded',
+                    # Here we use cast because the dict is an incompatible type.
                     cast(Any, {'Retry-After': 'invalid'}),
                     None,
                 )

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -709,6 +709,177 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         self.assertEqual(attempts, [test_url, test_url])
         self.assertEqual(sleep_calls, [1])
 
+    def test_url_open_retries_when_rate_limited_with_invalid_retry_after(
+        self,
+    ) -> None:
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                raise urlerror.HTTPError(
+                    url,
+                    403,
+                    'rate limit exceeded',
+                    # Here we use cast because the dict is an incompatible type.
+                    cast(Any, {'Retry-After': 'invalid'}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+
+        with urlopen_swap, sleep_swap:
+            # Should raise because delay is 0 (invalid header treated as 0).
+            with self.assertRaisesRegex(
+                urlerror.HTTPError, 'rate limit exceeded'
+            ):
+                install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(attempts, [test_url])
+        self.assertEqual(sleep_calls, [])
+
+    def test_url_open_retries_when_rate_limited_with_x_rate_limit_reset(
+        self,
+    ) -> None:
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                # Mock current time as 1000, reset at 1005 -> delay 5s.
+                raise urlerror.HTTPError(
+                    url,
+                    403,
+                    'rate limit exceeded',
+                    # Here we use cast because the dict is an incompatible type.
+                    cast(Any, {'X-RateLimit-Reset': '1005'}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        # Mock time.time() to return 1000.
+        def mock_time() -> float:
+            return 1000.0
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+        time_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'time',
+            mock_time,
+        )
+
+        with urlopen_swap, sleep_swap, time_swap:
+            response = install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(response.getcode(), 200)
+        self.assertEqual(response.url, test_url)
+        self.assertEqual(attempts, [test_url, test_url])
+        self.assertEqual(sleep_calls, [5])
+
+    def test_url_open_retries_when_rate_limited_with_invalid_x_rate_limit_reset(
+        self,
+    ) -> None:
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                raise urlerror.HTTPError(
+                    url,
+                    403,
+                    'rate limit exceeded',
+                    # Here we use cast because the dict is an incompatible type.
+                    cast(Any, {'X-RateLimit-Reset': 'invalid'}),
+                    None,
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            # Here we use cast because the module type does not explicitly expose 'time'.
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
+        )
+
+        with urlopen_swap, sleep_swap:
+            # Should raise because delay is 0 (invalid header).
+            with self.assertRaisesRegex(
+                urlerror.HTTPError, 'rate limit exceeded'
+            ):
+                install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(attempts, [test_url])
+        self.assertEqual(sleep_calls, [])
+
     def _assert_ssl_context_matches_default(
         self, context: ssl.SSLContext
     ) -> None:

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -645,12 +645,52 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             self._assert_ssl_context_matches_default(context)
             return MockResponse()
 
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
-
         with urlopen_swap:
             response = install_dependencies_json_packages.url_open(test_url)
         self.assertEqual(response.getcode(), 200)
         self.assertEqual(response.url, test_url)
+
+    def test_url_open_retries_when_rate_limited_with_retry_after(self) -> None:
+        test_url = 'https://example.com/test'
+        attempts = []
+
+        class MockResponse:
+            """Mock response object for urlopen."""
+
+            def __init__(self) -> None:
+                self.url = test_url
+
+            def getcode(self) -> int:
+                """Return HTTP status code."""
+                return 200
+
+        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
+            attempts.append(url)
+            self.assertEqual(url, test_url)
+            self._assert_ssl_context_matches_default(context)
+            if len(attempts) == 1:
+                raise urlerror.HTTPError(
+                    url, 403, 'rate limit exceeded', {'Retry-After': '1'}, None
+                )
+            return MockResponse()
+
+        sleep_calls = []
+
+        def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
+        sleep_swap = self.swap(
+            install_dependencies_json_packages.time, 'sleep', mock_sleep
+        )
+
+        with urlopen_swap, sleep_swap:
+            response = install_dependencies_json_packages.url_open(test_url)
+
+        self.assertEqual(response.getcode(), 200)
+        self.assertEqual(response.url, test_url)
+        self.assertEqual(attempts, [test_url, test_url])
+        self.assertEqual(sleep_calls, [1])
 
     def _assert_ssl_context_matches_default(
         self, context: ssl.SSLContext

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -1132,7 +1132,9 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         test_url = 'https://example.com/test'
         attempts = []
 
-        def mock_urlopen(url: str, context: ssl.SSLContext) -> NoReturn:
+        def mock_urlopen(
+            url: str, context: ssl.SSLContext
+        ) -> NoReturn:  # pylint: disable=unused-argument
             attempts.append(url)
             # On the final attempt, raise a non-rate-limited error (500)
             raise urlerror.HTTPError(
@@ -1151,7 +1153,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             with self.assertRaisesRegex(
                 urlerror.HTTPError, 'Internal Server Error'
             ):
-                # Use max_attempts=1 to ensure error is raised immediately
+                # Use max_attempts=1 to ensure error is raised immediately.
                 install_dependencies_json_packages.url_open(
                     test_url, max_attempts=1
                 )
@@ -1178,7 +1180,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             self.assertEqual(url, test_url)
             self._assert_ssl_context_matches_default(context)
             if len(attempts) == 1:
-                # Rate limit error with no retry header
+                # Rate limit error with no retry header.
                 raise urlerror.HTTPError(
                     url,
                     429,
@@ -1210,7 +1212,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         self.assertEqual(response.getcode(), 200)
         self.assertEqual(response.url, test_url)
         self.assertEqual(attempts, [test_url, test_url])
-        # Should use exponential backoff: 2^attempt = 2^1 = 2 seconds
+        # Should use exponential backoff: 2^attempt = 2^1 = 2 seconds.
         self.assertEqual(sleep_calls, [2])
 
     def test_url_open_with_zero_max_attempts(self) -> None:

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -734,8 +734,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     url,
                     403,
                     'rate limit exceeded',
-                    # Here we use cast because the dict is an incompatible type.
-                    # Here we use type Any because the dict is an incompatible type.
+                    # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
                     cast(Any, {'Retry-After': 'invalid'}),
                     None,
                 )
@@ -748,8 +747,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            # Here we use type Any because the module type does not explicitly expose 'time'.
+            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
@@ -791,8 +789,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     url,
                     403,
                     'rate limit exceeded',
-                    # Here we use cast because the dict is an incompatible type.
-                    # Here we use type Any because the dict is an incompatible type.
+                    # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
                     cast(Any, {'X-RateLimit-Reset': '1005'}),
                     None,
                 )
@@ -809,15 +806,13 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            # Here we use type Any because the module type does not explicitly expose 'time'.
+            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
         )
         time_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            # Here we use type Any because the module type does not explicitly expose 'time'.
+            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
             cast(Any, install_dependencies_json_packages).time,
             'time',
             mock_time,
@@ -856,8 +851,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                     url,
                     403,
                     'rate limit exceeded',
-                    # Here we use cast because the dict is an incompatible type.
-                    # Here we use type Any because the dict is an incompatible type.
+                    # Here we use type Any because the 'headers' argument in HTTPError expects an email.message.Message object, but a dict is sufficient for our mock.
                     cast(Any, {'X-RateLimit-Reset': 'invalid'}),
                     None,
                 )
@@ -870,8 +864,7 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            # Here we use type Any because the module type does not explicitly expose 'time'.
+            # Here we use type Any because install_dependencies_json_packages is a module and we need to access its internal attribute 'time' which is not explicitly exported.
             cast(Any, install_dependencies_json_packages).time,
             'sleep',
             mock_sleep,
@@ -885,177 +878,6 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
                 install_dependencies_json_packages.url_open(test_url)
 
         self.assertEqual(attempts, [test_url])
-
-    def test_url_open_retries_when_rate_limited_with_invalid_retry_after(
-        self,
-    ) -> None:
-        test_url = 'https://example.com/test'
-        attempts = []
-
-        class MockResponse:
-            """Mock response object for urlopen."""
-
-            def __init__(self) -> None:
-                self.url = test_url
-
-            def getcode(self) -> int:
-                """Return HTTP status code."""
-                return 200
-
-        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
-            attempts.append(url)
-            self.assertEqual(url, test_url)
-            self._assert_ssl_context_matches_default(context)
-            if len(attempts) == 1:
-                raise urlerror.HTTPError(
-                    url,
-                    403,
-                    'rate limit exceeded',
-                    # Here we use cast because the dict is an incompatible type.
-                    cast(Any, {'Retry-After': 'invalid'}),
-                    None,
-                )
-            return MockResponse()
-
-        sleep_calls = []
-
-        def mock_sleep(seconds: float) -> None:
-            sleep_calls.append(seconds)
-
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
-        sleep_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            cast(Any, install_dependencies_json_packages).time,
-            'sleep',
-            mock_sleep,
-        )
-
-        with urlopen_swap, sleep_swap:
-            # Should raise because delay is 0 (invalid header treated as 0).
-            with self.assertRaisesRegex(
-                urlerror.HTTPError, 'rate limit exceeded'
-            ):
-                install_dependencies_json_packages.url_open(test_url)
-
-        self.assertEqual(attempts, [test_url])
-        self.assertEqual(sleep_calls, [])
-
-    def test_url_open_retries_when_rate_limited_with_x_rate_limit_reset(
-        self,
-    ) -> None:
-        test_url = 'https://example.com/test'
-        attempts = []
-
-        class MockResponse:
-            """Mock response object for urlopen."""
-
-            def __init__(self) -> None:
-                self.url = test_url
-
-            def getcode(self) -> int:
-                """Return HTTP status code."""
-                return 200
-
-        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
-            attempts.append(url)
-            self.assertEqual(url, test_url)
-            self._assert_ssl_context_matches_default(context)
-            if len(attempts) == 1:
-                # Mock current time as 1000, reset at 1005 -> delay 5s.
-                raise urlerror.HTTPError(
-                    url,
-                    403,
-                    'rate limit exceeded',
-                    # Here we use cast because the dict is an incompatible type.
-                    cast(Any, {'X-RateLimit-Reset': '1005'}),
-                    None,
-                )
-            return MockResponse()
-
-        sleep_calls = []
-
-        def mock_sleep(seconds: float) -> None:
-            sleep_calls.append(seconds)
-
-        # Mock time.time() to return 1000.
-        def mock_time() -> float:
-            return 1000.0
-
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
-        sleep_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            cast(Any, install_dependencies_json_packages).time,
-            'sleep',
-            mock_sleep,
-        )
-        time_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            cast(Any, install_dependencies_json_packages).time,
-            'time',
-            mock_time,
-        )
-
-        with urlopen_swap, sleep_swap, time_swap:
-            response = install_dependencies_json_packages.url_open(test_url)
-
-        self.assertEqual(response.getcode(), 200)
-        self.assertEqual(response.url, test_url)
-        self.assertEqual(attempts, [test_url, test_url])
-        self.assertEqual(sleep_calls, [5])
-
-    def test_url_open_retries_when_rate_limited_with_invalid_x_rate_limit_reset(
-        self,
-    ) -> None:
-        test_url = 'https://example.com/test'
-        attempts = []
-
-        class MockResponse:
-            """Mock response object for urlopen."""
-
-            def __init__(self) -> None:
-                self.url = test_url
-
-            def getcode(self) -> int:
-                """Return HTTP status code."""
-                return 200
-
-        def mock_urlopen(url: str, context: ssl.SSLContext) -> MockResponse:
-            attempts.append(url)
-            self.assertEqual(url, test_url)
-            self._assert_ssl_context_matches_default(context)
-            if len(attempts) == 1:
-                raise urlerror.HTTPError(
-                    url,
-                    403,
-                    'rate limit exceeded',
-                    # Here we use cast because the dict is an incompatible type.
-                    cast(Any, {'X-RateLimit-Reset': 'invalid'}),
-                    None,
-                )
-            return MockResponse()
-
-        sleep_calls = []
-
-        def mock_sleep(seconds: float) -> None:
-            sleep_calls.append(seconds)
-
-        urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
-        sleep_swap = self.swap(
-            # Here we use cast because the module type does not explicitly expose 'time'.
-            cast(Any, install_dependencies_json_packages).time,
-            'sleep',
-            mock_sleep,
-        )
-
-        with urlopen_swap, sleep_swap:
-            # Should raise because delay is 0 (invalid header).
-            with self.assertRaisesRegex(
-                urlerror.HTTPError, 'rate limit exceeded'
-            ):
-                install_dependencies_json_packages.url_open(test_url)
-
-        self.assertEqual(attempts, [test_url])
-        self.assertEqual(sleep_calls, [])
 
     def _assert_ssl_context_matches_default(
         self, context: ssl.SSLContext

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -30,7 +30,7 @@ from urllib import request as urlrequest
 
 from core.tests import test_utils
 
-from typing import Any, BinaryIO, Final, NoReturn, Tuple
+from typing import Any, BinaryIO, Final, NoReturn, Tuple, cast
 
 from . import common, install_dependencies_json_packages
 
@@ -673,7 +673,11 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
             self._assert_ssl_context_matches_default(context)
             if len(attempts) == 1:
                 raise urlerror.HTTPError(
-                    url, 403, 'rate limit exceeded', {'Retry-After': '1'}, None
+                    url,
+                    403,
+                    'rate limit exceeded',
+                    cast(Any, {'Retry-After': '1'}),
+                    None,
                 )
             return MockResponse()
 
@@ -684,7 +688,9 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
 
         urlopen_swap = self.swap(urlrequest, 'urlopen', mock_urlopen)
         sleep_swap = self.swap(
-            install_dependencies_json_packages.time, 'sleep', mock_sleep
+            cast(Any, install_dependencies_json_packages).time,
+            'sleep',
+            mock_sleep,
         )
 
         with urlopen_swap, sleep_swap:

--- a/scripts/install_dependencies_json_packages_test.py
+++ b/scripts/install_dependencies_json_packages_test.py
@@ -1132,9 +1132,9 @@ class InstallThirdPartyTests(test_utils.GenericTestBase):
         test_url = 'https://example.com/test'
         attempts = []
 
-        def mock_urlopen(
+        def mock_urlopen(  # pylint: disable=unused-argument
             url: str, context: ssl.SSLContext
-        ) -> NoReturn:  # pylint: disable=unused-argument
+        ) -> NoReturn:
             attempts.append(url)
             # On the final attempt, raise a non-rate-limited error (500)
             raise urlerror.HTTPError(


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #23905 .
2. This PR does the following: This PR adds proper rate-limit handling to the url_open utility used while installing dependencies.
Specifically, it updates url_open to retry the request when a 403 rate-limit error occurs. The function waits before retrying by using the Retry-After header when available, or by calculating the delay from the X-RateLimit-Reset header otherwise. The retry behavior is capped to avoid infinite loops, and all existing SSL and certifi settings remain unchanged.
3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because url_open did not handle HTTP 403 rate-limit errors gracefully. As a result, CI failed when GitHub API rate limits were hit, instead of retrying after the appropriate delay.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] Please follow the instructions for making a code change.
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #23905: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can’t assign them directly).


## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<img width="1526" height="650" alt="image" src="https://github.com/user-attachments/assets/e0660431-5961-4676-be34-9f67bdd97c16" />

<img width="1536" height="687" alt="image" src="https://github.com/user-attachments/assets/99454e42-0b7e-4523-acbb-f805d44eecc3" />


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
