### PR TITLE
Fix part of #10450: Update Questions tab icon in mobile Skill Editor navbar

### DIFF
--- a/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.component.html
+++ b/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.component.html
@@ -61,7 +61,7 @@
           </div>
           <div class="skill-nav-dropdown-option"
                (click)="selectQuestionsTab()">
-            <i class="fas fa-book-open navbar-tab-icon e2e-test-mobile-questions-tab"></i>
+            <i class="fas fa-question-circle navbar-tab-icon e2e-test-mobile-questions-tab"></i>
             <span>Questions</span>
           </div>
           <div class="skill-nav-dropdown-option"


### PR DESCRIPTION
## Overview

1. This PR fixes part of #10450.
2. This PR updates the Questions tab icon in the mobile Skill Editor navbar dropdown,
   replacing the book icon (`fa-book-open`) with a question icon (`fa-question-circle`)
   to better match the Questions section.
3. N/A (UI improvement).

## Essential Checklist

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code (not needed for icon-only UI change).
- [X] The PR title starts with "Fix part of #10450:".
- [X] I will tag the required reviewer.

## Proof that changes are correct

### Proof of changes on mobile phone

Updated Questions tab icon in the Skill Editor mobile dropdown:

![Mobile Skill Editor Questions tab icon updated](https://github.com/user-attachments/assets/41029ef2-7d77-4dad-9fa5-620ff1504f6e)


Tagging reviewer: @oppia/ace-frontend-reviewers PTAL.