### PR TITLE
Fix #24693: Remove trailing empty HTML elements from study guides

### DIFF
--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -263,6 +263,106 @@ def is_html_empty(html_str: str) -> bool:
     return False
 
 
+def strip_trailing_empty_elements(html_string: str) -> str:
+    """Strips trailing empty HTML elements from an HTML string.
+
+    This removes empty paragraphs, list items, and lists that contain only
+    non-breaking spaces or are completely empty from the end of the HTML.
+    This is useful for cleaning up HTML content that may have trailing
+    whitespace artifacts from rich text editors or markdown conversion.
+
+    Args:
+        html_string: str. An HTML string.
+
+    Returns:
+        str. The HTML string with trailing empty elements removed.
+    """
+    if not html_string or not html_string.strip():
+        return html_string
+
+    soup = bs4.BeautifulSoup(html_string, 'html.parser')
+
+    # Get all top-level elements (direct children of the root)
+    elements = list(soup.children)
+
+    # Filter out NavigableString objects that are just whitespace
+    elements = [
+        el for el in elements
+        if not isinstance(el, bs4.NavigableString) or el.strip()
+    ]
+
+    if not elements:
+        return html_string
+
+    # Iterate backwards and remove trailing empty elements
+    while elements:
+        last_element = elements[-1]
+
+        # Skip if it's a NavigableString (text node)
+        if isinstance(last_element, bs4.NavigableString):
+            if not last_element.strip():
+                elements.pop()
+                continue
+            break
+
+        # Check if the element is empty
+        if _is_element_empty(last_element):
+            elements.pop()
+        else:
+            break
+
+    # Reconstruct the HTML from remaining elements
+    if not elements:
+        return ''
+
+    # Create a new soup with the cleaned elements
+    result_parts = []
+    for element in elements:
+        if isinstance(element, bs4.NavigableString):
+            result_parts.append(str(element))
+        else:
+            result_parts.append(str(element))
+
+    return ''.join(result_parts)
+
+
+def _is_element_empty(element: bs4.Tag) -> bool:
+    """Checks if an HTML element is empty or contains only whitespace/nbsp.
+
+    An element is considered empty if:
+    - It has no children
+    - It contains only whitespace or &nbsp;
+    - It contains only nested empty elements
+
+    Args:
+        element: bs4.Tag. The HTML element to check.
+
+    Returns:
+        bool. True if the element is empty, False otherwise.
+    """
+    # Get the text content, replacing &nbsp; with space
+    text_content = element.get_text().replace('\xa0', '').strip()
+
+    # If there's actual text content, it's not empty
+    if text_content:
+        return False
+
+    # Check if element has any non-empty children
+    for child in element.children:
+        if isinstance(child, bs4.NavigableString):
+            # Check if the text node has content other than whitespace/nbsp
+            child_text = str(child).replace('&nbsp;', '').replace('\xa0', '').strip()
+            if child_text:
+                return False
+        elif isinstance(child, bs4.Tag):
+            # Recursively check if child element is empty
+            if not _is_element_empty(child):
+                return False
+
+    return True
+
+
+
 def _raise_validation_errors_for_escaped_html_tag(
     tag: bs4.BeautifulSoup, attr: str, tag_name: str
 ) -> None:

--- a/core/domain/html_cleaner_test.py
+++ b/core/domain/html_cleaner_test.py
@@ -130,6 +130,74 @@ class HtmlCleanerUnitTests(test_utils.GenericTestBase):
                 msg='\n\nOriginal text: %s' % datum[0],
             )
 
+    def test_strip_trailing_empty_elements_with_empty_paragraph(self) -> None:
+        """Test stripping trailing empty paragraph."""
+        html_with_trailing_p = '<p>Valid content</p><p>&nbsp;</p>'
+        result = html_cleaner.strip_trailing_empty_elements(html_with_trailing_p)
+        self.assertEqual(result, '<p>Valid content</p>')
+
+    def test_strip_trailing_empty_elements_with_empty_list(self) -> None:
+        """Test stripping trailing empty list with bullet point."""
+        html_with_trailing_list = (
+            '<p>Valid content</p>'
+            '<p>&nbsp;</p>'
+            '<ul><li><p>&nbsp;</p></li></ul>'
+        )
+        result = html_cleaner.strip_trailing_empty_elements(html_with_trailing_list)
+        self.assertEqual(result, '<p>Valid content</p>')
+
+    def test_strip_trailing_empty_elements_preserves_valid_content(
+        self,
+    ) -> None:
+        """Test that valid content is not removed."""
+        html_with_valid_list = (
+            '<p>Introduction</p>'
+            '<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>'
+        )
+        result = html_cleaner.strip_trailing_empty_elements(html_with_valid_list)
+        self.assertEqual(result, html_with_valid_list)
+
+    def test_strip_trailing_empty_elements_with_mixed_content(self) -> None:
+        """Test stripping only trailing empty elements, not leading ones."""
+        html_with_mixed = (
+            '<p>&nbsp;</p>'
+            '<p>Valid content</p>'
+            '<p>&nbsp;</p>'
+        )
+        result = html_cleaner.strip_trailing_empty_elements(html_with_mixed)
+        # Leading empty paragraph should be preserved, trailing one removed
+        self.assertEqual(result, '<p>&nbsp;</p><p>Valid content</p>')
+
+    def test_strip_trailing_empty_elements_with_nested_empty_lists(
+        self,
+    ) -> None:
+        """Test stripping nested empty list structures."""
+        html_with_nested = (
+            '<p>Content</p>'
+            '<ul><li><ul><li><p>&nbsp;</p></li></ul></li></ul>'
+        )
+        result = html_cleaner.strip_trailing_empty_elements(html_with_nested)
+        self.assertEqual(result, '<p>Content</p>')
+
+    def test_strip_trailing_empty_elements_with_empty_string(self) -> None:
+        """Test handling of empty string input."""
+        result = html_cleaner.strip_trailing_empty_elements('')
+        self.assertEqual(result, '')
+
+    def test_strip_trailing_empty_elements_with_only_empty_elements(
+        self,
+    ) -> None:
+        """Test handling when all elements are empty."""
+        html_all_empty = '<p>&nbsp;</p><ul><li><p>&nbsp;</p></li></ul>'
+        result = html_cleaner.strip_trailing_empty_elements(html_all_empty)
+        self.assertEqual(result, '')
+
+    def test_strip_trailing_empty_elements_with_whitespace_only(self) -> None:
+        """Test handling of elements with only whitespace."""
+        html_with_whitespace = '<p>Content</p><p>   </p><p>\n\t</p>'
+        result = html_cleaner.strip_trailing_empty_elements(html_with_whitespace)
+        self.assertEqual(result, '<p>Content</p>')
+
 
 class HtmlStripperUnitTests(test_utils.GenericTestBase):
     """Test the HTML stripper."""

--- a/core/domain/study_guide_domain.py
+++ b/core/domain/study_guide_domain.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 from core import feconf, utils
 from core.constants import constants
-from core.domain import change_domain, state_domain, translation_domain
+from core.domain import change_domain, html_cleaner, state_domain, translation_domain
+
 
 from typing import (
     Any,
@@ -496,6 +497,12 @@ class StudyGuide:
             StudyGuide. A study guide object with given id, topic_id and
             sections field.
         """
+        # Clean trailing empty elements from content to prevent
+        # extra bullet points and spacing at the bottom of study guides.
+        cleaned_content_html = html_cleaner.strip_trailing_empty_elements(
+            content_html
+        )
+
         content_id_generator = translation_domain.ContentIdGenerator()
         study_guide_id = cls.get_study_guide_id(topic_id, subtopic_id)
         sections = []
@@ -507,7 +514,7 @@ class StudyGuide:
             content_id_generator.generate(
                 translation_domain.ContentType.SECTION, 'content'
             ),
-            content_html,
+            cleaned_content_html,
         )
         sections.append(section)
         return cls(

--- a/core/domain/study_guide_domain_test.py
+++ b/core/domain/study_guide_domain_test.py
@@ -447,6 +447,22 @@ class StudyGuideDomainUnitTests(test_utils.GenericTestBase):
         self.study_guide.language_code = 'xz'
         self._assert_study_guide_validation_error('Invalid language code')
 
+    def test_create_study_guide_strips_trailing_empty_elements(self) -> None:
+        """Test that create_study_guide removes trailing empty HTML elements."""
+        content_with_trailing_empty = (
+            '<p>Valid content</p>'
+            '<p>&nbsp;</p>'
+            '<ul><li><p>&nbsp;</p></li></ul>'
+        )
+        study_guide = study_guide_domain.StudyGuide.create_study_guide(
+            1, 'topic_id', 'Test Heading', content_with_trailing_empty
+        )
+        # Should only contain the valid content, trailing empty elements removed
+        self.assertEqual(
+            study_guide.sections[0].content.html,
+            '<p>Valid content</p>'
+        )
+
 
 class StudyGuideChangeDomainUnitTests(test_utils.GenericTestBase):
     """Tests for StudyGuideChange domain objects."""


### PR DESCRIPTION
This PR fixes an issue where some study guide pages showed an extra bullet point (a single dot) and unnecessary spacing at the bottom when the study guide migration flag was enabled.

The issue was caused by an empty list element being rendered at the end of the study guide content. This change removes that unintended element while keeping all valid list formatting intact.

The fix was verified locally on affected pages such as adding-decimals and subtracting-decimals, and no regressions were observed on other study guide pages.

Fixes #24693
