### PR TITLE
Fix: Constrain Play Store button touch zone to visible button size

### DIFF
--- a/core/templates/components/button-directives/social-buttons.component.css
+++ b/core/templates/components/button-directives/social-buttons.component.css
@@ -27,10 +27,12 @@
 .oppia-footer-social a:focus {
   text-decoration: none;
 }
-.oppia-footer-social a > img {
-  width: 30px;
+
+.oppia-footer-social a>img {
+  width: auto;
 }
-.oppia-footer-social a:focus > img {
+
+.oppia-footer-social a:focus>img {
   outline: 1px dotted #fff;
   outline: auto 5px -webkit-focus-ring-color;
 }
@@ -43,54 +45,63 @@
 
 .oppia-footer-social .oppia-footer-social-icons .oppia-instagram-follow {
   background: #d6249f;
-  background: radial-gradient(circle at 30% 107%, #fdf497 0%, #fdf497 5%, #fd5949 45%,#d6249f 60%,#285aeb 90%);
+  background: radial-gradient(circle at 30% 107%, #fdf497 0%, #fdf497 5%, #fd5949 45%, #d6249f 60%, #285aeb 90%);
   border-radius: 8px;
   margin-right: 6px;
   padding: 9px 12px;
 }
+
 .oppia-footer-social .oppia-footer-social-icons .oppia-youtube-follow {
   background: #cd201f;
   border-radius: 8px;
   margin-right: 6px;
   padding: 9px 9px;
 }
+
 .oppia-footer-social .oppia-footer-social-icons .oppia-facebook-follow {
   background: #3b5998;
   border-radius: 8px;
   margin-right: 6px;
   padding: 10px 15px;
 }
+
 .oppia-footer-social .oppia-footer-social-icons .oppia-twitter-follow {
   background: #000;
   border-radius: 8px;
   margin-right: 6px;
   padding: 10px 10px;
 }
+
 .oppia-footer-social .oppia-footer-social-icons .oppia-github-follow {
   background: #fff;
   border-radius: 8px;
   margin-right: 6px;
   padding: 10px 10px;
 }
+
 .oppia-follow-github-icon {
   color: #000;
 }
+
 .oppia-footer-social .oppia-footer-social-icons .oppia-linkedin-follow {
   background: #0077b5;
   border-radius: 8px;
   margin-right: 6px;
   padding: 10px 10px;
 }
+
 .oppia-follow-linkedin-icon {
   color: #fff;
 }
-.oppia-footer-social .oppia-facebook-follow  i.oppia-follow-icons.fab.fa-facebook {
+
+.oppia-footer-social .oppia-facebook-follow i.oppia-follow-icons.fab.fa-facebook {
   border-radius: 5px;
   bottom: -7px;
   position: relative;
   right: -5px;
 }
-.oppia-footer-social .oppia-youtube-follow  i.oppia-follow-icons.fab.fa-youtube-play {
+
+.oppia-footer-social .oppia-youtube-follow i.oppia-follow-icons.fab.fa-youtube-play {
   border-radius: 5px;
   font-size: 18px;
   left: -0.35px;
@@ -106,7 +117,12 @@
   box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, .4);
 }
 
-.oppia-footer-social a .oppia-android-app-button {
+.oppia-android-app-link {
+  display: inline-block;
+  width: fit-content;
+}
+
+.oppia-android-app-link .oppia-android-app-button {
   display: block;
   margin-top: 20px;
   width: auto;

--- a/core/templates/components/button-directives/social-buttons.component.html
+++ b/core/templates/components/button-directives/social-buttons.component.html
@@ -8,7 +8,8 @@
   <div class="oppia-footer-social-icons">
 
     <div class="oppia-youtube-follow">
-      <a class="e2e-test-oppia-youtube-follow" href="https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw" target="_blank" rel="noopener">
+      <a class="e2e-test-oppia-youtube-follow" href="https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw"
+        target="_blank" rel="noopener">
         <i class="oppia-follow-icons fab fa-youtube"></i>
         <span class="oppia-icon-accessibility-label">Youtube</span>
       </a>
@@ -20,7 +21,8 @@
       </a>
     </div>
     <div class="oppia-instagram-follow">
-      <a class="e2e-test-oppia-instagram-follow" href="https://www.instagram.com/oppia.global" target="_blank" rel="noopener">
+      <a class="e2e-test-oppia-instagram-follow" href="https://www.instagram.com/oppia.global" target="_blank"
+        rel="noopener">
         <i class="oppia-follow-icons fa-brands fa-instagram"></i>
         <span class="oppia-icon-accessibility-label">Instagram</span>
       </a>
@@ -38,17 +40,18 @@
       </a>
     </div>
     <div class="oppia-linkedin-follow">
-      <a class="e2e-test-oppia-linkedin-follow" href="https://www.linkedin.com/company/oppia-org" target="_blank" rel="noopener">
+      <a class="e2e-test-oppia-linkedin-follow" href="https://www.linkedin.com/company/oppia-org" target="_blank"
+        rel="noopener">
         <i class="oppia-follow-icons fa-brands fa-linkedin oppia-follow-linkedin-icon"></i>
         <span class="oppia-icon-accessibility-label">LinkedIn</span>
       </a>
     </div>
   </div>
   <div class="oppia-android-app">
-    <a class="e2e-test-oppia-android-app" href="https://play.google.com/store/apps/details?id=org.oppia.android" target="_blank" rel="noopener">
-      <img class="oppia-android-app-button"
-           src="/assets/images/android/android-landing-google-play.svg"
-           alt="Link to Android app page">
+    <a class="oppia-android-app-link e2e-test-oppia-android-app"
+      href="https://play.google.com/store/apps/details?id=org.oppia.android" target="_blank" rel="noopener">
+      <img class="oppia-android-app-button" src="/assets/images/android/android-landing-google-play.svg"
+        alt="Link to Android app page">
     </a>
   </div>
 </div>

--- a/core/templates/pages/android-page/android-page.component.css
+++ b/core/templates/pages/android-page/android-page.component.css
@@ -1,4 +1,3 @@
-
 .oppia-android-avatar-img {
   height: 200px;
   margin-bottom: -27px;
@@ -21,9 +20,8 @@
 
 .oppia-android-speech-bubble {
   align-items: center;
-  background-image: url(
-    '/assets/images/android/android-landing-speech-bubble.svg'
-  );
+  background-image: url('/assets/images/android/android-landing-speech-bubble.svg'
+    );
   background-size: cover;
   display: flex;
   height: 300px;
@@ -62,7 +60,9 @@
   font-size: 18px;
   font-weight: 400;
   margin-top: -25px;
-  padding-left: 30px /*rtl:ignore*/;
+  padding-left: 30px
+    /*rtl:ignore*/
+  ;
 }
 
 .oppia-android-updates-input-padding {
@@ -256,13 +256,20 @@
   font-size: 11px;
 }
 
-.oppia-android-google-play-logo {
+.oppia-android-google-play-link {
   display: inline-block;
   margin-top: 50px;
+  width: fit-content;
+}
+
+.oppia-android-google-play-logo {
+  display: block;
 }
 
 .oppia-android-hero-image {
-  margin: 0 /*rtl:0 0 0 -60px*/;
+  margin: 0
+    /*rtl:0 0 0 -60px*/
+  ;
   transform: scale(1.5);
 }
 
@@ -270,6 +277,7 @@
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
     visibility: visible;
@@ -345,7 +353,9 @@
 }
 
 .oppia-android-carousel-direction {
-  flex-direction: row /*rtl:row-reverse*/;
+  flex-direction: row
+    /*rtl:row-reverse*/
+  ;
 }
 
 @media only screen and (max-width: 1024px) {
@@ -416,7 +426,7 @@
     word-break: break-word;
   }
 
-  .oppia-android-google-play-logo {
+  .oppia-android-google-play-link {
     margin-left: 0;
   }
 
@@ -510,7 +520,9 @@
 
 @media only screen and (max-width: 575px) {
   .oppia-android-hero-image {
-    margin: 0 /*rtl:0 0 0 -100px*/;
+    margin: 0
+      /*rtl:0 0 0 -100px*/
+    ;
     transform: scale(4) translateY(50px);
   }
 

--- a/core/templates/pages/android-page/android-page.component.html
+++ b/core/templates/pages/android-page/android-page.component.html
@@ -10,24 +10,21 @@
               </div>
             </div>
             <div class="oppia-android-beta-description-container">
-              <p class="oppia-android-beta-description"
-                 [innerHTML]="'I18N_ANDROID_PAGE_BETA_DESCRIPTION' | translate">
+              <p class="oppia-android-beta-description" [innerHTML]="'I18N_ANDROID_PAGE_BETA_DESCRIPTION' | translate">
               </p>
               <p class="oppia-mobile-only oppia-android-support-text">
                 {{ 'I18N_ANDROID_PAGE_SUPPORT_TEXT' | translate }}
               </p>
-              <a [href]="ANDROID_APP_URL" target="_blank" rel="noopener">
+              <a class="oppia-android-google-play-link" [href]="ANDROID_APP_URL" target="_blank" rel="noopener">
                 <img class="oppia-android-google-play-logo e2e-test-play-store-redirect-img"
-                     src="/assets/images/android/android-landing-google-play.svg"
-                     alt="Link to Android app page">
+                  src="/assets/images/android/android-landing-google-play.svg" alt="Link to Android app page">
               </a>
             </div>
           </div>
         </div>
         <div class="col-sm-6 col-4 px-3">
-          <img class="oppia-android-hero-image"
-               src="/assets/images/android/android-landing-0.svg"
-               alt="Image showing the application in use">
+          <img class="oppia-android-hero-image" src="/assets/images/android/android-landing-0.svg"
+            alt="Image showing the application in use">
         </div>
       </div>
     </div>
@@ -37,7 +34,8 @@
         {{ 'I18N_ANDROID_PAGE_REVIEWS_SECTION_HEADER' | translate }}
       </div>
       <div class="oppia-android-review-section-5-star-container">
-        <img class="oppia-android-5-star-image" src="/assets/images/android/android-reviews-5-star.svg" alt="Image of 5 stars">
+        <img class="oppia-android-5-star-image" src="/assets/images/android/android-reviews-5-star.svg"
+          alt="Image of 5 stars">
       </div>
       <div class="oppia-android-review-section row gx-3">
         <div class="oppia-android-review-component col-md-4 px-3">
@@ -61,16 +59,20 @@
       </div>
     </div>
     <div class="oppia-android-features oppia-android-features-tablet">
-      <p class="oppia-android-features-main-text"
-         [innerHTML]="'I18N_ANDROID_PAGE_FEATURES_SECTION_HEADER' | translate">
+      <p class="oppia-android-features-main-text" [innerHTML]="'I18N_ANDROID_PAGE_FEATURES_SECTION_HEADER' | translate">
       </p>
       <div class="container">
         <div class="row gx-0">
           <div class="oppia-android-key-feature-image-container">
-            <img *ngIf="featuresShown === 0" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-1.svg" alt="Image showing the story page">
-            <img *ngIf="featuresShown === 1" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-2.svg" alt="Image showing a lesson being played">
-            <img *ngIf="featuresShown === 2" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-3.svg" alt="Image showing the lesson in different languages">
-            <img *ngIf="featuresShown === 3" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-4.svg" alt="Image showing that maintaining different profiles are possible">
+            <img *ngIf="featuresShown === 0" class="oppia-android-key-feature-image"
+              src="/assets/images/android/android-landing-1.svg" alt="Image showing the story page">
+            <img *ngIf="featuresShown === 1" class="oppia-android-key-feature-image"
+              src="/assets/images/android/android-landing-2.svg" alt="Image showing a lesson being played">
+            <img *ngIf="featuresShown === 2" class="oppia-android-key-feature-image"
+              src="/assets/images/android/android-landing-3.svg" alt="Image showing the lesson in different languages">
+            <img *ngIf="featuresShown === 3" class="oppia-android-key-feature-image"
+              src="/assets/images/android/android-landing-4.svg"
+              alt="Image showing that maintaining different profiles are possible">
           </div>
         </div>
         <div class="oppia-android-key-feature-container row gx-3">
@@ -96,10 +98,10 @@
                 {{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_3' | translate }}
               </div>
               <div class="oppia-android-key-feature-subtext mb-4"
-                   [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_3' | translate">
+                [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_3' | translate">
               </div>
               <div class="oppia-android-key-feature-subtext"
-                   [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_4' | translate">
+                [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_4' | translate">
               </div>
             </div>
             <div *ngIf="featuresShown === 3" class="oppia-android-key-feature text-center">
@@ -113,62 +115,89 @@
           </div>
         </div>
         <div class="oppia-android-carousel-item-container row gx-3">
-          <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 0}" (click)="changeFeaturesShown(0)"></button>
-          <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 1}" (click)="changeFeaturesShown(1)"></button>
-          <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 2}" (click)="changeFeaturesShown(2)"></button>
-          <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 3}" (click)="changeFeaturesShown(3)"></button>
+          <button class="oppia-android-carousel-item"
+            [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 0}"
+            (click)="changeFeaturesShown(0)"></button>
+          <button class="oppia-android-carousel-item"
+            [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 1}"
+            (click)="changeFeaturesShown(1)"></button>
+          <button class="oppia-android-carousel-item"
+            [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 2}"
+            (click)="changeFeaturesShown(2)"></button>
+          <button class="oppia-android-carousel-item"
+            [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 3}"
+            (click)="changeFeaturesShown(3)"></button>
         </div>
       </div>
     </div>
     <div class="oppia-android-features-web oppia-android-empty-div"></div>
     <div class="oppia-android-features oppia-android-features-web oppia-web-only container mb-5">
       <span [innerHTML]="'I18N_ANDROID_PAGE_FEATURES_SECTION_HEADER' | translate"
-            class="oppia-android-features-main-text row">
+        class="oppia-android-features-main-text row">
       </span>
       <div class="oppia-android-key-feature-container row">
         <div class="oppia-android-key-feature-description col-md-5 ps-0 px-3">
           <div class="oppia-android-key-feature">
-            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_1' | translate }}</div>
+            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_1' |
+              translate }}</div>
             <div class="oppia-android-key-feature-subtext">{{ 'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_1' | translate }}</div>
           </div>
           <div class="oppia-android-key-feature">
-            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_2' | translate }}</div>
+            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_2' |
+              translate }}</div>
             <div class="oppia-android-key-feature-subtext">{{ 'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_2' | translate }}</div>
           </div>
           <div class="oppia-android-key-feature">
-            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_3' | translate }}</div>
+            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_3' |
+              translate }}</div>
             <div class="oppia-android-key-feature-subtext mb-4"
-                 [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_3' | translate">
+              [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_3' | translate">
             </div>
             <div class="oppia-android-key-feature-subtext"
-                 [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_4' | translate">
+              [innerHTML]="'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_4' | translate">
             </div>
           </div>
           <div class="oppia-android-key-feature">
-            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_4' | translate }}</div>
+            <div class="oppia-android-key-feature-text oppia-android-text-color">{{ 'I18N_ANDROID_PAGE_FEATURE_TEXT_4' |
+              translate }}</div>
             <div class="oppia-android-key-feature-subtext">{{ 'I18N_ANDROID_PAGE_FEATURE_SUBTEXT_5' | translate }}</div>
           </div>
         </div>
         <div class="oppia-android-key-feature-image-container oppia-web-only col-md-7 px-3">
           <div class="row oppia-android-carousel-direction">
-            <button class="col-md-2 px-3 align-self-center oppia-android-carousel-button" (click)="changeFeaturesShown((3 + featuresShown) % 4)">
+            <button class="col-md-2 px-3 align-self-center oppia-android-carousel-button"
+              (click)="changeFeaturesShown((3 + featuresShown) % 4)">
               <i class="fas fa-chevron-left oppia-android-carousel-chevron float-end "></i>
             </button>
             <div class="oppia-android-key-feature-image-container col-md-8">
-              <img *ngIf="featuresShown === 0" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-1.svg" alt="Image showing the story page">
-              <img *ngIf="featuresShown === 1" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-2.svg" alt="Image showing a lesson being played">
-              <img *ngIf="featuresShown === 2" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-3.svg" alt="Image showing the lesson in different languages">
-              <img *ngIf="featuresShown === 3" class="oppia-android-key-feature-image" src="/assets/images/android/android-landing-4.svg" alt="Image showing that maintaining different profiles are possible">
+              <img *ngIf="featuresShown === 0" class="oppia-android-key-feature-image"
+                src="/assets/images/android/android-landing-1.svg" alt="Image showing the story page">
+              <img *ngIf="featuresShown === 1" class="oppia-android-key-feature-image"
+                src="/assets/images/android/android-landing-2.svg" alt="Image showing a lesson being played">
+              <img *ngIf="featuresShown === 2" class="oppia-android-key-feature-image"
+                src="/assets/images/android/android-landing-3.svg"
+                alt="Image showing the lesson in different languages">
+              <img *ngIf="featuresShown === 3" class="oppia-android-key-feature-image"
+                src="/assets/images/android/android-landing-4.svg"
+                alt="Image showing that maintaining different profiles are possible">
             </div>
             <div class="col-md-2 px-3 align-self-center" (click)="changeFeaturesShown((5 + featuresShown) % 4)">
               <i class="fas fa-chevron-right oppia-android-carousel-chevron"></i>
             </div>
           </div>
           <div class="oppia-android-carousel-item-container row oppia-android-carousel-direction">
-            <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 0}" (click)="changeFeaturesShown(0)"></button>
-            <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 1}" (click)="changeFeaturesShown(1)"></button>
-            <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 2}" (click)="changeFeaturesShown(2)"></button>
-            <button class="oppia-android-carousel-item" [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 3}" (click)="changeFeaturesShown(3)"></button>
+            <button class="oppia-android-carousel-item"
+              [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 0}"
+              (click)="changeFeaturesShown(0)"></button>
+            <button class="oppia-android-carousel-item"
+              [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 1}"
+              (click)="changeFeaturesShown(1)"></button>
+            <button class="oppia-android-carousel-item"
+              [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 2}"
+              (click)="changeFeaturesShown(2)"></button>
+            <button class="oppia-android-carousel-item"
+              [ngClass]="{'oppia-android-carousel-item-active': featuresShown === 3}"
+              (click)="changeFeaturesShown(3)"></button>
           </div>
         </div>
       </div>
@@ -178,39 +207,32 @@
         <div class="row">
           <div class="oppia-android-updates-text-container col-md-6 px-3 col-12">
             <div class="oppia-android-updates-main-text"
-                 [innerHTML]="'I18N_ANDROID_PAGE_UPDATES_MAIN_TEXT' | translate">
+              [innerHTML]="'I18N_ANDROID_PAGE_UPDATES_MAIN_TEXT' | translate">
             </div>
             <div class="oppia-android-sub-text oppia-android-updates-sub-text mb-5 pe-5"
-                 [innerHTML]="'I18N_ANDROID_PAGE_UPDATES_SUBTEXT' | translate">
+              [innerHTML]="'I18N_ANDROID_PAGE_UPDATES_SUBTEXT' | translate">
             </div>
           </div>
-          <div *ngIf="!userHasSubscribed"
-               class="oppia-android-updates-input-container col-md-6 px-3 col-12">
+          <div *ngIf="!userHasSubscribed" class="oppia-android-updates-input-container col-md-6 px-3 col-12">
             <div>
-              <div class="oppia-android-updates-input-label">{{ 'I18N_ANDROID_PAGE_NAME_FIELD_LABEL' | translate }}</div>
-              <input class="oppia-android-updates-input w-100"
-                     type="text"
-                     [(ngModel)]="name"
-                     [ngModelOptions]="{standalone: true}">
+              <div class="oppia-android-updates-input-label">{{ 'I18N_ANDROID_PAGE_NAME_FIELD_LABEL' | translate }}
+              </div>
+              <input class="oppia-android-updates-input w-100" type="text" [(ngModel)]="name"
+                [ngModelOptions]="{standalone: true}">
             </div>
             <div class="oppia-android-updates-input-padding">
               <div class="oppia-android-updates-input-label">
                 {{ 'I18N_ANDROID_PAGE_EMAIL_FIELD_LABEL' | translate }}
                 <span class="oppia-android-updates-asterisk-color">*</span>
               </div>
-              <input class="oppia-android-updates-input w-100"
-                     type="email"
-                     [(ngModel)]="emailAddress"
-                     [ngModelOptions]="{standalone: true}"
-                     required="true">
+              <input class="oppia-android-updates-input w-100" type="email" [(ngModel)]="emailAddress"
+                [ngModelOptions]="{standalone: true}" required="true">
               <div *ngIf="emailAddress && !validateEmailAddress()" class="text-danger">
                 Please enter a valid email address.
               </div>
             </div>
             <div class="oppia-android-updates-input-padding">
-              <input class="oppia-android-updates-checkbox"
-                     [(ngModel)]="userCanSubscribe"
-                     type="checkbox">
+              <input class="oppia-android-updates-checkbox" [(ngModel)]="userCanSubscribe" type="checkbox">
               <span class="oppia-android-updates-checkbox-label">
                 {{ 'I18N_ANDROID_PAGE_CONSENT_CHECKBOX_LABEL' | translate }}
                 <span class="oppia-android-updates-asterisk-color">*</span>
@@ -221,20 +243,21 @@
             </div>
             <div class="oppia-android-updates-input-padding text-center">
               <oppia-primary-button (onClickPrimaryButton)="subscribeToAndroidList()"
-                                    [disabled]="!userCanSubscribe || !validateEmailAddress()"
-                                    [customClasses]="'btn oppia-android-updates-button w-100'"
-                                    [buttonText]="'I18N_ANDROID_PAGE_UPDATES_SUBMIT_BUTTON_TEXT' | translate">
+                [disabled]="!userCanSubscribe || !validateEmailAddress()"
+                [customClasses]="'btn oppia-android-updates-button w-100'"
+                [buttonText]="'I18N_ANDROID_PAGE_UPDATES_SUBMIT_BUTTON_TEXT' | translate">
               </oppia-primary-button>
             </div>
           </div>
           <div *ngIf="userHasSubscribed"
-               class="oppia-android-updates-input-container col-md-6 px-3 col-12 oppia-android-sub-text">
+            class="oppia-android-updates-input-container col-md-6 px-3 col-12 oppia-android-sub-text">
             You have subscribed to receive updates!
           </div>
         </div>
       </div>
       <div class="container">
-        <img class="oppia-android-avatar-img mx-auto d-block" [src]="OPPIA_AVATAR_IMAGE_URL" alt="Image of Oppia mascot">
+        <img class="oppia-android-avatar-img mx-auto d-block" [src]="OPPIA_AVATAR_IMAGE_URL"
+          alt="Image of Oppia mascot">
       </div>
     </div>
     <div class="oppia-android-app-updates-background oppia-android-otter-help-container">


### PR DESCRIPTION
## Overview

The anchor tags wrapping the Play Store images in both the footer  (social-buttons component) and the Android landing page were not properly constrained, allowing the clickable area to overflow beyond the visible button boundaries.

### Solution
Added CSS constraints to the anchor elements wrapping the Play Store buttons:
- `display: inline-block` - Prevents the link from stretching to full width
- `width: fit-content` - Constrains the clickable area to match only the 
  content (image) size

### Files Changed
1. `core/templates/components/button-directives/social-buttons.component.html`
   - Added `oppia-android-app-link` class to the anchor tag
2. `core/templates/components/button-directives/social-buttons.component.css`
   - Added `.oppia-android-app-link` styles with touch zone constraints
   - Updated image selector to use more specific class
3. `core/templates/pages/android-page/android-page.component.html`
   - Added `oppia-android-google-play-link` class to the anchor tag
4. `core/templates/pages/android-page/android-page.component.css`
   - Added `.oppia-android-google-play-link` styles with touch zone constraints
   - Separated margin from image class to link class

### Essential Checklist

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR.

### Proof that changes are correct

**Before (Issue):**
<video src="https://github.com/user-attachments/assets/6df37a27-34f4-4afb-9c9b-4ffd705ddc2b" controls></video>

**After (Fix):**
<video src="https://github.com/user-attachments/assets/037acdc4-05b2-485b-b1a7-886711082920" controls></video>

### Testing
- Verified on desktop that clicking outside the visible button no longer 
  triggers navigation
- Verified button appearance remains unchanged (correct size and positioning)
- Tested in footer on homepage and on /android page