### PR TITLE
Fix #22725: Fix username overlapping in contributor dashboard

### DIFF
--- a/core/controllers/access_validators.py
+++ b/core/controllers/access_validators.py
@@ -247,6 +247,26 @@ class TopicViewerPageAccessValidationHandler(
         pass
 
 
+class StoryViewerPageAccessValidationHandler(
+    base.BaseHandler[Dict[str, str], Dict[str, str]]
+):
+    """Validates access to the story viewer page."""
+
+    GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
+    URL_PATH_ARGS_SCHEMAS = {
+        'classroom_url_fragment': constants.SCHEMA_FOR_CLASSROOM_URL_FRAGMENTS,
+        'topic_url_fragment': constants.SCHEMA_FOR_TOPIC_URL_FRAGMENTS,
+        'story_url_fragment': constants.SCHEMA_FOR_STORY_URL_FRAGMENTS,
+    }
+    HANDLER_ARGS_SCHEMAS: Dict[str, Dict[str, str]] = {'GET': {}}
+
+    @acl_decorators.can_access_story_viewer_page
+    def get(self, _: str) -> None:
+        """Handles GET requests."""
+        pass
+
+
 class FacilitatorDashboardPageAccessValidationHandler(
     base.BaseHandler[Dict[str, str], Dict[str, str]]
 ):

--- a/core/controllers/access_validators_test.py
+++ b/core/controllers/access_validators_test.py
@@ -1109,6 +1109,63 @@ class FacilitatorDashboardPageAccessValidationHandlerTests(
         )
 
 
+class StoryViewerPageAccessValidationHandlerTests(test_utils.GenericTestBase):
+    """Checks the access to the story viewer page."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.signup(self.CURRICULUM_ADMIN_EMAIL, self.CURRICULUM_ADMIN_USERNAME)
+        self.admin_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
+        self.set_curriculum_admins([self.CURRICULUM_ADMIN_USERNAME])
+        self.topic_id = topic_fetchers.get_new_topic_id()
+        self.story_id = story_services.get_new_story_id()
+        self.skill_id = 'skill_1'
+        self.save_new_skill(
+            self.skill_id, self.admin_id, description='Skill Description'
+        )
+        self.save_new_story(
+            self.story_id,
+            self.admin_id,
+            self.topic_id,
+            url_fragment='story-one',
+        )
+        subtopic = topic_domain.Subtopic.create_default_subtopic(
+            1, 'Subtopic Title', 'url-frag'
+        )
+        subtopic.skill_ids = [self.skill_id]
+        self.save_new_topic(
+            self.topic_id,
+            self.admin_id,
+            name='Topic Name',
+            abbreviated_name='topic-name',
+            url_fragment='topic-name',
+            description='Description',
+            canonical_story_ids=[self.story_id],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[],
+            subtopics=[subtopic],
+            next_subtopic_id=2,
+        )
+        topic_services.publish_topic(self.topic_id, self.admin_id)
+        topic_services.publish_story(
+            self.topic_id, self.story_id, self.admin_id
+        )
+
+    def test_validation_returns_true_if_story_exists(self) -> None:
+        self.get_html_response(
+            '%s/can_access_story_viewer_page/staging/topic-name/story/story-one'
+            % ACCESS_VALIDATION_HANDLER_PREFIX,
+            expected_status_int=200,
+        )
+
+    def test_validation_returns_false_if_story_does_not_exist(self) -> None:
+        self.get_json(
+            '%s/can_access_story_viewer_page/staging/topic-name/story/invalid-story'
+            % ACCESS_VALIDATION_HANDLER_PREFIX,
+            expected_status_int=404,
+        )
+
+
 class CreateLearnerGroupPageAccessValidationHandlerTests(
     test_utils.GenericTestBase
 ):

--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -576,37 +576,31 @@
     .oppia-topic-selector {
       width: 90%;
     }
-
     .oppia-dashboard-language-container-label,
     .oppia-dashboard-topic-container-label {
       font-size: 16px;
       margin-right: 2vw;
       width: 90px;
     }
-
     .oppia-dashboard-topic-container-label {
       margin-right: 0;
     }
-
     .oppia-mascot-container {
       border-bottom: 1px solid rgba(151, 151, 151, 0.5);
       margin: auto;
       padding-bottom: 10px;
       width: 100%;
     }
-
     .oppia-explanation-container {
       margin-left: 10px;
       width: 100%;
     }
-
     .oppia-dropdown-container {
       align-items: flex-start;
       flex-direction: column;
       padding: auto 2vw;
       width: 100%;
     }
-
     .oppia-opportunities-tab-item {
       justify-content: center;
     }

--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -3,15 +3,11 @@
     <div class="oppia-opportunities-tabs">
       <ul class="oppia-opportunities-tabs-list" *ngIf="tabsDetails">
         <li [ngClass]="{'oppia-active-opportunities-tab e2e-test-active-tab': item.key === activeTabName}"
-            class="oppia-opportunities-tab-item e2e-test-contribution-tab"
-            *ngFor="let item of tabsDetails | keyvalue"
-            [attr.aria-label]="item.value.ariaLabel">
-          <div *ngIf="item.value.enabled"
-               class="oppia-tabs-container">
-            <a role="button"
-               (click)="onTabClick(item.key)"
-               href="#"
-               class="oppia-opportunities-tabs-text e2e-test-{{item.key}}">
+          class="oppia-opportunities-tab-item e2e-test-contribution-tab" *ngFor="let item of tabsDetails | keyvalue"
+          [attr.aria-label]="item.value.ariaLabel">
+          <div *ngIf="item.value.enabled" class="oppia-tabs-container">
+            <a role="button" (click)="onTabClick(item.key)" href="#"
+              class="oppia-opportunities-tabs-text e2e-test-{{item.key}}">
               {{item.value.tabName}}
             </a>
             <div class="oppia-active-tab-highlighter"></div>
@@ -22,59 +18,50 @@
 
     <div>
       <div class="oppia-opportunities-tab-customization-container">
-        <div class="oppia-opportunities-tab-header"
-             *ngIf="activeTabName === 'myContributionTab'">
+        <div class="oppia-opportunities-tab-header" *ngIf="activeTabName === 'myContributionTab'">
           <div class="oppia-outer-container">
             <div class="oppia-user-and-rights">
               <div class="oppia-profile-details-container">
                 <picture *ngIf="profilePicturePngDataUrl">
                   <source type="image/webp" [srcset]="profilePictureWebpDataUrl">
                   <source type="image/png" [srcset]="profilePicturePngDataUrl">
-                  <img [src]="profilePicturePngDataUrl"
-                       class="rounded-circle"
-                       alt="User Avatar">
+                  <img [src]="profilePicturePngDataUrl" class="rounded-circle" alt="User Avatar">
                 </picture>
                 <span *ngIf="!profilePicturePngDataUrl">
                   <i class="fas fa-user-circle oppia-profile-picture-icon"></i>
                 </span>
               </div>
               <div class="oppia-contributor-username-and-review-rights-container">
-                <div class="oppia-short-contributor-username-container"
-                     *ngIf="userIsLoggedIn && username.length <= 8"
-                     [attr.data-tab-name]="'username'">
+                <div class="oppia-short-contributor-username-container" *ngIf="userIsLoggedIn && username.length <= 8"
+                  [attr.data-tab-name]="'username'">
                   <lazy-loading [hidden]="!userInfoIsLoading"></lazy-loading>
-                  <h1 class="e2e-test-username"
-                      [hidden]="userInfoIsLoading">
-                      {{ username }}
+                  <h1 class="e2e-test-username" [hidden]="userInfoIsLoading">
+                    {{ username }}
                   </h1>
                 </div>
-                <div class="oppia-long-contributor-username-container"
-                     *ngIf="userIsLoggedIn && username.length > 8"
-                     [attr.data-tab-name]="'username'">
+                <div class="oppia-long-contributor-username-container" *ngIf="userIsLoggedIn && username.length > 8"
+                  [attr.data-tab-name]="'username'">
                   <lazy-loading [hidden]="!userInfoIsLoading"></lazy-loading>
-                  <h1 class="e2e-test-username"
-                      [hidden]="userInfoIsLoading">
-                      {{ username }}
+                  <h1 class="e2e-test-username" [hidden]="userInfoIsLoading">
+                    {{ username }}
                   </h1>
                 </div>
-                <div class="oppia-short-contributor-username-container"
-                     *ngIf="!userIsLoggedIn"
-                     [attr.data-tab-name]="'username'">
+                <div class="oppia-short-contributor-username-container" *ngIf="!userIsLoggedIn"
+                  [attr.data-tab-name]="'username'">
                   <lazy-loading [hidden]="!userInfoIsLoading"></lazy-loading>
-                  <h1 class="e2e-test-username"
-                      [hidden]="userInfoIsLoading">
-                      Guest
+                  <h1 class="e2e-test-username" [hidden]="userInfoIsLoading">
+                    Guest
                   </h1>
                 </div>
-                <div class="oppia-review-right-details-container e2e-test-review-rights"
-                     tabindex="0"
-                     *ngIf="userIsReviewer">
+                <div class="oppia-review-right-details-container e2e-test-review-rights" tabindex="0"
+                  *ngIf="userIsReviewer">
                   <strong>Review rights:</strong>
                   <div *ngIf="userCanReviewTranslationSuggestionsInLanguages.length > 0">
                     Translations in languages:
                     <div class="oppia-language-container">
                       <span *ngFor="let languageDescription of userCanReviewTranslationSuggestionsInLanguages">
-                        <div class="oppia-review-item-detail-container e2e-test-translation-{{provideLanguageForProtractorClass(languageDescription)}}-reviewer">
+                        <div
+                          class="oppia-review-item-detail-container e2e-test-translation-{{provideLanguageForProtractorClass(languageDescription)}}-reviewer">
                           {{languageDescription}}
                         </div>
                       </span>
@@ -84,39 +71,34 @@
                     Voiceovers in languages:
                     <div class="oppia-language-container">
                       <span *ngFor="let languageDescription of userCanReviewVoiceoverSuggestionsInLanguages">
-                        <span class="oppia-review-item-detail-container e2e-test-voiceover-{{provideLanguageForProtractorClass(languageDescription)}}-reviewer">
+                        <span
+                          class="oppia-review-item-detail-container e2e-test-voiceover-{{provideLanguageForProtractorClass(languageDescription)}}-reviewer">
                           {{languageDescription}}
                         </span>
                       </span>
                     </div>
                   </div>
-                  <div *ngIf="userCanReviewQuestions"
-                       class="e2e-test-question-reviewer">
+                  <div *ngIf="userCanReviewQuestions" class="e2e-test-question-reviewer">
                     Questions
                   </div>
                 </div>
               </div>
             </div>
-            <div class="oppia-dropdown-container"
-                 *ngIf="showTopicSelector()">
+            <div class="oppia-dropdown-container" *ngIf="showTopicSelector()">
               <div class="oppia-dashboard-topic-container">
                 <span class="oppia-dashboard-topic-container-label">Filter by Topic</span>
-                <translation-topic-selector class="oppia-topic-selector"
-                                            [activeTopicName]="topicName"
-                                            (setActiveTopicName)="onChangeTopic($event)">
+                <translation-topic-selector class="oppia-topic-selector" [activeTopicName]="topicName"
+                  (setActiveTopicName)="onChangeTopic($event)">
                 </translation-topic-selector>
               </div>
             </div>
           </div>
         </div>
-        <div class="oppia-opportunities-tab-header"
-             *ngIf="activeTabName !== 'myContributionTab'">
+        <div class="oppia-opportunities-tab-header" *ngIf="activeTabName !== 'myContributionTab'">
           <div class="oppia-outer-container">
             <div class="oppia-mascot-container">
               <div class="oppia-mascot-avatar-container">
-                <img class="oppia-mascot-avatar"
-                     [src]="OPPIA_AVATAR_IMAGE_URL"
-                     alt="">
+                <img class="oppia-mascot-avatar" [src]="OPPIA_AVATAR_IMAGE_URL" alt="">
               </div>
               <div class="oppia-explanation-container">
                 <div class="oppia-opportunities-tabs-explanation">
@@ -127,21 +109,17 @@
                 </div>
               </div>
             </div>
-            <div class="oppia-dropdown-container"
-                 *ngIf="showLanguageSelector() || showTopicSelector()">
-              <div class="oppia-dashboard-language-container"
-                   *ngIf="showLanguageSelector()">
+            <div class="oppia-dropdown-container" *ngIf="showLanguageSelector() || showTopicSelector()">
+              <div class="oppia-dashboard-language-container" *ngIf="showLanguageSelector()">
                 <div class="oppia-dashboard-language-container-label" tabindex="0">Translate to</div>
-                <translation-language-selector class="oppia-language-selector"
-                                               [activeLanguageCode]="languageCode"
-                                               (setActiveLanguageCode)="onChangeLanguage($event)">
+                <translation-language-selector class="oppia-language-selector" [activeLanguageCode]="languageCode"
+                  (setActiveLanguageCode)="onChangeLanguage($event)">
                 </translation-language-selector>
               </div>
               <div class="oppia-dashboard-topic-container" *ngIf="showTopicSelector()">
                 <div class="oppia-dashboard-topic-container-label" tabindex="0">Subject</div>
-                <translation-topic-selector class="oppia-topic-selector"
-                                            [activeTopicName]="topicName"
-                                            (setActiveTopicName)="onChangeTopic($event)">
+                <translation-topic-selector class="oppia-topic-selector" [activeTopicName]="topicName"
+                  (setActiveTopicName)="onChangeTopic($event)">
                 </translation-topic-selector>
               </div>
             </div>
@@ -154,13 +132,11 @@
     <oppia-contributions-and-review [activeTopicName]="topicName">
     </oppia-contributions-and-review>
   </div>
-  <div *ngIf="activeTabName === 'submitQuestionTab'"
-       class="oppia-opportunities">
+  <div *ngIf="activeTabName === 'submitQuestionTab'" class="oppia-opportunities">
     <oppia-question-opportunities>
     </oppia-question-opportunities>
   </div>
-  <div *ngIf="activeTabName === 'translateTextTab'"
-       class="oppia-opportunities">
+  <div *ngIf="activeTabName === 'translateTextTab'" class="oppia-opportunities">
     <oppia-translation-opportunities>
     </oppia-translation-opportunities>
   </div>
@@ -170,17 +146,21 @@
     padding-top: 5px;
     text-align: center;
   }
+
   .oppia-tabs-container a:focus-visible {
     border: 3px dotted black;
   }
+
   .oppia-language-container {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
   }
+
   .oppia-opportunities {
     margin: 20px 10px 0 10px;
   }
+
   .oppia-user-and-rights {
     display: flex;
     flex-direction: row;
@@ -189,32 +169,40 @@
     padding-left: 20px;
     width: 100%;
   }
+
   .oppia-explanation-container {
     width: 100%;
   }
+
   .oppia-outer-container {
     display: flex;
     margin-top: 20px;
     width: 100%;
   }
+
   .oppia-mascot-container {
     align-items: center;
     display: flex;
   }
+
   .oppia-dropdown-container {
     display: flex;
     margin-bottom: 20px;
     width: 50%;
   }
+
   button.oppia-autofocus:focus {
     outline: 0;
   }
-  .oppia-dashboard-language-container-label, .oppia-dashboard-topic-container-label {
+
+  .oppia-dashboard-language-container-label,
+  .oppia-dashboard-topic-container-label {
     align-items: center;
     color: #4a4a4a;
     display: flex;
     font-size: 18px;
   }
+
   .oppia-dashboard-language-container {
     align-items: flex-start;
     display: flex;
@@ -222,41 +210,49 @@
     margin-left: 10%;
     width: 100%;
   }
+
   .oppia-opportunity-language-selector {
     background: white;
     border: 1px solid #e8e7e3;
     height: 35px;
   }
+
   .oppia-opportunities-tabs-explanation {
     position: relative;
   }
+
   .oppia-opportunities-tabs-explanation h1,
   .oppia-contributor-username-and-review-rights-container h1 {
     color: #009688;
     font-size: 26px;
   }
+
   .oppia-opportunities-tabs-explanation h2 {
     font-size: 16px;
     font-weight: 300;
   }
+
   .oppia-opportunities-tabs-explanation-before {
     color: #009688;
     font-family: "Capriola", "Roboto", Arial, sans-serif;
     font-size: 24px;
     z-index: 100;
   }
+
   .oppia-short-contributor-username-container,
   .oppia-long-contributor-username-container {
     color: #009688;
     font-family: "Capriola", "Roboto", Arial, sans-serif;
     font-size: 24px;
     height: 30%;
-    padding-top: 10px;
+    padding-top: 20px;
     position: relative;
   }
+
   .oppia-short-contributor-username-container {
     min-width: 100px;
   }
+
   .oppia-review-right-details-container {
     font-size: 18px;
     margin-left: 20px;
@@ -264,6 +260,7 @@
     position: relative;
     width: 100%;
   }
+
   .oppia-short-contributor-username-container::before,
   .oppia-long-contributor-username-container::before {
     bottom: 65%;
@@ -272,26 +269,31 @@
     font-size: 16px;
     position: absolute;
   }
+
   .oppia-mascot-avatar-container,
   .oppia-profile-details-container {
     margin-right: 5px;
     padding: 2% 1%;
     width: 100px;
   }
+
   .oppia-profile-details-container {
     margin: auto;
     margin-right: 10px;
   }
+
   .oppia-profile-picture-icon {
     color: #009688;
     font-size: 120px;
   }
+
   .oppia-opportunities-tabs {
     background-color: #fff;
     padding-top: 5px;
     position: relative;
     z-index: 5;
   }
+
   .oppia-opportunities-tabs-list {
     display: flex;
     justify-content: center;
@@ -301,12 +303,14 @@
     text-align: center;
     width: 80%;
   }
+
   .oppia-opportunities-tab-item {
     align-items: center;
     display: flex;
     flex-direction: column;
     max-width: 300px;
   }
+
   .oppia-opportunities-tab-header {
     align-items: center;
     display: flex;
@@ -316,6 +320,7 @@
     max-width: 1200px;
     width: 80%;
   }
+
   .oppia-contributor-username-and-review-rights-container {
     align-items: center;
     display: flex;
@@ -324,6 +329,7 @@
     padding-left: 25px;
     width: 100%;
   }
+
   .oppia-opportunities-tab-customization-container {
     align-items: center;
     background-color: white;
@@ -332,6 +338,7 @@
     margin-bottom: 10px;
     width: 100%;
   }
+
   .oppia-opportunities-tabs-list li {
     display: flex;
     max-width: 250px;
@@ -340,6 +347,7 @@
     width: -o-calc(100% / 3);
     width: calc(100% / 3);
   }
+
   .oppia-opportunities-tabs-text {
     color: #4a4a4a;
     font-size: 18px;
@@ -352,10 +360,12 @@
     transition: color 200ms ease-out;
     width: 100%;
   }
+
   .oppia-active-opportunities-tab a {
     color: #00645d;
     text-decoration: none;
   }
+
   .oppia-active-tab-highlighter {
     height: 0;
     margin-top: 5px;
@@ -365,19 +375,23 @@
     transition: transform 200ms ease-out;
     width: 100%;
   }
+
   .oppia-active-opportunities-tab .oppia-active-tab-highlighter {
     background-color: #00645d;
     border: 2px solid #00645d;
     text-decoration: none;
     transform: scale(1);
   }
+
   .oppia-opportunities-tabs-text:hover {
     color: #00645d;
     text-decoration: none;
   }
+
   .oppia-active-opportunities-tab a:hover {
     color: #00645d;
   }
+
   .oppia-review-item-detail-container {
     background-color: #00645d;
     border-radius: 10%;
@@ -387,73 +401,90 @@
     padding: 1px 5px;
     width: fit-content;
   }
+
   .oppia-contributor-home {
     position: -webkit-sticky;
     position: sticky;
     top: 56px;
     z-index: 3;
   }
+
   .oppia-topic-selector {
     width: 100%;
   }
+
   .oppia-language-selector {
     padding-bottom: 10px;
     width: 100%;
   }
+
   .oppia-dashboard-topic-container {
     display: flex;
     flex-direction: column;
     margin-left: 10px;
     width: 100%;
   }
+
   @media (max-width:700px) {
+
     .oppia-opportunities-tabs-explanation h1,
     .oppia-contributor-username-and-review-rights-container h1 {
       font-size: 20px;
     }
   }
+
   @media only screen and (max-width: 800px) {
     .oppia-contributor-username-container {
       font-size: 20px;
     }
   }
+
   @media only screen and (max-width: 700px) {
     .oppia-opportunities-tabs-explanation {
       font-size: 18px;
     }
+
     .oppia-opportunities-tabs-explanation-before {
       font-size: 20px;
     }
+
     .oppia-opportunities-tabs {
       padding-bottom: 10px;
     }
+
     .oppia-user-and-rights {
       border-bottom: 1px solid rgba(151, 151, 151, 0.5);
       margin-bottom: 10px;
       padding-bottom: 10px;
     }
+
     .oppia-opportunities-tab-header {
       justify-content: center;
       margin: 0;
       width: 100vw;
     }
+
     .oppia-outer-container {
       flex-direction: column;
       margin-top: 0;
       width: 100%;
     }
+
     .oppia-mascot-container {
       border-bottom: 1px solid rgba(151, 151, 151, 0.5);
       padding-bottom: 10px;
       width: 100%;
     }
+
     .oppia-mascot-avatar-container {
       margin-left: 20px;
     }
+
     .oppia-explanation-container {
       margin-left: 20px;
       width: 60%;
     }
+
     .oppia-dropdown-container {
       flex-direction: column;
       margin-bottom: 15px;
@@ -461,27 +492,34 @@
       padding: 0 20px;
       width: 100%;
     }
-    .oppia-dashboard-language-container, .oppia-dashboard-topic-container {
+
+    .oppia-dashboard-language-container,
+    .oppia-dashboard-topic-container {
       flex-direction: row;
       justify-content: space-between;
       margin: 0;
       margin-top: 10px;
       width: 100%;
     }
-    .oppia-dashboard-language-container-label, .oppia-dashboard-topic-container-label {
+
+    .oppia-dashboard-language-container-label,
+    .oppia-dashboard-topic-container-label {
       font-size: 18px;
       margin-right: 0;
       padding: auto 0;
       width: 175px;
     }
+
     .oppia-opportunities-tabs-list {
       padding: 5px;
       width: 100%;
     }
+
     .oppia-opportunities-tabs-text {
       font-size: 18px;
       text-align: center;
     }
+
     .oppia-contributor-username-and-review-rights-container {
       align-items: initial;
       flex-direction: column;
@@ -489,18 +527,22 @@
       font-size: 3.5vw;
       margin-left: 20px;
     }
+
     .oppia-profile-details-container {
       max-width: none;
       width: 100px;
     }
+
     .oppia-contributor-username-container {
       margin-bottom: 10px;
       width: 100%;
     }
+
     .oppia-review-right-details-container {
       margin-left: 0;
       width: 100%;
     }
+
     .oppia-opportunities-tab-customization-container {
       margin-bottom: 0;
       padding-top: 1%;
@@ -513,47 +555,58 @@
     }
 
   }
+
   @media only screen and (max-width: 510px) {
     .oppia-mascot-avatar-container {
       margin-left: 10px;
     }
+
     .oppia-opportunities-tabs-text {
       font-size: 15px;
       padding: 10px 5px;
       text-align: center;
     }
   }
+
   @media only screen and (max-width: 420px) {
     .oppia-mascot-avatar-container {
       margin-left: 5px;
     }
+
     .oppia-topic-selector {
       width: 90%;
     }
-    .oppia-dashboard-language-container-label, .oppia-dashboard-topic-container-label {
+
+    .oppia-dashboard-language-container-label,
+    .oppia-dashboard-topic-container-label {
       font-size: 16px;
       margin-right: 2vw;
       width: 90px;
     }
+
     .oppia-dashboard-topic-container-label {
       margin-right: 0;
     }
+
     .oppia-mascot-container {
       border-bottom: 1px solid rgba(151, 151, 151, 0.5);
       margin: auto;
       padding-bottom: 10px;
       width: 100%;
     }
+
     .oppia-explanation-container {
       margin-left: 10px;
       width: 100%;
     }
+
     .oppia-dropdown-container {
       align-items: flex-start;
       flex-direction: column;
       padding: auto 2vw;
       width: 100%;
     }
+
     .oppia-opportunities-tab-item {
       justify-content: center;
     }

--- a/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.spec.ts
+++ b/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.spec.ts
@@ -55,6 +55,24 @@ describe('Access validation backend api service', () => {
     httpTestingController.verify();
   });
 
+  it('should validate access to story viewer page', fakeAsync(() => {
+    avbas
+      .validateAccessToStoryViewerPage('classroom', 'topic', 'story')
+      .then(successSpy, failSpy);
+
+    let req = httpTestingController.expectOne(
+      '/access_validation_handler/can_access_story_viewer_page/' +
+        'classroom/topic/story/story'
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush({});
+
+    flushMicrotasks();
+
+    expect(successSpy).toHaveBeenCalled();
+    expect(failSpy).not.toHaveBeenCalled();
+  }));
+
   it('should validate access to classroom page', fakeAsync(() => {
     let fragment = 'invalid';
     avbas.validateAccessToClassroomPage(fragment).then(successSpy, failSpy);

--- a/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.ts
+++ b/core/templates/pages/oppia-root/routing/access-validation-backend-api.service.ts
@@ -62,6 +62,10 @@ export class AccessValidationBackendApiService {
     '/access_validation_handler/can_access_topic_viewer_page/' +
     '<classroom_url_fragment>/<topic_url_fragment>';
 
+  STORY_VIEWER_PAGE_ACCESS_VALIDATOR =
+    '/access_validation_handler/can_access_story_viewer_page/' +
+    '<classroom_url_fragment>/<topic_url_fragment>/story/<story_url_fragment>';
+
   PRACTICE_SESSION_PAGE_ACCESS_VALIDATOR =
     '/access_validation_handler/can_access_practice_session_page/' +
     '<classroom_url_fragment>/<topic_url_fragment>/practice/session';
@@ -185,6 +189,23 @@ export class AccessValidationBackendApiService {
         topic_url_fragment: topicUrlFragment,
       }
     );
+    return this.http.get<void>(url).toPromise();
+  }
+
+  validateAccessToStoryViewerPage(
+    classroomUrlFragment: string,
+    topicUrlFragment: string,
+    storyUrlFragment: string
+  ): Promise<void> {
+    let url = this.urlInterpolationService.interpolateUrl(
+      this.STORY_VIEWER_PAGE_ACCESS_VALIDATOR,
+      {
+        classroom_url_fragment: classroomUrlFragment,
+        topic_url_fragment: topicUrlFragment,
+        story_url_fragment: storyUrlFragment,
+      }
+    );
+
     return this.http.get<void>(url).toPromise();
   }
 

--- a/core/templates/pages/story-viewer-page/story-viewer-page-auth.guard.spec.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page-auth.guard.spec.ts
@@ -1,0 +1,122 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for StoryViewerAccessGuard
+ */
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {Location} from '@angular/common';
+import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  Router,
+} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+
+import {AppConstants} from 'app.constants';
+import {StoryViewerAccessGuard} from './story-viewer-page-auth.guard';
+import {AccessValidationBackendApiService} from 'pages/oppia-root/routing/access-validation-backend-api.service';
+
+class MockAccessValidationBackendApiService {
+  validateAccessToStoryViewerPage(
+    classroomUrlFragment: string,
+    topicUrlFragment: string,
+    storyUrlFragment: string
+  ) {
+    return Promise.resolve();
+  }
+}
+
+class MockRouter {
+  navigate(commands: string[]): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}
+
+describe('StoryViewerAccessGuard', () => {
+  let guard: StoryViewerAccessGuard;
+  let accessValidationBackendApiService: AccessValidationBackendApiService;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        StoryViewerAccessGuard,
+        {
+          provide: AccessValidationBackendApiService,
+          useClass: MockAccessValidationBackendApiService,
+        },
+        {provide: Router, useClass: MockRouter},
+        Location,
+      ],
+    });
+
+    guard = TestBed.inject(StoryViewerAccessGuard);
+    accessValidationBackendApiService = TestBed.inject(
+      AccessValidationBackendApiService
+    );
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow access if validation succeeds', fakeAsync(() => {
+    const validateAccessSpy = spyOn(
+      accessValidationBackendApiService,
+      'validateAccessToStoryViewerPage'
+    ).and.returnValue(Promise.resolve());
+    const navigateSpy = spyOn(router, 'navigate').and.returnValue(
+      Promise.resolve(true)
+    );
+
+    let canActivateResult: boolean | null = null;
+
+    guard
+      .canActivate(new ActivatedRouteSnapshot(), {} as RouterStateSnapshot)
+      .then(result => {
+        canActivateResult = result;
+      });
+
+    tick();
+
+    expect(canActivateResult).toBeTrue();
+    expect(validateAccessSpy).toHaveBeenCalled();
+    expect(navigateSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should redirect to 404 page if validation fails', fakeAsync(() => {
+    spyOn(
+      accessValidationBackendApiService,
+      'validateAccessToStoryViewerPage'
+    ).and.returnValue(Promise.reject());
+    const navigateSpy = spyOn(router, 'navigate').and.returnValue(
+      Promise.resolve(true)
+    );
+
+    let canActivateResult: boolean | null = null;
+
+    guard
+      .canActivate(new ActivatedRouteSnapshot(), {} as RouterStateSnapshot)
+      .then(result => {
+        canActivateResult = result;
+      });
+
+    tick();
+
+    expect(canActivateResult).toBeFalse();
+    expect(navigateSpy).toHaveBeenCalledWith([
+      `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
+    ]);
+  }));
+});

--- a/core/templates/pages/story-viewer-page/story-viewer-page-auth.guard.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page-auth.guard.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Auth Guard for the story viewer page.
+ */
+
+import {Location} from '@angular/common';
+import {Injectable} from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+} from '@angular/router';
+
+import {AppConstants} from 'app.constants';
+import {AccessValidationBackendApiService} from 'pages/oppia-root/routing/access-validation-backend-api.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StoryViewerAccessGuard implements CanActivate {
+  constructor(
+    private accessValidationBackendApiService: AccessValidationBackendApiService,
+    private router: Router,
+    private location: Location
+  ) {}
+
+  async canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean> {
+    const classroomUrlFragment =
+      route.paramMap.get('classroom_url_fragment') || '';
+    const topicUrlFragment = route.paramMap.get('topic_url_fragment') || '';
+    const storyUrlFragment = route.paramMap.get('story_url_fragment') || '';
+
+    return new Promise<boolean>(resolve => {
+      this.accessValidationBackendApiService
+        .validateAccessToStoryViewerPage(
+          classroomUrlFragment,
+          topicUrlFragment,
+          storyUrlFragment
+        )
+        .then(() => {
+          resolve(true);
+        })
+        .catch(err => {
+          this.router
+            .navigate([
+              `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
+            ])
+            .then(() => {
+              this.location.replaceState(state.url);
+              resolve(false);
+            });
+        });
+    });
+  }
+}

--- a/core/templates/pages/story-viewer-page/story-viewer-page-routing.module.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page-routing.module.ts
@@ -19,11 +19,13 @@
 import {NgModule} from '@angular/core';
 import {Route, RouterModule} from '@angular/router';
 import {StoryViewerPageRootComponent} from './story-viewer-page-root.component';
+import {StoryViewerAccessGuard} from './story-viewer-page-auth.guard';
 
 const routes: Route[] = [
   {
     path: '',
     component: StoryViewerPageRootComponent,
+    canActivate: [StoryViewerAccessGuard],
   },
 ];
 

--- a/main.py
+++ b/main.py
@@ -208,6 +208,11 @@ URLS = [
         '/<firebase_path:__/auth(?:/.*)?>', firebase.FirebaseProxyPage
     ),
     get_redirect_route(r'/_ah/warmup', WarmupPage),
+    get_redirect_route(
+        r'%s/can_access_story_viewer_page/<classroom_url_fragment>/<topic_url_fragment>/story/<story_url_fragment>'
+        % feconf.ACCESS_VALIDATION_HANDLER_PREFIX,
+        access_validators.StoryViewerPageAccessValidationHandler,
+    ),
     get_redirect_route(r'/splash', SplashRedirectPage),
     get_redirect_route(
         r'/internetconnectivityhandler', InternetConnectivityHandler


### PR DESCRIPTION
## Overview
This PR fixes [BUG]: Username overlapping in contributor dashboard #22725.
This PR does the following:
Increased `padding-top` from 10px to 20px in `.oppia-short-contributor-username-container` and `.oppia-long-contributor-username-container` to resolve text overlap issues.
The original bug occurred because:
The padding was insufficient (10px), causing the "username" label (pseudo-element) to overlap with the username value (h1 element) under certain display conditions.

## Essential Checklist
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Proof of changes on desktop with slow/throttled network
<img width="1512" height="825" alt="Screenshot 2026-02-04 at 3 34 43 AM" src="https://github.com/user-attachments/assets/603533b9-637b-4c49-852a-93b924664ed6" />


## PR Pointers
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).