### PR TITLE
Fix #22727: Remove SERVER_CAN_SEND_EMAILS platform parameter

### DIFF
--- a/core/domain/platform_parameter_registry.py
+++ b/core/domain/platform_parameter_registry.py
@@ -505,16 +505,7 @@ Registry.create_platform_parameter(
 # correspond to owners of the app before setting this to True. If
 # SYSTEM_EMAIL_ADDRESS is not that of an app owner, email messages from this
 # address cannot be sent. If True then emails can be sent to any user.
-Registry.create_platform_parameter(
-    ParamName.SERVER_CAN_SEND_EMAILS,
-    (
-        'Whether the application can send emails.'
-        'Change this value to True for production environments using the '
-        'platform parameter dashboard.'
-    ),
-    platform_parameter_domain.DataTypes.BOOL,
-    default=False,
-)
+
 
 Registry.create_platform_parameter(
     ParamName.SYSTEM_EMAIL_ADDRESS,


### PR DESCRIPTION
## Overview

1. This PR fixes #22727.
2. This PR removes the obsolete SERVER_CAN_SEND_EMAILS platform parameter,
   including its registration and enum definition. This parameter is no longer
   required and has been cleaned up from the codebase.
3. N/A

## Essential Checklist

Please follow the instructions for making a code change.

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

No proof of changes needed because this PR removes an obsolete backend
platform parameter and does not affect any user-facing UI.
