### PR TITLE
Fix part of #10450: Update Questions tab icon in mobile Skill Editor navbar

### DIFF
--- a/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.component.html
+++ b/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.component.html
@@ -61,7 +61,7 @@
           </div>
           <div class="skill-nav-dropdown-option"
                (click)="selectQuestionsTab()">
-            <i class="fas fa-book-open navbar-tab-icon e2e-test-mobile-questions-tab"></i>
+            <i class="fas fa-question-circle navbar-tab-icon e2e-test-mobile-questions-tab"></i>
             <span>Questions</span>
           </div>
           <div class="skill-nav-dropdown-option"


### PR DESCRIPTION
## Overview

1. This PR fixes part of #10450.
2. This PR updates the Questions tab icon in the **mobile Skill Editor navbar**, replacing the book icon (`fa-book-open`) with a question icon (`fa-question-circle`) to better match the Questions section.
3. N/A (UI improvement, not a bug regression).

## Essential Checklist

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] Tests are not required because this is a visual-only icon change with no logic impact.
- [X] The **PR title** starts with "Fix part of #10450:", followed by a short, clear summary of the changes.
- [X] I have requested the correct reviewers.

## Proof that changes are correct

### Proof of changes on mobile phone

Before: The Questions tab icon in the Skill Editor mobile dropdown was a book icon.  
After: It has been updated to a question-circle icon.

![Mobile Questions tab icon update](https://github.com/user-attachments/assets/563738bf-f16c-40e3-bd6d-6bbb1cddcb39)

## Review Request

@oppia/ace-frontend-reviewers PTAL.
