### PR TITLE
fixed the issue #24734-forum-link-newtab

### DIFF
--- a/core/templates/base-components/oppia-footer.component.html
+++ b/core/templates/base-components/oppia-footer.component.html
@@ -59,7 +59,9 @@
             </a>
           </li>
           <li>
-            <a href="https://groups.google.com/g/oppia" class="e2e-test-footer-forum-link">
+            <a href="https://groups.google.com/g/oppia"
+            target="_blank" 
+            class="e2e-test-footer-forum-link">
               {{ 'I18N_FOOTER_FORUM' | translate }}
             </a>
           </li>


### PR DESCRIPTION
## Overview

1. This PR addresses issue #24734.
2. This PR updates the external Forum link in the footer to open in a new tab
   using target="_blank"  to improve user experience
   and follow best practices.

## Essential Checklist

- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] The PR title is clear and descriptive.
- [ ] I have written tests for my code. (Not applicable for this small UI-only change.)

## Proof that changes are correct

- Verified locally .
- Clicking the Forum link in the footer now opens the link in a new browser tab as expected.
