### PR TITLE
Fix accessibility: Add missing alt text to contact page images

### DIFF
--- a/core/templates/pages/contact-page/contact-page.component.html
+++ b/core/templates/pages/contact-page/contact-page.component.html
@@ -8,7 +8,7 @@
 
     <div class="oppia-contact-page flex">
       <div class="oppia-contact-page-content e2e-test-contact-page-content" tabindex="0">
-        <img id="donate" src="assets/images/contact_page/Donate img.svg" alt="">
+        <img id="donate" src="assets/images/contact_page/Donate img.svg" alt="Donate icon">
         <h2 [innerHTML]="'I18N_CONTACT_PAGE_DONATE_HEADING' | translate"></h2>
         <p [innerHTML]="'I18N_CONTACT_PAGE_DONATE_PARAGRAPH' | translate"></p>
         <oppia-primary-button
@@ -18,7 +18,7 @@
         </oppia-primary-button>
       </div>
       <div class="oppia-contact-page-content e2e-test-contact-page-content" tabindex="0">
-        <img id="Partner" src="assets/images/contact_page/Partner img.svg" alt="">
+        <img id="Partner" src="assets/images/contact_page/Partner img.svg" alt="Partner icon">
         <h2 [innerHTML]="'I18N_CONTACT_PAGE_PARTNER_HEADING' | translate"></h2>
         <p [innerHTML]="'I18N_CONTACT_PAGE_PARTNER_PARAGRAPH' | translate"></p>
         <oppia-primary-button
@@ -28,7 +28,7 @@
         </oppia-primary-button>
       </div>
       <div class="oppia-contact-page-content e2e-test-contact-page-content" tabindex="0">
-        <img id="volunteer" src="assets/images/contact_page/Volunteer img.svg" alt="">
+        <img id="volunteer" src="assets/images/contact_page/Volunteer img.svg" alt="Volunteer icon">
         <h2 [innerHTML]="'I18N_CONTACT_PAGE_VOLUNTEER_HEADING' | translate"></h2>
         <p [innerHTML]="'I18N_CONTACT_PAGE_VOLUNTEER_PARAGRAPH' | translate"></p>
         <oppia-primary-button
@@ -38,7 +38,7 @@
         </oppia-primary-button>
       </div>
       <div class="oppia-contact-page-content e2e-test-contact-page-content" tabindex="0">
-        <img id="other_inquiries" src="assets/images/contact_page/Other inquiries img.svg" alt="">
+        <img id="other_inquiries" src="assets/images/contact_page/Other inquiries img.svg" alt="Other inquiries icon">
         <h2 [innerHTML]="'I18N_CONTACT_PAGE_OTHER_INQUIRIES_HEADING' | translate"></h2>
         <p [innerHTML]="'I18N_CONTACT_PAGE_OTHER_INQUIRIES_PARAGRAPH_1' | translate"></p>
         <p [innerHTML]="'I18N_CONTACT_PAGE_OTHER_INQUIRIES_PARAGRAPH_2' | translate"></p>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #N/A (No existing issue - this is a small accessibility improvement).
2. This PR does the following: Adds descriptive alt text to 4 images on the contact page that previously had empty `alt=""` attributes. This improves accessibility for screen reader users and helps Oppia comply with WCAG 2.1 guidelines.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar. 
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
The change is purely adding `alt` attributes to `<img>` tags. These attributes have no performance impact and do not affect rendering or network requests.

**Before:** Images had empty alt text (`alt=""`)
```html
<img id="donate" src="assets/images/contact_page/Donate img.svg" alt="">
```

**After:** Images have descriptive alt text
```html
<img id="donate" src="assets/images/contact_page/Donate img.svg" alt="Donate icon">
```

<img width="2560" height="1528" alt="Screenshot 2026-01-28 180637" src="https://github.com/user-attachments/assets/cd1cd550-8cbe-44e7-a813-8f6d406792b2" />


#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->


