### PR TITLE
Fix #22521: Suppress unsaved changes alert on sign-in

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
@@ -36,6 +36,7 @@ import {SearchService} from 'services/search.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
 import {UserService} from 'services/user.service';
 import {AlertsService} from 'services/alerts.service';
+import {AuthService} from 'services/auth.service';
 import {MockI18nService, MockTranslatePipe} from 'tests/unit-test-utils';
 import {TopNavigationBarComponent} from './top-navigation-bar.component';
 import {SidebarStatusService} from 'services/sidebar-status.service';
@@ -91,6 +92,10 @@ class MockWindowRef {
       },
     },
   };
+}
+
+class MockAuthService {
+  onUserSignIn = new EventEmitter<void>();
 }
 
 describe('TopNavigationBarComponent', () => {
@@ -182,6 +187,10 @@ describe('TopNavigationBarComponent', () => {
         {
           provide: PlatformFeatureService,
           useValue: mockPlatformFeatureService,
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -50,6 +50,7 @@ import {LearnerGroupBackendApiService} from 'domain/learner_group/learner-group-
 import {FeedbackUpdatesBackendApiService} from 'domain/feedback_updates/feedback-updates-backend-api.service';
 import {FeedbackThreadSummaryBackendDict} from 'domain/feedback_thread/feedback-thread-summary.model';
 import {LanguageBannerService} from 'components/language-banner/language-banner.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 
 import './top-navigation-bar.component.css';
 import {ContentTranslationManagerService} from 'pages/exploration-player-page/services/content-translation-manager.service';
@@ -209,6 +210,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     private platformFeatureService: PlatformFeatureService,
     private learnerGroupBackendApiService: LearnerGroupBackendApiService,
     private languageBannerService: LanguageBannerService,
+    private preventPageUnloadEventService: PreventPageUnloadEventService,
     private contentTranslationManagerService: ContentTranslationManagerService
   ) {}
 
@@ -459,6 +461,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   onLoginButtonClicked(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
+        this.preventPageUnloadEventService.removeListener();
         this.siteAnalyticsService.registerStartLoginEvent('loginButton');
         setTimeout(() => {
           this.windowRef.nativeWindow.location.href = loginUrl;

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -462,6 +462,8 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
         this.preventPageUnloadEventService.removeListener();
+        // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
+        // rather than manually being triggered by buttons.
         this.siteAnalyticsService.registerStartLoginEvent('loginButton');
         setTimeout(() => {
           this.windowRef.nativeWindow.location.href = loginUrl;

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -50,7 +50,7 @@ import {LearnerGroupBackendApiService} from 'domain/learner_group/learner-group-
 import {FeedbackUpdatesBackendApiService} from 'domain/feedback_updates/feedback-updates-backend-api.service';
 import {FeedbackThreadSummaryBackendDict} from 'domain/feedback_thread/feedback-thread-summary.model';
 import {LanguageBannerService} from 'components/language-banner/language-banner.service';
-import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
+import {AuthService} from 'services/auth.service';
 
 import './top-navigation-bar.component.css';
 import {ContentTranslationManagerService} from 'pages/exploration-player-page/services/content-translation-manager.service';
@@ -210,7 +210,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     private platformFeatureService: PlatformFeatureService,
     private learnerGroupBackendApiService: LearnerGroupBackendApiService,
     private languageBannerService: LanguageBannerService,
-    private preventPageUnloadEventService: PreventPageUnloadEventService,
+    private authService: AuthService,
     private contentTranslationManagerService: ContentTranslationManagerService
   ) {}
 
@@ -461,7 +461,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   onLoginButtonClicked(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
-        this.preventPageUnloadEventService.removeListener();
+        this.authService.onUserSignIn.emit();
         // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
         // rather than manually being triggered by buttons.
         this.siteAnalyticsService.registerStartLoginEvent('loginButton');

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.spec.ts
@@ -31,6 +31,8 @@ import {
   HttpClientTestingModule,
   HttpTestingController,
 } from '@angular/common/http/testing';
+import {EventEmitter} from '@angular/core';
+import {AuthService} from 'services/auth.service';
 
 describe('Login required message component', () => {
   let component: LoginRequiredMessageComponent;
@@ -43,6 +45,14 @@ describe('Login required message component', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       declarations: [LoginRequiredMessageComponent],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            onUserSignIn: new EventEmitter<void>(),
+          },
+        },
+      ],
     });
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(LoginRequiredMessageComponent);

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
@@ -20,6 +20,7 @@ import {SiteAnalyticsService} from 'services/site-analytics.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {UserService} from 'services/user.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import {Component} from '@angular/core';
 
 @Component({
@@ -37,7 +38,8 @@ export class LoginRequiredMessageComponent {
     private readonly siteAnalyticsService: SiteAnalyticsService,
     private readonly urlInterpolationService: UrlInterpolationService,
     private readonly userService: UserService,
-    private readonly windowRef: WindowRef
+    private readonly windowRef: WindowRef,
+    private readonly preventPageUnloadEventService: PreventPageUnloadEventService
   ) {}
 
   ngOnInit(): void {
@@ -50,6 +52,9 @@ export class LoginRequiredMessageComponent {
   onLoginButtonClicked(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
+        this.preventPageUnloadEventService.removeListener();
+        // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
+        // rather than manually being triggered by buttons.
         this.siteAnalyticsService.registerStartLoginEvent('loginButton');
         setTimeout(() => {
           this.windowRef.nativeWindow.location.href = loginUrl;

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
@@ -20,7 +20,7 @@ import {SiteAnalyticsService} from 'services/site-analytics.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {UserService} from 'services/user.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
+import {AuthService} from 'services/auth.service';
 import {Component} from '@angular/core';
 
 @Component({
@@ -39,7 +39,7 @@ export class LoginRequiredMessageComponent {
     private readonly urlInterpolationService: UrlInterpolationService,
     private readonly userService: UserService,
     private readonly windowRef: WindowRef,
-    private readonly preventPageUnloadEventService: PreventPageUnloadEventService
+    private readonly authService: AuthService
   ) {}
 
   ngOnInit(): void {
@@ -52,7 +52,7 @@ export class LoginRequiredMessageComponent {
   onLoginButtonClicked(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
-        this.preventPageUnloadEventService.removeListener();
+        this.authService.onUserSignIn.emit();
         // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
         // rather than manually being triggered by buttons.
         this.siteAnalyticsService.registerStartLoginEvent('loginButton');

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/login-required-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/login-required-modal.component.spec.ts
@@ -17,8 +17,10 @@
  */
 
 import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {EventEmitter} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import {AuthService} from 'services/auth.service';
 import {LoginRequiredModalContent} from 'pages/contributor-dashboard-page/modal-templates/login-required-modal.component';
 import {LoginRequiredMessageComponent} from '../login-required-message/login-required-message.component';
 
@@ -30,7 +32,15 @@ describe('Login Required Modal Content', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       declarations: [LoginRequiredModalContent, LoginRequiredMessageComponent],
-      providers: [NgbActiveModal],
+      providers: [
+        NgbActiveModal,
+        {
+          provide: AuthService,
+          useValue: {
+            onUserSignIn: new EventEmitter<void>(),
+          },
+        },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(LoginRequiredModalContent);
     component = fixture.componentInstance;

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -2157,4 +2157,98 @@ describe('Conversation skin component', () => {
     flush();
     expect(preventPageUnloadEventService.addListener).toHaveBeenCalled();
   }));
+  describe('PreventPageUnloadEvent integration', () => {
+    let capturedCallback: () => boolean;
+
+    beforeEach(() => {
+      spyOn(userService, 'getUserInfoAsync').and.returnValue(
+        Promise.resolve(
+          new UserInfo([], false, false, false, false, false, '', '', '', true)
+        )
+      );
+      spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+        null
+      );
+      spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+      spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+      spyOn(urlService, 'isIframed').and.returnValue(false);
+      spyOn(loaderService, 'showLoadingScreen');
+      spyOn(
+        urlInterpolationService,
+        'getStaticCopyrightedImageUrl'
+      ).and.returnValue('url');
+      spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+        false
+      );
+
+      // Capture the callback passed to addListener.
+      spyOn(preventPageUnloadEventService, 'addListener').and.callFake(
+        (callback: () => boolean) => {
+          capturedCallback = callback;
+        }
+      );
+    });
+
+    it('should validate unload conditions in the listener callback', fakeAsync(() => {
+      componentInstance.ngOnInit();
+      tick();
+      expect(capturedCallback).toBeDefined();
+
+      // Mock dependencies for callback logic.
+      const getRedirectSpy = spyOn(
+        conversationFlowService,
+        'getRedirectToRefresherExplorationConfirmed'
+      );
+      const getHasInteractedSpy = spyOn(
+        conversationFlowService,
+        'getHasInteractedAtLeastOnce'
+      );
+      const getDisplayedCardSpy = spyOn(
+        conversationFlowService,
+        'getDisplayedCard'
+      );
+      const isInQuestionModeSpy = spyOn(
+        explorationModeService,
+        'isInQuestionMode'
+      );
+      const recordEventSpy = spyOn(
+        statsReportingService,
+        'recordMaybeLeaveEvent'
+      );
+      spyOn(playerTranscriptService, 'getLastStateName').and.returnValue(
+        'State'
+      );
+      spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
+
+      // Case 1: Redirect confirmed -> should return false (allow unload).
+      getRedirectSpy.and.returnValue(true);
+      expect(capturedCallback()).toBeFalse();
+
+      // Case 2: Redirect not confirmed, Interacted, Valid state -> should return true (prevent unload).
+      getRedirectSpy.and.returnValue(false);
+      getHasInteractedSpy.and.returnValue(true);
+      componentInstance._editorPreviewMode = false;
+      const mockStateCard = jasmine.createSpyObj('StateCard', ['isTerminal']);
+      mockStateCard.isTerminal.and.returnValue(false);
+      getDisplayedCardSpy.and.returnValue(mockStateCard);
+      isInQuestionModeSpy.and.returnValue(false);
+
+      expect(capturedCallback()).toBeTrue();
+      expect(recordEventSpy).toHaveBeenCalled();
+
+      // Case 3: Editor preview mode -> should return false.
+      componentInstance._editorPreviewMode = true;
+      expect(capturedCallback()).toBeFalse();
+
+      // Case 4: Terminal state -> should return false.
+      componentInstance._editorPreviewMode = false;
+      mockStateCard.isTerminal.and.returnValue(true);
+      expect(capturedCallback()).toBeFalse();
+
+      // Case 5: Question mode -> should return false.
+      mockStateCard.isTerminal.and.returnValue(false);
+      isInQuestionModeSpy.and.returnValue(true);
+      expect(capturedCallback()).toBeFalse();
+    }));
+  });
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -2125,4 +2125,36 @@ describe('Conversation skin component', () => {
     componentInstance.ngOnDestroy();
     expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
   });
+
+  it('should add before unload listener on init', fakeAsync(() => {
+    spyOn(userService, 'getUserInfoAsync').and.returnValue(
+      Promise.resolve(
+        new UserInfo([], false, false, false, false, false, '', '', '', true)
+      )
+    );
+    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+      null
+    );
+    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+    spyOn(urlService, 'isIframed').and.returnValue(false);
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(
+      urlInterpolationService,
+      'getStaticCopyrightedImageUrl'
+    ).and.returnValue('url');
+    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+      false
+    );
+
+    spyOn(preventPageUnloadEventService, 'addListener').and.callFake(
+      (callback: () => void) => {
+        callback();
+      }
+    );
+    componentInstance.ngOnInit();
+    tick();
+    flush();
+    expect(preventPageUnloadEventService.addListener).toHaveBeenCalled();
+  }));
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -95,7 +95,7 @@ class MockWindowRef {
     },
     onresize: () => {},
     addEventListener(event: string, callback) {
-      callback({returnValue: null});
+      callback({returnValue: null, preventDefault: () => {}});
     },
     scrollTo: (x, y) => {},
   };

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -87,6 +87,8 @@ import {CurrentEngineService} from '../../services/current-engine.service';
 import {LearnerExplorationSummary} from '../../../../domain/summary/learner-exploration-summary.model';
 import {ChapterProgressService} from '../../services/chapter-progress.service';
 import {CardAnimationService} from '../../services/card-animation.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
+import {AuthService} from 'services/auth.service';
 class MockWindowRef {
   nativeWindow = {
     location: {
@@ -99,6 +101,10 @@ class MockWindowRef {
     },
     scrollTo: (x, y) => {},
   };
+}
+
+class MockAuthService {
+  onUserSignIn = new EventEmitter<void>();
 }
 
 describe('Conversation skin component', () => {
@@ -147,6 +153,7 @@ describe('Conversation skin component', () => {
   let translateService: TranslateService;
   let learnerDashboardBackendApiService: LearnerDashboardBackendApiService;
   let conceptCardManagerService: ConceptCardManagerService;
+  let preventPageUnloadEventService: PreventPageUnloadEventService;
 
   let displayedCard = new StateCard(
     null,
@@ -444,6 +451,11 @@ describe('Conversation skin component', () => {
           provide: TranslateService,
           useClass: MockTranslateService,
         },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        PreventPageUnloadEventService,
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -517,6 +529,9 @@ describe('Conversation skin component', () => {
     translateService = TestBed.inject(TranslateService);
     learnerDashboardBackendApiService = TestBed.inject(
       LearnerDashboardBackendApiService
+    );
+    preventPageUnloadEventService = TestBed.inject(
+      PreventPageUnloadEventService
     );
   }));
 
@@ -2104,4 +2119,10 @@ describe('Conversation skin component', () => {
     tick(2000);
     flush();
   }));
+
+  it('should remove before unload listener on ngOnDestroy', () => {
+    spyOn(preventPageUnloadEventService, 'removeListener');
+    componentInstance.ngOnDestroy();
+    expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
+  });
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
@@ -58,6 +58,7 @@ import {ExplorationModeService} from 'pages/exploration-player-page/services/exp
 import {ChapterProgressService} from 'pages/exploration-player-page/services/chapter-progress.service';
 import {CurrentEngineService} from 'pages/exploration-player-page/services/current-engine.service';
 import {CardAnimationService} from 'pages/exploration-player-page/services/card-animation.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import {LearnerExplorationSummary} from 'domain/summary/learner-exploration-summary.model';
 
 @Component({
@@ -125,7 +126,8 @@ export class ConversationSkinComponent {
     private readOnlyExplorationBackendApiService: ReadOnlyExplorationBackendApiService,
     private checkpointProgressService: CheckpointProgressService,
     private conversationFlowService: ConversationFlowService,
-    private chapterProgressService: ChapterProgressService
+    private chapterProgressService: ChapterProgressService,
+    private preventPageUnloadEventService: PreventPageUnloadEventService
   ) {}
 
   ngOnInit(): void {
@@ -269,11 +271,11 @@ export class ConversationSkinComponent {
       this.isLoggedIn = userInfo.isLoggedIn();
       this.conversationFlowService.setIsLoggedIn(this.isLoggedIn);
 
-      this.windowRef.nativeWindow.addEventListener('beforeunload', e => {
+      this.preventPageUnloadEventService.addListener(() => {
         let redirectToRefresherExplorationConfirmed =
           this.conversationFlowService.getRedirectToRefresherExplorationConfirmed();
         if (redirectToRefresherExplorationConfirmed) {
-          return;
+          return false;
         }
         if (
           this.conversationFlowService.getHasInteractedAtLeastOnce() &&
@@ -286,13 +288,9 @@ export class ConversationSkinComponent {
             this.learnerParamsService.getAllParams()
           );
 
-          let confirmationMessage =
-            'Please save your progress before navigating away from the' +
-            ' page; else, you will lose your exploration progress.';
-          (e || this.windowRef.nativeWindow.event).returnValue =
-            confirmationMessage;
-          return confirmationMessage;
+          return true;
         }
+        return false;
       });
 
       let pid =
@@ -399,6 +397,7 @@ export class ConversationSkinComponent {
 
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
+    this.preventPageUnloadEventService.removeListener();
   }
 
   getAnswerIsBeingProcessed(): boolean {

--- a/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.spec.ts
@@ -38,6 +38,7 @@ import {MockTranslatePipe} from '../../../../tests/unit-test-utils';
 import {ExplorationEngineService} from '../../services/exploration-engine.service';
 import {PlayerTranscriptService} from '../../services/player-transcript.service';
 import {LessonInformationCardModalComponent} from './lesson-information-card-modal.component';
+import {AuthService} from 'services/auth.service';
 import {LocalStorageService} from '../../../../services/local-storage.service';
 import {DateTimeFormatService} from '../../../../services/date-time-format.service';
 import {ProgressUrlService} from '../../services/progress-url.service';
@@ -98,6 +99,10 @@ class MockPlayerPositionService {
   getDisplayedCardIndex(): number {
     return this.displayedCardIndex;
   }
+}
+
+class MockAuthService {
+  onUserSignIn = new EventEmitter<void>();
 }
 
 class MockWindowRef {
@@ -187,6 +192,10 @@ describe('Lesson Information card modal component', () => {
         {
           provide: TranslateService,
           useClass: MockTranslateService,
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
@@ -38,6 +38,8 @@ import {PlayerTranscriptService} from '../../services/player-transcript.service'
 import {ProgressUrlService} from '../../services/progress-url.service';
 import {ExplorationEngineService} from '../../services/exploration-engine.service';
 import {CheckpointCelebrationUtilityService} from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
+import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 
 interface ExplorationTagSummary {
   tagsToShow: string[];
@@ -105,7 +107,9 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
     private localStorageService: LocalStorageService,
     private progressUrlService: ProgressUrlService,
     private checkpointCelebrationUtilityService: CheckpointCelebrationUtilityService,
-    private playerPositionService: PlayerPositionService
+    private playerPositionService: PlayerPositionService,
+    private siteAnalyticsService: SiteAnalyticsService,
+    private preventPageUnloadEventService: PreventPageUnloadEventService
   ) {
     super(ngbActiveModal);
   }
@@ -277,6 +281,12 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
             'loggedOutProgressUniqueUrlId is not null.'
         );
       }
+      this.preventPageUnloadEventService.removeListener();
+      // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
+      // rather than manually being triggered by buttons.
+      this.siteAnalyticsService.registerStartLoginEvent(
+        'lessonInformationCardModal'
+      );
       this.localStorageService.updateUniqueProgressIdOfLoggedOutLearner(urlId);
       this.windowRef.nativeWindow.location.href = loginUrl;
     });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
@@ -39,7 +39,7 @@ import {ProgressUrlService} from '../../services/progress-url.service';
 import {ExplorationEngineService} from '../../services/exploration-engine.service';
 import {CheckpointCelebrationUtilityService} from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
-import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
+import {AuthService} from 'services/auth.service';
 
 interface ExplorationTagSummary {
   tagsToShow: string[];
@@ -109,7 +109,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
     private checkpointCelebrationUtilityService: CheckpointCelebrationUtilityService,
     private playerPositionService: PlayerPositionService,
     private siteAnalyticsService: SiteAnalyticsService,
-    private preventPageUnloadEventService: PreventPageUnloadEventService
+    private authService: AuthService
   ) {
     super(ngbActiveModal);
   }
@@ -281,7 +281,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
             'loggedOutProgressUniqueUrlId is not null.'
         );
       }
-      this.preventPageUnloadEventService.removeListener();
+      this.authService.onUserSignIn.emit();
       // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
       // rather than manually being triggered by buttons.
       this.siteAnalyticsService.registerStartLoginEvent(

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progess-modal.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progess-modal.component.spec.ts
@@ -27,7 +27,8 @@ import {
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
 import {SaveProgressModalComponent} from './save-progress-modal.component';
 import {MockTranslatePipe} from 'tests/unit-test-utils';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {NO_ERRORS_SCHEMA, EventEmitter} from '@angular/core';
+import {AuthService} from 'services/auth.service';
 import {UserService} from 'services/user.service';
 import {LocalStorageService} from 'services/local-storage.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
@@ -61,6 +62,10 @@ class MockWindowRef {
   };
 }
 
+class MockAuthService {
+  onUserSignIn = new EventEmitter<void>();
+}
+
 describe('SaveProgressModalComponent', () => {
   let fixture: ComponentFixture<SaveProgressModalComponent>;
   let componentInstance: SaveProgressModalComponent;
@@ -87,6 +92,10 @@ describe('SaveProgressModalComponent', () => {
         {
           provide: WindowRef,
           useClass: MockWindowRef,
+        },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progress-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progress-modal.component.ts
@@ -22,6 +22,8 @@ import {UserService} from 'services/user.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {LocalStorageService} from 'services/local-storage.service';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
+import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import './save-progress-modal.component.css';
 
 @Component({
@@ -38,7 +40,9 @@ export class SaveProgressModalComponent {
     private userService: UserService,
     private windowRef: WindowRef,
     private localStorageService: LocalStorageService,
-    private ngbActiveModal: NgbActiveModal
+    private ngbActiveModal: NgbActiveModal,
+    private siteAnalyticsService: SiteAnalyticsService,
+    private preventPageUnloadEventService: PreventPageUnloadEventService
   ) {}
 
   isLanguageRTL(): boolean {
@@ -55,6 +59,10 @@ export class SaveProgressModalComponent {
             'loggedOutProgressUniqueUrlId is not null.'
         );
       }
+      this.preventPageUnloadEventService.removeListener();
+      // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
+      // rather than manually being triggered by buttons.
+      this.siteAnalyticsService.registerStartLoginEvent('saveProgressModal');
       this.localStorageService.updateUniqueProgressIdOfLoggedOutLearner(urlId);
       this.windowRef.nativeWindow.location.href = loginUrl;
     });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progress-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progress-modal.component.ts
@@ -23,7 +23,7 @@ import {WindowRef} from 'services/contextual/window-ref.service';
 import {LocalStorageService} from 'services/local-storage.service';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
-import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
+import {AuthService} from 'services/auth.service';
 import './save-progress-modal.component.css';
 
 @Component({
@@ -42,7 +42,7 @@ export class SaveProgressModalComponent {
     private localStorageService: LocalStorageService,
     private ngbActiveModal: NgbActiveModal,
     private siteAnalyticsService: SiteAnalyticsService,
-    private preventPageUnloadEventService: PreventPageUnloadEventService
+    private authService: AuthService
   ) {}
 
   isLanguageRTL(): boolean {
@@ -59,7 +59,7 @@ export class SaveProgressModalComponent {
             'loggedOutProgressUniqueUrlId is not null.'
         );
       }
-      this.preventPageUnloadEventService.removeListener();
+      this.authService.onUserSignIn.emit();
       // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
       // rather than manually being triggered by buttons.
       this.siteAnalyticsService.registerStartLoginEvent('saveProgressModal');

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -2467,4 +2467,42 @@ describe('New Conversation skin component', () => {
     componentInstance.ngOnDestroy();
     expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
   });
+
+  it('should add before unload listener on init', fakeAsync(() => {
+    spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+      false
+    );
+    spyOn(pageContextService, 'isInDiagnosticTestPlayerPage').and.returnValue(
+      false
+    );
+    spyOn(userService, 'getUserInfoAsync').and.returnValue(
+      Promise.resolve(
+        new UserInfo([], false, false, false, false, false, '', '', '', true)
+      )
+    );
+    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+      null
+    );
+    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+    spyOn(urlService, 'isIframed').and.returnValue(false);
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(
+      urlInterpolationService,
+      'getStaticCopyrightedImageUrl'
+    ).and.returnValue('url');
+    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+      false
+    );
+
+    spyOn(preventPageUnloadEventService, 'addListener').and.callFake(
+      (callback: () => void) => {
+        callback();
+      }
+    );
+    componentInstance.ngOnInit();
+    tick();
+    flush();
+    expect(preventPageUnloadEventService.addListener).toHaveBeenCalled();
+  }));
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -88,6 +88,8 @@ import {LearnerExplorationSummary} from '../../../../domain/summary/learner-expl
 import {ChapterProgressService} from '../../services/chapter-progress.service';
 import {CardAnimationService} from '../../services/card-animation.service';
 import {MobileMenuService} from '../../services/mobile-menu.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
+import {AuthService} from 'services/auth.service';
 class MockWindowRef {
   nativeWindow = {
     location: {
@@ -100,6 +102,10 @@ class MockWindowRef {
     },
     scrollTo: (x, y) => {},
   };
+}
+
+class MockAuthService {
+  onUserSignIn = new EventEmitter<void>();
 }
 
 describe('New Conversation skin component', () => {
@@ -149,6 +155,7 @@ describe('New Conversation skin component', () => {
   let translateService: TranslateService;
   let learnerDashboardBackendApiService: LearnerDashboardBackendApiService;
   let conceptCardManagerService: ConceptCardManagerService;
+  let preventPageUnloadEventService: PreventPageUnloadEventService;
 
   let displayedCard = new StateCard(
     null,
@@ -446,6 +453,11 @@ describe('New Conversation skin component', () => {
           provide: TranslateService,
           useClass: MockTranslateService,
         },
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+        PreventPageUnloadEventService,
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -520,6 +532,9 @@ describe('New Conversation skin component', () => {
     translateService = TestBed.inject(TranslateService);
     learnerDashboardBackendApiService = TestBed.inject(
       LearnerDashboardBackendApiService
+    );
+    preventPageUnloadEventService = TestBed.inject(
+      PreventPageUnloadEventService
     );
   }));
 
@@ -2446,4 +2461,10 @@ describe('New Conversation skin component', () => {
     tick(2000);
     flush();
   }));
+
+  it('should remove before unload listener on ngOnDestroy', () => {
+    spyOn(preventPageUnloadEventService, 'removeListener');
+    componentInstance.ngOnDestroy();
+    expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
+  });
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -96,7 +96,7 @@ class MockWindowRef {
     },
     onresize: () => {},
     addEventListener(event: string, callback) {
-      callback({returnValue: null});
+      callback({returnValue: null, preventDefault: () => {}});
     },
     scrollTo: (x, y) => {},
   };

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -2505,4 +2505,104 @@ describe('New Conversation skin component', () => {
     flush();
     expect(preventPageUnloadEventService.addListener).toHaveBeenCalled();
   }));
+  describe('PreventPageUnloadEvent integration', () => {
+    let capturedCallback: () => boolean;
+
+    beforeEach(() => {
+      spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+        false
+      );
+      spyOn(pageContextService, 'isInDiagnosticTestPlayerPage').and.returnValue(
+        false
+      );
+      spyOn(userService, 'getUserInfoAsync').and.returnValue(
+        Promise.resolve(
+          new UserInfo([], false, false, false, false, false, '', '', '', true)
+        )
+      );
+      spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+        null
+      );
+      spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+      spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+      spyOn(urlService, 'isIframed').and.returnValue(false);
+      spyOn(loaderService, 'showLoadingScreen');
+      spyOn(
+        urlInterpolationService,
+        'getStaticCopyrightedImageUrl'
+      ).and.returnValue('url');
+      spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+        false
+      );
+
+      // Capture the callback passed to addListener.
+      spyOn(preventPageUnloadEventService, 'addListener').and.callFake(
+        (callback: () => boolean) => {
+          capturedCallback = callback;
+        }
+      );
+    });
+
+    it('should validate unload conditions in the listener callback', fakeAsync(() => {
+      componentInstance.ngOnInit();
+      tick();
+      expect(capturedCallback).toBeDefined();
+
+      // Mock dependencies for callback logic.
+      const getRedirectSpy = spyOn(
+        conversationFlowService,
+        'getRedirectToRefresherExplorationConfirmed'
+      );
+      const getHasInteractedSpy = spyOn(
+        conversationFlowService,
+        'getHasInteractedAtLeastOnce'
+      );
+      const getDisplayedCardSpy = spyOn(
+        conversationFlowService,
+        'getDisplayedCard'
+      );
+      const isInQuestionModeSpy = spyOn(
+        explorationModeService,
+        'isInQuestionMode'
+      );
+      const recordEventSpy = spyOn(
+        statsReportingService,
+        'recordMaybeLeaveEvent'
+      );
+      spyOn(playerTranscriptService, 'getLastStateName').and.returnValue(
+        'State'
+      );
+      spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
+
+      // Case 1: Redirect confirmed -> should return false (allow unload).
+      getRedirectSpy.and.returnValue(true);
+      expect(capturedCallback()).toBeFalse();
+
+      // Case 2: Redirect not confirmed, Interacted, Valid state -> should return true (prevent unload).
+      getRedirectSpy.and.returnValue(false);
+      getHasInteractedSpy.and.returnValue(true);
+      componentInstance._editorPreviewMode = false;
+      const mockStateCard = jasmine.createSpyObj('StateCard', ['isTerminal']);
+      mockStateCard.isTerminal.and.returnValue(false);
+      getDisplayedCardSpy.and.returnValue(mockStateCard);
+      isInQuestionModeSpy.and.returnValue(false);
+
+      expect(capturedCallback()).toBeTrue();
+      expect(recordEventSpy).toHaveBeenCalled();
+
+      // Case 3: Editor preview mode -> should return false.
+      componentInstance._editorPreviewMode = true;
+      expect(capturedCallback()).toBeFalse();
+
+      // Case 4: Terminal state -> should return false.
+      componentInstance._editorPreviewMode = false;
+      mockStateCard.isTerminal.and.returnValue(true);
+      expect(capturedCallback()).toBeFalse();
+
+      // Case 5: Question mode -> should return false.
+      mockStateCard.isTerminal.and.returnValue(false);
+      isInQuestionModeSpy.and.returnValue(true);
+      expect(capturedCallback()).toBeFalse();
+    }));
+  });
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
@@ -61,6 +61,7 @@ import {LearnerExplorationSummary} from 'domain/summary/learner-exploration-summ
 import {DiagnosticTestTopicTrackerModel} from 'pages/diagnostic-test-player-page/diagnostic-test-topic-tracker.model';
 import {ExplorationEngineService} from 'pages/exploration-player-page/services/exploration-engine.service';
 import {MobileMenuService} from 'pages/exploration-player-page/services/mobile-menu.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 
 @Component({
   selector: 'oppia-new-conversation-skin',
@@ -133,7 +134,8 @@ export class NewConversationSkinComponent {
     private checkpointProgressService: CheckpointProgressService,
     private conversationFlowService: ConversationFlowService,
     private chapterProgressService: ChapterProgressService,
-    private mobileMenuService: MobileMenuService
+    private mobileMenuService: MobileMenuService,
+    private preventPageUnloadEventService: PreventPageUnloadEventService
   ) {}
 
   ngOnInit(): void {
@@ -286,11 +288,11 @@ export class NewConversationSkinComponent {
       this.isLoggedIn = userInfo.isLoggedIn();
       this.conversationFlowService.setIsLoggedIn(this.isLoggedIn);
 
-      this.windowRef.nativeWindow.addEventListener('beforeunload', e => {
+      this.preventPageUnloadEventService.addListener(() => {
         let redirectToRefresherExplorationConfirmed =
           this.conversationFlowService.getRedirectToRefresherExplorationConfirmed();
         if (redirectToRefresherExplorationConfirmed) {
-          return;
+          return false;
         }
         if (
           this.conversationFlowService.getHasInteractedAtLeastOnce() &&
@@ -303,13 +305,9 @@ export class NewConversationSkinComponent {
             this.learnerParamsService.getAllParams()
           );
 
-          let confirmationMessage =
-            'Please save your progress before navigating away from the' +
-            ' page; else, you will lose your exploration progress.';
-          (e || this.windowRef.nativeWindow.event).returnValue =
-            confirmationMessage;
-          return confirmationMessage;
+          return true;
         }
+        return false;
       });
 
       let pid =
@@ -423,6 +421,7 @@ export class NewConversationSkinComponent {
 
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
+    this.preventPageUnloadEventService.removeListener();
   }
 
   getAnswerIsBeingProcessed(): boolean {

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
@@ -312,7 +312,7 @@ export class NewConversationSkinComponent {
 
       let pid =
         this.localStorageService.getUniqueProgressIdOfLoggedOutLearner();
-      if (pid && this.isLoggedIn) {
+      if (pid && this.isLoggedIn && this.explorationId) {
         await this.editableExplorationBackendApiService.changeLoggedOutProgressToLoggedInProgressAsync(
           this.explorationId,
           pid

--- a/core/templates/pages/lightweight-oppia-root/app.module.ts
+++ b/core/templates/pages/lightweight-oppia-root/app.module.ts
@@ -27,6 +27,13 @@ import {
 } from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {AppRoutingModule} from './routing/app.routing.module';
+import {AngularFireModule} from '@angular/fire';
+import {
+  AngularFireAuth,
+  AngularFireAuthModule,
+  USE_EMULATOR,
+} from '@angular/fire/auth';
+import {AuthService} from 'services/auth.service';
 
 // Components.
 import {LightweightOppiaRootComponent} from './lightweight-oppia-root.component';
@@ -84,6 +91,8 @@ export class HammerConfig extends HammerGestureConfig {
     HttpClientModule,
     AppRoutingModule,
     ToastrModule.forRoot(toastrConfig),
+    AngularFireModule.initializeApp(AuthService.firebaseConfig),
+    AngularFireAuthModule,
   ],
   declarations: [LightweightOppiaRootComponent],
   entryComponents: [LightweightOppiaRootComponent],
@@ -103,6 +112,11 @@ export class HammerConfig extends HammerGestureConfig {
     {
       provide: HAMMER_GESTURE_CONFIG,
       useClass: HammerConfig,
+    },
+    AngularFireAuth,
+    {
+      provide: USE_EMULATOR,
+      useValue: AuthService.firebaseEmulatorConfig,
     },
   ],
   bootstrap: [LightweightOppiaRootComponent],

--- a/core/templates/services/auth.service.spec.ts
+++ b/core/templates/services/auth.service.spec.ts
@@ -22,6 +22,7 @@ import {md5} from 'hash-wasm';
 
 import {AuthService} from 'services/auth.service';
 import {AuthBackendApiService} from 'services/auth-backend-api.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import firebase from 'firebase';
 
 describe('Auth service', function () {
@@ -32,6 +33,7 @@ describe('Auth service', function () {
   let creds: firebase.auth.UserCredential;
   let authBackendApiService: jasmine.SpyObj<AuthBackendApiService>;
   let angularFireAuth: jasmine.SpyObj<AngularFireAuth>;
+  let preventPageUnloadEventService: jasmine.SpyObj<PreventPageUnloadEventService>;
 
   beforeEach(async () => {
     angularFireAuth = jasmine.createSpyObj<AngularFireAuth>([
@@ -45,11 +47,20 @@ describe('Auth service', function () {
       beginSessionAsync: Promise.resolve(),
       endSessionAsync: Promise.resolve(),
     });
+    preventPageUnloadEventService =
+      jasmine.createSpyObj<PreventPageUnloadEventService>(
+        'PreventPageUnloadEventService',
+        ['removeListener']
+      );
 
     TestBed.configureTestingModule({
       providers: [
         {provide: AngularFireAuth, useValue: angularFireAuth},
         {provide: AuthBackendApiService, useValue: authBackendApiService},
+        {
+          provide: PreventPageUnloadEventService,
+          useValue: preventPageUnloadEventService,
+        },
       ],
     });
 
@@ -99,19 +110,31 @@ describe('Auth service', function () {
 
   it('should throw if signOutAsync is called without angular fire', async () => {
     await expectAsync(
-      new AuthService(null, authBackendApiService).signOutAsync()
+      new AuthService(
+        null,
+        authBackendApiService,
+        preventPageUnloadEventService
+      ).signOutAsync()
     ).toBeRejectedWithError('AngularFireAuth is not available');
   });
 
   it('should throw if signInWithRedirectAsync is called without angular fire', async () => {
     await expectAsync(
-      new AuthService(null, authBackendApiService).signInWithRedirectAsync()
+      new AuthService(
+        null,
+        authBackendApiService,
+        preventPageUnloadEventService
+      ).signInWithRedirectAsync()
     ).toBeRejectedWithError('AngularFireAuth is not available');
   });
 
   it('should throw if handleRedirectResultAsync is called without angular fire', async () => {
     await expectAsync(
-      new AuthService(null, authBackendApiService).handleRedirectResultAsync()
+      new AuthService(
+        null,
+        authBackendApiService,
+        preventPageUnloadEventService
+      ).handleRedirectResultAsync()
     ).toBeRejectedWithError('AngularFireAuth is not available');
   });
 
@@ -175,7 +198,11 @@ describe('Auth service', function () {
         additionalUserInfo: null,
       };
 
-      authService = new AuthService(angularFireAuth, authBackendApiService);
+      authService = new AuthService(
+        angularFireAuth,
+        authBackendApiService,
+        preventPageUnloadEventService
+      );
     });
 
     it('should fail to call signInWithEmail', async () => {
@@ -239,7 +266,11 @@ describe('Auth service', function () {
         'get'
       ).and.returnValue(true);
 
-      authService = new AuthService(angularFireAuth, authBackendApiService);
+      authService = new AuthService(
+        angularFireAuth,
+        authBackendApiService,
+        preventPageUnloadEventService
+      );
     });
 
     it('should not delegate to signInWithRedirectAsync', async () => {
@@ -272,6 +303,11 @@ describe('Auth service', function () {
         messagingSenderId: '',
         appId: '',
       });
+    });
+
+    it('should remove listener on user sign in', () => {
+      authService.onUserSignIn.emit();
+      expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
     });
   });
 });

--- a/core/templates/services/auth.service.spec.ts
+++ b/core/templates/services/auth.service.spec.ts
@@ -144,6 +144,7 @@ describe('Auth service', function () {
     });
     angularFireAuth.createUserWithEmailAndPassword.and.resolveTo(creds);
 
+    spyOn(authService.onUserSignIn, 'emit');
     await expectAsync(authService.signInWithEmail(email)).toBeResolvedTo();
 
     expect(angularFireAuth.signInWithEmailAndPassword).toHaveBeenCalledWith(
@@ -157,6 +158,7 @@ describe('Auth service', function () {
     expect(authBackendApiService.beginSessionAsync).toHaveBeenCalledWith(
       idToken
     );
+    expect(authService.onUserSignIn.emit).toHaveBeenCalled();
   });
 
   it('should propogate signInWithEmailAndPassword errors', async () => {

--- a/core/templates/services/auth.service.ts
+++ b/core/templates/services/auth.service.ts
@@ -191,6 +191,7 @@ export class AuthService {
     if (this.creds?.user !== null) {
       const idToken = await this.creds.user.getIdToken();
       await this.authBackendApiService.beginSessionAsync(idToken);
+      this.onUserSignIn.emit();
     }
   }
 

--- a/core/templates/services/auth.service.ts
+++ b/core/templates/services/auth.service.ts
@@ -16,7 +16,7 @@
  * @fileoverview Service for managing the authorizations of logged-in users.
  */
 
-import {Injectable, Optional} from '@angular/core';
+import {EventEmitter, Injectable, Optional} from '@angular/core';
 import {FirebaseOptions} from '@angular/fire';
 import {AngularFireAuth} from '@angular/fire/auth';
 import firebase from 'firebase/app';
@@ -96,6 +96,7 @@ class ProdAuthServiceImpl extends AuthServiceImpl {
 export class AuthService {
   private authServiceImpl: AuthServiceImpl;
   creds!: firebase.auth.UserCredential;
+  onUserSignIn: EventEmitter<void> = new EventEmitter<void>();
 
   constructor(
     @Optional() private angularFireAuth: AngularFireAuth | null,

--- a/core/templates/services/auth.service.ts
+++ b/core/templates/services/auth.service.ts
@@ -25,6 +25,7 @@ import {md5} from 'hash-wasm';
 
 import {AppConstants} from 'app.constants';
 import {AuthBackendApiService} from 'services/auth-backend-api.service';
+import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 
 abstract class AuthServiceImpl {
   abstract getRedirectResultAsync(): Promise<firebase.auth.UserCredential | null>;
@@ -100,7 +101,8 @@ export class AuthService {
 
   constructor(
     @Optional() private angularFireAuth: AngularFireAuth | null,
-    private authBackendApiService: AuthBackendApiService
+    private authBackendApiService: AuthBackendApiService,
+    private preventPageUnloadEventService: PreventPageUnloadEventService
   ) {
     if (!this.angularFireAuth) {
       this.authServiceImpl = new NullAuthServiceImpl();
@@ -109,6 +111,10 @@ export class AuthService {
     } else {
       this.authServiceImpl = new ProdAuthServiceImpl(this.angularFireAuth);
     }
+
+    this.onUserSignIn.subscribe(() => {
+      this.preventPageUnloadEventService.removeListener();
+    });
   }
 
   static get firebaseEmulatorIsEnabled(): boolean {

--- a/core/templates/services/prevent-page-unload-event.service.spec.ts
+++ b/core/templates/services/prevent-page-unload-event.service.spec.ts
@@ -16,20 +16,13 @@
  * @fileoverview Unit tests for the preventPageUnloadEventService.
  */
 
-import {EventEmitter} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {AuthService} from 'services/auth.service';
-
-class MockAuthService {
-  onUserSignIn = new EventEmitter<void>();
-}
 
 describe('Prevent page unload event service', function () {
   let preventPageUnloadEventService: PreventPageUnloadEventService;
   let windowRef: WindowRef;
-  let authService: AuthService;
 
   var reloadEvt = document.createEvent('Event');
   reloadEvt.initEvent('mockbeforeunload', true, true);
@@ -38,19 +31,12 @@ describe('Prevent page unload event service', function () {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        PreventPageUnloadEventService,
-        {
-          provide: AuthService,
-          useClass: MockAuthService,
-        },
-      ],
+      providers: [PreventPageUnloadEventService],
     });
     preventPageUnloadEventService = TestBed.inject(
       PreventPageUnloadEventService
     );
     windowRef = TestBed.inject(WindowRef);
-    authService = TestBed.inject(AuthService);
   });
 
   // Mocking window object here because beforeunload requres the
@@ -117,13 +103,6 @@ describe('Prevent page unload event service', function () {
   it('should remove listener on ngondestroy', () => {
     spyOn(preventPageUnloadEventService, 'removeListener');
     preventPageUnloadEventService.ngOnDestroy();
-
-    expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
-  });
-
-  it('should remove listener on user sign in', () => {
-    spyOn(preventPageUnloadEventService, 'removeListener');
-    authService.onUserSignIn.emit();
 
     expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
   });

--- a/core/templates/services/prevent-page-unload-event.service.spec.ts
+++ b/core/templates/services/prevent-page-unload-event.service.spec.ts
@@ -55,25 +55,25 @@ describe('Prevent page unload event service', function () {
   } as Window;
 
   it('should adding listener', () => {
-    expect(preventPageUnloadEventService.isListenerActive()).toBeFalse();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(false);
 
     preventPageUnloadEventService.addListener();
 
-    expect(preventPageUnloadEventService.isListenerActive()).toBeTrue();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(true);
   });
 
   it('should removing listener', () => {
     spyOn(preventPageUnloadEventService, 'removeListener').and.callThrough();
-    expect(preventPageUnloadEventService.isListenerActive()).toBeFalse();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(false);
     preventPageUnloadEventService.removeListener();
-    expect(preventPageUnloadEventService.isListenerActive()).toBeFalse();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(false);
     preventPageUnloadEventService.addListener();
-    expect(preventPageUnloadEventService.isListenerActive()).toBeTrue();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(true);
 
     preventPageUnloadEventService.removeListener();
 
     expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
-    expect(preventPageUnloadEventService.isListenerActive()).toBeFalse();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(false);
   });
 
   it('should test if Alert is displayed', () => {
@@ -84,7 +84,7 @@ describe('Prevent page unload event service', function () {
     windowRef.nativeWindow.location.reload();
 
     expect(reloadEvt.preventDefault).toHaveBeenCalled();
-    expect(preventPageUnloadEventService.isListenerActive()).toBeTrue();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(true);
   });
 
   it('should prevent multiple listeners', () => {
@@ -93,7 +93,7 @@ describe('Prevent page unload event service', function () {
     expect(windowRef.nativeWindow.addEventListener).toHaveBeenCalledTimes(0);
     preventPageUnloadEventService.addListener();
     expect(windowRef.nativeWindow.addEventListener).toHaveBeenCalledTimes(1);
-    expect(preventPageUnloadEventService.isListenerActive()).toBeTrue();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(true);
 
     preventPageUnloadEventService.addListener();
 
@@ -117,7 +117,7 @@ describe('Prevent page unload event service', function () {
     windowRef.nativeWindow.location.reload();
 
     expect(reloadEvt.preventDefault).toHaveBeenCalled();
-    expect(preventPageUnloadEventService.isListenerActive()).toBeTrue();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(true);
   });
 
   it('should test if Alert is not displayed when a condition is passed', () => {
@@ -136,6 +136,6 @@ describe('Prevent page unload event service', function () {
     windowRef.nativeWindow.location.reload(validationCallback());
 
     expect(reloadEvt.preventDefault).not.toHaveBeenCalled();
-    expect(preventPageUnloadEventService.isListenerActive()).toBeTrue();
+    expect(preventPageUnloadEventService.isListenerActive()).toBe(true);
   });
 });

--- a/core/templates/services/prevent-page-unload-event.service.spec.ts
+++ b/core/templates/services/prevent-page-unload-event.service.spec.ts
@@ -16,13 +16,20 @@
  * @fileoverview Unit tests for the preventPageUnloadEventService.
  */
 
+import {EventEmitter} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {AuthService} from 'services/auth.service';
+
+class MockAuthService {
+  onUserSignIn = new EventEmitter<void>();
+}
 
 describe('Prevent page unload event service', function () {
   let preventPageUnloadEventService: PreventPageUnloadEventService;
   let windowRef: WindowRef;
+  let authService: AuthService;
 
   var reloadEvt = document.createEvent('Event');
   reloadEvt.initEvent('mockbeforeunload', true, true);
@@ -31,12 +38,19 @@ describe('Prevent page unload event service', function () {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [PreventPageUnloadEventService],
+      providers: [
+        PreventPageUnloadEventService,
+        {
+          provide: AuthService,
+          useClass: MockAuthService,
+        },
+      ],
     });
     preventPageUnloadEventService = TestBed.inject(
       PreventPageUnloadEventService
     );
     windowRef = TestBed.inject(WindowRef);
+    authService = TestBed.inject(AuthService);
   });
 
   // Mocking window object here because beforeunload requres the
@@ -103,6 +117,13 @@ describe('Prevent page unload event service', function () {
   it('should remove listener on ngondestroy', () => {
     spyOn(preventPageUnloadEventService, 'removeListener');
     preventPageUnloadEventService.ngOnDestroy();
+
+    expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
+  });
+
+  it('should remove listener on user sign in', () => {
+    spyOn(preventPageUnloadEventService, 'removeListener');
+    authService.onUserSignIn.emit();
 
     expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
   });

--- a/core/templates/services/prevent-page-unload-event.service.ts
+++ b/core/templates/services/prevent-page-unload-event.service.ts
@@ -17,10 +17,8 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Subscription} from 'rxjs';
 
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {AuthService} from 'services/auth.service';
 
 @Injectable({
   providedIn: 'root',
@@ -32,16 +30,7 @@ export class PreventPageUnloadEventService {
     this: Window,
     ev: BeforeUnloadEvent
   ) => void;
-  private signInSubscription: Subscription;
-
-  constructor(
-    private windowRef: WindowRef,
-    private authService: AuthService
-  ) {
-    this.signInSubscription = this.authService.onUserSignIn.subscribe(() => {
-      this.removeListener();
-    });
-  }
+  constructor(private windowRef: WindowRef) {}
 
   addListener(callback?: () => boolean): void {
     if (this.listenerActive) {
@@ -95,8 +84,5 @@ export class PreventPageUnloadEventService {
 
   ngOnDestroy(): void {
     this.removeListener();
-    if (this.signInSubscription) {
-      this.signInSubscription.unsubscribe();
-    }
   }
 }

--- a/core/templates/services/prevent-page-unload-event.service.ts
+++ b/core/templates/services/prevent-page-unload-event.service.ts
@@ -17,8 +17,10 @@
  */
 
 import {Injectable} from '@angular/core';
+import {Subscription} from 'rxjs';
 
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {AuthService} from 'services/auth.service';
 
 @Injectable({
   providedIn: 'root',
@@ -30,8 +32,16 @@ export class PreventPageUnloadEventService {
     this: Window,
     ev: BeforeUnloadEvent
   ) => void;
+  private signInSubscription: Subscription;
 
-  constructor(private windowRef: WindowRef) {}
+  constructor(
+    private windowRef: WindowRef,
+    private authService: AuthService
+  ) {
+    this.signInSubscription = this.authService.onUserSignIn.subscribe(() => {
+      this.removeListener();
+    });
+  }
 
   addListener(callback?: () => boolean): void {
     if (this.listenerActive) {
@@ -85,5 +95,8 @@ export class PreventPageUnloadEventService {
 
   ngOnDestroy(): void {
     this.removeListener();
+    if (this.signInSubscription) {
+      this.signInSubscription.unsubscribe();
+    }
   }
 }

--- a/core/templates/services/prevent-page-unload-event.service.ts
+++ b/core/templates/services/prevent-page-unload-event.service.ts
@@ -24,17 +24,14 @@ import {WindowRef} from 'services/contextual/window-ref.service';
   providedIn: 'root',
 })
 export class PreventPageUnloadEventService {
-  private listenerActive: boolean;
-  validationCallback: undefined | (() => boolean);
+  private listenerActive = false;
+  private validationCallback: (() => boolean) | null = null;
   _preventPageUnloadEventHandlerBind?: (
     this: Window,
     ev: BeforeUnloadEvent
   ) => void;
 
-  constructor(private windowRef: WindowRef) {
-    this.listenerActive = false;
-    this.validationCallback = undefined;
-  }
+  constructor(private windowRef: WindowRef) {}
 
   addListener(callback?: () => boolean): void {
     if (this.listenerActive) {

--- a/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/publish-the-exploration-with-an-interaction.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/exploration-editor/publish-the-exploration-with-an-interaction.spec.ts
@@ -57,7 +57,10 @@ describe('Exploration Creator', function () {
       await explorationEditor.navigateToExplorationEditorFromCreatorDashboard();
       await explorationEditor.dismissWelcomeModal();
       await explorationEditor.updateCardContent(INTRODUCTION_CARD_CONTENT);
-      await explorationEditor.addImageInteraction();
+      await explorationEditor.addImageInteraction(
+        'Correct!',
+        CARD_NAME.LAST_CARD
+      );
       await explorationEditor.editDefaultResponseFeedbackInExplorationEditorPage(
         'Wrong.'
       );

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -231,10 +231,8 @@ export class BaseUser {
 
         this.page.on('dialog', async dialog => {
           const alertText = dialog.message();
-          if (
-            acceptedBrowserAlerts.includes(alertText) ||
-            dialog.type() === 'beforeunload'
-          ) {
+
+          if (acceptedBrowserAlerts.includes(alertText)) {
             await dialog.accept();
           } else {
             throw new Error(`Unexpected alert: ${alertText}`);

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -231,7 +231,10 @@ export class BaseUser {
 
         this.page.on('dialog', async dialog => {
           const alertText = dialog.message();
-          if (acceptedBrowserAlerts.includes(alertText)) {
+          if (
+            acceptedBrowserAlerts.includes(alertText) ||
+            dialog.type() === 'beforeunload'
+          ) {
             await dialog.accept();
           } else {
             throw new Error(`Unexpected alert: ${alertText}`);


### PR DESCRIPTION
# Fix #22521: Suppress "unsaved changes" alert during login redirect

## Overview

1. This PR fixes #22521.
2. This PR suppresses the "Changes you made may not be saved" alert when a learner clicks the "Sign in" button while in an exploration. It achieves this by using the `PreventPageUnloadEventService` to manage the `beforeunload` listener and explicitly removing that listener before the login redirect occurs.
3. The original bug occurred because the `beforeunload` event listener was permanently attached to the window during the exploration, so any navigation away from the page (including the intentional redirect to the login page) triggered the browser's unsaved changes warning.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #22521: " followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

**Demonstration Video:**


https://github.com/user-attachments/assets/fc3dac2a-7147-40bf-b6cb-2b875a0e212b


#### Proof of changes on desktop with slow/throttled network
Not needed - this is a logic fix for an event listener and does not depend on network speed or loading states.

#### Proof of changes on mobile phone
The behavior is identical on mobile viewports. The "Sign In" button now correctly redirects without the browser alert.

#### Proof of changes in Arabic language
Not applicable - this PR affects browser-level event handling and does not modify the visual UI layout or text translation.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.