### PR TITLE
Fix #19650: Prevent ValueError when limit is missing in question suggestions

### DIFF
--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -895,7 +895,7 @@ class ReviewableSuggestionsHandler(
             )
         elif suggestion_type == feconf.SUGGESTION_TYPE_ADD_QUESTION:
             if limit is None:
-                raise ValueError(
+                raise self.InvalidInputException(
                     'Limit must be provided for question suggestions.'
                 )
             topic_name = self.normalized_request.get('topic_name')

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -4190,7 +4190,7 @@ class ReviewableSuggestionsHandlerTest(test_utils.GenericTestBase):
         self.get_json(
             '/getreviewablesuggestions/skill/add_question',
             {'offset': 0, 'sort_key': constants.SUGGESTIONS_SORT_KEY_DATE},
-            expected_status_int=500,
+            expected_status_int=400,
         )
 
     def test_handler_with_invalid_target_type_raise_error(self) -> None:

--- a/core/templates/pages/contributor-dashboard-page/services/contribution-and-review-backend-api.service.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/contribution-and-review-backend-api.service.spec.ts
@@ -390,4 +390,61 @@ describe('Contribution and review backend API service', () => {
     expect(successHandler).toHaveBeenCalled();
     expect(failureHandler).not.toHaveBeenCalled();
   }));
+
+  it('should fetch contributor certificate without language', fakeAsync(() => {
+    const successHandler = jasmine.createSpy('success');
+    const failureHandler = jasmine.createSpy('failure');
+    const url =
+      '/contributorcertificate/user/translate_content?' +
+      'from_date=2022-01-01&to_date=2022-01-02';
+    const response = {
+      from_date: '1 Nov 2022',
+      to_date: '1 Dec 2022',
+      contribution_hours: 1.0,
+      team_lead: 'Test User',
+      language: null,
+    };
+
+    carbas
+      .downloadContributorCertificateAsync(
+        'user',
+        'translate_content',
+        null,
+        '2022-01-01',
+        '2022-01-02'
+      )
+      .then(successHandler, failureHandler);
+    const req = http.expectOne(url);
+    expect(req.request.method).toEqual('GET');
+    req.flush(response);
+    flushMicrotasks();
+
+    expect(successHandler).toHaveBeenCalled();
+    expect(failureHandler).not.toHaveBeenCalled();
+  }));
+
+  it('should return empty response when limit is 0', fakeAsync(() => {
+    const successHandler = jasmine.createSpy('success');
+    const failureHandler = jasmine.createSpy('failure');
+
+    carbas
+      .fetchReviewableSuggestionsAsync(
+        'exploration',
+        'translate_content',
+        0,
+        0,
+        'Date',
+        null,
+        null
+      )
+      .then(successHandler, failureHandler);
+    flushMicrotasks();
+
+    expect(successHandler).toHaveBeenCalledWith({
+      suggestions: [],
+      target_id_to_opportunity_dict: {},
+      next_offset: 0,
+    });
+    expect(failureHandler).not.toHaveBeenCalled();
+  }));
 });

--- a/core/templates/pages/contributor-dashboard-page/services/contribution-and-review-backend-api.service.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/contribution-and-review-backend-api.service.ts
@@ -197,6 +197,19 @@ export class ContributionAndReviewBackendApiService {
       offset: offset.toString(),
       sort_key: sortKey,
     };
+    // If the limit is 0, we return an empty response immediately. A limit of 0
+    // can occur if the frontend cache is already full due to redundant
+    // concurrent calls. We must handle this case explicitly because '0' is
+    // falsy in JavaScript and would be omitted from the backend request,
+    // which would lead to a 'ValueError' on the backend for certain
+    // suggestion types.
+    if (limit === 0) {
+      return Promise.resolve({
+        suggestions: [],
+        target_id_to_opportunity_dict: {},
+        next_offset: offset,
+      });
+    }
     if (limit) {
       params.limit = limit.toString();
     }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19650 .
2. This PR does the following: This PR fixes a crash that happened when fetching question suggestions without a valid limit parameter.
Frontend: Added a check in contribution-and-review-backend-api.service.ts so that if limit is 0, the service returns an empty result and does not send a request to the backend.
Backend: Updated suggestion.py to raise an InvalidInputException instead of a Python ValueError when the limit is missing. This ensures the API returns a proper 400 Bad Request instead of a 500 error.
3. (For bug-fixing PRs only) The original bug occurred because: The bug happened because the frontend sometimes calculated the limit as 0 (when the cache was full), and since 0 is falsy in JavaScript/TypeScript, the limit parameter was not sent to the backend. The backend expected this value and threw an error, so this PR fixes it by preventing invalid requests and improving backend error handling.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #19650: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

I have recreate this issue in my local host 

https://github.com/user-attachments/assets/7efcef5d-97cc-4481-ba7b-057d3f8695fa

Code i Changed-

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/070a52fd-717a-43b1-89af-42272fbd4303" />

<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/1dbfc147-48b7-4535-a9a6-787f39c69414" />

Video proof-

https://github.com/user-attachments/assets/0cc9f3f7-f5c0-40ac-8228-d81a4d9026de

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
