### PR TITLE
Fixes #24814, #24815, #24816: Voiceover Regeneration Feature Updates

### DIFF
--- a/core/controllers/tasks.py
+++ b/core/controllers/tasks.py
@@ -345,6 +345,7 @@ class DeferredTasksHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
                     cloud_task_model_id
                 )
             )
+            assert updated_cloud_task_run_domain_instance is not None
 
             if (
                 updated_cloud_task_run_domain_instance.latest_job_state

--- a/core/controllers/tasks.py
+++ b/core/controllers/tasks.py
@@ -323,6 +323,10 @@ class DeferredTasksHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
             assert cloud_task_run_domain_instance is not None
             cloud_task_run_domain_instance.latest_job_state = 'RUNNING'
 
+            taskqueue_services.update_cloud_task_run_model(
+                cloud_task_run_domain_instance
+            )
+
             deferred_task_function = self.DEFERRED_TASK_FUNCTIONS[
                 payload['fn_identifier']
             ]
@@ -336,10 +340,26 @@ class DeferredTasksHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
 
             deferred_task_function(*payload['args'], **payload['kwargs'])
 
-            cloud_task_run_domain_instance.latest_job_state = 'SUCCEEDED'
+            updated_cloud_task_run_domain_instance = (
+                taskqueue_services.get_cloud_task_run_by_model_id(
+                    cloud_task_model_id
+                )
+            )
+
+            if (
+                updated_cloud_task_run_domain_instance.latest_job_state
+                == 'PERMANENTLY_FAILED'
+            ):
+                # If the task has permanently failed during its execution,
+                # we do not update its state to SUCCEEDED.
+                return
+
+            updated_cloud_task_run_domain_instance.latest_job_state = (
+                'SUCCEEDED'
+            )
 
             taskqueue_services.update_cloud_task_run_model(
-                cloud_task_run_domain_instance
+                updated_cloud_task_run_domain_instance
             )
         except Exception as e:
             assert cloud_task_run_domain_instance is not None

--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -545,7 +545,6 @@ class TasksTests(test_utils.EmailTestBase):
         self.assertEqual(cloud_task_run_model_obj.latest_job_state, 'SUCCEEDED')
 
     def test_should_handle_voiceover_deferred_tasks_successfully(self) -> None:
-        self.signup('user@example.com', 'user')
         exploration_id = 'exploration_id'
         self.save_new_valid_exploration(exploration_id, self.owner_id)
         rights_manager.publish_exploration(self.owner, exploration_id)

--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -546,7 +546,6 @@ class TasksTests(test_utils.EmailTestBase):
 
     def test_should_handle_voiceover_deferred_tasks_successfully(self) -> None:
         self.signup('user@example.com', 'user')
-        user_id = self.get_user_id_from_email('user@example.com')
         exploration_id = 'exploration_id'
         self.save_new_valid_exploration(exploration_id, self.owner_id)
         rights_manager.publish_exploration(self.owner, exploration_id)

--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -545,6 +545,8 @@ class TasksTests(test_utils.EmailTestBase):
         self.assertEqual(cloud_task_run_model_obj.latest_job_state, 'SUCCEEDED')
 
     def test_should_handle_voiceover_deferred_tasks_successfully(self) -> None:
+        self.signup('user@example.com', 'user')
+        user_id = self.get_user_id_from_email('user@example.com')
         exploration_id = 'exploration_id'
         self.save_new_valid_exploration(exploration_id, self.owner_id)
         rights_manager.publish_exploration(self.owner, exploration_id)
@@ -572,7 +574,7 @@ class TasksTests(test_utils.EmailTestBase):
         payload = {
             'fn_identifier': function_id,
             'cloud_task_model_id': new_model_id,
-            'args': [exploration_id, '2025-12-13 21:08:46', 'author_id'],
+            'args': [exploration_id, '2025-12-13 21:08:46', self.owner_id],
             'kwargs': {},
         }
 

--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -29,11 +29,13 @@ from core.domain import (
     stats_services,
     taskqueue_services,
     user_services,
+    voiceover_regeneration_services,
+    voiceover_services,
 )
 from core.platform import models
 from core.tests import test_utils
 
-from typing import Final, List
+from typing import Dict, Final, List, Tuple
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -594,6 +596,85 @@ class TasksTests(test_utils.EmailTestBase):
         )
         assert cloud_task_run_model_obj is not None
         self.assertEqual(cloud_task_run_model_obj.latest_job_state, 'SUCCEEDED')
+
+    def test_should_handle_failure_case_for_voiceover_deferred_tasks(
+        self,
+    ) -> None:
+        exploration_id = 'exploration_id'
+        self.save_new_valid_exploration(exploration_id, self.owner_id)
+        rights_manager.publish_exploration(self.owner, exploration_id)
+
+        language_codes_mapping: Dict[str, Dict[str, bool]] = {
+            'en': {'en-US': True, 'en-NG': True},
+        }
+        voiceover_services.save_language_accent_support(
+            language_codes_mapping=language_codes_mapping
+        )
+
+        url = feconf.TASK_URL_DEFERRED
+        csrf_token = self.get_new_csrf_token()
+        headers = {
+            'X-Appengine-QueueName': 'queue',
+            'X-Appengine-TaskName': 'None',
+            'X-AppEngine-Fake-Is-Admin': '1',
+        }
+        new_model_id = 'cloud_task_model_id'
+        project_id = 'dev-project-id'
+        location_id = 'us-central'
+        task_id = uuid.uuid4().hex
+        queue_name = 'test_queue_name'
+        task_name = 'projects/%s/locations/%s/queues/%s/tasks/%s' % (
+            project_id,
+            location_id,
+            queue_name,
+            task_id,
+        )
+        function_id = 'regenerate_voiceovers_on_exploration_added_to_topic'
+
+        payload = {
+            'fn_identifier': function_id,
+            'cloud_task_model_id': new_model_id,
+            'args': [exploration_id, '2025-12-13 21:08:46', self.owner_id],
+            'kwargs': {},
+        }
+
+        cloud_task_run_model = taskqueue_services.create_new_cloud_task_model(
+            new_model_id, task_name, function_id
+        )
+        self.assertEqual(cloud_task_run_model.latest_job_state, 'PENDING')
+
+        def mock_regenerate_voiceovers_of_exploration(
+            _exploration_id: str,
+            _exploration_version: int,
+            _content_id_to_content_html: Dict[str, str],
+            _language_accent_code: str,
+        ) -> List[Tuple[str, str]]:
+            errors_while_voiceover_regeneration = [
+                ('content5', 'Error 1 occurred'),
+            ]
+            return errors_while_voiceover_regeneration
+
+        with self.swap(
+            voiceover_regeneration_services,
+            'regenerate_voiceovers_of_exploration',
+            mock_regenerate_voiceovers_of_exploration,
+        ):
+            self.post_task(
+                url,
+                payload,
+                expect_errors=False,
+                expected_status_int=200,
+                csrf_token=csrf_token,
+                headers=headers,
+            )
+
+        cloud_task_run_model_obj = (
+            taskqueue_services.get_cloud_task_run_by_model_id(new_model_id)
+        )
+        assert cloud_task_run_model_obj is not None
+        self.assertEqual(
+            cloud_task_run_model_obj.latest_job_state, 'PERMANENTLY_FAILED'
+        )
 
     def test_should_raise_error_for_missing_cloud_task_model_id(self) -> None:
         url = feconf.TASK_URL_DEFERRED

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import datetime
 import logging
 import pathlib
+import tempfile
 
 from core import feconf, utils
 from core.constants import constants
@@ -3165,6 +3166,9 @@ def _generate_attachments_for_failed_voiceovers(
 
     filename = 'voiceover_regeneration_errors.txt'
 
+    temp_dir = tempfile.gettempdir()
+    file_path = pathlib.Path(temp_dir) / filename
+
     lines = [
         'Synthesis details for each piece of content are presented below.\n',
         'Date: %s\n' % date,
@@ -3187,11 +3191,9 @@ def _generate_attachments_for_failed_voiceovers(
             )
             lines.append('\n----------------------------------------\n')
 
-    file = open(filename, 'w', encoding='utf-8')
-    file.writelines(lines)
-    file.close()
+    with open(file_path, 'w', encoding='utf-8') as file:
+        file.writelines(lines)
 
-    file_path = pathlib.Path(filename).resolve()
     return [{'filename': filename, 'path': str(file_path)}]
 
 

--- a/core/domain/email_services.py
+++ b/core/domain/email_services.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 import textwrap
 
@@ -132,28 +133,50 @@ def send_mail(
     )
     assert isinstance(admin_email_address, str)
     bcc = [admin_email_address] if bcc_admin else None
-    response = email_services.send_email_to_recipients(
-        sender_email,
-        [recipient_email],
-        subject,
-        plaintext_body,
-        html_body,
-        cc_emails,
-        bcc,
-        '',
-        None,
-        attachments,
+
+    logging.info(
+        convert_email_to_loggable_string(
+            sender_email,
+            [recipient_email],
+            subject,
+            plaintext_body,
+            html_body,
+            cc_emails,
+            bcc,
+            '',
+            None,
+            attachments,
+        )
     )
 
-    if not response:
-        raise Exception(
-            (
-                'Email to %s failed to send. Please try again later or '
-                'contact us to report a bug at '
-                'https://www.oppia.org/contact.'
-            )
-            % recipient_email
+    server_can_send_emails = (
+        platform_parameter_services.get_platform_parameter_value(
+            platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
         )
+    )
+    if server_can_send_emails:
+        response = email_services.send_email_to_recipients(
+            sender_email,
+            [recipient_email],
+            subject,
+            plaintext_body,
+            html_body,
+            cc_emails,
+            bcc,
+            '',
+            None,
+            attachments,
+        )
+
+        if not response:
+            raise Exception(
+                (
+                    'Email to %s failed to send. Please try again later or '
+                    'contact us to report a bug at '
+                    'https://www.oppia.org/contact.'
+                )
+                % recipient_email
+            )
 
 
 def send_bulk_mail(
@@ -193,14 +216,6 @@ def send_bulk_mail(
             send_email_to_recipients() function returned False
             (signifying API returned bad status code).
     """
-    server_can_send_emails = (
-        platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-        )
-    )
-    if not server_can_send_emails:
-        raise Exception('This app cannot send emails to users.')
-
     for recipient_email in recipient_emails:
         if not _is_email_valid(recipient_email):
             raise ValueError(
@@ -210,20 +225,38 @@ def send_bulk_mail(
     if not _is_sender_email_valid(sender_email):
         raise ValueError('Malformed sender email address: %s' % sender_email)
 
-    response = email_services.send_email_to_recipients(
-        sender_email,
-        recipient_emails,
-        subject,
-        plaintext_body,
-        html_body,
-        attachments=attachments,
+    logging.info(
+        convert_email_to_loggable_string(
+            sender_email,
+            recipient_emails,
+            subject,
+            plaintext_body,
+            html_body,
+            attachments,
+        )
     )
 
-    if not response:
-        raise Exception(
-            'Bulk email failed to send. Please try again later or contact us '
-            'to report a bug at https://www.oppia.org/contact.'
+    server_can_send_emails = (
+        platform_parameter_services.get_platform_parameter_value(
+            platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
         )
+    )
+
+    if server_can_send_emails:
+        response = email_services.send_email_to_recipients(
+            sender_email,
+            recipient_emails,
+            subject,
+            plaintext_body,
+            html_body,
+            attachments=attachments,
+        )
+
+        if not response:
+            raise Exception(
+                'Bulk email failed to send. Please try again later or contact us '
+                'to report a bug at https://www.oppia.org/contact.'
+            )
 
 
 def convert_email_to_loggable_string(

--- a/core/domain/email_services.py
+++ b/core/domain/email_services.py
@@ -232,7 +232,7 @@ def send_bulk_mail(
             subject,
             plaintext_body,
             html_body,
-            attachments,
+            attachments=attachments,
         )
     )
 

--- a/core/domain/email_services_test.py
+++ b/core/domain/email_services_test.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import textwrap
 
-from core.constants import constants
 from core.domain import email_services, platform_parameter_list
 from core.platform import models
 from core.tests import test_utils
@@ -89,23 +88,6 @@ class EmailServicesTest(test_utils.EmailTestBase):
         messages = self._get_sent_email_messages(self.admin_email_address)
         self.assertEqual(len(messages), 1)
         self.assertEqual(messages[0].bcc, self.admin_email_address)
-
-    def test_send_bulk_mail_exception_for_invalid_permissions(self) -> None:
-        """Tests the send_bulk_mail exception raised for invalid user
-        permissions.
-        """
-        send_email_exception = self.assertRaisesRegex(
-            Exception, 'This app cannot send emails to users.'
-        )
-
-        with send_email_exception, self.swap(constants, 'DEV_MODE', False):
-            email_services.send_bulk_mail(
-                self.system_email_address,
-                [self.admin_email_address],
-                'subject',
-                'body',
-                'html',
-            )
 
     @test_utils.set_platform_parameters(
         [
@@ -347,4 +329,72 @@ class EmailServicesTest(test_utils.EmailTestBase):
                 'body',
                 'html',
             ),
+        )
+
+    def test_should_be_able_to_log_email_successfully(self) -> None:
+        """Tests that emails are logged successfully."""
+
+        sender_email = 'test@oppia.org'
+        recipient_emails = [
+            'testrecipient@oppia.org',
+            'user1@gmail.com',
+            'user2@yahoo.com',
+            'user3@hotmail.com',
+        ]
+        subject = 'Test Subject'
+        plaintext_body = 'This is a test email.'
+        html_body = '<p>This is a test email.</p>'
+        cc = [
+            'test1@example.com',
+            'test2@example.com',
+            'test3@example.com',
+            'test4@example.com',
+        ]
+        bcc = [
+            'bccUser1@example.com',
+            'bccUser2@example.com',
+            'bccUser3@example.com',
+            'bccUser4@example.com',
+        ]
+        attachments = [
+            {'filename': 'file1.txt', 'path': '/path/to/file1.txt'},
+            {'filename': 'file2.jpg', 'path': '/path/to/file2.jpg'},
+        ]
+
+        response = email_services.convert_email_to_loggable_string(
+            sender_email,
+            recipient_emails,
+            subject,
+            plaintext_body,
+            html_body,
+            cc,
+            bcc,
+            reply_to=None,
+            recipient_variables=None,
+            attachments=attachments,
+        )
+
+        expected_email_log = """
+            EmailService.SendMail
+            From: test@oppia.org
+            To: testrecipient@oppia.org user1@gmail.com user2@yahoo.com... Total: 4 emails.
+            Subject: Test Subject
+            Body:
+                Content-type: text/plain
+                Data length: 21
+            Body:
+                Content-type: text/html
+                Data length: 28
+                Html content: <p>This is a test email.</p>
+
+            Cc: test1@example.com test2@example.com test3@example.com... Total: 4 emails.
+            Bcc: bccUser1@example.com bccUser2@example.com bccUser3@example.com... Total: 4 emails.
+            Reply_to: None
+            Recipient Variables:
+                Length: 0
+
+            Attachments: file1.txt, file2.jpg
+        """
+        self.assertEqual(
+            textwrap.dedent(expected_email_log).strip(), response.strip()
         )

--- a/core/domain/voiceover_regeneration_services.py
+++ b/core/domain/voiceover_regeneration_services.py
@@ -24,7 +24,6 @@ import html
 import io
 import json
 import logging
-import time
 import uuid
 
 from core import feconf, utils
@@ -52,8 +51,6 @@ if MYPY:  # pragma: no cover
 (voiceover_models,) = models.Registry.import_models([models.Names.VOICEOVER])
 
 speech_synthesis_services = models.Registry.import_speech_synthesis_services()
-
-WAIT_TIME_FOR_VOICEOVER_REGENERATION_IN_SECONDS = 3
 
 
 def _extract_text_from_link_tag(element: bs4.Tag) -> str:
@@ -600,9 +597,6 @@ def regenerate_voiceovers_of_exploration(
         voiceover_filename = generate_new_voiceover_filename(
             content_id, language_accent_code
         )
-
-        # Pause for 3 seconds to prevent sudden spikes in workload.
-        time.sleep(WAIT_TIME_FOR_VOICEOVER_REGENERATION_IN_SECONDS)
 
         try:
             # Generates a voiceover for the provided HTML content in the

--- a/core/domain/voiceover_services.py
+++ b/core/domain/voiceover_services.py
@@ -1012,6 +1012,8 @@ def _regenerate_voiceovers_for_given_contents(
             voiceover_regeneration_task
         )
 
+    errors_while_voiceover_regeneration = []
+
     for language_code in language_codes:
         language_accent_codes = (
             language_code_to_autogeneratable_accent_codes.get(language_code, [])

--- a/core/domain/voiceover_services.py
+++ b/core/domain/voiceover_services.py
@@ -28,9 +28,8 @@ from core.domain import (
     email_manager,
     exp_domain,
     exp_fetchers,
-    platform_parameter_list,
-    platform_parameter_services,
     state_domain,
+    taskqueue_services,
     translation_domain,
     translation_fetchers,
     user_services,
@@ -1076,22 +1075,39 @@ def _regenerate_voiceovers_for_given_contents(
             voiceover_regeneration_task
         )
 
-    # Confirming that the app can deliver emails.
-    server_can_send_emails = (
-        platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-        )
+    send_email_to_voiceover_admins_and_tech_leads_after_regeneration(
+        exploration_id,
+        exploration_title,
+        date_time,
+        language_accents_used_for_voiceover_regeneration,
+        error_collections_during_voiceover_regeneration,
+        number_of_contents_for_voiceover_regeneration,
+        number_of_contents_failed_to_regenerate,
+        author_id,
     )
-    if server_can_send_emails:
-        send_email_to_voiceover_admins_and_tech_leads_after_regeneration(
-            exploration_id,
-            exploration_title,
-            date_time,
-            language_accents_used_for_voiceover_regeneration,
-            error_collections_during_voiceover_regeneration,
-            number_of_contents_for_voiceover_regeneration,
-            number_of_contents_failed_to_regenerate,
-            author_id,
+
+    cloud_task_run_domain_instance = (
+        taskqueue_services.get_cloud_task_run_by_model_id(task_run_id)
+    )
+
+    error_string = ''
+    for error_collection in error_collections_during_voiceover_regeneration:
+        error_string += (
+            'Exploration ID: %s\nLanguage Accent Code: %s\nErrors: %s \n'
+            % (
+                error_collection['exploration_id'],
+                error_collection['language_accent_code'],
+                error_collection['error_messages'],
+            )
+        )
+
+    if errors_while_voiceover_regeneration:
+        cloud_task_run_domain_instance.latest_job_state = 'PERMANENTLY_FAILED'
+        cloud_task_run_domain_instance.exception_messages_for_failed_runs.append(
+            error_string
+        )
+        taskqueue_services.update_cloud_task_run_model(
+            cloud_task_run_domain_instance
         )
 
 

--- a/core/domain/voiceover_services.py
+++ b/core/domain/voiceover_services.py
@@ -1088,29 +1088,36 @@ def _regenerate_voiceovers_for_given_contents(
         author_id,
     )
 
-    cloud_task_run_domain_instance = (
-        taskqueue_services.get_cloud_task_run_by_model_id(task_run_id)
-    )
-
-    error_string = ''
-    for error_collection in error_collections_during_voiceover_regeneration:
-        error_string += (
-            'Exploration ID: %s\nLanguage Accent Code: %s\nErrors: %s \n'
-            % (
-                error_collection['exploration_id'],
-                error_collection['language_accent_code'],
-                error_collection['error_messages'],
+    if requested_task_is_async:
+        error_string = ''
+        for error_collection in error_collections_during_voiceover_regeneration:
+            error_string += (
+                'Exploration ID: %s\nLanguage Accent Code: %s\nErrors: %s \n'
+                % (
+                    error_collection['exploration_id'],
+                    error_collection['language_accent_code'],
+                    error_collection['error_messages'],
+                )
             )
-        )
 
-    if errors_while_voiceover_regeneration:
-        cloud_task_run_domain_instance.latest_job_state = 'PERMANENTLY_FAILED'
-        cloud_task_run_domain_instance.exception_messages_for_failed_runs.append(
-            error_string
+        # Ruling out the possibility of None for mypy type checking.
+        assert task_run_id is not None
+        cloud_task_run_domain_instance = (
+            taskqueue_services.get_cloud_task_run_by_model_id(task_run_id)
         )
-        taskqueue_services.update_cloud_task_run_model(
-            cloud_task_run_domain_instance
-        )
+        # Ruling out the possibility of None for mypy type checking.
+        assert cloud_task_run_domain_instance is not None
+
+        if errors_while_voiceover_regeneration:
+            cloud_task_run_domain_instance.latest_job_state = (
+                'PERMANENTLY_FAILED'
+            )
+            cloud_task_run_domain_instance.exception_messages_for_failed_runs.append(
+                error_string
+            )
+            taskqueue_services.update_cloud_task_run_model(
+                cloud_task_run_domain_instance
+            )
 
 
 def regenerate_voiceovers_on_exploration_update(

--- a/core/domain/voiceover_services_test.py
+++ b/core/domain/voiceover_services_test.py
@@ -1302,6 +1302,19 @@ class VoiceoverRegenerationTests(test_utils.GenericTestBase):
         self.signup('tester@org.com', 'tester')
         author_id = self.get_user_id_from_email('tester@org.com')
         date_time = '2025-08-01T08:35:05.864077'
+        cloud_task_run_model_id = (
+            cloud_task_models.CloudTaskRunModel.get_new_id()
+        )
+        cloud_task_models.CloudTaskRunModel.create_cloud_task_run_model(
+            cloud_task_run_model_id=cloud_task_run_model_id,
+            cloud_task_name=(
+                'projects/dev-project-id/locations/us-central1/queues/'
+                'voiceover-regeneration/tasks/task1'
+            ),
+            latest_job_state='RUNNING',
+            function_id='update_stats',
+            current_retry_attempt=1,
+        )
 
         commit1 = exp_models.ExplorationCommitLogEntryModel.create(
             exploration_id,
@@ -1365,6 +1378,7 @@ class VoiceoverRegenerationTests(test_utils.GenericTestBase):
                 exploration_version=exploration_version,
                 author_id=author_id,
                 date_time=date_time,
+                task_run_id=cloud_task_run_model_id,
             )
 
         all_models: Sequence[email_models.SentEmailModel] = (
@@ -1391,6 +1405,14 @@ class VoiceoverRegenerationTests(test_utils.GenericTestBase):
                 == 'Report on Automatic Voiceovers Generated for Test Exploration'
             ):
                 self.assertEqual(email_model.html_body, expected_html_body)
+
+        updated_cloud_task_run_model = cloud_task_models.CloudTaskRunModel.get(
+            cloud_task_run_model_id
+        )
+        assert updated_cloud_task_run_model is not None
+        self.assertEqual(
+            updated_cloud_task_run_model.latest_job_state, 'PERMANENTLY_FAILED'
+        )
 
     def _create_exploration_and_arabic_translation(
         self, exploration_id: str, language_code: str


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes: 
- https://github.com/oppia/oppia/issues/24814,
- https://github.com/oppia/oppia/issues/24815
- https://github.com/oppia/oppia/issues/24816
2. This PR does the following: 
- The PR adds logging of the email body across all the servers.
- Fixes the error `Invalid Suggestion: [Errno 30] Read-only file system: 'voiceover_regeneration_errors.txt.'`
- Displays updated voiceover regeneration status on the voiceover admin page for partial failures.
3. (For bug-fixing PRs only) The original bug occurred because: n/a

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

**Description of the video below:** 

In the first half of the video, the behavior is recorded on the develop branch. An exploration is added to a chapter to make it curated, which triggers voiceover regeneration in the background. This step results in a failure, and the error message is visible in the terminal and on the Exploration Editor page. However, the voiceover admin page still shows the regeneration attempt as Succeeded.

In the second half of the video, the branch is switched to email_logging_fix, and the same steps are repeated. This time, the error is correctly reflected on the voiceover admin page.


https://github.com/user-attachments/assets/97231d6d-74a6-46cf-9635-d42e2f28b897




#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
