### PR TITLE
Fix typos and grammar in markdown files

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -4,5 +4,5 @@ This folder contains the scripts for Oppia backend & frontend.
 - domain: Services & classes for various data models used in Oppia codebase.
 - platform: Google app engine services.
 - storage: Definitions for storage models on Google App engine.
-- templates: All the frontend directive, controllers, filters & services.
+- templates: All the frontend directives, controllers, filters & services.
 - tests: E2E tests for various Oppia pages.

--- a/core/tests/release_sources/release_summary.md
+++ b/core/tests/release_sources/release_summary.md
@@ -79,7 +79,7 @@ Improvements to editors and players
 
 ### Commit History:
 
-- Changed parent to ctrl in stettings tab. (#7058)
+- Changed parent to ctrl in settings tab. (#7058)
 - Fix #6864: Fix console error in learner dashboard and empty suggestion modal (#7056)
 - Add missing ctrl (#7032)
 


### PR DESCRIPTION
Hi, I was looking through the documentation and noticed a couple of small errors, so I’ve fixed them.

Changes:

core/tests/release_sources/release_summary.md: Fixed a typo ("stettings" to "settings").

core/README.md: Updated "frontend directive" to "frontend directives" (plural) to match the grammar of the rest of the list.