### PR TITLE
Fix UI inconsistency in topic editor preview tab

### DIFF
--- a/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
+++ b/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
@@ -51,11 +51,11 @@
       </stories-list>
     </div>
     <div *ngIf="activeTab === 'subtopic'">
-      <subtopics-list [classroomUrlFragment]="''"
+      <subtopics-list [classroomUrlFragment]="classroomUrlFragment"
                       [subtopicsList]="subtopics"
                       [topicId]="topic.getId()"
                       [topicName]="topicName"
-                      [topicUrlFragment]="''">
+                      [topicUrlFragment]="topicUrlFragment">
       </subtopics-list>
     </div>
     <div  *ngIf="activeTab === 'practice'">
@@ -78,11 +78,11 @@
     background-color: #fff;
     margin: 0 auto;
     position: relative;
-    top: 50px;
+    top: 0;
     width: 50%;
   }
   .topic-preview-parent {
-    margin-top: -40px;
+    margin-top: 0;
   }
   .topic-preview-nav {
     background-color: #00645c;
@@ -102,7 +102,7 @@
     display: inline-block;
     flex: 1;
     height: 100%;
-    padding: 20px 0;
+    padding: 10px 0;
     text-align: center;
   }
   .topic-preview-icon img {


### PR DESCRIPTION
## Overview
1. This PR fixes #22315.
2. This PR does the following:
    - Passed `classroomUrlFragment` and `topicUrlFragment` to the `<subtopics-list>` component to enable interactions on skill tiles.
    - Removed unnecessary top whitespace (`50px`) in `.topic-preview-container`.
    - Adjusted padding for tabs to match Learner View.
3. The original bug occurred because:
    - The [topic-preview-tab.component.html](cci:7://file:///Users/sahityasingh/oppia/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html:0:0-0:0) was passing empty strings for url fragments, breaking functionality.
    - CSS styling for `.topic-preview-container` had hardcoded `top: 50px` which caused misalignment.
## Essential Checklist
Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
## Proof that changes are correct
#### Proof of changes on desktop with slow/throttled network
*Please attach the verification screenshot here*
#### Proof of changes on mobile phone
N/A - Topic Editor is desktop optimized.
#### Proof of changes in Arabic language
N/A
