### PR TITLE
Fix part of #20088: Hide empty translation cards and correct voiceover fallback

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
@@ -30,6 +30,8 @@ import {InteractionSpecsKey} from 'pages/interaction-specs.constants';
 import {TranslatedContent} from 'domain/exploration/translated-content.model';
 import {PlatformFeatureService} from 'services/platform-feature.service';
 import {EntityVoiceoversService} from 'services/entity-voiceovers.services';
+import { SubtitledHtml } from 'domain/exploration/subtitled-html.model';
+import { SubtitledUnicode } from 'domain/exploration/subtitled-unicode.model';
 
 interface AvailabilityStatus {
   available: boolean;
@@ -165,6 +167,20 @@ export class TranslationStatusService implements OnInit {
 
         let allContentIds =
           this.explorationStatesService.getAllContentIdsByStateName(stateName);
+         // Filter out empty content
+        allContentIds = allContentIds.filter(contentId => {
+          const content =
+            this.explorationStatesService.initalContentsMapping[contentId];
+          if (!content) {
+            return true;
+          }
+          if (content instanceof SubtitledHtml) {
+            return content.html !== '';
+          } else if (content instanceof SubtitledUnicode) {
+            return content.unicode !== '';
+          }
+          return true;
+        });
         let interactionId =
           this.explorationStatesService.getInteractionIdMemento(stateName);
         // This is used to prevent users from adding unwanted hints audio, as

--- a/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
@@ -167,7 +167,7 @@ export class TranslationStatusService implements OnInit {
 
         let allContentIds =
           this.explorationStatesService.getAllContentIdsByStateName(stateName);
-         // Filter out empty content
+         // Filter out empty content.
         allContentIds = allContentIds.filter(contentId => {
           const content =
             this.explorationStatesService.initalContentsMapping[contentId];

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -272,7 +272,7 @@
   </div>
   <div class="translation-state-contents">
     <div
-      *ngIf="isActive(TAB_ID_CONTENT)"
+      *ngIf="isActive(TAB_ID_CONTENT) && hasOriginalContent(stateContent)"
       class="translation-state-content e2e-test-content-text"
     >
       <span>
@@ -317,6 +317,7 @@
             let caContent of interactionCustomizationArgTranslatableContent;
             index as index
           "
+          [hidden]="!hasOriginalContent(caContent.content)"
           [ngClass]="{active: activeCustomizationArgContentIndex === index}"
         >
           <a
@@ -448,6 +449,7 @@
           <li
             class="oppia-rule-block e2e-test-translation-feedback mt-0"
             *ngFor="let answerGroup of stateAnswerGroups; index as index"
+            [hidden]="!hasOriginalContent(answerGroup.outcome.feedback)"
             [ngClass]="{active: activeAnswerGroupIndex === index}"
           >
             <a
@@ -538,6 +540,7 @@
             [ngClass]="{
               active: activeAnswerGroupIndex === stateAnswerGroups.length
             }"
+            [hidden]="!hasOriginalContent(stateDefaultOutcome.feedback)"
             class="oppia-rule-block e2e-test-translation-feedback"
           >
             <a
@@ -617,6 +620,7 @@
         <li
           class="oppia-rule-block e2e-test-translation-hint mt-0"
           *ngFor="let hint of stateHints; index as index"
+          [hidden]="!hasOriginalContent(hint.hintContent)"
           [ngClass]="{active: activeHintIndex === index}"
         >
           <a
@@ -666,7 +670,7 @@
     </div>
 
     <div
-      *ngIf="isActive(TAB_ID_SOLUTION)"
+      *ngIf="isActive(TAB_ID_SOLUTION) && hasOriginalContent(stateSolution.explanation)"
       class="translation-state-content e2e-test-solution-text"
     >
       <span

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -1,54 +1,46 @@
 <ng-template #TranslationTabCardOptions>
-  <h3 class="e2e-test-joyride-title" tabindex="0">
-    Choose a Part of the Card to Translate
-  </h3>
+  <h3 class="e2e-test-joyride-title" tabindex="0">Choose a Part of the Card to Translate</h3>
   <p tabindex="0">
-    Next, choose a part of the lesson card to translate. This menu at the top
-    lists all the translatable parts of the card. Within each tab, multiple
-    sections may be available for translating.
+    Next, choose a part of the lesson card to translate. This menu at the top lists all the translatable parts of the card. Within each tab, multiple sections may be available for translating.
   </p>
 </ng-template>
 
 <ng-template #TranslationTabTutorialComplete>
   <h3 class="e2e-test-joyride-title" tabindex="0">Tutorial Complete</h3>
   <p tabindex="0">
-    Now, you are ready to begin adding translations to your explorations! This
-    marks the end of this tour. Remember to save your progress periodically
-    using the save button in the navigation bar at the top:
+    Now, you are ready to begin adding translations
+    to your explorations!
+    This marks the end of this tour.
+    Remember to save your progress periodically using
+    the save button in the navigation bar at the top:
     <button class="btn btn-success" disabled>
-      <i class="material-icons">&#xE161;</i></button
-    >.<br />
-    Thank you for making this lesson more accessible for non-native speakers!'
+      <i class="material-icons">&#xE161;</i>
+    </button>.<br>
+    Thank you for making this lesson more accessible
+    for non-native speakers!'
   </p>
 </ng-template>
 
 <ng-template #TranslationTabReRecordingOverview>
   <h3 class="e2e-test-joyride-title" tabindex="0">Re-record/Re-upload audio</h3>
   <div tabindex="0">
-    <p>
-      The audio recording also has options related to updating and deleting
-      translations.
-    </p>
+    <p>The audio recording also has options related to updating and deleting translations.</p>
     <ul>
       <li>
         To revert and cancel any unsaved translation(s), click the
-        <i class="material-icons oppia-state-translation-icons">&#xE5C9;</i>
-        button.
+        <i class="material-icons oppia-state-translation-icons">&#xE5C9;</i> button.
       </li>
       <li>
         To play the audio, click the
-        <i class="material-icons oppia-state-translation-icons">&#xE039;</i>
-        button.
+        <i class="material-icons oppia-state-translation-icons">&#xE039;</i> button.
       </li>
       <li>
         To do retakes, click the
-        <i class="material-icons oppia-state-translation-icons">&#xE028;</i>
-        button.
+        <i class="material-icons oppia-state-translation-icons">&#xE028;</i> button.
       </li>
       <li>
         To delete a recording, click the
-        <i class="material-icons oppia-state-translation-icons">&#xE872;</i>
-        button.
+        <i class="material-icons oppia-state-translation-icons">&#xE872;</i> button.
       </li>
     </ul>
   </div>
@@ -57,21 +49,17 @@
 <ng-template #TranslationTabRecordingOverview>
   <h3 class="e2e-test-joyride-title" tabindex="0">Recording Audio</h3>
   <div>
-    <p tabindex="0">
-      To create audio translations in Oppia, we recommend using the
-      <i class="material-icons oppia-state-translation-icons">&#xE2C6;</i>
-      button to <b>upload</b> audio files from your computer.
-    </p>
-    <p tabindex="0">
-      You can also record via your browser, but that may lead to degraded audio
-      quality. If you would like to do so anyway, simply follow these 3 steps:
+    <p tabindex="0">To create audio translations in Oppia, we recommend using the <i class="material-icons oppia-state-translation-icons">&#xE2C6;</i>
+    button to <b>upload</b> audio files from your computer.</p>
+    <p tabindex="0">You can also record via your browser, but that may lead to degraded audio quality. If you would like to do so anyway,
+       simply follow these 3 steps:
     </p>
     <ol tabindex="0">
       <li>
         To start <b>recording</b>, click the
         <i class="material-icons oppia-state-translation-icons">mic</i> button.
-        If the browser pops up a message asking if you’d like to record audio,
-        accept it.
+        If the browser pops up a message asking if you’d
+        like to record audio, accept it.
       </li>
       <li>
         When you are ready to end the recording, click
@@ -80,305 +68,126 @@
       </li>
       <li>
         Hit the <b>save</b>
-        <i class="material-icons oppia-state-translation-icons"> &#xE161;</i>
-        button to confirm the recording.
+        <i class="material-icons oppia-state-translation-icons"> &#xE161;</i> button 
+        to confirm the recording.
       </li>
     </ol>
   </div>
 </ng-template>
 
 <div class="oppia-translation-page-statename">
-  <strong
-    class="e2e-test-state-name-text"
-    tabindex="0"
-    [attr.aria-label]="'State name:' + stateName"
-    >{{ stateName }}</strong
-  >
+   <strong class="e2e-test-state-name-text" tabindex="0" [attr.aria-label]="'State name:' + stateName">{{ stateName }}</strong>
 </div>
 <div class="oppia-page-card oppia-state-translation-page">
-  <div
-    class="translation-nav"
-    joyrideStep="translationTabCardOptions"
-    [stepContent]="TranslationTabCardOptions"
-  >
+  <div class="translation-nav" joyrideStep="translationTabCardOptions" [stepContent]="TranslationTabCardOptions">
     <ul id="tutorialTranslationState" class="oppia-translation-tabs">
-      <li
-        [ngClass]="{
-          'oppia-active-translation-tab e2e-test-active-translation-tab':
-            isActive(TAB_ID_CONTENT)
-        }"
-        class="e2e-test-accessibility-translation-content"
-        aria-label="Content of the card"
-        role="button"
-      >
-        <div
-          (click)="onTabClick(TAB_ID_CONTENT)"
-          tabindex="0"
-          (keydown.enter)="onTabClick(TAB_ID_CONTENT)"
-          [ngStyle]="tabStatusColorStyle(TAB_ID_CONTENT)"
-          class="oppia-translation-tabs-text e2e-test-translation-content-tab"
-        >
-          <span
-            [hidden]="!tabNeedUpdatesStatus(TAB_ID_CONTENT)"
-            class="oppia-tab-needs-update"
-            tabindex="0"
-            [ngbTooltip]="needsUpdateTooltipMessage"
-            placement="top"
-            >⚠ </span
-          >Content
+       <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_CONTENT)}" class="e2e-test-accessibility-translation-content" aria-label="Content of the card" role="button">
+        <div (click)="onTabClick(TAB_ID_CONTENT)" tabindex="0" (keydown.enter)="onTabClick(TAB_ID_CONTENT)" [ngStyle]="tabStatusColorStyle(TAB_ID_CONTENT)" class="oppia-translation-tabs-text e2e-test-translation-content-tab">
+          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_CONTENT)" class="oppia-tab-needs-update"
+                tabindex="0"
+                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
+          </span>Content
         </div>
       </li>
-      <li
-        [ngClass]="{
-          'oppia-active-translation-tab e2e-test-active-translation-tab':
-            isActive(TAB_ID_CUSTOMIZATION_ARGS),
-          'oppia-disabled-translation-tab': isDisabled(
-            TAB_ID_CUSTOMIZATION_ARGS
-          )
-        }"
-        aria-label="Interaction content"
-        role="button"
-      >
-        <div
-          (click)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)"
-          [attr.tabindex]="!isDisabled(TAB_ID_CUSTOMIZATION_ARGS) ? '0' : '-1'"
-          (keydown.enter)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)"
-          [ngStyle]="tabStatusColorStyle(TAB_ID_CUSTOMIZATION_ARGS)"
-          class="oppia-translation-tabs-text"
-        >
-          <span
-            [hidden]="!tabNeedUpdatesStatus(TAB_ID_CUSTOMIZATION_ARGS)"
-            class="oppia-tab-needs-update"
-            tabindex="0"
-            [ngbTooltip]="needsUpdateTooltipMessage"
-            placement="top"
-            >⚠ </span
-          >Interaction
+      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_CUSTOMIZATION_ARGS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_CUSTOMIZATION_ARGS)}" aria-label="Interaction content" role="button">
+        <div (click)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)" [attr.tabindex]="!isDisabled(TAB_ID_CUSTOMIZATION_ARGS) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)" [ngStyle]="tabStatusColorStyle(TAB_ID_CUSTOMIZATION_ARGS)" class="oppia-translation-tabs-text">
+          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_CUSTOMIZATION_ARGS)" class="oppia-tab-needs-update"
+                tabindex="0"
+                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
+          </span>Interaction
         </div>
       </li>
-      <li
-        *ngIf="!isVoiceoverModeActive()"
-        [ngClass]="{
-          'oppia-active-translation-tab e2e-test-active-translation-tab':
-            isActive(TAB_ID_RULE_INPUTS),
-          'oppia-disabled-translation-tab': isDisabled(TAB_ID_RULE_INPUTS)
-        }"
-        aria-label="Rule Inputs"
-        role="button"
-      >
-        <div
-          (click)="onTabClick(TAB_ID_RULE_INPUTS)"
-          [attr.tabindex]="!isDisabled(TAB_ID_RULE_INPUTS) ? '0' : '-1'"
-          (keydown.enter)="onTabClick(TAB_ID_RULE_INPUTS)"
-          [ngStyle]="tabStatusColorStyle(TAB_ID_RULE_INPUTS)"
-          class="oppia-translation-tabs-text"
-        >
-          <span
-            [hidden]="!tabNeedUpdatesStatus(TAB_ID_RULE_INPUTS)"
-            class="oppia-tab-needs-update"
-            tabindex="0"
-            [ngbTooltip]="needsUpdateTooltipMessage"
-            placement="top"
-            >⚠ </span
-          >Rules
+       <li *ngIf="!isVoiceoverModeActive()" [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_RULE_INPUTS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_RULE_INPUTS)}" aria-label="Rule Inputs" role="button">
+        <div (click)="onTabClick(TAB_ID_RULE_INPUTS)" [attr.tabindex]="!isDisabled(TAB_ID_RULE_INPUTS) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_RULE_INPUTS)" [ngStyle]="tabStatusColorStyle(TAB_ID_RULE_INPUTS)" class="oppia-translation-tabs-text">
+          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_RULE_INPUTS)" class="oppia-tab-needs-update"
+                tabindex="0"
+                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
+          </span>Rules
         </div>
       </li>
-      <li
-        [ngClass]="{
-          'oppia-active-translation-tab e2e-test-active-translation-tab':
-            isActive(TAB_ID_FEEDBACK),
-          'oppia-disabled-translation-tab': isDisabled(TAB_ID_FEEDBACK)
-        }"
-        class="e2e-test-accessibility-translation-feedback"
-        aria-label="Feedback responses for answer groups"
-        role="button"
-      >
-        <div
-          (click)="onTabClick(TAB_ID_FEEDBACK)"
-          [attr.tabindex]="!isDisabled(TAB_ID_FEEDBACK) ? '0' : '-1'"
-          (keydown.enter)="onTabClick(TAB_ID_FEEDBACK)"
-          [ngStyle]="tabStatusColorStyle(TAB_ID_FEEDBACK)"
-          class="oppia-translation-tabs-text e2e-test-translation-feedback-tab"
-        >
-          <span
-            [hidden]="!tabNeedUpdatesStatus(TAB_ID_FEEDBACK)"
-            class="oppia-tab-needs-update"
-            tabindex="0"
-            [ngbTooltip]="needsUpdateTooltipMessage"
-            placement="top"
-            >⚠ </span
-          >Feedback
+      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_FEEDBACK), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_FEEDBACK)}" class="e2e-test-accessibility-translation-feedback" aria-label="Feedback responses for answer groups" role="button">
+        <div (click)="onTabClick(TAB_ID_FEEDBACK)" [attr.tabindex]="!isDisabled(TAB_ID_FEEDBACK) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_FEEDBACK)" [ngStyle]="tabStatusColorStyle(TAB_ID_FEEDBACK)" class="oppia-translation-tabs-text e2e-test-translation-feedback-tab">
+          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_FEEDBACK)" class="oppia-tab-needs-update"
+                tabindex="0"
+                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
+          </span>Feedback
         </div>
       </li>
-      <li
-        [ngClass]="{
-          'oppia-active-translation-tab e2e-test-active-translation-tab':
-            isActive(TAB_ID_HINTS),
-          'oppia-disabled-translation-tab': isDisabled(TAB_ID_HINTS)
-        }"
-        class="e2e-test-accessibility-translation-hint"
-        aria-label="Hints for the state"
-        role="button"
-      >
-        <div
-          (click)="onTabClick(TAB_ID_HINTS)"
-          [attr.tabindex]="!isDisabled(TAB_ID_HINTS) ? '0' : '-1'"
-          (keydown.enter)="onTabClick(TAB_ID_HINTS)"
-          [ngStyle]="tabStatusColorStyle(TAB_ID_HINTS)"
-          class="oppia-translation-tabs-text e2e-test-translation-hints-tab"
-        >
-          <span
-            [hidden]="!tabNeedUpdatesStatus(TAB_ID_HINTS)"
-            class="oppia-tab-needs-update"
-            tabindex="0"
-            [ngbTooltip]="needsUpdateTooltipMessage"
-            placement="top"
-            >⚠ </span
-          >Hints
+      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_HINTS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_HINTS)}" class="e2e-test-accessibility-translation-hint" aria-label="Hints for the state" role="button">
+        <div (click)="onTabClick(TAB_ID_HINTS)" [attr.tabindex]="!isDisabled(TAB_ID_HINTS) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_HINTS)" [ngStyle]="tabStatusColorStyle(TAB_ID_HINTS)" class="oppia-translation-tabs-text e2e-test-translation-hints-tab">
+          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_HINTS)" class="oppia-tab-needs-update"
+                tabindex="0"
+                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
+          </span>Hints
         </div>
       </li>
-      <li
-        [ngClass]="{
-          'oppia-active-translation-tab e2e-test-active-translation-tab':
-            isActive(TAB_ID_SOLUTION),
-          'oppia-disabled-translation-tab': isDisabled(TAB_ID_SOLUTION)
-        }"
-        class="e2e-test-accessibility-translation-solution"
-        aria-label="Solutions for the state"
-        role="button"
-      >
-        <div
-          (click)="onTabClick(TAB_ID_SOLUTION)"
-          [attr.tabindex]="!isDisabled(TAB_ID_SOLUTION) ? '0' : '-1'"
-          (keydown.enter)="onTabClick(TAB_ID_SOLUTION)"
-          [ngStyle]="tabStatusColorStyle(TAB_ID_SOLUTION)"
-          class="oppia-translation-tabs-text e2e-test-translation-solution-tab"
-        >
-          <span
-            [hidden]="!tabNeedUpdatesStatus(TAB_ID_SOLUTION)"
-            class="oppia-tab-needs-update"
-            tabindex="0"
-            [ngbTooltip]="needsUpdateTooltipMessage"
-            placement="top"
-            >⚠ </span
-          >Solution
+     <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_SOLUTION), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_SOLUTION)}" class="e2e-test-accessibility-translation-solution" aria-label="Solutions for the state" role="button">
+        <div (click)="onTabClick(TAB_ID_SOLUTION)" [attr.tabindex]="!isDisabled(TAB_ID_SOLUTION) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_SOLUTION)" [ngStyle]="tabStatusColorStyle(TAB_ID_SOLUTION)" class="oppia-translation-tabs-text e2e-test-translation-solution-tab" >
+          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_SOLUTION)" class="oppia-tab-needs-update"
+                tabindex="0"
+                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
+          </span>Solution
         </div>
       </li>
     </ul>
   </div>
 
-  <div *ngIf="!isVoiceoverModeActive()" class="oppia-state-content-header">
-    Original content
-  </div>
+  <div *ngIf="!isVoiceoverModeActive()" class="oppia-state-content-header">Original content</div>
   <div class="translation-state-contents">
-    <div
-      *ngIf="isActive(TAB_ID_CONTENT) && hasOriginalContent(stateContent)"
-      class="translation-state-content e2e-test-content-text"
-    >
+    <div *ngIf="isActive(TAB_ID_CONTENT) && hasOriginalContent(stateContent)" class="translation-state-content e2e-test-content-text">
       <span>
-        <span
-          *ngIf="!getRequiredHtml(stateContent)"
-          class="oppia-placeholder"
-          tabindex="0"
-        >
+        <span *ngIf="!getRequiredHtml(stateContent)" class="oppia-placeholder" tabindex="0">
           {{ getEmptyContentMessage() }}
         </span>
         <span tabindex="0">
-          <oppia-rte-output-display
-            [rteString]="getRequiredHtml(stateContent)"
-            [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-            (click)="onContentClick($event)"
-            class="oppia-rte-editor"
-          >
+          <oppia-rte-output-display [rteString]="getRequiredHtml(stateContent)"
+                                    [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                                    (click)="onContentClick($event)"
+                                    class="oppia-rte-editor">
           </oppia-rte-output-display>
         </span>
       </span>
     </div>
-    <div
-      *ngIf="isActive(TAB_ID_CUSTOMIZATION_ARGS)"
-      class="translation-state-content"
-    >
-      <h3 tabindex="0">
-        Preview - {{ INTERACTION_SPECS[stateInteractionId].name }}
-      </h3>
-      <oppia-rte-output-display
-        class="oppia-translation-state-content-html-data"
-        [rteString]="interactionPreviewHtml"
-      >
+    <div *ngIf="isActive(TAB_ID_CUSTOMIZATION_ARGS)" class="translation-state-content">
+      <h3 tabindex="0">Preview - {{INTERACTION_SPECS[stateInteractionId].name}}</h3>
+      <oppia-rte-output-display class="oppia-translation-state-content-html-data" [rteString]="interactionPreviewHtml">
       </oppia-rte-output-display>
       <h3 tabindex="0">Content</h3>
-      <ul
-        class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
-        role="tablist"
-      >
-        <li
-          class="oppia-rule-block mt-0"
-          *ngFor="
-            let caContent of interactionCustomizationArgTranslatableContent;
-            index as index
-          "
-          [hidden]="!hasOriginalContent(caContent.content)"
-          [ngClass]="{active: activeCustomizationArgContentIndex === index}"
-        >
-          <a
-            (click)="changeActiveCustomizationArgContentIndex(index)"
-            (keydown.enter)="changeActiveCustomizationArgContentIndex(index)"
-            tabindex="0"
-            class="oppia-rule-tab oppia-translation-preview-list"
-            [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
-            [ngStyle]="contentIdStatusColorStyle(caContent.content.contentId)"
-          >
-            <oppia-response-header
-              [index]="index"
-              [defaultOutcome]="true"
-              [summary]="
-                caContent.name +
-                ': ' +
-                getSubtitledContentSummary(caContent.content)
-              "
-              [shortSummary]="
-                caContent.name +
-                ': ' +
-                getSubtitledContentSummary(caContent.content)
-              "
-              [isActive]="index === activeCustomizationArgContentIndex"
-              [showWarning]="contentIdNeedUpdates(caContent.content.contentId)"
-            >
+      <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
+        <li class="oppia-rule-block mt-0"
+            *ngFor="let caContent of interactionCustomizationArgTranslatableContent; index as index"
+            [ngClass]="{'active': activeCustomizationArgContentIndex === index}">
+          <a (click)="changeActiveCustomizationArgContentIndex(index)"
+             (keydown.enter)="changeActiveCustomizationArgContentIndex(index)"
+             tabindex="0"
+             class="oppia-rule-tab oppia-translation-preview-list"
+             [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
+             [ngStyle]="contentIdStatusColorStyle(caContent.content.contentId)">
+            <oppia-response-header [index]="index"
+                                   [defaultOutcome]="true"
+                                   [summary]="caContent.name + ': ' + getSubtitledContentSummary(caContent.content)"
+                                   [shortSummary]="caContent.name + ': ' + getSubtitledContentSummary(caContent.content)"
+                                   [isActive]="index === activeCustomizationArgContentIndex"
+                                   [showWarning]="contentIdNeedUpdates(caContent.content.contentId)">
             </oppia-response-header>
           </a>
           <div *ngIf="activeCustomizationArgContentIndex === index">
-            <div
-              class="oppia-editor-card-section"
-              *ngIf="caContent.content._html"
-            >
-              <span
-                *ngIf="!getRequiredHtml(caContent.content)"
-                class="oppia-placeholder"
-                tabindex="0"
-              >
+            <div class="oppia-editor-card-section" *ngIf="caContent.content._html">
+              <span *ngIf="!getRequiredHtml(caContent.content)" class="oppia-placeholder" tabindex="0">
                 {{ getEmptyContentMessage() }}
               </span>
               <span>
-                <oppia-rte-output-display
-                  [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                  (click)="onContentClick($event)"
-                  (keydown.enter)="onContentClick($event)"
-                  tabindex="0"
-                  class="oppia-rte-editor"
-                  [rteString]="getRequiredHtml(caContent.content)"
-                >
+                <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                                          (click)="onContentClick($event)"
+                                          (keydown.enter)="onContentClick($event)"
+                                          tabindex="0"
+                                          class="oppia-rte-editor"
+                                          [rteString]="getRequiredHtml(caContent.content)">
                 </oppia-rte-output-display>
               </span>
             </div>
-            <div
-              class="oppia-editor-card-section"
-              *ngIf="caContent.content._unicode"
-            >
-              <span
-                *ngIf="!caContent.content._unicode"
-                class="oppia-placeholder"
-                tabindex="0"
-              >
+            <div class="oppia-editor-card-section" *ngIf="caContent.content._unicode">
+              <span *ngIf="!caContent.content._unicode" class="oppia-placeholder" tabindex="0">
                 {{ getEmptyContentMessage() }}
               </span>
               <span>
@@ -391,47 +200,23 @@
     </div>
     <div *ngIf="isActive(TAB_ID_RULE_INPUTS)" class="translation-state-content">
       <div>
-        <ul
-          class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
-          role="tablist"
-        >
-          <li
-            class="oppia-rule-block e2e-test-translation-feedback mt-0"
-            *ngFor="
-              let ruleContent of interactionRuleTranslatableContents;
-              index as index
-            "
-            [ngClass]="{active: activeRuleContentIndex === index}"
-          >
-            <a
-              class="oppia-rule-tab e2e-test-feedback-{{
-                index
-              }} oppia-translation-preview-list"
-              tabindex="0"
-              (keydown.enter)="changeActiveRuleContentIndex(index)"
-              (click)="changeActiveRuleContentIndex(index)"
-              [ngClass]="{
-                'oppia-rule-tab-active': activeRuleContentIndex === index
-              }"
-              [ngStyle]="contentIdStatusColorStyle(ruleContent.contentId)"
-            >
-              {{
-                ruleContent.rule
-                  | parameterizeRuleDescriptionPipe
-                    : stateInteractionId
-                    : answerChoices
-              }}
+        <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
+          <li class="oppia-rule-block e2e-test-translation-feedback mt-0"
+              *ngFor="let ruleContent of interactionRuleTranslatableContents; index as index"
+              [ngClass]="{'active': activeRuleContentIndex === index}">
+            <a class="oppia-rule-tab e2e-test-feedback-{{ index }} oppia-translation-preview-list"
+               tabindex="0"
+               (keydown.enter)="changeActiveRuleContentIndex(index)"
+               (click)="changeActiveRuleContentIndex(index)"
+               [ngClass]="{'oppia-rule-tab-active': activeRuleContentIndex === index}"
+               [ngStyle]="contentIdStatusColorStyle(ruleContent.contentId)">
+               {{ ruleContent.rule | parameterizeRuleDescriptionPipe: stateInteractionId: answerChoices }}
             </a>
             <div *ngIf="activeRuleContentIndex === index">
               <div class="oppia-editor-card-section">
                 <div class="oppia-rule-body-container" tabindex="0">
                   <span>
-                    {{
-                      getHumanReadableRuleInputValues(
-                        ruleContent.rule.inputs[ruleContent.inputName],
-                        ruleContent.rule.inputTypes[ruleContent.inputName]
-                      )
-                    }}
+                    {{ getHumanReadableRuleInputValues(ruleContent.rule.inputs[ruleContent.inputName], ruleContent.rule.inputTypes[ruleContent.inputName]) }}
                   </span>
                 </div>
               </div>
@@ -442,68 +227,30 @@
     </div>
     <div *ngIf="isActive(TAB_ID_FEEDBACK)" class="translation-state-content">
       <div>
-        <ul
-          class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
-          role="tablist"
-        >
-          <li
-            class="oppia-rule-block e2e-test-translation-feedback mt-0"
-            *ngFor="let answerGroup of stateAnswerGroups; index as index"
-            [hidden]="!hasOriginalContent(answerGroup.outcome.feedback)"
-            [ngClass]="{active: activeAnswerGroupIndex === index}"
-          >
-            <a
-              class="oppia-rule-tab e2e-test-feedback-{{
-                index
-              }} oppia-translation-preview-list"
-              tabindex="0"
-              (keydown.enter)="changeActiveAnswerGroupIndex(index)"
-              (click)="changeActiveAnswerGroupIndex(index)"
-              [ngClass]="{
-                'oppia-rule-tab-active': activeAnswerGroupIndex === index
-              }"
-              [ngStyle]="
-                contentIdStatusColorStyle(
-                  answerGroup.outcome.feedback.contentId
-                )
-              "
-            >
-              <oppia-response-header
-                [index]="index"
-                [summary]="
-                  summarizeAnswerGroup(
-                    answerGroup,
-                    stateInteractionId,
-                    answerChoices,
-                    false
-                  )
-                "
-                [shortSummary]="
-                  summarizeAnswerGroup(
-                    answerGroup,
-                    stateInteractionId,
-                    answerChoices,
-                    true
-                  )
-                "
-                [isActive]="index === activeAnswerGroupIndex"
-                [outcome]="answerGroup.outcome"
-                [defaultOutcome]="true"
-                [numRules]="answerGroup.rules.length"
-                [isResponse]="true"
-                [showWarning]="
-                  contentIdNeedUpdates(answerGroup.outcome.feedback.contentId)
-                "
-                (navigateToState)="navigateToState($event)"
-              >
+        <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
+          <li class="oppia-rule-block e2e-test-translation-feedback mt-0"
+              *ngFor="let answerGroup of stateAnswerGroups; index as index"
+              [ngClass]="{'active': activeAnswerGroupIndex === index}">
+            <a class="oppia-rule-tab e2e-test-feedback-{{ index }} oppia-translation-preview-list"
+               tabindex="0"
+               (keydown.enter)="changeActiveAnswerGroupIndex(index)"
+               (click)="changeActiveAnswerGroupIndex(index)"
+               [ngClass]="{'oppia-rule-tab-active': activeAnswerGroupIndex === index}"
+               [ngStyle]="contentIdStatusColorStyle(answerGroup.outcome.feedback.contentId)">
+              <oppia-response-header [index]="index"
+                                     [summary]="summarizeAnswerGroup(answerGroup, stateInteractionId, answerChoices, false)"
+                                     [shortSummary]="summarizeAnswerGroup(answerGroup, stateInteractionId, answerChoices, true)"
+                                     [isActive]="index === activeAnswerGroupIndex"
+                                     [outcome]="answerGroup.outcome"
+                                     [defaultOutcome]="true"
+                                     [numRules]="answerGroup.rules.length"
+                                     [isResponse]="true"
+                                     [showWarning]="contentIdNeedUpdates(answerGroup.outcome.feedback.contentId)"
+                                     (navigateToState)="navigateToState($event)">
               </oppia-response-header>
             </a>
             <div *ngIf="activeAnswerGroupIndex === index">
-              <div
-                class="oppia-editor-card-section e2e-test-feedback-{{
-                  index
-                }}-text"
-              >
+              <div class="oppia-editor-card-section e2e-test-feedback-{{ stateAnswerGroups.length }}-text">
                 <div class="oppia-rule-body-container" tabindex="0">
                   <span
                     *ngIf="!getRequiredHtml(answerGroup.outcome.feedback)"
@@ -512,16 +259,10 @@
                     {{ getEmptyContentMessage() }}
                   </span>
                   <span>
-                    <oppia-rte-output-display
-                      [ngClass]="{
-                        'oppia-rte-editor-focused': isCopyModeActive()
-                      }"
-                      (click)="onContentClick($event)"
-                      [rteString]="
-                        getRequiredHtml(answerGroup.outcome.feedback)
-                      "
-                      class="oppia-rte-editor"
-                    >
+                    <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                                              (click)="onContentClick($event)"
+                                              [rteString]="getRequiredHtml(answerGroup.outcome.feedback)"
+                                              class="oppia-rte-editor">
                     </oppia-rte-output-display>
                   </span>
                 </div>
@@ -613,54 +354,35 @@
       </div>
     </div>
     <div *ngIf="isActive(TAB_ID_HINTS)" class="translation-state-content">
-      <ul
-        class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
-        role="tablist"
-      >
-        <li
-          class="oppia-rule-block e2e-test-translation-hint mt-0"
-          *ngFor="let hint of stateHints; index as index"
-          [hidden]="!hasOriginalContent(hint.hintContent)"
-          [ngClass]="{active: activeHintIndex === index}"
-        >
-          <a
-            (click)="changeActiveHintIndex(index)"
-            (keydown.enter)="changeActiveHintIndex(index)"
-            tabindex="0"
-            class="oppia-rule-tab e2e-test-hint-{{
-              index
-            }} oppia-translation-preview-list"
-            [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
-            [ngStyle]="contentIdStatusColorStyle(hint.hintContent.contentId)"
-          >
-            <oppia-response-header
-              [index]="index"
-              [defaultOutcome]="true"
-              [summary]="getSubtitledContentSummary(hint.hintContent)"
-              [shortSummary]="getSubtitledContentSummary(hint.hintContent)"
-              [isActive]="index === activeHintIndex"
-              [showWarning]="contentIdNeedUpdates(hint.hintContent.contentId)"
-            >
+      <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
+        <li class="oppia-rule-block e2e-test-translation-hint mt-0"
+            *ngFor="let hint of stateHints; index as index"
+            [hidden]="!hasOriginalContent(hint.hintContent)"
+            [ngClass]="{'active': activeHintIndex === index}">
+          <a (click)="changeActiveHintIndex(index)"
+             (keydown.enter)="changeActiveHintIndex(index)"
+             tabindex="0"
+             class="oppia-rule-tab e2e-test-hint-{{ index }} oppia-translation-preview-list"
+             [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
+             [ngStyle]="contentIdStatusColorStyle(hint.hintContent.contentId)">
+            <oppia-response-header [index]="index"
+                                   [defaultOutcome]="true"
+                                   [summary]="getSubtitledContentSummary(hint.hintContent)"
+                                   [shortSummary]="getSubtitledContentSummary(hint.hintContent)"
+                                   [isActive]="index === activeHintIndex"
+                                   [showWarning]="contentIdNeedUpdates(hint.hintContent.contentId)">
             </oppia-response-header>
           </a>
           <div *ngIf="activeHintIndex === index">
-            <div
-              class="oppia-editor-card-section e2e-test-hint-{{ index }}-text"
-              tabindex="0"
-            >
-              <span
-                *ngIf="!getRequiredHtml(hint.hintContent)"
-                class="oppia-placeholder"
-              >
+             <div class="oppia-editor-card-section e2e-test-hint-{{ index }}-text" tabindex="0">
+              <span *ngIf="!getRequiredHtml(hint.hintContent)" class="oppia-placeholder">
                 {{ getEmptyContentMessage() }}
               </span>
               <span>
-                <oppia-rte-output-display
-                  [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                  (click)="onContentClick($event)"
-                  [rteString]="getRequiredHtml(hint.hintContent)"
-                  class="oppia-rte-editor"
-                >
+                <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                                          (click)="onContentClick($event)"
+                                          [rteString]="getRequiredHtml(hint.hintContent)"
+                                          class="oppia-rte-editor">
                 </oppia-rte-output-display>
               </span>
             </div>
@@ -669,51 +391,30 @@
       </ul>
     </div>
 
-    <div
-      *ngIf="isActive(TAB_ID_SOLUTION) && hasOriginalContent(stateSolution.explanation)"
-      class="translation-state-content e2e-test-solution-text"
-    >
-      <span
-        *ngIf="!getRequiredHtml(stateSolution.explanation)"
-        class="oppia-placeholder"
-        tabindex="0"
-      >
+    <div *ngIf="isActive(TAB_ID_SOLUTION) && hasOriginalContent(stateSolution.explanation)" class="translation-state-content e2e-test-solution-text">
+      <span *ngIf="!getRequiredHtml(stateSolution.explanation)" class="oppia-placeholder" tabindex="0">
         {{ getEmptyContentMessage() }}
       </span>
       <span tabindex="0">
-        <oppia-rte-output-display
-          [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-          (click)="onContentClick($event)"
-          [rteString]="getRequiredHtml(stateSolution.explanation)"
-          class="oppia-rte-editor"
-        >
+        <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                                  (click)="onContentClick($event)"
+                                  [rteString]="getRequiredHtml(stateSolution.explanation)"
+                                  class="oppia-rte-editor">
         </oppia-rte-output-display>
       </span>
     </div>
   </div>
-  <div
-    joyrideStep="translationTabRecordingOverview"
-    [stepContent]="TranslationTabRecordingOverview"
-  ></div>
-  <div
-    joyrideStep="translationTabReRecordingOverview"
-    [stepContent]="TranslationTabReRecordingOverview"
-  ></div>
-  <div
-    joyrideStep="translationTabTutorialComplete"
-    [stepContent]="TranslationTabTutorialComplete"
-  ></div>
-  <div
-    *ngIf="isVoiceoverModeActive()"
-    id="tutorialTranslationAudioBar"
-    class="oppia-audio-translation-bar"
-  >
+  <div joyrideStep="translationTabRecordingOverview" [stepContent]="TranslationTabRecordingOverview"></div>
+  <div joyrideStep="translationTabReRecordingOverview" [stepContent]="TranslationTabReRecordingOverview"></div>
+  <div joyrideStep="translationTabTutorialComplete" [stepContent]="TranslationTabTutorialComplete"></div>
+  <div *ngIf="isVoiceoverModeActive()" id="tutorialTranslationAudioBar" class="oppia-audio-translation-bar">
     <oppia-voiceover-card></oppia-voiceover-card>
   </div>
   <div *ngIf="!isVoiceoverModeActive()">
     <oppia-state-translation-editor></oppia-state-translation-editor>
   </div>
 </div>
+
 
 <style>
   .oppia-translation-preview-list {
@@ -812,7 +513,7 @@
     pointer-events: none;
   }
   .oppia-translation-tabs-text {
-    background: rgba(243, 243, 243, 0.75);
+    background: rgba(243,243,243,.75);
     border: 1px solid #eee;
     border-bottom-width: 2px;
     border-top-width: 3px;
@@ -862,10 +563,7 @@
   .oppia-rte-editor-focused:focus > oppia-noninteractive-tabs > div {
     outline: solid 2px #009688;
   }
-  .oppia-rte-editor-focused:focus
-    > oppia-noninteractive-collapsible
-    > ngb-accordion
-    > div {
+  .oppia-rte-editor-focused:focus > oppia-noninteractive-collapsible > ngb-accordion > div {
     outline: solid 2px #009688;
   }
   .oppia-rte-editor-focused:focus > oppia-noninteractive-image > figure {

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -80,7 +80,7 @@
 </div>
 <div class="oppia-page-card oppia-state-translation-page">
   <div class="translation-nav" joyrideStep="translationTabCardOptions" [stepContent]="TranslationTabCardOptions">
-     <ul id="tutorialTranslationState" class="oppia-translation-tabs">
+    <ul id="tutorialTranslationState" class="oppia-translation-tabs">
       <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_CONTENT)}" class="e2e-test-accessibility-translation-content" aria-label="Content of the card" role="button">
         <div (click)="onTabClick(TAB_ID_CONTENT)" tabindex="0" (keydown.enter)="onTabClick(TAB_ID_CONTENT)" [ngStyle]="tabStatusColorStyle(TAB_ID_CONTENT)" class="oppia-translation-tabs-text e2e-test-translation-content-tab">
           <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_CONTENT)" class="oppia-tab-needs-update"
@@ -268,9 +268,9 @@
           </li>
         </ul>
       </div>
-      
 
-     <div>
+
+      <div>
         <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
           <li [ngClass]="{'active': activeAnswerGroupIndex === stateAnswerGroups.length}"
               class="oppia-rule-block e2e-test-translation-feedback">
@@ -299,7 +299,6 @@
                                             [rteString]="getRequiredHtml(stateDefaultOutcome.feedback)"
                                             class="oppia-rte-editor">
                   </oppia-rte-output-display>
-                </div>
                 </div>
               </div>
             </div>

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -63,12 +63,12 @@
       </li>
       <li>
         When you are ready to end the recording, click
-        <i class="material-icons oppia-state-translation-icons"> &#xE047;</i> to
-        <b>stop</b>.
+        <i class="material-icons oppia-state-translation-icons">
+        &#xE047;</i> to <b>stop</b>.
       </li>
       <li>
         Hit the <b>save</b>
-        <i class="material-icons oppia-state-translation-icons"> &#xE161;</i> button 
+        <i class="material-icons oppia-state-translation-icons"> &#xE161;</i> button
         to confirm the recording.
       </li>
     </ol>
@@ -76,12 +76,12 @@
 </ng-template>
 
 <div class="oppia-translation-page-statename">
-   <strong class="e2e-test-state-name-text" tabindex="0" [attr.aria-label]="'State name:' + stateName">{{ stateName }}</strong>
+  <strong class="e2e-test-state-name-text" tabindex="0" [attr.aria-label]="'State name:' + stateName">{{ stateName }}</strong>
 </div>
 <div class="oppia-page-card oppia-state-translation-page">
   <div class="translation-nav" joyrideStep="translationTabCardOptions" [stepContent]="TranslationTabCardOptions">
-    <ul id="tutorialTranslationState" class="oppia-translation-tabs">
-       <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_CONTENT)}" class="e2e-test-accessibility-translation-content" aria-label="Content of the card" role="button">
+     <ul id="tutorialTranslationState" class="oppia-translation-tabs">
+      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_CONTENT)}" class="e2e-test-accessibility-translation-content" aria-label="Content of the card" role="button">
         <div (click)="onTabClick(TAB_ID_CONTENT)" tabindex="0" (keydown.enter)="onTabClick(TAB_ID_CONTENT)" [ngStyle]="tabStatusColorStyle(TAB_ID_CONTENT)" class="oppia-translation-tabs-text e2e-test-translation-content-tab">
           <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_CONTENT)" class="oppia-tab-needs-update"
                 tabindex="0"
@@ -97,7 +97,7 @@
           </span>Interaction
         </div>
       </li>
-       <li *ngIf="!isVoiceoverModeActive()" [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_RULE_INPUTS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_RULE_INPUTS)}" aria-label="Rule Inputs" role="button">
+      <li *ngIf="!isVoiceoverModeActive()" [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_RULE_INPUTS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_RULE_INPUTS)}" aria-label="Rule Inputs" role="button">
         <div (click)="onTabClick(TAB_ID_RULE_INPUTS)" [attr.tabindex]="!isDisabled(TAB_ID_RULE_INPUTS) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_RULE_INPUTS)" [ngStyle]="tabStatusColorStyle(TAB_ID_RULE_INPUTS)" class="oppia-translation-tabs-text">
           <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_RULE_INPUTS)" class="oppia-tab-needs-update"
                 tabindex="0"
@@ -121,7 +121,7 @@
           </span>Hints
         </div>
       </li>
-     <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_SOLUTION), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_SOLUTION)}" class="e2e-test-accessibility-translation-solution" aria-label="Solutions for the state" role="button">
+      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_SOLUTION), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_SOLUTION)}" class="e2e-test-accessibility-translation-solution" aria-label="Solutions for the state" role="button">
         <div (click)="onTabClick(TAB_ID_SOLUTION)" [attr.tabindex]="!isDisabled(TAB_ID_SOLUTION) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_SOLUTION)" [ngStyle]="tabStatusColorStyle(TAB_ID_SOLUTION)" class="oppia-translation-tabs-text e2e-test-translation-solution-tab" >
           <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_SOLUTION)" class="oppia-tab-needs-update"
                 tabindex="0"
@@ -250,12 +250,9 @@
               </oppia-response-header>
             </a>
             <div *ngIf="activeAnswerGroupIndex === index">
-              <div class="oppia-editor-card-section e2e-test-feedback-{{ stateAnswerGroups.length }}-text">
+              <div class="oppia-editor-card-section e2e-test-feedback-{{ index }}-text">
                 <div class="oppia-rule-body-container" tabindex="0">
-                  <span
-                    *ngIf="!getRequiredHtml(answerGroup.outcome.feedback)"
-                    class="oppia-placeholder"
-                  >
+                  <span *ngIf="!getRequiredHtml(answerGroup.outcome.feedback)" class="oppia-placeholder">
                     {{ getEmptyContentMessage() }}
                   </span>
                   <span>
@@ -271,81 +268,38 @@
           </li>
         </ul>
       </div>
+      
 
-      <div>
-        <ul
-          class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
-          role="tablist"
-        >
-          <li
-            [ngClass]="{
-              active: activeAnswerGroupIndex === stateAnswerGroups.length
-            }"
-            [hidden]="!hasOriginalContent(stateDefaultOutcome.feedback)"
-            class="oppia-rule-block e2e-test-translation-feedback"
-          >
-            <a
-              class="oppia-rule-tab oppia-default-rule-tab e2e-test-feedback-{{
-                stateAnswerGroups.length
-              }} oppia-translation-preview-list"
-              (click)="changeActiveAnswerGroupIndex(stateAnswerGroups.length)"
-              tabindex="0"
-              (keydown.enter)="
-                changeActiveAnswerGroupIndex(stateAnswerGroups.length)
-              "
-              [ngClass]="{
-                'oppia-rule-tab-active':
-                  activeAnswerGroupIndex == stateAnswerGroups.length
-              }"
-              [ngStyle]="
-                contentIdStatusColorStyle(
-                  stateDefaultOutcome.feedback.contentId
-                )
-              "
-            >
-              <oppia-response-header
-                [index]="index"
-                [isActive]="index === activeAnswerGroupIndex"
-                [summary]="
-                  summarizeDefaultOutcome(
-                    stateDefaultOutcome,
-                    stateInteractionId,
-                    stateDefaultOutcome.length,
-                    false
-                  )
-                "
-                [shortSummary]="
-                  summarizeDefaultOutcome(
-                    stateDefaultOutcome,
-                    stateInteractionId,
-                    stateDefaultOutcome.length,
-                    true
-                  )
-                "
-                [outcome]="stateDefaultOutcome"
-                [defaultOutcome]="true"
-                [isResponse]="true"
-                [showWarning]="
-                  contentIdNeedUpdates(stateDefaultOutcome.feedback.contentId)
-                "
-                (navigateToState)="navigateToState($event)"
-              >
+     <div>
+        <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
+          <li [ngClass]="{'active': activeAnswerGroupIndex === stateAnswerGroups.length}"
+              class="oppia-rule-block e2e-test-translation-feedback">
+            <a class="oppia-rule-tab oppia-default-rule-tab e2e-test-feedback-{{ stateAnswerGroups.length }} oppia-translation-preview-list"
+               (click)="changeActiveAnswerGroupIndex(stateAnswerGroups.length)"
+               tabindex="0"
+               (keydown.enter)="changeActiveAnswerGroupIndex(stateAnswerGroups.length)"
+               [ngClass]="{'oppia-rule-tab-active': activeAnswerGroupIndex == stateAnswerGroups.length}"
+               [ngStyle]="contentIdStatusColorStyle(stateDefaultOutcome.feedback.contentId)">
+              <oppia-response-header [index]="index"
+                                     [isActive]="index === activeAnswerGroupIndex"
+                                     [summary]="summarizeDefaultOutcome(stateDefaultOutcome, stateInteractionId, stateDefaultOutcome.length, false)"
+                                     [shortSummary]="summarizeDefaultOutcome(stateDefaultOutcome, stateInteractionId, stateDefaultOutcome.length, true)"
+                                     [outcome]="stateDefaultOutcome"
+                                     [defaultOutcome]="true"
+                                     [isResponse]="true"
+                                     [showWarning]="contentIdNeedUpdates(stateDefaultOutcome.feedback.contentId)"
+                                     (navigateToState)="navigateToState($event)">
               </oppia-response-header>
             </a>
             <div *ngIf="activeAnswerGroupIndex === stateAnswerGroups.length">
-              <div
-                class="oppia-editor-card-section e2e-test-feedback-{{
-                  stateAnswerGroups.length
-                }}-text"
-              >
+              <div class="oppia-editor-card-section e2e-test-feedback-{{ stateAnswerGroups.length }}-text">
                 <div class="oppia-rule-body-container" tabindex="0">
-                  <oppia-rte-output-display
-                    [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                    (click)="onContentClick($event)"
-                    [rteString]="getRequiredHtml(stateDefaultOutcome.feedback)"
-                    class="oppia-rte-editor"
-                  >
+                  <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                                            (click)="onContentClick($event)"
+                                            [rteString]="getRequiredHtml(stateDefaultOutcome.feedback)"
+                                            class="oppia-rte-editor">
                   </oppia-rte-output-display>
+                </div>
                 </div>
               </div>
             </div>
@@ -374,7 +328,7 @@
             </oppia-response-header>
           </a>
           <div *ngIf="activeHintIndex === index">
-             <div class="oppia-editor-card-section e2e-test-hint-{{ index }}-text" tabindex="0">
+            <div class="oppia-editor-card-section e2e-test-hint-{{ index }}-text" tabindex="0">
               <span *ngIf="!getRequiredHtml(hint.hintContent)" class="oppia-placeholder">
                 {{ getEmptyContentMessage() }}
               </span>

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -1,47 +1,54 @@
 <ng-template #TranslationTabCardOptions>
-  <h3 class="e2e-test-joyride-title" tabindex="0">Choose a Part of the Card to Translate</h3>
+  <h3 class="e2e-test-joyride-title" tabindex="0">
+    Choose a Part of the Card to Translate
+  </h3>
   <p tabindex="0">
-    Next, choose a part of the lesson card to translate. This menu at the top lists all the translatable parts of the card. Within each tab, multiple sections may be available for translating.
+    Next, choose a part of the lesson card to translate. This menu at the top
+    lists all the translatable parts of the card. Within each tab, multiple
+    sections may be available for translating.
   </p>
 </ng-template>
 
 <ng-template #TranslationTabTutorialComplete>
   <h3 class="e2e-test-joyride-title" tabindex="0">Tutorial Complete</h3>
   <p tabindex="0">
-    Now, you are ready to begin adding translations
-    to your explorations!
-    This marks the end of this tour.
-    Remember to save your progress periodically using
-    the save button in the navigation bar at the top:
+    Now, you are ready to begin adding translations to your explorations! This
+    marks the end of this tour. Remember to save your progress periodically
+    using the save button in the navigation bar at the top:
     <button class="btn btn-success" disabled>
-      <i class="material-icons" >&#xE161;</i>
-    </button>.<br>
-    Thank you for making this lesson more accessible
-    for non-native speakers!'
+      <i class="material-icons">&#xE161;</i></button
+    >.<br />
+    Thank you for making this lesson more accessible for non-native speakers!'
   </p>
 </ng-template>
 
 <ng-template #TranslationTabReRecordingOverview>
   <h3 class="e2e-test-joyride-title" tabindex="0">Re-record/Re-upload audio</h3>
   <div tabindex="0">
-    <p>The audio recording also has options related to updating and deleting translations.</p>
+    <p>
+      The audio recording also has options related to updating and deleting
+      translations.
+    </p>
     <ul>
       <li>
-        To revert and cancel any unsaved translation(s),
-        click the
-        <i class="material-icons oppia-state-translation-icons">&#xE5C9;</i> button.
+        To revert and cancel any unsaved translation(s), click the
+        <i class="material-icons oppia-state-translation-icons">&#xE5C9;</i>
+        button.
       </li>
       <li>
         To play the audio, click the
-        <i class="material-icons oppia-state-translation-icons" >&#xE039;</i> button.
+        <i class="material-icons oppia-state-translation-icons">&#xE039;</i>
+        button.
       </li>
       <li>
         To do retakes, click the
-        <i class="material-icons oppia-state-translation-icons">&#xE028;</i> button.
+        <i class="material-icons oppia-state-translation-icons">&#xE028;</i>
+        button.
       </li>
       <li>
         To delete a recording, click the
-        <i class="material-icons oppia-state-translation-icons">&#xE872;</i> button.
+        <i class="material-icons oppia-state-translation-icons">&#xE872;</i>
+        button.
       </li>
     </ul>
   </div>
@@ -50,145 +57,327 @@
 <ng-template #TranslationTabRecordingOverview>
   <h3 class="e2e-test-joyride-title" tabindex="0">Recording Audio</h3>
   <div>
-    <p tabindex="0">To create audio translations in Oppia, we recommend using the <i class="material-icons oppia-state-translation-icons">&#xE2C6;</i>
-    button to <b>upload</b> audio files from your computer.</p>
-    <p tabindex="0">You can also record via your browser, but that may lead to degraded audio quality. If you would like to do so anyway,
-       simply follow these 3 steps:
+    <p tabindex="0">
+      To create audio translations in Oppia, we recommend using the
+      <i class="material-icons oppia-state-translation-icons">&#xE2C6;</i>
+      button to <b>upload</b> audio files from your computer.
+    </p>
+    <p tabindex="0">
+      You can also record via your browser, but that may lead to degraded audio
+      quality. If you would like to do so anyway, simply follow these 3 steps:
     </p>
     <ol tabindex="0">
       <li>
         To start <b>recording</b>, click the
         <i class="material-icons oppia-state-translation-icons">mic</i> button.
-        If the browser pops up a message asking if you’d
-        like to record audio, accept it.
+        If the browser pops up a message asking if you’d like to record audio,
+        accept it.
       </li>
       <li>
         When you are ready to end the recording, click
-        <i class="material-icons oppia-state-translation-icons">
-        &#xE047;</i> to <b>stop</b>.
+        <i class="material-icons oppia-state-translation-icons"> &#xE047;</i> to
+        <b>stop</b>.
       </li>
       <li>
         Hit the <b>save</b>
-        <i class="material-icons oppia-state-translation-icons"> &#xE161;</i> button
-        to confirm the recording.
+        <i class="material-icons oppia-state-translation-icons"> &#xE161;</i>
+        button to confirm the recording.
       </li>
     </ol>
   </div>
 </ng-template>
 
 <div class="oppia-translation-page-statename">
-  <strong class="e2e-test-state-name-text" tabindex="0" [attr.aria-label]="'State name:' + stateName">{{ stateName }}</strong>
+  <strong
+    class="e2e-test-state-name-text"
+    tabindex="0"
+    [attr.aria-label]="'State name:' + stateName"
+    >{{ stateName }}</strong
+  >
 </div>
 <div class="oppia-page-card oppia-state-translation-page">
-  <div class="translation-nav" joyrideStep="translationTabCardOptions" [stepContent]="TranslationTabCardOptions">
+  <div
+    class="translation-nav"
+    joyrideStep="translationTabCardOptions"
+    [stepContent]="TranslationTabCardOptions"
+  >
     <ul id="tutorialTranslationState" class="oppia-translation-tabs">
-      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_CONTENT)}" class="e2e-test-accessibility-translation-content" aria-label="Content of the card" role="button">
-        <div (click)="onTabClick(TAB_ID_CONTENT)" tabindex="0" (keydown.enter)="onTabClick(TAB_ID_CONTENT)" [ngStyle]="tabStatusColorStyle(TAB_ID_CONTENT)" class="oppia-translation-tabs-text e2e-test-translation-content-tab">
-          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_CONTENT)" class="oppia-tab-needs-update"
-                tabindex="0"
-                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
-          </span>Content
+      <li
+        [ngClass]="{
+          'oppia-active-translation-tab e2e-test-active-translation-tab':
+            isActive(TAB_ID_CONTENT)
+        }"
+        class="e2e-test-accessibility-translation-content"
+        aria-label="Content of the card"
+        role="button"
+      >
+        <div
+          (click)="onTabClick(TAB_ID_CONTENT)"
+          tabindex="0"
+          (keydown.enter)="onTabClick(TAB_ID_CONTENT)"
+          [ngStyle]="tabStatusColorStyle(TAB_ID_CONTENT)"
+          class="oppia-translation-tabs-text e2e-test-translation-content-tab"
+        >
+          <span
+            [hidden]="!tabNeedUpdatesStatus(TAB_ID_CONTENT)"
+            class="oppia-tab-needs-update"
+            tabindex="0"
+            [ngbTooltip]="needsUpdateTooltipMessage"
+            placement="top"
+            >⚠ </span
+          >Content
         </div>
       </li>
-      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_CUSTOMIZATION_ARGS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_CUSTOMIZATION_ARGS)}" aria-label="Interaction content" role="button">
-        <div (click)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)" [attr.tabindex]="!isDisabled(TAB_ID_CUSTOMIZATION_ARGS) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)" [ngStyle]="tabStatusColorStyle(TAB_ID_CUSTOMIZATION_ARGS)" class="oppia-translation-tabs-text">
-          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_CUSTOMIZATION_ARGS)" class="oppia-tab-needs-update"
-                tabindex="0"
-                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
-          </span>Interaction
+      <li
+        [ngClass]="{
+          'oppia-active-translation-tab e2e-test-active-translation-tab':
+            isActive(TAB_ID_CUSTOMIZATION_ARGS),
+          'oppia-disabled-translation-tab': isDisabled(
+            TAB_ID_CUSTOMIZATION_ARGS
+          )
+        }"
+        aria-label="Interaction content"
+        role="button"
+      >
+        <div
+          (click)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)"
+          [attr.tabindex]="!isDisabled(TAB_ID_CUSTOMIZATION_ARGS) ? '0' : '-1'"
+          (keydown.enter)="onTabClick(TAB_ID_CUSTOMIZATION_ARGS)"
+          [ngStyle]="tabStatusColorStyle(TAB_ID_CUSTOMIZATION_ARGS)"
+          class="oppia-translation-tabs-text"
+        >
+          <span
+            [hidden]="!tabNeedUpdatesStatus(TAB_ID_CUSTOMIZATION_ARGS)"
+            class="oppia-tab-needs-update"
+            tabindex="0"
+            [ngbTooltip]="needsUpdateTooltipMessage"
+            placement="top"
+            >⚠ </span
+          >Interaction
         </div>
       </li>
-      <li *ngIf="!isVoiceoverModeActive()" [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_RULE_INPUTS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_RULE_INPUTS)}" aria-label="Rule Inputs" role="button">
-        <div (click)="onTabClick(TAB_ID_RULE_INPUTS)" [attr.tabindex]="!isDisabled(TAB_ID_RULE_INPUTS) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_RULE_INPUTS)" [ngStyle]="tabStatusColorStyle(TAB_ID_RULE_INPUTS)" class="oppia-translation-tabs-text">
-          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_RULE_INPUTS)" class="oppia-tab-needs-update"
-                tabindex="0"
-                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
-          </span>Rules
+      <li
+        *ngIf="!isVoiceoverModeActive()"
+        [ngClass]="{
+          'oppia-active-translation-tab e2e-test-active-translation-tab':
+            isActive(TAB_ID_RULE_INPUTS),
+          'oppia-disabled-translation-tab': isDisabled(TAB_ID_RULE_INPUTS)
+        }"
+        aria-label="Rule Inputs"
+        role="button"
+      >
+        <div
+          (click)="onTabClick(TAB_ID_RULE_INPUTS)"
+          [attr.tabindex]="!isDisabled(TAB_ID_RULE_INPUTS) ? '0' : '-1'"
+          (keydown.enter)="onTabClick(TAB_ID_RULE_INPUTS)"
+          [ngStyle]="tabStatusColorStyle(TAB_ID_RULE_INPUTS)"
+          class="oppia-translation-tabs-text"
+        >
+          <span
+            [hidden]="!tabNeedUpdatesStatus(TAB_ID_RULE_INPUTS)"
+            class="oppia-tab-needs-update"
+            tabindex="0"
+            [ngbTooltip]="needsUpdateTooltipMessage"
+            placement="top"
+            >⚠ </span
+          >Rules
         </div>
       </li>
-      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_FEEDBACK), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_FEEDBACK)}" class="e2e-test-accessibility-translation-feedback" aria-label="Feedback responses for answer groups" role="button">
-        <div (click)="onTabClick(TAB_ID_FEEDBACK)" [attr.tabindex]="!isDisabled(TAB_ID_FEEDBACK) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_FEEDBACK)" [ngStyle]="tabStatusColorStyle(TAB_ID_FEEDBACK)" class="oppia-translation-tabs-text e2e-test-translation-feedback-tab">
-          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_FEEDBACK)" class="oppia-tab-needs-update"
-                tabindex="0"
-                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
-          </span>Feedback
+      <li
+        [ngClass]="{
+          'oppia-active-translation-tab e2e-test-active-translation-tab':
+            isActive(TAB_ID_FEEDBACK),
+          'oppia-disabled-translation-tab': isDisabled(TAB_ID_FEEDBACK)
+        }"
+        class="e2e-test-accessibility-translation-feedback"
+        aria-label="Feedback responses for answer groups"
+        role="button"
+      >
+        <div
+          (click)="onTabClick(TAB_ID_FEEDBACK)"
+          [attr.tabindex]="!isDisabled(TAB_ID_FEEDBACK) ? '0' : '-1'"
+          (keydown.enter)="onTabClick(TAB_ID_FEEDBACK)"
+          [ngStyle]="tabStatusColorStyle(TAB_ID_FEEDBACK)"
+          class="oppia-translation-tabs-text e2e-test-translation-feedback-tab"
+        >
+          <span
+            [hidden]="!tabNeedUpdatesStatus(TAB_ID_FEEDBACK)"
+            class="oppia-tab-needs-update"
+            tabindex="0"
+            [ngbTooltip]="needsUpdateTooltipMessage"
+            placement="top"
+            >⚠ </span
+          >Feedback
         </div>
       </li>
-      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_HINTS), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_HINTS)}" class="e2e-test-accessibility-translation-hint" aria-label="Hints for the state" role="button">
-        <div (click)="onTabClick(TAB_ID_HINTS)" [attr.tabindex]="!isDisabled(TAB_ID_HINTS) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_HINTS)" [ngStyle]="tabStatusColorStyle(TAB_ID_HINTS)" class="oppia-translation-tabs-text e2e-test-translation-hints-tab">
-          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_HINTS)" class="oppia-tab-needs-update"
-                tabindex="0"
-                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
-          </span>Hints
+      <li
+        [ngClass]="{
+          'oppia-active-translation-tab e2e-test-active-translation-tab':
+            isActive(TAB_ID_HINTS),
+          'oppia-disabled-translation-tab': isDisabled(TAB_ID_HINTS)
+        }"
+        class="e2e-test-accessibility-translation-hint"
+        aria-label="Hints for the state"
+        role="button"
+      >
+        <div
+          (click)="onTabClick(TAB_ID_HINTS)"
+          [attr.tabindex]="!isDisabled(TAB_ID_HINTS) ? '0' : '-1'"
+          (keydown.enter)="onTabClick(TAB_ID_HINTS)"
+          [ngStyle]="tabStatusColorStyle(TAB_ID_HINTS)"
+          class="oppia-translation-tabs-text e2e-test-translation-hints-tab"
+        >
+          <span
+            [hidden]="!tabNeedUpdatesStatus(TAB_ID_HINTS)"
+            class="oppia-tab-needs-update"
+            tabindex="0"
+            [ngbTooltip]="needsUpdateTooltipMessage"
+            placement="top"
+            >⚠ </span
+          >Hints
         </div>
       </li>
-      <li [ngClass]="{'oppia-active-translation-tab e2e-test-active-translation-tab': isActive(TAB_ID_SOLUTION), 'oppia-disabled-translation-tab': isDisabled(TAB_ID_SOLUTION)}" class="e2e-test-accessibility-translation-solution" aria-label="Solutions for the state" role="button">
-        <div (click)="onTabClick(TAB_ID_SOLUTION)" [attr.tabindex]="!isDisabled(TAB_ID_SOLUTION) ? '0' : '-1'" (keydown.enter)="onTabClick(TAB_ID_SOLUTION)" [ngStyle]="tabStatusColorStyle(TAB_ID_SOLUTION)" class="oppia-translation-tabs-text e2e-test-translation-solution-tab" >
-          <span [hidden]="!tabNeedUpdatesStatus(TAB_ID_SOLUTION)" class="oppia-tab-needs-update"
-                tabindex="0"
-                [ngbTooltip]="needsUpdateTooltipMessage" placement="top">⚠
-          </span>Solution
+      <li
+        [ngClass]="{
+          'oppia-active-translation-tab e2e-test-active-translation-tab':
+            isActive(TAB_ID_SOLUTION),
+          'oppia-disabled-translation-tab': isDisabled(TAB_ID_SOLUTION)
+        }"
+        class="e2e-test-accessibility-translation-solution"
+        aria-label="Solutions for the state"
+        role="button"
+      >
+        <div
+          (click)="onTabClick(TAB_ID_SOLUTION)"
+          [attr.tabindex]="!isDisabled(TAB_ID_SOLUTION) ? '0' : '-1'"
+          (keydown.enter)="onTabClick(TAB_ID_SOLUTION)"
+          [ngStyle]="tabStatusColorStyle(TAB_ID_SOLUTION)"
+          class="oppia-translation-tabs-text e2e-test-translation-solution-tab"
+        >
+          <span
+            [hidden]="!tabNeedUpdatesStatus(TAB_ID_SOLUTION)"
+            class="oppia-tab-needs-update"
+            tabindex="0"
+            [ngbTooltip]="needsUpdateTooltipMessage"
+            placement="top"
+            >⚠ </span
+          >Solution
         </div>
       </li>
     </ul>
   </div>
 
-  <div *ngIf="!isVoiceoverModeActive()" class="oppia-state-content-header">Original content</div>
+  <div *ngIf="!isVoiceoverModeActive()" class="oppia-state-content-header">
+    Original content
+  </div>
   <div class="translation-state-contents">
-    <div *ngIf="isActive(TAB_ID_CONTENT)" class="translation-state-content e2e-test-content-text">
+    <div
+      *ngIf="isActive(TAB_ID_CONTENT)"
+      class="translation-state-content e2e-test-content-text"
+    >
       <span>
-        <span *ngIf="!getRequiredHtml(stateContent)" class="oppia-placeholder" tabindex="0">
+        <span
+          *ngIf="!getRequiredHtml(stateContent)"
+          class="oppia-placeholder"
+          tabindex="0"
+        >
           {{ getEmptyContentMessage() }}
         </span>
         <span tabindex="0">
-          <oppia-rte-output-display [rteString]="getRequiredHtml(stateContent)"
-                                    [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                                    (click)="onContentClick($event)"
-                                    class="oppia-rte-editor">
+          <oppia-rte-output-display
+            [rteString]="getRequiredHtml(stateContent)"
+            [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+            (click)="onContentClick($event)"
+            class="oppia-rte-editor"
+          >
           </oppia-rte-output-display>
         </span>
       </span>
     </div>
-    <div *ngIf="isActive(TAB_ID_CUSTOMIZATION_ARGS)" class="translation-state-content">
-      <h3 tabindex="0">Preview - {{INTERACTION_SPECS[stateInteractionId].name}}</h3>
-      <oppia-rte-output-display class="oppia-translation-state-content-html-data" [rteString]="interactionPreviewHtml">
+    <div
+      *ngIf="isActive(TAB_ID_CUSTOMIZATION_ARGS)"
+      class="translation-state-content"
+    >
+      <h3 tabindex="0">
+        Preview - {{ INTERACTION_SPECS[stateInteractionId].name }}
+      </h3>
+      <oppia-rte-output-display
+        class="oppia-translation-state-content-html-data"
+        [rteString]="interactionPreviewHtml"
+      >
       </oppia-rte-output-display>
       <h3 tabindex="0">Content</h3>
-      <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
-        <li class="oppia-rule-block mt-0"
-            *ngFor="let caContent of interactionCustomizationArgTranslatableContent; index as index"
-            [ngClass]="{'active': activeCustomizationArgContentIndex === index}">
-          <a (click)="changeActiveCustomizationArgContentIndex(index)"
-             (keydown.enter)="changeActiveCustomizationArgContentIndex(index)"
-             tabindex="0"
-             class="oppia-rule-tab oppia-translation-preview-list"
-             [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
-             [ngStyle]="contentIdStatusColorStyle(caContent.content.contentId)">
-            <oppia-response-header [index]="index"
-                                   [defaultOutcome]="true"
-                                   [summary]="caContent.name + ': ' + getSubtitledContentSummary(caContent.content)"
-                                   [shortSummary]="caContent.name + ': ' + getSubtitledContentSummary(caContent.content)"
-                                   [isActive]="index === activeCustomizationArgContentIndex"
-                                   [showWarning]="contentIdNeedUpdates(caContent.content.contentId)">
+      <ul
+        class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
+        role="tablist"
+      >
+        <li
+          class="oppia-rule-block mt-0"
+          *ngFor="
+            let caContent of interactionCustomizationArgTranslatableContent;
+            index as index
+          "
+          [ngClass]="{active: activeCustomizationArgContentIndex === index}"
+        >
+          <a
+            (click)="changeActiveCustomizationArgContentIndex(index)"
+            (keydown.enter)="changeActiveCustomizationArgContentIndex(index)"
+            tabindex="0"
+            class="oppia-rule-tab oppia-translation-preview-list"
+            [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
+            [ngStyle]="contentIdStatusColorStyle(caContent.content.contentId)"
+          >
+            <oppia-response-header
+              [index]="index"
+              [defaultOutcome]="true"
+              [summary]="
+                caContent.name +
+                ': ' +
+                getSubtitledContentSummary(caContent.content)
+              "
+              [shortSummary]="
+                caContent.name +
+                ': ' +
+                getSubtitledContentSummary(caContent.content)
+              "
+              [isActive]="index === activeCustomizationArgContentIndex"
+              [showWarning]="contentIdNeedUpdates(caContent.content.contentId)"
+            >
             </oppia-response-header>
           </a>
           <div *ngIf="activeCustomizationArgContentIndex === index">
-            <div class="oppia-editor-card-section" *ngIf="caContent.content._html">
-              <span *ngIf="!getRequiredHtml(caContent.content)" class="oppia-placeholder" tabindex="0">
+            <div
+              class="oppia-editor-card-section"
+              *ngIf="caContent.content._html"
+            >
+              <span
+                *ngIf="!getRequiredHtml(caContent.content)"
+                class="oppia-placeholder"
+                tabindex="0"
+              >
                 {{ getEmptyContentMessage() }}
               </span>
               <span>
-                <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                                          (click)="onContentClick($event)"
-                                          (keydown.enter)="onContentClick($event)"
-                                          tabindex="0"
-                                          class="oppia-rte-editor"
-                                          [rteString]="getRequiredHtml(caContent.content)">
+                <oppia-rte-output-display
+                  [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                  (click)="onContentClick($event)"
+                  (keydown.enter)="onContentClick($event)"
+                  tabindex="0"
+                  class="oppia-rte-editor"
+                  [rteString]="getRequiredHtml(caContent.content)"
+                >
                 </oppia-rte-output-display>
               </span>
             </div>
-            <div class="oppia-editor-card-section" *ngIf="caContent.content._unicode">
-              <span *ngIf="!caContent.content._unicode" class="oppia-placeholder" tabindex="0">
+            <div
+              class="oppia-editor-card-section"
+              *ngIf="caContent.content._unicode"
+            >
+              <span
+                *ngIf="!caContent.content._unicode"
+                class="oppia-placeholder"
+                tabindex="0"
+              >
                 {{ getEmptyContentMessage() }}
               </span>
               <span>
@@ -201,23 +390,47 @@
     </div>
     <div *ngIf="isActive(TAB_ID_RULE_INPUTS)" class="translation-state-content">
       <div>
-        <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
-          <li class="oppia-rule-block e2e-test-translation-feedback mt-0"
-              *ngFor="let ruleContent of interactionRuleTranslatableContents; index as index"
-              [ngClass]="{'active': activeRuleContentIndex === index}">
-            <a class="oppia-rule-tab e2e-test-feedback-{{ index }} oppia-translation-preview-list"
-               tabindex="0"
-               (keydown.enter)="changeActiveRuleContentIndex(index)"
-               (click)="changeActiveRuleContentIndex(index)"
-               [ngClass]="{'oppia-rule-tab-active': activeRuleContentIndex === index}"
-               [ngStyle]="contentIdStatusColorStyle(ruleContent.contentId)">
-               {{ ruleContent.rule | parameterizeRuleDescriptionPipe: stateInteractionId: answerChoices }}
+        <ul
+          class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
+          role="tablist"
+        >
+          <li
+            class="oppia-rule-block e2e-test-translation-feedback mt-0"
+            *ngFor="
+              let ruleContent of interactionRuleTranslatableContents;
+              index as index
+            "
+            [ngClass]="{active: activeRuleContentIndex === index}"
+          >
+            <a
+              class="oppia-rule-tab e2e-test-feedback-{{
+                index
+              }} oppia-translation-preview-list"
+              tabindex="0"
+              (keydown.enter)="changeActiveRuleContentIndex(index)"
+              (click)="changeActiveRuleContentIndex(index)"
+              [ngClass]="{
+                'oppia-rule-tab-active': activeRuleContentIndex === index
+              }"
+              [ngStyle]="contentIdStatusColorStyle(ruleContent.contentId)"
+            >
+              {{
+                ruleContent.rule
+                  | parameterizeRuleDescriptionPipe
+                    : stateInteractionId
+                    : answerChoices
+              }}
             </a>
             <div *ngIf="activeRuleContentIndex === index">
               <div class="oppia-editor-card-section">
                 <div class="oppia-rule-body-container" tabindex="0">
                   <span>
-                    {{ getHumanReadableRuleInputValues(ruleContent.rule.inputs[ruleContent.inputName], ruleContent.rule.inputTypes[ruleContent.inputName]) }}
+                    {{
+                      getHumanReadableRuleInputValues(
+                        ruleContent.rule.inputs[ruleContent.inputName],
+                        ruleContent.rule.inputTypes[ruleContent.inputName]
+                      )
+                    }}
                   </span>
                 </div>
               </div>
@@ -228,39 +441,85 @@
     </div>
     <div *ngIf="isActive(TAB_ID_FEEDBACK)" class="translation-state-content">
       <div>
-        <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
-          <li class="oppia-rule-block e2e-test-translation-feedback mt-0"
-              *ngFor="let answerGroup of stateAnswerGroups; index as index"
-              [ngClass]="{'active': activeAnswerGroupIndex === index}">
-            <a class="oppia-rule-tab e2e-test-feedback-{{ index }} oppia-translation-preview-list"
-               tabindex="0"
-               (keydown.enter)="changeActiveAnswerGroupIndex(index)"
-               (click)="changeActiveAnswerGroupIndex(index)"
-               [ngClass]="{'oppia-rule-tab-active': activeAnswerGroupIndex === index}"
-               [ngStyle]="contentIdStatusColorStyle(answerGroup.outcome.feedback.contentId)">
-              <oppia-response-header [index]="index"
-                                     [summary]="summarizeAnswerGroup(answerGroup, stateInteractionId, answerChoices, false)"
-                                     [shortSummary]="summarizeAnswerGroup(answerGroup, stateInteractionId, answerChoices, true)"
-                                     [isActive]="index === activeAnswerGroupIndex"
-                                     [outcome]="answerGroup.outcome"
-                                     [defaultOutcome]="true"
-                                     [numRules]="answerGroup.rules.length"
-                                     [isResponse]="true"
-                                     [showWarning]="contentIdNeedUpdates(answerGroup.outcome.feedback.contentId)"
-                                     (navigateToState)="navigateToState($event)">
+        <ul
+          class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
+          role="tablist"
+        >
+          <li
+            class="oppia-rule-block e2e-test-translation-feedback mt-0"
+            *ngFor="let answerGroup of stateAnswerGroups; index as index"
+            [ngClass]="{active: activeAnswerGroupIndex === index}"
+          >
+            <a
+              class="oppia-rule-tab e2e-test-feedback-{{
+                index
+              }} oppia-translation-preview-list"
+              tabindex="0"
+              (keydown.enter)="changeActiveAnswerGroupIndex(index)"
+              (click)="changeActiveAnswerGroupIndex(index)"
+              [ngClass]="{
+                'oppia-rule-tab-active': activeAnswerGroupIndex === index
+              }"
+              [ngStyle]="
+                contentIdStatusColorStyle(
+                  answerGroup.outcome.feedback.contentId
+                )
+              "
+            >
+              <oppia-response-header
+                [index]="index"
+                [summary]="
+                  summarizeAnswerGroup(
+                    answerGroup,
+                    stateInteractionId,
+                    answerChoices,
+                    false
+                  )
+                "
+                [shortSummary]="
+                  summarizeAnswerGroup(
+                    answerGroup,
+                    stateInteractionId,
+                    answerChoices,
+                    true
+                  )
+                "
+                [isActive]="index === activeAnswerGroupIndex"
+                [outcome]="answerGroup.outcome"
+                [defaultOutcome]="true"
+                [numRules]="answerGroup.rules.length"
+                [isResponse]="true"
+                [showWarning]="
+                  contentIdNeedUpdates(answerGroup.outcome.feedback.contentId)
+                "
+                (navigateToState)="navigateToState($event)"
+              >
               </oppia-response-header>
             </a>
             <div *ngIf="activeAnswerGroupIndex === index">
-              <div class="oppia-editor-card-section e2e-test-feedback-{{ index }}-text">
+              <div
+                class="oppia-editor-card-section e2e-test-feedback-{{
+                  index
+                }}-text"
+              >
                 <div class="oppia-rule-body-container" tabindex="0">
-                  <span *ngIf="!getRequiredHtml(answerGroup.outcome.feedback)" class="oppia-placeholder">
+                  <span
+                    *ngIf="!getRequiredHtml(answerGroup.outcome.feedback)"
+                    class="oppia-placeholder"
+                  >
                     {{ getEmptyContentMessage() }}
                   </span>
                   <span>
-                    <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                                              (click)="onContentClick($event)"
-                                              [rteString]="getRequiredHtml(answerGroup.outcome.feedback)"
-                                              class="oppia-rte-editor">
+                    <oppia-rte-output-display
+                      [ngClass]="{
+                        'oppia-rte-editor-focused': isCopyModeActive()
+                      }"
+                      (click)="onContentClick($event)"
+                      [rteString]="
+                        getRequiredHtml(answerGroup.outcome.feedback)
+                      "
+                      class="oppia-rte-editor"
+                    >
                     </oppia-rte-output-display>
                   </span>
                 </div>
@@ -270,35 +529,78 @@
         </ul>
       </div>
 
-
       <div>
-        <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
-          <li [ngClass]="{'active': activeAnswerGroupIndex === stateAnswerGroups.length}"
-              class="oppia-rule-block e2e-test-translation-feedback">
-            <a class="oppia-rule-tab oppia-default-rule-tab e2e-test-feedback-{{ stateAnswerGroups.length }} oppia-translation-preview-list"
-               (click)="changeActiveAnswerGroupIndex(stateAnswerGroups.length)"
-               tabindex="0"
-               (keydown.enter)="changeActiveAnswerGroupIndex(stateAnswerGroups.length)"
-               [ngClass]="{'oppia-rule-tab-active': activeAnswerGroupIndex == stateAnswerGroups.length}"
-               [ngStyle]="contentIdStatusColorStyle(stateDefaultOutcome.feedback.contentId)">
-              <oppia-response-header [index]="index"
-                                     [isActive]="index === activeAnswerGroupIndex"
-                                     [summary]="summarizeDefaultOutcome(stateDefaultOutcome, stateInteractionId, stateDefaultOutcome.length, false)"
-                                     [shortSummary]="summarizeDefaultOutcome(stateDefaultOutcome, stateInteractionId, stateDefaultOutcome.length, true)"
-                                     [outcome]="stateDefaultOutcome"
-                                     [defaultOutcome]="true"
-                                     [isResponse]="true"
-                                     [showWarning]="contentIdNeedUpdates(stateDefaultOutcome.feedback.contentId)"
-                                     (navigateToState)="navigateToState($event)">
+        <ul
+          class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
+          role="tablist"
+        >
+          <li
+            [ngClass]="{
+              active: activeAnswerGroupIndex === stateAnswerGroups.length
+            }"
+            class="oppia-rule-block e2e-test-translation-feedback"
+          >
+            <a
+              class="oppia-rule-tab oppia-default-rule-tab e2e-test-feedback-{{
+                stateAnswerGroups.length
+              }} oppia-translation-preview-list"
+              (click)="changeActiveAnswerGroupIndex(stateAnswerGroups.length)"
+              tabindex="0"
+              (keydown.enter)="
+                changeActiveAnswerGroupIndex(stateAnswerGroups.length)
+              "
+              [ngClass]="{
+                'oppia-rule-tab-active':
+                  activeAnswerGroupIndex == stateAnswerGroups.length
+              }"
+              [ngStyle]="
+                contentIdStatusColorStyle(
+                  stateDefaultOutcome.feedback.contentId
+                )
+              "
+            >
+              <oppia-response-header
+                [index]="index"
+                [isActive]="index === activeAnswerGroupIndex"
+                [summary]="
+                  summarizeDefaultOutcome(
+                    stateDefaultOutcome,
+                    stateInteractionId,
+                    stateDefaultOutcome.length,
+                    false
+                  )
+                "
+                [shortSummary]="
+                  summarizeDefaultOutcome(
+                    stateDefaultOutcome,
+                    stateInteractionId,
+                    stateDefaultOutcome.length,
+                    true
+                  )
+                "
+                [outcome]="stateDefaultOutcome"
+                [defaultOutcome]="true"
+                [isResponse]="true"
+                [showWarning]="
+                  contentIdNeedUpdates(stateDefaultOutcome.feedback.contentId)
+                "
+                (navigateToState)="navigateToState($event)"
+              >
               </oppia-response-header>
             </a>
             <div *ngIf="activeAnswerGroupIndex === stateAnswerGroups.length">
-              <div class="oppia-editor-card-section e2e-test-feedback-{{ stateAnswerGroups.length }}-text">
+              <div
+                class="oppia-editor-card-section e2e-test-feedback-{{
+                  stateAnswerGroups.length
+                }}-text"
+              >
                 <div class="oppia-rule-body-container" tabindex="0">
-                  <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                                            (click)="onContentClick($event)"
-                                            [rteString]="getRequiredHtml(stateDefaultOutcome.feedback)"
-                                            class="oppia-rte-editor">
+                  <oppia-rte-output-display
+                    [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                    (click)="onContentClick($event)"
+                    [rteString]="getRequiredHtml(stateDefaultOutcome.feedback)"
+                    class="oppia-rte-editor"
+                  >
                   </oppia-rte-output-display>
                 </div>
               </div>
@@ -308,34 +610,53 @@
       </div>
     </div>
     <div *ngIf="isActive(TAB_ID_HINTS)" class="translation-state-content">
-      <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
-        <li class="oppia-rule-block e2e-test-translation-hint mt-0"
-            *ngFor="let hint of stateHints; index as index"
-            [ngClass]="{'active': activeHintIndex === index}">
-          <a (click)="changeActiveHintIndex(index)"
-             (keydown.enter)="changeActiveHintIndex(index)"
-             tabindex="0"
-             class="oppia-rule-tab e2e-test-hint-{{ index }} oppia-translation-preview-list"
-             [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
-             [ngStyle]="contentIdStatusColorStyle(hint.hintContent.contentId)">
-            <oppia-response-header [index]="index"
-                                   [defaultOutcome]="true"
-                                   [summary]="getSubtitledContentSummary(hint.hintContent)"
-                                   [shortSummary]="getSubtitledContentSummary(hint.hintContent)"
-                                   [isActive]="index === activeHintIndex"
-                                   [showWarning]="contentIdNeedUpdates(hint.hintContent.contentId)">
+      <ul
+        class="oppia-translation-preview oppia-option-list nav-stacked nav-pills"
+        role="tablist"
+      >
+        <li
+          class="oppia-rule-block e2e-test-translation-hint mt-0"
+          *ngFor="let hint of stateHints; index as index"
+          [ngClass]="{active: activeHintIndex === index}"
+        >
+          <a
+            (click)="changeActiveHintIndex(index)"
+            (keydown.enter)="changeActiveHintIndex(index)"
+            tabindex="0"
+            class="oppia-rule-tab e2e-test-hint-{{
+              index
+            }} oppia-translation-preview-list"
+            [ngClass]="{'oppia-rule-tab-active': activeHintIndex === index}"
+            [ngStyle]="contentIdStatusColorStyle(hint.hintContent.contentId)"
+          >
+            <oppia-response-header
+              [index]="index"
+              [defaultOutcome]="true"
+              [summary]="getSubtitledContentSummary(hint.hintContent)"
+              [shortSummary]="getSubtitledContentSummary(hint.hintContent)"
+              [isActive]="index === activeHintIndex"
+              [showWarning]="contentIdNeedUpdates(hint.hintContent.contentId)"
+            >
             </oppia-response-header>
           </a>
           <div *ngIf="activeHintIndex === index">
-            <div class="oppia-editor-card-section e2e-test-hint-{{ index }}-text" tabindex="0">
-              <span *ngIf="!getRequiredHtml(hint.hintContent)" class="oppia-placeholder">
+            <div
+              class="oppia-editor-card-section e2e-test-hint-{{ index }}-text"
+              tabindex="0"
+            >
+              <span
+                *ngIf="!getRequiredHtml(hint.hintContent)"
+                class="oppia-placeholder"
+              >
                 {{ getEmptyContentMessage() }}
               </span>
               <span>
-                <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                                          (click)="onContentClick($event)"
-                                          [rteString]="getRequiredHtml(hint.hintContent)"
-                                          class="oppia-rte-editor">
+                <oppia-rte-output-display
+                  [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+                  (click)="onContentClick($event)"
+                  [rteString]="getRequiredHtml(hint.hintContent)"
+                  class="oppia-rte-editor"
+                >
                 </oppia-rte-output-display>
               </span>
             </div>
@@ -344,30 +665,51 @@
       </ul>
     </div>
 
-    <div *ngIf="isActive(TAB_ID_SOLUTION)" class="translation-state-content e2e-test-solution-text">
-      <span *ngIf="!getRequiredHtml(stateSolution.explanation)" class="oppia-placeholder" tabindex="0">
+    <div
+      *ngIf="isActive(TAB_ID_SOLUTION)"
+      class="translation-state-content e2e-test-solution-text"
+    >
+      <span
+        *ngIf="!getRequiredHtml(stateSolution.explanation)"
+        class="oppia-placeholder"
+        tabindex="0"
+      >
         {{ getEmptyContentMessage() }}
       </span>
       <span tabindex="0">
-        <oppia-rte-output-display [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
-                                  (click)="onContentClick($event)"
-                                  [rteString]="getRequiredHtml(stateSolution.explanation)"
-                                  class="oppia-rte-editor">
+        <oppia-rte-output-display
+          [ngClass]="{'oppia-rte-editor-focused': isCopyModeActive()}"
+          (click)="onContentClick($event)"
+          [rteString]="getRequiredHtml(stateSolution.explanation)"
+          class="oppia-rte-editor"
+        >
         </oppia-rte-output-display>
       </span>
     </div>
   </div>
-  <div joyrideStep="translationTabRecordingOverview" [stepContent]="TranslationTabRecordingOverview"></div>
-  <div joyrideStep="translationTabReRecordingOverview" [stepContent]="TranslationTabReRecordingOverview"></div>
-  <div joyrideStep="translationTabTutorialComplete" [stepContent]="TranslationTabTutorialComplete"></div>
-  <div *ngIf="isVoiceoverModeActive()" id="tutorialTranslationAudioBar" class="oppia-audio-translation-bar">
+  <div
+    joyrideStep="translationTabRecordingOverview"
+    [stepContent]="TranslationTabRecordingOverview"
+  ></div>
+  <div
+    joyrideStep="translationTabReRecordingOverview"
+    [stepContent]="TranslationTabReRecordingOverview"
+  ></div>
+  <div
+    joyrideStep="translationTabTutorialComplete"
+    [stepContent]="TranslationTabTutorialComplete"
+  ></div>
+  <div
+    *ngIf="isVoiceoverModeActive()"
+    id="tutorialTranslationAudioBar"
+    class="oppia-audio-translation-bar"
+  >
     <oppia-voiceover-card></oppia-voiceover-card>
   </div>
   <div *ngIf="!isVoiceoverModeActive()">
     <oppia-state-translation-editor></oppia-state-translation-editor>
   </div>
 </div>
-
 
 <style>
   .oppia-translation-preview-list {
@@ -466,7 +808,7 @@
     pointer-events: none;
   }
   .oppia-translation-tabs-text {
-    background: rgba(243,243,243,.75);
+    background: rgba(243, 243, 243, 0.75);
     border: 1px solid #eee;
     border-bottom-width: 2px;
     border-top-width: 3px;
@@ -516,7 +858,10 @@
   .oppia-rte-editor-focused:focus > oppia-noninteractive-tabs > div {
     outline: solid 2px #009688;
   }
-  .oppia-rte-editor-focused:focus > oppia-noninteractive-collapsible > ngb-accordion > div {
+  .oppia-rte-editor-focused:focus
+    > oppia-noninteractive-collapsible
+    > ngb-accordion
+    > div {
     outline: solid 2px #009688;
   }
   .oppia-rte-editor-focused:focus > oppia-noninteractive-image > figure {
@@ -529,7 +874,7 @@
     background-color: rgba(233, 241, 242);
   }
   .oppia-state-translation-icons {
-    color: #009688
+    color: #009688;
   }
   state-translation .oppia-translation-state-content-html-data {
     pointer-events: none;

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -119,6 +119,7 @@ describe('State translation component', () => {
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
   let explorationLanguageCodeService: ExplorationLanguageCodeService;
+
   let explorationState1 = {
     Introduction: {
       content: {
@@ -346,12 +347,12 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
-    
-    spyOn(
+
+     spyOn(
       translationTabActiveModeService,
       'isTranslationModeActive'
     ).and.returnValue(false);
-    
+
     explorationStatesService.init(explorationState1, false);
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
@@ -361,6 +362,7 @@ describe('State translation component', () => {
   });
 
   afterEach(() => {
+    component.ngOnDestroy();
     if (component) {
       component.ngOnDestroy();
     }
@@ -372,7 +374,7 @@ describe('State translation component', () => {
       it('should init state translation when refreshing page', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         refreshStateTranslationEmitter.emit();
-        
+
         expect(component.isActive('content')).toBe(true);
         expect(component.isVoiceoverModeActive()).toBe(true);
         expect(component.isDisabled('content')).toBe(false);
@@ -400,7 +402,7 @@ describe('State translation component', () => {
               content,
             },
           ]);
-       }
+        }
       );
 
       it('should broadcast copy to ck editor when clicking on content', () => {
@@ -461,7 +463,7 @@ describe('State translation component', () => {
             }
           );
         }
-     );
+      );
 
       it('should activate feedback tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
@@ -499,11 +501,11 @@ describe('State translation component', () => {
         expect(component.contentIdStatusColorStyle('hint_1')).toEqual({
           'border-left': '3px solid #808080',
         });
-       });
+      });
 
       it('should activate solution tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
-         component.onTabClick('solution');
+        component.onTabClick('solution');
 
         expect(component.isActive('solution')).toBe(true);
         expect(component.isDisabled('solution')).toBe(false);
@@ -529,15 +531,15 @@ describe('State translation component', () => {
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_4', 'set_of_normalized_string');
-       });
+      });
 
       it('should change active rule content index', () => {
-          component.onTabClick('rule_input');
+        component.onTabClick('rule_input');
 
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveRuleContentIndex(1);
 
-         expect(
+        expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_5', 'set_of_normalized_string');
       });
@@ -555,7 +557,7 @@ describe('State translation component', () => {
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
-     );
+      );
 
       it('should change active hint index', () => {
         component.onTabClick('hint');
@@ -566,7 +568,7 @@ describe('State translation component', () => {
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('hint_2', 'html');
-       });
+      });
 
       it('should not change active hint index if it is equal to the current one', () => {
         component.onTabClick('hint');
@@ -577,7 +579,7 @@ describe('State translation component', () => {
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).not.toHaveBeenCalled();
-       });
+      });
 
       it('should change active answer group index', () => {
         component.onTabClick('feedback');
@@ -609,7 +611,7 @@ describe('State translation component', () => {
         'should change active answer group index to default outcome when' +
           ' index provided is equal to answer groups length',
         () => {
-         component.onTabClick('feedback');
+          component.onTabClick('feedback');
 
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveAnswerGroupIndex(2);
@@ -621,7 +623,7 @@ describe('State translation component', () => {
       );
 
       it('should not change active hint index if it is equal to the current one', () => {
-    component.onTabClick('feedback');
+        component.onTabClick('feedback');
 
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveAnswerGroupIndex(0);
@@ -664,7 +666,7 @@ describe('State translation component', () => {
           'This is the unicode'
         );
       });
-      
+
       it('should return null when html translation is missing in non-original language', () => {
         spyOnProperty(
           explorationLanguageCodeService,
@@ -681,7 +683,7 @@ describe('State translation component', () => {
         // So getWrittenTranslation will return null.
         expect(component.getRequiredHtml(subtitledObject)).toBeNull();
       });
-      
+
       it('should return null when unicode translation is missing in non-original language', () => {
         spyOnProperty(
           explorationLanguageCodeService,
@@ -695,7 +697,7 @@ describe('State translation component', () => {
         });
         expect(component.getRequiredUnicode(subtitledObject)).toBeNull();
       });
-      
+
       it('should return original html content if language matches exploration language', () => {
         spyOnProperty(
           explorationLanguageCodeService,
@@ -711,7 +713,7 @@ describe('State translation component', () => {
           'Original Content'
         );
       });
-      
+
       it(
         "should get empty content message when text translations haven't" +
           ' been added yet',
@@ -721,7 +723,7 @@ describe('State translation component', () => {
               ' Switch to translation mode to add a text translation.'
           );
         }
-     );
+      );
 
       it('should get summary default outcome when outcome is linear', () => {
         expect(
@@ -732,7 +734,7 @@ describe('State translation component', () => {
             'true'
           )
         ).toBe('[] Feedback Text');
-     });
+      });
 
       it(
         'should get summary default outcome when answer group count' +
@@ -747,7 +749,7 @@ describe('State translation component', () => {
             )
           ).toBe('[] Feedback Text');
         }
-     );
+      );
 
       it(
         'should get summary default outcome when answer group count' +
@@ -779,7 +781,7 @@ describe('State translation component', () => {
               Outcome.createNew('unused', '1', 'Feedback text', []),
               null,
               '0'
-              ),
+            ),
             '1',
             null,
             true
@@ -842,7 +844,7 @@ describe('State translation component', () => {
       expect(component.hasOriginalContent(subtitledObject)).toBe(false);
     });
 });
-  
+
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -974,7 +976,7 @@ describe('State translation component', () => {
 
   class MockPageContextService {
     getExplorationId() {
-       return 'expId';
+      return 'expId';
     }
   }
 
@@ -1066,7 +1068,7 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(false);
-    
+
     spyOn(
       translationTabActiveModeService,
       'isTranslationModeActive'
@@ -1269,7 +1271,7 @@ describe('State translation component', () => {
   let translationTabActiveModeService: TranslationTabActiveModeService;
   let routerService: RouterService;
   let translationLanguageService: TranslationLanguageService;
-  
+
   let explorationState1 = {
     Introduction: {
       content: {
@@ -1627,9 +1629,9 @@ describe('State translation component', () => {
 
   it('should correctly navigate to the given state', () => {
     spyOn(routerService, 'navigateToMainTab').and.callFake(() => {});
-    
+
     component.navigateToState('new_state');
-    
+
     expect(routerService.navigateToMainTab).toHaveBeenCalledWith('new_state');
   });
 
@@ -1645,7 +1647,7 @@ describe('State translation component', () => {
 
     expect(htmlData).toBe('<p>HTML data</p>');
   });
-  
+
   it('should return null when translation not available', () => {
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
@@ -1933,7 +1935,6 @@ describe('State translation component', () => {
   let ckEditorCopyContentService: CkEditorCopyContentService;
   let explorationStatesService: ExplorationStatesService;
   let stateEditorService: StateEditorService;
-  let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
   let explorationHtmlFormatterService: ExplorationHtmlFormatterService;
@@ -2055,7 +2056,7 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-  
+
   let explorationState4 = {
     Introduction: {
       classifier_model_id: null,
@@ -2152,6 +2153,7 @@ describe('State translation component', () => {
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
+    translationLanguageService = TestBed.inject(TranslationLanguageService);
     translationTabActiveContentIdService = TestBed.inject(
       TranslationTabActiveContentIdService
     );
@@ -2239,7 +2241,7 @@ describe('State translation component', () => {
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('ca_1', 'html');
-        
+
         component.changeActiveCustomizationArgContentIndex(0);
         expect(
           translationTabActiveContentIdService.setActiveContent

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -8,14 +8,12 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS-IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 /**
- * @fileoverview Unit tests for stateTranslation.
+ * @fileoverview Unit tests for stateTranslation
  */
-
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {EventEmitter, NO_ERRORS_SCHEMA, Pipe} from '@angular/core';
 import {ComponentFixture, waitForAsync, TestBed} from '@angular/core/testing';
@@ -33,7 +31,7 @@ import {ReadOnlyExplorationBackendApiService} from 'domain/exploration/read-only
 import {Rule} from 'domain/exploration/rule.model';
 import {StateObjectsBackendDict} from 'domain/exploration/states.model';
 import {SubtitledHtml} from 'domain/exploration/subtitled-html.model';
-import {SubtitledUnicode} from 'domain/exploration/subtitled-unicode.model.ts';
+import {SubtitledUnicode} from 'domain/exploration/subtitled-unicode.model';
 import {EntityTranslation} from 'domain/translation/entity-translation.model';
 import {ParameterizeRuleDescriptionPipe} from 'filters/parameterize-rule-description.pipe';
 import {ConvertToPlainTextPipe} from 'filters/string-utility-filters/convert-to-plain-text.pipe';
@@ -52,14 +50,16 @@ import {ExternalSaveService} from 'services/external-save.service';
 import {TranslationLanguageService} from '../services/translation-language.service';
 import {TranslationTabActiveContentIdService} from '../services/translation-tab-active-content-id.service';
 import {TranslationTabActiveModeService} from '../services/translation-tab-active-mode.service';
+import {TranslationStatusService} from '../services/translation-status.service';
 import {StateTranslationComponent} from './state-translation.component';
 import {RouterService} from 'pages/exploration-editor-page/services/router.service';
 import {TranslatedContent} from 'domain/exploration/translated-content.model';
 import {Hint} from 'domain/exploration/hint-object.model';
 import {AnswerGroup} from 'domain/exploration/answer-group.model';
-
+import {TruncatePipe} from 'filters/string-utility-filters/truncate.pipe';
+import {FormatRtePreviewPipe} from 'filters/format-rte-preview.pipe';
+import {PlatformFeatureService} from 'services/platform-feature.service';
 const DEFAULT_OBJECT_VALUES = require('objects/object_defaults.json');
-
 class MockNgbModal {
   open() {
     return {
@@ -67,7 +67,6 @@ class MockNgbModal {
     };
   }
 }
-
 @Pipe({name: 'parameterizeRuleDescriptionPipe'})
 class MockParameterizeRuleDescriptionPipe {
   transform(
@@ -84,32 +83,62 @@ class MockWrapTextWithEllipsisPipe {
     return '';
   }
 }
-
 @Pipe({name: 'truncate'})
 class MockTruncatePipe {
   transform(value: string, params: number): string {
     return value;
   }
 }
-
 @Pipe({name: 'convertToPlainText'})
 class MockConvertToPlainTextPipe {
   transform(value: string): string {
     return value;
   }
 }
-
+class MockExplorationLanguageCodeService {
+  onExplorationPropertyChanged = new EventEmitter();
+  get displayed() {
+    return 'en';
+  }
+  init(value: unknown) {}
+  saveDisplayedValue() {}
+  restoreFromMemento() {}
+}
+class MockTranslationStatusService {
+  getActiveStateComponentStatusColor(tabId) {
+    return '#D14836';
+  }
+  getActiveStateComponentNeedsUpdateStatus(tabId) {
+    return false;
+  }
+  getActiveStateContentIdNeedsUpdateStatus(contentId) {
+    return false;
+  }
+  getActiveStateContentIdStatusColor(contentId) {
+    return '#D14836';
+  }
+  refresh() {}
+}
+@Pipe({name: 'formatRtePreview'})
+class MockFormatRtePreviewPipe {
+  transform(value: string): string {
+    return value;
+  }
+}
+class MockPlatformFeatureService {
+  // Add any methods that are used in the component if needed
+}
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
   let ckEditorCopyContentService: CkEditorCopyContentService;
   let entityTranslationsService: EntityTranslationsService;
+  let explorationLanguageCodeService: ExplorationLanguageCodeService;
   let explorationStatesService: ExplorationStatesService;
   let stateEditorService: StateEditorService;
   let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
-
   let explorationState1 = {
     Introduction: {
       content: {
@@ -228,15 +257,12 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-
   let refreshStateTranslationEmitter = new EventEmitter();
-
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -246,10 +272,13 @@ describe('State translation component', () => {
         MockTruncatePipe,
         MockConvertToPlainTextPipe,
         MockWrapTextWithEllipsisPipe,
+        MockFormatRtePreviewPipe,
       ],
       providers: [
         WrapTextWithEllipsisPipe,
         ConvertToPlainTextPipe,
+        {provide: TruncatePipe, useClass: MockTruncatePipe},
+        {provide: FormatRtePreviewPipe, useClass: MockFormatRtePreviewPipe},
         AngularNameService,
         {provide: PageContextService, useClass: MockPageContextService},
         ContinueValidationService,
@@ -267,6 +296,10 @@ describe('State translation component', () => {
         TranslationLanguageService,
         TranslationTabActiveContentIdService,
         TranslationTabActiveModeService,
+        ExplorationHtmlFormatterService,
+        RouterService,
+        EntityTranslationsService,
+        {provide: PlatformFeatureService, useClass: MockPlatformFeatureService},
         {
           provide: NgbModal,
           useClass: MockNgbModal,
@@ -276,20 +309,23 @@ describe('State translation component', () => {
           useClass: MockParameterizeRuleDescriptionPipe,
         },
         {
-          provide: WrapTextWithEllipsisPipe,
-          useClass: MockWrapTextWithEllipsisPipe,
+          provide: ExplorationLanguageCodeService,
+          useClass: MockExplorationLanguageCodeService,
+        },
+        {
+          provide: TranslationStatusService,
+          useClass: MockTranslationStatusService,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
+    TestBed.inject(ExplorationLanguageCodeService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
     translationLanguageService = TestBed.inject(TranslationLanguageService);
     translationTabActiveContentIdService = TestBed.inject(
@@ -309,7 +345,6 @@ describe('State translation component', () => {
         language_code: 'hi',
         translations: {},
       });
-
     spyOnProperty(
       stateEditorService,
       'onRefreshStateTranslation'
@@ -318,33 +353,31 @@ describe('State translation component', () => {
       'Introduction'
     );
     ckEditorCopyContentService.copyModeActive = true;
-    spyOn(translationLanguageService, 'getActiveLanguageCode').and.returnValue(
-      'en'
-    );
     spyOn(
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
-
+    spyOn(
+      translationTabActiveModeService,
+      'isTranslationModeActive'
+    ).and.returnValue(false);
     explorationStatesService.init(explorationState1, false);
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
-
     component.ngOnInit();
     fixture.detectChanges();
   });
-
   afterEach(() => {
-    component.ngOnDestroy();
+    if (component) {
+      component.ngOnDestroy();
+    }
   });
-
   describe(
     'when translation tab is not busy and voiceover mode is' + ' active',
     () => {
       it('should init state translation when refreshing page', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         refreshStateTranslationEmitter.emit();
-
         expect(component.isActive('content')).toBe(true);
         expect(component.isVoiceoverModeActive()).toBe(true);
         expect(component.isDisabled('content')).toBe(false);
@@ -352,7 +385,6 @@ describe('State translation component', () => {
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('content_1', 'html');
       });
-
       it(
         'should get customization argument translatable customization' +
           ' arguments',
@@ -374,27 +406,22 @@ describe('State translation component', () => {
           ]);
         }
       );
-
       it('should broadcast copy to ck editor when clicking on content', () => {
         spyOn(ckEditorCopyContentService, 'broadcastCopy').and.callFake(
           () => {}
         );
-
         let mockEvent = {
           stopPropagation: () => {},
           target: {},
         } as Event;
         component.onContentClick(mockEvent);
-
         expect(ckEditorCopyContentService.broadcastCopy).toHaveBeenCalledWith(
           mockEvent.target
         );
       });
-
       it('should activate content tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('content');
-
         expect(component.isActive('content')).toBe(true);
         expect(component.isDisabled('content')).toBe(false);
         expect(
@@ -406,17 +433,15 @@ describe('State translation component', () => {
         expect(component.tabNeedUpdatesStatus('content')).toBe(false);
         expect(component.contentIdNeedUpdates('content_1')).toBe(false);
         expect(component.contentIdStatusColorStyle('content_1')).toEqual({
-          'border-left': '3px solid #D14836',
+          'border-left': '3px solid #808080',
         });
       });
-
       it(
         'should activate interaction custimization arguments tab when ' +
           'clicking on tab',
         () => {
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('ca');
-
           expect(component.isActive('ca')).toBe(true);
           expect(component.isDisabled('ca')).toBe(false);
           expect(
@@ -429,16 +454,14 @@ describe('State translation component', () => {
           expect(component.contentIdNeedUpdates('ca_placeholder')).toBe(false);
           expect(component.contentIdStatusColorStyle('ca_placeholder')).toEqual(
             {
-              'border-left': '3px solid #D14836',
+              'border-left': '3px solid #808080',
             }
           );
         }
       );
-
       it('should activate feedback tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('feedback');
-
         expect(component.isActive('feedback')).toBe(true);
         expect(component.isDisabled('feedback')).toBe(false);
         expect(
@@ -450,14 +473,12 @@ describe('State translation component', () => {
         expect(component.tabNeedUpdatesStatus('feedback')).toBe(false);
         expect(component.contentIdNeedUpdates('feedback_1')).toBe(false);
         expect(component.contentIdStatusColorStyle('feedback_1')).toEqual({
-          'border-left': '3px solid #D14836',
+          'border-left': '3px solid #808080',
         });
       });
-
       it('should activate hint tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('hint');
-
         expect(component.isActive('hint')).toBe(true);
         expect(component.isDisabled('hint')).toBe(false);
         expect(
@@ -469,14 +490,12 @@ describe('State translation component', () => {
         expect(component.tabNeedUpdatesStatus('hint')).toBe(false);
         expect(component.contentIdNeedUpdates('hint_1')).toBe(false);
         expect(component.contentIdStatusColorStyle('hint_1')).toEqual({
-          'border-left': '3px solid #D14836',
+          'border-left': '3px solid #808080',
         });
       });
-
       it('should activate solution tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('solution');
-
         expect(component.isActive('solution')).toBe(true);
         expect(component.isDisabled('solution')).toBe(false);
         expect(
@@ -488,122 +507,99 @@ describe('State translation component', () => {
         expect(component.tabNeedUpdatesStatus('solution')).toBe(false);
         expect(component.contentIdNeedUpdates('solution')).toBe(false);
         expect(component.contentIdStatusColorStyle('solution_1')).toEqual({
-          'border-left': '3px solid #D14836',
+          'border-left': '3px solid #808080',
         });
       });
-
       it('should activate rule inputs tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('rule_input');
-
         expect(component.isActive('rule_input')).toBe(true);
         expect(component.isDisabled('rule_input')).toBe(false);
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_4', 'set_of_normalized_string');
       });
-
       it('should change active rule content index', () => {
         component.onTabClick('rule_input');
-
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveRuleContentIndex(1);
-
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_5', 'set_of_normalized_string');
       });
-
       it(
         'should not change active rule content index if it is equal to the ' +
           'current one',
         () => {
           component.onTabClick('rule_input');
-
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveRuleContentIndex(0);
-
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it('should change active hint index', () => {
         component.onTabClick('hint');
-
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveHintIndex(1);
-
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('hint_2', 'html');
       });
-
       it('should not change active hint index if it is equal to the current one', () => {
         component.onTabClick('hint');
-
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveHintIndex(0);
-
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).not.toHaveBeenCalled();
       });
-
       it('should change active answer group index', () => {
         component.onTabClick('feedback');
-
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveAnswerGroupIndex(1);
-
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('feedback_2', 'html');
       });
-
       it(
         'should not change active customization argument index if it is equal' +
           ' to the current one',
         () => {
           component.onTabClick('ca');
-
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveCustomizationArgContentIndex(0);
-
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should change active answer group index to default outcome when' +
           ' index provided is equal to answer groups length',
         () => {
           component.onTabClick('feedback');
-
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveAnswerGroupIndex(2);
-
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).toHaveBeenCalledWith('default_outcome', 'html');
         }
       );
-
       it('should not change active hint index if it is equal to the current one', () => {
         component.onTabClick('feedback');
-
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveAnswerGroupIndex(0);
-
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).not.toHaveBeenCalled();
       });
-
       it('should get subtitled html data translation', () => {
+        spyOn(
+          translationLanguageService,
+          'getActiveLanguageCode'
+        ).and.returnValue('en');
         let subtitledObject = SubtitledHtml.createFromBackendDict({
           content_id: 'content_1',
           html: 'This is the html',
@@ -615,8 +611,11 @@ describe('State translation component', () => {
           'This is the html'
         );
       });
-
       it('should get subtitled Unicode data translation', () => {
+        spyOn(
+          translationLanguageService,
+          'getActiveLanguageCode'
+        ).and.returnValue('en');
         let subtitledObject = SubtitledUnicode.createFromBackendDict({
           content_id: 'content_1',
           unicode_str: 'This is the unicode',
@@ -628,7 +627,50 @@ describe('State translation component', () => {
           'This is the unicode'
         );
       });
-
+      it('should return null when html translation is missing in non-original language', () => {
+        spyOnProperty(
+          explorationLanguageCodeService,
+          'displayed',
+          'get'
+        ).and.returnValue('en');
+        // Change language to Hindi ('hi'), which is different from original ('en').
+        translationLanguageService.setActiveLanguageCode('hi');
+        let subtitledObject = SubtitledHtml.createFromBackendDict({
+          content_id: 'content_1',
+          html: 'Original Content',
+        });
+        // The entityTranslationsService was initialized with 'hi' but empty translations in beforeEach.
+        // So getWrittenTranslation will return null.
+        expect(component.getRequiredHtml(subtitledObject)).toBeNull();
+      });
+      it('should return null when unicode translation is missing in non-original language', () => {
+        spyOnProperty(
+          explorationLanguageCodeService,
+          'displayed',
+          'get'
+        ).and.returnValue('en');
+        translationLanguageService.setActiveLanguageCode('hi');
+        let subtitledObject = SubtitledUnicode.createFromBackendDict({
+          content_id: 'content_1',
+          unicode_str: 'Original Unicode',
+        });
+        expect(component.getRequiredUnicode(subtitledObject)).toBeNull();
+      });
+      it('should return original html content if language matches exploration language', () => {
+        spyOnProperty(
+          explorationLanguageCodeService,
+          'displayed',
+          'get'
+        ).and.returnValue('en');
+        translationLanguageService.setActiveLanguageCode('en');
+        let subtitledObject = SubtitledHtml.createFromBackendDict({
+          content_id: 'content_1',
+          html: 'Original Content',
+        });
+        expect(component.getRequiredHtml(subtitledObject)).toBe(
+          'Original Content'
+        );
+      });
       it(
         "should get empty content message when text translations haven't" +
           ' been added yet',
@@ -639,7 +681,6 @@ describe('State translation component', () => {
           );
         }
       );
-
       it('should get summary default outcome when outcome is linear', () => {
         expect(
           component.summarizeDefaultOutcome(
@@ -650,7 +691,6 @@ describe('State translation component', () => {
           )
         ).toBe('[] Feedback Text');
       });
-
       it(
         'should get summary default outcome when answer group count' +
           ' is greater than 0',
@@ -665,7 +705,6 @@ describe('State translation component', () => {
           ).toBe('[] Feedback Text');
         }
       );
-
       it(
         'should get summary default outcome when answer group count' +
           ' is equal to 0',
@@ -680,13 +719,11 @@ describe('State translation component', () => {
           ).toBe('[] Feedback Text');
         }
       );
-
       it('should get an empty summary when default outcome is a falsy value', () => {
         expect(
           component.summarizeDefaultOutcome(null, 'Continue', 0, 'true')
         ).toBe('');
       });
-
       it('should get summary answer group', () => {
         expect(
           component.summarizeAnswerGroup(
@@ -706,7 +743,6 @@ describe('State translation component', () => {
     }
   );
 });
-
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -714,10 +750,8 @@ describe('State translation component', () => {
   let entityTranslationsService: EntityTranslationsService;
   let explorationStatesService: ExplorationStatesService;
   let stateEditorService: StateEditorService;
-  let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
-
   let explorationState1 = {
     Introduction: {
       content: {
@@ -833,16 +867,13 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-
   let refreshStateTranslationEmitter = new EventEmitter();
   let showTranslationTabBusyModalEmitter = new EventEmitter();
-
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -874,6 +905,10 @@ describe('State translation component', () => {
         TranslationTabActiveContentIdService,
         TranslationTabActiveModeService,
         {
+          provide: ExplorationLanguageCodeService,
+          useClass: MockExplorationLanguageCodeService,
+        },
+        {
           provide: NgbModal,
           useClass: MockNgbModal,
         },
@@ -889,15 +924,12 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
-    translationLanguageService = TestBed.inject(TranslationLanguageService);
     translationTabActiveContentIdService = TestBed.inject(
       TranslationTabActiveContentIdService
     );
@@ -905,7 +937,6 @@ describe('State translation component', () => {
       TranslationTabActiveModeService
     );
     explorationStatesService.init(explorationState1, false);
-
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
     entityTranslationsService.entityTranslation =
@@ -924,14 +955,14 @@ describe('State translation component', () => {
       'Introduction'
     );
     ckEditorCopyContentService.copyModeActive = true;
-    spyOn(translationLanguageService, 'getActiveLanguageCode').and.returnValue(
-      'en'
-    );
     spyOn(
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(false);
-
+    spyOn(
+      translationTabActiveModeService,
+      'isTranslationModeActive'
+    ).and.returnValue(true);
     explorationStatesService.init(explorationState1, false);
     spyOnProperty(
       stateEditorService,
@@ -939,14 +970,11 @@ describe('State translation component', () => {
     ).and.returnValue(showTranslationTabBusyModalEmitter);
     component.isTranslationTabBusy = true;
     component.stateName = 'Introduction';
-
     component.ngOnInit();
   });
-
   afterEach(() => {
     component.ngOnDestroy();
   });
-
   describe(
     'when translation tab is busy and voiceover mode is not' + ' activate',
     () => {
@@ -957,7 +985,6 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('content');
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(component.isVoiceoverModeActive()).toBe(false);
           expect(
@@ -965,7 +992,6 @@ describe('State translation component', () => {
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when clicking on interaction' +
           'customization arguments tab',
@@ -973,14 +999,12 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('ca');
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when clicking on feedback' +
           ' tab',
@@ -988,28 +1012,24 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('feedback');
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when clicking on hint' + ' tab',
         () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('hint');
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when clicking on solution' +
           ' tab',
@@ -1017,14 +1037,12 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('solution');
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when trying to change' +
           ' active rule content index',
@@ -1032,14 +1050,12 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveRuleContentIndex(1);
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when trying to change' +
           ' active hint index',
@@ -1047,14 +1063,12 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveHintIndex(1);
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when trying to change' +
           ' active answer group index',
@@ -1062,14 +1076,12 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveAnswerGroupIndex(1);
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it(
         'should open translation tab busy modal when trying to change' +
           ' interaction customization argument index',
@@ -1077,14 +1089,12 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveCustomizationArgContentIndex(0);
-
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-
       it('should get subtitled data', () => {
         let subtitledObject = SubtitledHtml.createFromBackendDict({
           content_id: 'content_1',
@@ -1096,7 +1106,6 @@ describe('State translation component', () => {
         expect(component.getSubtitledContentSummary(subtitledObject)).toBe(
           'This is the html'
         );
-
         let subtitledObjectBack = SubtitledUnicode.createFromBackendDict({
           content_id: 'content_1',
           unicode_str: 'This is the unicode',
@@ -1105,7 +1114,6 @@ describe('State translation component', () => {
           'This is the unicode'
         );
       });
-
       it(
         'should get content message warning that there is not text available' +
           ' to translate',
@@ -1118,7 +1126,6 @@ describe('State translation component', () => {
     }
   );
 });
-
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -1126,11 +1133,10 @@ describe('State translation component', () => {
   let entityTranslationsService: EntityTranslationsService;
   let explorationStatesService: ExplorationStatesService;
   let stateEditorService: StateEditorService;
-  let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
   let routerService: RouterService;
-
+  let translationLanguageService: TranslationLanguageService;
   let explorationState1 = {
     Introduction: {
       content: {
@@ -1246,7 +1252,6 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-
   let explorationState2 = {
     Introduction: {
       content: {
@@ -1310,15 +1315,12 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-
   let refreshStateTranslationEmitter = new EventEmitter();
-
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -1365,11 +1367,9 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
@@ -1382,7 +1382,6 @@ describe('State translation component', () => {
     );
     routerService = TestBed.inject(RouterService);
     explorationStatesService.init(explorationState1, false);
-
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
     entityTranslationsService.entityTranslation =
@@ -1393,7 +1392,6 @@ describe('State translation component', () => {
         language_code: 'hi',
         translations: {},
       });
-
     spyOnProperty(
       stateEditorService,
       'onRefreshStateTranslation'
@@ -1409,20 +1407,15 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
-
     explorationStatesService.init(explorationState2, false);
-
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
-
     component.ngOnInit();
     fixture.detectChanges();
   });
-
   afterEach(() => {
     component.ngOnDestroy();
   });
-
   it('should cover all translatable objects', () => {
     Object.keys(DEFAULT_OBJECT_VALUES).forEach(objName => {
       if (
@@ -1439,14 +1432,12 @@ describe('State translation component', () => {
       }).not.toThrowError();
     });
   });
-
   it('should update correct translation with updateTranslatedContent', () => {
     component.activeTranslatedContent = new TranslatedContent();
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated HTML', 'html', true),
       });
-
     translationTabActiveModeService.isVoiceoverModeActive = jasmine
       .createSpy()
       .and.returnValue(false);
@@ -1454,14 +1445,11 @@ describe('State translation component', () => {
       translationTabActiveContentIdService,
       'getActiveContentId'
     ).and.returnValue('content_0');
-
     component.updateTranslatedContent();
-
     expect(component.activeTranslatedContent.translation).toBe(
       'Translated HTML'
     );
   });
-
   it('should format TranslatableSetOfNormalizedString values', () => {
     expect(
       component.getHumanReadableRuleInputValues(
@@ -1470,7 +1458,6 @@ describe('State translation component', () => {
       )
     ).toEqual('[input1, input2]');
   });
-
   it('should format TranslatableSetOfUnicodeString values', () => {
     expect(
       component.getHumanReadableRuleInputValues(
@@ -1479,42 +1466,32 @@ describe('State translation component', () => {
       )
     ).toEqual('[input1, input2]');
   });
-
   it('should throw an error on invalid type', () => {
     expect(() => {
       component.getHumanReadableRuleInputValues(null, 'InvalidType');
     }).toThrowError('The InvalidType type is not implemented.');
   });
-
   it('should correctly navigate to the given state', () => {
     spyOn(routerService, 'navigateToMainTab').and.callFake(() => {});
-
     component.navigateToState('new_state');
-
     expect(routerService.navigateToMainTab).toHaveBeenCalledWith('new_state');
   });
-
   it('should return original html when translation tab is active', () => {
     spyOn(
       translationTabActiveModeService,
       'isTranslationModeActive'
     ).and.returnValue(true);
-
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-
     expect(htmlData).toBe('<p>HTML data</p>');
   });
-
-  it('should return original html when translation not available', () => {
+  it('should return null when translation not available', () => {
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-
-    expect(htmlData).toBe('<p>HTML data</p>');
+    expect(htmlData).toBeNull();
   });
-
   it('should return unicode when translation tab is active', () => {
     spyOn(
       translationTabActiveModeService,
@@ -1527,21 +1504,17 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBe('This is the unicode');
   });
-
   it('should return translation html when translation available', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated HTML', 'html', true),
       });
-
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-
     expect(htmlData).toBe('Translated HTML');
   });
-
-  it('should return unicode when translation is empty in voiceover mode', () => {
+  it('should return null when translation is empty in voiceover mode', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated unicode', 'unicode', true),
@@ -1551,22 +1524,18 @@ describe('State translation component', () => {
       unicode_str: 'This is the unicode',
     });
     const unicodeData = component.getRequiredUnicode(subtitledObject);
-    expect(unicodeData).toBe('This is the unicode');
+    expect(unicodeData).toBeNull();
   });
-
-  it('should return translation html when translation no available', () => {
+  it('should return null when translation no available', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_1: new TranslatedContent('Translated HTML', 'html', true),
       });
-
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-
-    expect(htmlData).toBe('<p>HTML data</p>');
+    expect(htmlData).toBeNull();
   });
-
   it('should return translated unicode in voiceover mode when translation exist', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
@@ -1579,7 +1548,6 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBe('Translated UNICODE');
   });
-
   describe('when rules input tab is accessed but with no rules', () => {
     it('should throw an error when there are no rules', () => {
       spyOn(component, 'isDisabled').and.returnValue(false);
@@ -1591,7 +1559,6 @@ describe('State translation component', () => {
         'Accessed rule input translation tab when there are no rules'
       );
     });
-
     it('should throw an error when there are no rules', () => {
       component.interactionRuleTranslatableContents = [];
       expect(() => {
@@ -1601,7 +1568,6 @@ describe('State translation component', () => {
       );
     });
   });
-
   describe('when state has default outcome and no answer groups', () => {
     it(
       'should activate feedback tab with default outcome when' +
@@ -1609,7 +1575,6 @@ describe('State translation component', () => {
       () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('feedback');
-
         expect(component.isActive('feedback')).toBe(true);
         expect(component.isDisabled('feedback')).toBe(false);
         expect(
@@ -1618,7 +1583,6 @@ describe('State translation component', () => {
       }
     );
   });
-
   describe('when initContentId and initTabName are provided', () => {
     const mockStateAnswerGroups = [
       {
@@ -1679,7 +1643,6 @@ describe('State translation component', () => {
         trainingData: [],
       },
     ];
-
     const mockStateHints = [
       {
         hintContent: {
@@ -1697,7 +1660,6 @@ describe('State translation component', () => {
         },
       },
     ];
-
     const mockinteractionCustomizationArgTranslatableContent = [
       {
         name: 'demo',
@@ -1718,76 +1680,59 @@ describe('State translation component', () => {
         },
       },
     ];
-
     it('should return correct index for card of type feedback', () => {
       component.stateAnswerGroups =
         mockStateAnswerGroups as unknown as AnswerGroup[];
       component.activeTab = 'feedback';
       component.initActiveContentId = 'feedback_29';
-
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'feedback_29'
       );
-
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(2);
     });
-
     it('should return correct index for card of type hint', () => {
       component.stateHints = mockStateHints as unknown as Hint[];
       component.activeTab = 'hint';
       component.initActiveContentId = 'hint_2';
-
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'hint_2'
       );
-
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(1);
     });
-
     it('should return correct index for card of type custom args', () => {
       component.interactionCustomizationArgTranslatableContent =
         mockinteractionCustomizationArgTranslatableContent;
       component.activeTab = 'ca';
       component.initActiveContentId = 'ca_1';
-
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'ca_1'
       );
-
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(0);
     });
-
     it('should return 0 as index for unknown tabs', () => {
       component.activeTab = 'unknown';
       component.initActiveContentId = 'unknown_1';
-
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'ca_1'
       );
-
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(0);
     });
-
     it('should return correct active tab name', () => {
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'content_29'
       );
-
       expect(component.getActiveTab()).toBe('content');
     });
-
     it('should return active tab name as null when contentId is null', () => {
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(null);
-
       expect(component.getActiveTab()).toBe(null);
     });
   });
 });
-
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -1916,7 +1861,6 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-
   let explorationState4 = {
     Introduction: {
       classifier_model_id: null,
@@ -1949,15 +1893,12 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-
   let refreshStateTranslationEmitter = new EventEmitter();
-
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -2005,20 +1946,21 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
-    translationLanguageService = TestBed.inject(TranslationLanguageService);
     translationTabActiveContentIdService = TestBed.inject(
       TranslationTabActiveContentIdService
     );
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
+    );
+    translationLanguageService = TestBed.inject(TranslationLanguageService);
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
     );
     explorationStatesService.init(explorationState1, false);
     explorationHtmlFormatterService = TestBed.inject(
@@ -2039,7 +1981,6 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
-
     explorationStatesService.init(explorationState4, false);
     // Because the customization arguments we are passing for testing are
     // invalid, we will skip getInteractionHtml(), which would error
@@ -2064,15 +2005,12 @@ describe('State translation component', () => {
     });
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
-
     component.ngOnInit();
     fixture.detectChanges();
   });
-
   afterEach(() => {
     component.ngOnDestroy();
   });
-
   describe(
     'when state has a multiple choice interaction with no hints, ' +
       'solution or outcome',
@@ -2080,34 +2018,27 @@ describe('State translation component', () => {
       it('should evaluate feedback tab as disabled', () => {
         expect(component.isDisabled('feedback')).toBe(true);
       });
-
       it('should evaluate hint tab as disabled', () => {
         expect(component.isDisabled('hint')).toBe(true);
       });
-
       it('should evaluate solution tab as disabled', () => {
         expect(component.isDisabled('solution')).toBe(true);
       });
-
       it('should change active customization argument index', () => {
         component.onTabClick('ca');
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
-
         component.changeActiveCustomizationArgContentIndex(1);
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('ca_1', 'html');
-
         component.changeActiveCustomizationArgContentIndex(0);
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('ca_0', 'unicode');
       });
-
       it('should isDisabled return true when stateinteractionId is null', () => {
         component.TAB_ID_CONTENT = 'some_id';
         component.stateInteractionId = null;
-
         expect(component.isDisabled('any')).toBeTrue();
       });
     }

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -11,9 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 /**
  * @fileoverview Unit tests for stateTranslation.
  */
+
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {EventEmitter, NO_ERRORS_SCHEMA, Pipe} from '@angular/core';
 import {ComponentFixture, waitForAsync, TestBed} from '@angular/core/testing';
@@ -235,15 +237,15 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-  
+
   let refreshStateTranslationEmitter = new EventEmitter();
-  
+
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
-  
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -301,11 +303,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-  
+
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-    
+
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     TestBed.inject(ExplorationLanguageCodeService);
@@ -331,7 +333,7 @@ describe('State translation component', () => {
         language_code: 'hi',
         translations: {},
       });
-    
+
     spyOnProperty(
       stateEditorService,
       'onRefreshStateTranslation'
@@ -344,6 +346,7 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
+    
     spyOn(
       translationTabActiveModeService,
       'isTranslationModeActive'
@@ -352,23 +355,24 @@ describe('State translation component', () => {
     explorationStatesService.init(explorationState1, false);
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
-    
+
     component.ngOnInit();
     fixture.detectChanges();
   });
-  
+
   afterEach(() => {
     if (component) {
       component.ngOnDestroy();
     }
   });
-  
+
   describe(
     'when translation tab is not busy and voiceover mode is' + ' active',
     () => {
       it('should init state translation when refreshing page', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         refreshStateTranslationEmitter.emit();
+        
         expect(component.isActive('content')).toBe(true);
         expect(component.isVoiceoverModeActive()).toBe(true);
         expect(component.isDisabled('content')).toBe(false);
@@ -376,7 +380,7 @@ describe('State translation component', () => {
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('content_1', 'html');
       });
-      
+
       it(
         'should get customization argument translatable customization' +
           ' arguments',
@@ -396,29 +400,29 @@ describe('State translation component', () => {
               content,
             },
           ]);
-        }
+       }
       );
-      
+
       it('should broadcast copy to ck editor when clicking on content', () => {
         spyOn(ckEditorCopyContentService, 'broadcastCopy').and.callFake(
           () => {}
         );
-        
+
         let mockEvent = {
           stopPropagation: () => {},
           target: {},
         } as Event;
         component.onContentClick(mockEvent);
-        
+
         expect(ckEditorCopyContentService.broadcastCopy).toHaveBeenCalledWith(
           mockEvent.target
         );
       });
-      
+
       it('should activate content tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('content');
-        
+
         expect(component.isActive('content')).toBe(true);
         expect(component.isDisabled('content')).toBe(false);
         expect(
@@ -433,14 +437,14 @@ describe('State translation component', () => {
           'border-left': '3px solid #808080',
         });
       });
-      
+
       it(
         'should activate interaction custimization arguments tab when ' +
           'clicking on tab',
         () => {
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('ca');
-          
+
           expect(component.isActive('ca')).toBe(true);
           expect(component.isDisabled('ca')).toBe(false);
           expect(
@@ -457,12 +461,12 @@ describe('State translation component', () => {
             }
           );
         }
-      );
-      
+     );
+
       it('should activate feedback tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('feedback');
-        
+
         expect(component.isActive('feedback')).toBe(true);
         expect(component.isDisabled('feedback')).toBe(false);
         expect(
@@ -477,11 +481,11 @@ describe('State translation component', () => {
           'border-left': '3px solid #808080',
         });
       });
-      
+
       it('should activate hint tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('hint');
-        
+
         expect(component.isActive('hint')).toBe(true);
         expect(component.isDisabled('hint')).toBe(false);
         expect(
@@ -495,12 +499,12 @@ describe('State translation component', () => {
         expect(component.contentIdStatusColorStyle('hint_1')).toEqual({
           'border-left': '3px solid #808080',
         });
-      });
-      
+       });
+
       it('should activate solution tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
-        component.onTabClick('solution');
-        
+         component.onTabClick('solution');
+
         expect(component.isActive('solution')).toBe(true);
         expect(component.isDisabled('solution')).toBe(false);
         expect(
@@ -515,112 +519,118 @@ describe('State translation component', () => {
           'border-left': '3px solid #808080',
         });
       });
-      
+
       it('should activate rule inputs tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('rule_input');
-        
+
         expect(component.isActive('rule_input')).toBe(true);
         expect(component.isDisabled('rule_input')).toBe(false);
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_4', 'set_of_normalized_string');
-      });
-      
+       });
+
       it('should change active rule content index', () => {
-        component.onTabClick('rule_input');
-        
+          component.onTabClick('rule_input');
+
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveRuleContentIndex(1);
-        
-        expect(
+
+         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_5', 'set_of_normalized_string');
       });
-      
+
       it(
         'should not change active rule content index if it is equal to the ' +
           'current one',
         () => {
           component.onTabClick('rule_input');
-          
+
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveRuleContentIndex(0);
-          
+
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
-      );
+     );
+
       it('should change active hint index', () => {
         component.onTabClick('hint');
-        
+
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveHintIndex(1);
-        
+
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('hint_2', 'html');
-      });
+       });
+
       it('should not change active hint index if it is equal to the current one', () => {
         component.onTabClick('hint');
-        
+
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveHintIndex(0);
-        
+
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).not.toHaveBeenCalled();
-      });
+       });
+
       it('should change active answer group index', () => {
         component.onTabClick('feedback');
-        
+
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveAnswerGroupIndex(1);
-        
+
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('feedback_2', 'html');
       });
+
       it(
         'should not change active customization argument index if it is equal' +
           ' to the current one',
         () => {
           component.onTabClick('ca');
-          
+
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveCustomizationArgContentIndex(0);
-          
+
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+
       it(
         'should change active answer group index to default outcome when' +
           ' index provided is equal to answer groups length',
         () => {
-          component.onTabClick('feedback');
-          
+         component.onTabClick('feedback');
+
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveAnswerGroupIndex(2);
-          
+
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).toHaveBeenCalledWith('default_outcome', 'html');
         }
       );
+
       it('should not change active hint index if it is equal to the current one', () => {
-        component.onTabClick('feedback');
-        
+    component.onTabClick('feedback');
+
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveAnswerGroupIndex(0);
-        
+
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).not.toHaveBeenCalled();
       });
-      
+
       it('should get subtitled html data translation', () => {
         spyOn(
           translationLanguageService,
@@ -637,7 +647,7 @@ describe('State translation component', () => {
           'This is the html'
         );
       });
-      
+
       it('should get subtitled Unicode data translation', () => {
         spyOn(
           translationLanguageService,
@@ -671,6 +681,7 @@ describe('State translation component', () => {
         // So getWrittenTranslation will return null.
         expect(component.getRequiredHtml(subtitledObject)).toBeNull();
       });
+      
       it('should return null when unicode translation is missing in non-original language', () => {
         spyOnProperty(
           explorationLanguageCodeService,
@@ -684,6 +695,7 @@ describe('State translation component', () => {
         });
         expect(component.getRequiredUnicode(subtitledObject)).toBeNull();
       });
+      
       it('should return original html content if language matches exploration language', () => {
         spyOnProperty(
           explorationLanguageCodeService,
@@ -709,8 +721,8 @@ describe('State translation component', () => {
               ' Switch to translation mode to add a text translation.'
           );
         }
-      );
-      
+     );
+
       it('should get summary default outcome when outcome is linear', () => {
         expect(
           component.summarizeDefaultOutcome(
@@ -720,8 +732,8 @@ describe('State translation component', () => {
             'true'
           )
         ).toBe('[] Feedback Text');
-      });
-      
+     });
+
       it(
         'should get summary default outcome when answer group count' +
           ' is greater than 0',
@@ -735,8 +747,8 @@ describe('State translation component', () => {
             )
           ).toBe('[] Feedback Text');
         }
-      );
-      
+     );
+
       it(
         'should get summary default outcome when answer group count' +
           ' is equal to 0',
@@ -751,13 +763,13 @@ describe('State translation component', () => {
           ).toBe('[] Feedback Text');
         }
       );
-      
+
       it('should get an empty summary when default outcome is a falsy value', () => {
         expect(
           component.summarizeDefaultOutcome(null, 'Continue', 0, 'true')
         ).toBe('');
       });
-      
+
       it('should get summary answer group', () => {
         expect(
           component.summarizeAnswerGroup(
@@ -767,18 +779,17 @@ describe('State translation component', () => {
               Outcome.createNew('unused', '1', 'Feedback text', []),
               null,
               '0'
-            ),
+              ),
             '1',
             null,
             true
-             )
+          )
         ).toBe('[] Feedback text');
       });
     }
   );
 });
 
-  it('should return null for missing translation in non-original language', () => {
     it('should return null for missing translation in non-original language', () => {
       (translationLanguageService.getActiveLanguageCode as any).and.returnValue('es');
       // explorationLanguageCodeService.displayed is 'en' by mock default.
@@ -841,7 +852,7 @@ describe('State translation component', () => {
   let stateEditorService: StateEditorService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
-  
+
   let explorationState1 = {
     Introduction: {
       content: {
@@ -957,16 +968,16 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-  
+
   let refreshStateTranslationEmitter = new EventEmitter();
   let showTranslationTabBusyModalEmitter = new EventEmitter();
-  
+
   class MockPageContextService {
     getExplorationId() {
-      return 'expId';
+       return 'expId';
     }
   }
-  
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -1017,11 +1028,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-  
+
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-    
+
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
@@ -1032,7 +1043,7 @@ describe('State translation component', () => {
       TranslationTabActiveModeService
     );
     explorationStatesService.init(explorationState1, false);
-    
+
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
     entityTranslationsService.entityTranslation =
@@ -1067,14 +1078,14 @@ describe('State translation component', () => {
     ).and.returnValue(showTranslationTabBusyModalEmitter);
     component.isTranslationTabBusy = true;
     component.stateName = 'Introduction';
-    
+
     component.ngOnInit();
   });
-  
+
   afterEach(() => {
     component.ngOnDestroy();
   });
-  
+
   describe(
     'when translation tab is busy and voiceover mode is not' + ' activate',
     () => {
@@ -1085,7 +1096,7 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('content');
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(component.isVoiceoverModeActive()).toBe(false);
           expect(
@@ -1093,7 +1104,7 @@ describe('State translation component', () => {
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when clicking on interaction' +
           'customization arguments tab',
@@ -1101,14 +1112,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('ca');
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when clicking on feedback' +
           ' tab',
@@ -1116,28 +1127,28 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('feedback');
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when clicking on hint' + ' tab',
         () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('hint');
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when clicking on solution' +
           ' tab',
@@ -1145,14 +1156,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('solution');
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when trying to change' +
           ' active rule content index',
@@ -1160,14 +1171,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveRuleContentIndex(1);
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when trying to change' +
           ' active hint index',
@@ -1175,14 +1186,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveHintIndex(1);
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when trying to change' +
           ' active answer group index',
@@ -1190,14 +1201,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveAnswerGroupIndex(1);
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it(
         'should open translation tab busy modal when trying to change' +
           ' interaction customization argument index',
@@ -1205,14 +1216,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveCustomizationArgContentIndex(0);
-          
+
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
-      
+
       it('should get subtitled data', () => {
         let subtitledObject = SubtitledHtml.createFromBackendDict({
           content_id: 'content_1',
@@ -1224,7 +1235,7 @@ describe('State translation component', () => {
         expect(component.getSubtitledContentSummary(subtitledObject)).toBe(
           'This is the html'
         );
-        
+
         let subtitledObjectBack = SubtitledUnicode.createFromBackendDict({
           content_id: 'content_1',
           unicode_str: 'This is the unicode',
@@ -1233,7 +1244,7 @@ describe('State translation component', () => {
           'This is the unicode'
         );
       });
-      
+
       it(
         'should get content message warning that there is not text available' +
           ' to translate',
@@ -1374,7 +1385,7 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-  
+
   let explorationState2 = {
     Introduction: {
       content: {
@@ -1438,15 +1449,15 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-  
+
   let refreshStateTranslationEmitter = new EventEmitter();
-  
+
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
-  
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -1493,11 +1504,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-  
+
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-    
+
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
@@ -1510,7 +1521,7 @@ describe('State translation component', () => {
     );
     routerService = TestBed.inject(RouterService);
     explorationStatesService.init(explorationState1, false);
-    
+
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
     entityTranslationsService.entityTranslation =
@@ -1521,7 +1532,7 @@ describe('State translation component', () => {
         language_code: 'hi',
         translations: {},
       });
-    
+
     spyOnProperty(
       stateEditorService,
       'onRefreshStateTranslation'
@@ -1537,20 +1548,20 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
-    
+
     explorationStatesService.init(explorationState2, false);
-    
+
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
+
     component.ngOnInit();
-    
     fixture.detectChanges();
   });
-  
+
   afterEach(() => {
     component.ngOnDestroy();
   });
-  
+
   it('should cover all translatable objects', () => {
     Object.keys(DEFAULT_OBJECT_VALUES).forEach(objName => {
       if (
@@ -1567,14 +1578,14 @@ describe('State translation component', () => {
       }).not.toThrowError();
     });
   });
-  
+
   it('should update correct translation with updateTranslatedContent', () => {
     component.activeTranslatedContent = new TranslatedContent();
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated HTML', 'html', true),
       });
-    
+
     translationTabActiveModeService.isVoiceoverModeActive = jasmine
       .createSpy()
       .and.returnValue(false);
@@ -1582,14 +1593,14 @@ describe('State translation component', () => {
       translationTabActiveContentIdService,
       'getActiveContentId'
     ).and.returnValue('content_0');
-    
+
     component.updateTranslatedContent();
-    
+
     expect(component.activeTranslatedContent.translation).toBe(
       'Translated HTML'
     );
   });
-  
+
   it('should format TranslatableSetOfNormalizedString values', () => {
     expect(
       component.getHumanReadableRuleInputValues(
@@ -1598,7 +1609,7 @@ describe('State translation component', () => {
       )
     ).toEqual('[input1, input2]');
   });
-  
+
   it('should format TranslatableSetOfUnicodeString values', () => {
     expect(
       component.getHumanReadableRuleInputValues(
@@ -1607,29 +1618,31 @@ describe('State translation component', () => {
       )
     ).toEqual('[input1, input2]');
   });
-  
+
   it('should throw an error on invalid type', () => {
     expect(() => {
       component.getHumanReadableRuleInputValues(null, 'InvalidType');
     }).toThrowError('The InvalidType type is not implemented.');
   });
-  
+
   it('should correctly navigate to the given state', () => {
     spyOn(routerService, 'navigateToMainTab').and.callFake(() => {});
+    
     component.navigateToState('new_state');
+    
     expect(routerService.navigateToMainTab).toHaveBeenCalledWith('new_state');
   });
-  
+
   it('should return original html when translation tab is active', () => {
     spyOn(
       translationTabActiveModeService,
       'isTranslationModeActive'
     ).and.returnValue(true);
-    
+
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-    
+
     expect(htmlData).toBe('<p>HTML data</p>');
   });
   
@@ -1637,10 +1650,10 @@ describe('State translation component', () => {
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-    
+
     expect(htmlData).toBeNull();
   });
-  
+
   it('should return unicode when translation tab is active', () => {
     spyOn(
       translationTabActiveModeService,
@@ -1653,20 +1666,20 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBe('This is the unicode');
   });
-  
+
   it('should return translation html when translation available', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated HTML', 'html', true),
       });
-    
+
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-    
+
     expect(htmlData).toBe('Translated HTML');
   });
-  
+
   it('should return null when translation is empty in voiceover mode', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
@@ -1679,20 +1692,20 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBeNull();
   });
-  
+
   it('should return null when translation no available', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_1: new TranslatedContent('Translated HTML', 'html', true),
       });
-    
+
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
-    
+
     expect(htmlData).toBeNull();
   });
-  
+
   it('should return translated unicode in voiceover mode when translation exist', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
@@ -1705,7 +1718,7 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBe('Translated UNICODE');
   });
-  
+
   describe('when rules input tab is accessed but with no rules', () => {
     it('should throw an error when there are no rules', () => {
       spyOn(component, 'isDisabled').and.returnValue(false);
@@ -1717,7 +1730,7 @@ describe('State translation component', () => {
         'Accessed rule input translation tab when there are no rules'
       );
     });
-    
+
     it('should throw an error when there are no rules', () => {
       component.interactionRuleTranslatableContents = [];
       expect(() => {
@@ -1727,7 +1740,7 @@ describe('State translation component', () => {
       );
     });
   });
-  
+
   describe('when state has default outcome and no answer groups', () => {
     it(
       'should activate feedback tab with default outcome when' +
@@ -1735,6 +1748,7 @@ describe('State translation component', () => {
       () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('feedback');
+
         expect(component.isActive('feedback')).toBe(true);
         expect(component.isDisabled('feedback')).toBe(false);
         expect(
@@ -1743,7 +1757,7 @@ describe('State translation component', () => {
       }
     );
   });
-  
+
   describe('when initContentId and initTabName are provided', () => {
     const mockStateAnswerGroups = [
       {
@@ -1804,7 +1818,7 @@ describe('State translation component', () => {
         trainingData: [],
       },
     ];
-    
+
     const mockStateHints = [
       {
         hintContent: {
@@ -1822,7 +1836,7 @@ describe('State translation component', () => {
         },
       },
     ];
-    
+
     const mockinteractionCustomizationArgTranslatableContent = [
       {
         name: 'demo',
@@ -1843,71 +1857,71 @@ describe('State translation component', () => {
         },
       },
     ];
-    
+
     it('should return correct index for card of type feedback', () => {
       component.stateAnswerGroups =
         mockStateAnswerGroups as unknown as AnswerGroup[];
       component.activeTab = 'feedback';
       component.initActiveContentId = 'feedback_29';
-      
+
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'feedback_29'
       );
-      
+
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(2);
     });
-    
+
     it('should return correct index for card of type hint', () => {
       component.stateHints = mockStateHints as unknown as Hint[];
       component.activeTab = 'hint';
       component.initActiveContentId = 'hint_2';
-      
+
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'hint_2'
       );
-      
+
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(1);
     });
-    
+
     it('should return correct index for card of type custom args', () => {
       component.interactionCustomizationArgTranslatableContent =
         mockinteractionCustomizationArgTranslatableContent;
       component.activeTab = 'ca';
       component.initActiveContentId = 'ca_1';
-      
+
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'ca_1'
       );
-      
+
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(0);
     });
-    
+
     it('should return 0 as index for unknown tabs', () => {
       component.activeTab = 'unknown';
       component.initActiveContentId = 'unknown_1';
-      
+
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'ca_1'
       );
-      
+
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(0);
     });
-    
+
     it('should return correct active tab name', () => {
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'content_29'
       );
-      
+
       expect(component.getActiveTab()).toBe('content');
     });
-    
+
     it('should return active tab name as null when contentId is null', () => {
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(null);
-      
+
       expect(component.getActiveTab()).toBe(null);
     });
   });
@@ -2074,15 +2088,15 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
-  
+
   let refreshStateTranslationEmitter = new EventEmitter();
-  
+
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
-  
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -2130,11 +2144,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
-  
+
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
-    
+
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
@@ -2167,7 +2181,7 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
-    
+
     explorationStatesService.init(explorationState4, false);
     // Because the customization arguments we are passing for testing are
     // invalid, we will skip getInteractionHtml(), which would error
@@ -2192,15 +2206,15 @@ describe('State translation component', () => {
     });
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
-    
+
     component.ngOnInit();
     fixture.detectChanges();
   });
-  
+
   afterEach(() => {
     component.ngOnDestroy();
   });
-  
+
   describe(
     'when state has a multiple choice interaction with no hints, ' +
       'solution or outcome',
@@ -2208,19 +2222,19 @@ describe('State translation component', () => {
       it('should evaluate feedback tab as disabled', () => {
         expect(component.isDisabled('feedback')).toBe(true);
       });
-      
+
       it('should evaluate hint tab as disabled', () => {
         expect(component.isDisabled('hint')).toBe(true);
       });
-      
+
       it('should evaluate solution tab as disabled', () => {
         expect(component.isDisabled('solution')).toBe(true);
       });
-      
+
       it('should change active customization argument index', () => {
         component.onTabClick('ca');
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
-        
+
         component.changeActiveCustomizationArgContentIndex(1);
         expect(
           translationTabActiveContentIdService.setActiveContent
@@ -2231,11 +2245,11 @@ describe('State translation component', () => {
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('ca_0', 'unicode');
       });
-      
+
       it('should isDisabled return true when stateinteractionId is null', () => {
         component.TAB_ID_CONTENT = 'some_id';
         component.stateInteractionId = null;
-        
+
         expect(component.isDisabled('any')).toBeTrue();
       });
     }

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -8,11 +8,11 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS-IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /**
- * @fileoverview Unit tests for stateTranslation
+ * @fileoverview Unit tests for stateTranslation.
  */
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {EventEmitter, NO_ERRORS_SCHEMA, Pipe} from '@angular/core';
@@ -60,7 +60,9 @@ import {AnswerGroup} from 'domain/exploration/answer-group.model';
 import {TruncatePipe} from 'filters/string-utility-filters/truncate.pipe';
 import {FormatRtePreviewPipe} from 'filters/format-rte-preview.pipe';
 import {PlatformFeatureService} from 'services/platform-feature.service';
+
 const DEFAULT_OBJECT_VALUES = require('objects/object_defaults.json');
+
 class MockNgbModal {
   open() {
     return {
@@ -68,6 +70,7 @@ class MockNgbModal {
     };
   }
 }
+
 @Pipe({name: 'parameterizeRuleDescriptionPipe'})
 class MockParameterizeRuleDescriptionPipe {
   transform(
@@ -87,51 +90,21 @@ class MockWrapTextWithEllipsisPipe {
     return '';
   }
 }
+
 @Pipe({name: 'truncate'})
 class MockTruncatePipe {
   transform(value: string, params: number): string {
     return value;
   }
 }
+
 @Pipe({name: 'convertToPlainText'})
 class MockConvertToPlainTextPipe {
   transform(value: string): string {
     return value;
   }
 }
-class MockExplorationLanguageCodeService {
-  onExplorationPropertyChanged = new EventEmitter();
-  get displayed() {
-    return 'en';
-  }
-  init(value: unknown) {}
-  saveDisplayedValue() {}
-  restoreFromMemento() {}
-}
-class MockTranslationStatusService {
-  getActiveStateComponentStatusColor(tabId) {
-    return '#D14836';
-  }
-  getActiveStateComponentNeedsUpdateStatus(tabId) {
-    return false;
-  }
-  getActiveStateContentIdNeedsUpdateStatus(contentId) {
-    return false;
-  }
-  getActiveStateContentIdStatusColor(contentId) {
-    return '#D14836';
-  }
-  refresh() {}
-}
-@Pipe({name: 'formatRtePreview'})
-class MockFormatRtePreviewPipe {
-  transform(value: string): string {
-    return value;
-  }
-}
-class MockPlatformFeatureService {
-  // Add any methods that are used in the component if needed
-}
+
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -262,12 +235,15 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
+  
   let refreshStateTranslationEmitter = new EventEmitter();
+  
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
+  
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -325,9 +301,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
+  
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
+    
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     TestBed.inject(ExplorationLanguageCodeService);
@@ -353,6 +331,7 @@ describe('State translation component', () => {
         language_code: 'hi',
         translations: {},
       });
+    
     spyOnProperty(
       stateEditorService,
       'onRefreshStateTranslation'
@@ -369,17 +348,21 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isTranslationModeActive'
     ).and.returnValue(false);
+    
     explorationStatesService.init(explorationState1, false);
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
+    
     component.ngOnInit();
     fixture.detectChanges();
   });
+  
   afterEach(() => {
     if (component) {
       component.ngOnDestroy();
     }
   });
+  
   describe(
     'when translation tab is not busy and voiceover mode is' + ' active',
     () => {
@@ -393,6 +376,7 @@ describe('State translation component', () => {
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('content_1', 'html');
       });
+      
       it(
         'should get customization argument translatable customization' +
           ' arguments',
@@ -414,22 +398,27 @@ describe('State translation component', () => {
           ]);
         }
       );
+      
       it('should broadcast copy to ck editor when clicking on content', () => {
         spyOn(ckEditorCopyContentService, 'broadcastCopy').and.callFake(
           () => {}
         );
+        
         let mockEvent = {
           stopPropagation: () => {},
           target: {},
         } as Event;
         component.onContentClick(mockEvent);
+        
         expect(ckEditorCopyContentService.broadcastCopy).toHaveBeenCalledWith(
           mockEvent.target
         );
       });
+      
       it('should activate content tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('content');
+        
         expect(component.isActive('content')).toBe(true);
         expect(component.isDisabled('content')).toBe(false);
         expect(
@@ -444,12 +433,14 @@ describe('State translation component', () => {
           'border-left': '3px solid #808080',
         });
       });
+      
       it(
         'should activate interaction custimization arguments tab when ' +
           'clicking on tab',
         () => {
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('ca');
+          
           expect(component.isActive('ca')).toBe(true);
           expect(component.isDisabled('ca')).toBe(false);
           expect(
@@ -467,9 +458,11 @@ describe('State translation component', () => {
           );
         }
       );
+      
       it('should activate feedback tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('feedback');
+        
         expect(component.isActive('feedback')).toBe(true);
         expect(component.isDisabled('feedback')).toBe(false);
         expect(
@@ -484,9 +477,11 @@ describe('State translation component', () => {
           'border-left': '3px solid #808080',
         });
       });
+      
       it('should activate hint tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('hint');
+        
         expect(component.isActive('hint')).toBe(true);
         expect(component.isDisabled('hint')).toBe(false);
         expect(
@@ -501,9 +496,11 @@ describe('State translation component', () => {
           'border-left': '3px solid #808080',
         });
       });
+      
       it('should activate solution tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('solution');
+        
         expect(component.isActive('solution')).toBe(true);
         expect(component.isDisabled('solution')).toBe(false);
         expect(
@@ -518,30 +515,38 @@ describe('State translation component', () => {
           'border-left': '3px solid #808080',
         });
       });
+      
       it('should activate rule inputs tab when clicking on tab', () => {
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.onTabClick('rule_input');
+        
         expect(component.isActive('rule_input')).toBe(true);
         expect(component.isDisabled('rule_input')).toBe(false);
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_4', 'set_of_normalized_string');
       });
+      
       it('should change active rule content index', () => {
         component.onTabClick('rule_input');
+        
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveRuleContentIndex(1);
+        
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('rule_input_5', 'set_of_normalized_string');
       });
+      
       it(
         'should not change active rule content index if it is equal to the ' +
           'current one',
         () => {
           component.onTabClick('rule_input');
+          
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveRuleContentIndex(0);
+          
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
@@ -549,24 +554,30 @@ describe('State translation component', () => {
       );
       it('should change active hint index', () => {
         component.onTabClick('hint');
+        
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveHintIndex(1);
+        
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('hint_2', 'html');
       });
       it('should not change active hint index if it is equal to the current one', () => {
         component.onTabClick('hint');
+        
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveHintIndex(0);
+        
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).not.toHaveBeenCalled();
       });
       it('should change active answer group index', () => {
         component.onTabClick('feedback');
+        
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveAnswerGroupIndex(1);
+        
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('feedback_2', 'html');
@@ -576,8 +587,10 @@ describe('State translation component', () => {
           ' to the current one',
         () => {
           component.onTabClick('ca');
+          
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveCustomizationArgContentIndex(0);
+          
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
@@ -588,8 +601,10 @@ describe('State translation component', () => {
           ' index provided is equal to answer groups length',
         () => {
           component.onTabClick('feedback');
+          
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveAnswerGroupIndex(2);
+          
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).toHaveBeenCalledWith('default_outcome', 'html');
@@ -597,12 +612,15 @@ describe('State translation component', () => {
       );
       it('should not change active hint index if it is equal to the current one', () => {
         component.onTabClick('feedback');
+        
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
         component.changeActiveAnswerGroupIndex(0);
+        
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).not.toHaveBeenCalled();
       });
+      
       it('should get subtitled html data translation', () => {
         spyOn(
           translationLanguageService,
@@ -619,6 +637,7 @@ describe('State translation component', () => {
           'This is the html'
         );
       });
+      
       it('should get subtitled Unicode data translation', () => {
         spyOn(
           translationLanguageService,
@@ -635,6 +654,7 @@ describe('State translation component', () => {
           'This is the unicode'
         );
       });
+      
       it('should return null when html translation is missing in non-original language', () => {
         spyOnProperty(
           explorationLanguageCodeService,
@@ -679,6 +699,7 @@ describe('State translation component', () => {
           'Original Content'
         );
       });
+      
       it(
         "should get empty content message when text translations haven't" +
           ' been added yet',
@@ -689,6 +710,7 @@ describe('State translation component', () => {
           );
         }
       );
+      
       it('should get summary default outcome when outcome is linear', () => {
         expect(
           component.summarizeDefaultOutcome(
@@ -699,6 +721,7 @@ describe('State translation component', () => {
           )
         ).toBe('[] Feedback Text');
       });
+      
       it(
         'should get summary default outcome when answer group count' +
           ' is greater than 0',
@@ -713,6 +736,7 @@ describe('State translation component', () => {
           ).toBe('[] Feedback Text');
         }
       );
+      
       it(
         'should get summary default outcome when answer group count' +
           ' is equal to 0',
@@ -727,11 +751,13 @@ describe('State translation component', () => {
           ).toBe('[] Feedback Text');
         }
       );
+      
       it('should get an empty summary when default outcome is a falsy value', () => {
         expect(
           component.summarizeDefaultOutcome(null, 'Continue', 0, 'true')
         ).toBe('');
       });
+      
       it('should get summary answer group', () => {
         expect(
           component.summarizeAnswerGroup(
@@ -745,11 +771,13 @@ describe('State translation component', () => {
             '1',
             null,
             true
-          )
+             )
         ).toBe('[] Feedback text');
       });
     }
   );
+});
+
   it('should return null for missing translation in non-original language', () => {
     it('should return null for missing translation in non-original language', () => {
       (translationLanguageService.getActiveLanguageCode as any).and.returnValue('es');
@@ -803,6 +831,7 @@ describe('State translation component', () => {
       expect(component.hasOriginalContent(subtitledObject)).toBe(false);
     });
 });
+  
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -812,6 +841,7 @@ describe('State translation component', () => {
   let stateEditorService: StateEditorService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
+  
   let explorationState1 = {
     Introduction: {
       content: {
@@ -927,13 +957,16 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
+  
   let refreshStateTranslationEmitter = new EventEmitter();
   let showTranslationTabBusyModalEmitter = new EventEmitter();
+  
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
+  
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -984,9 +1017,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
+  
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
+    
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
@@ -997,6 +1032,7 @@ describe('State translation component', () => {
       TranslationTabActiveModeService
     );
     explorationStatesService.init(explorationState1, false);
+    
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
     entityTranslationsService.entityTranslation =
@@ -1019,6 +1055,7 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(false);
+    
     spyOn(
       translationTabActiveModeService,
       'isTranslationModeActive'
@@ -1030,11 +1067,14 @@ describe('State translation component', () => {
     ).and.returnValue(showTranslationTabBusyModalEmitter);
     component.isTranslationTabBusy = true;
     component.stateName = 'Introduction';
+    
     component.ngOnInit();
   });
+  
   afterEach(() => {
     component.ngOnDestroy();
   });
+  
   describe(
     'when translation tab is busy and voiceover mode is not' + ' activate',
     () => {
@@ -1045,6 +1085,7 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('content');
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(component.isVoiceoverModeActive()).toBe(false);
           expect(
@@ -1052,6 +1093,7 @@ describe('State translation component', () => {
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when clicking on interaction' +
           'customization arguments tab',
@@ -1059,12 +1101,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('ca');
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when clicking on feedback' +
           ' tab',
@@ -1072,24 +1116,28 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('feedback');
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when clicking on hint' + ' tab',
         () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('hint');
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when clicking on solution' +
           ' tab',
@@ -1097,12 +1145,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.onTabClick('solution');
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when trying to change' +
           ' active rule content index',
@@ -1110,12 +1160,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveRuleContentIndex(1);
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when trying to change' +
           ' active hint index',
@@ -1123,12 +1175,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveHintIndex(1);
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when trying to change' +
           ' active answer group index',
@@ -1136,12 +1190,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveAnswerGroupIndex(1);
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it(
         'should open translation tab busy modal when trying to change' +
           ' interaction customization argument index',
@@ -1149,12 +1205,14 @@ describe('State translation component', () => {
           spyOn(showTranslationTabBusyModalEmitter, 'emit');
           spyOn(translationTabActiveContentIdService, 'setActiveContent');
           component.changeActiveCustomizationArgContentIndex(0);
+          
           expect(showTranslationTabBusyModalEmitter.emit).toHaveBeenCalled();
           expect(
             translationTabActiveContentIdService.setActiveContent
           ).not.toHaveBeenCalled();
         }
       );
+      
       it('should get subtitled data', () => {
         let subtitledObject = SubtitledHtml.createFromBackendDict({
           content_id: 'content_1',
@@ -1166,6 +1224,7 @@ describe('State translation component', () => {
         expect(component.getSubtitledContentSummary(subtitledObject)).toBe(
           'This is the html'
         );
+        
         let subtitledObjectBack = SubtitledUnicode.createFromBackendDict({
           content_id: 'content_1',
           unicode_str: 'This is the unicode',
@@ -1174,6 +1233,7 @@ describe('State translation component', () => {
           'This is the unicode'
         );
       });
+      
       it(
         'should get content message warning that there is not text available' +
           ' to translate',
@@ -1186,6 +1246,7 @@ describe('State translation component', () => {
     }
   );
 });
+
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -1197,6 +1258,7 @@ describe('State translation component', () => {
   let translationTabActiveModeService: TranslationTabActiveModeService;
   let routerService: RouterService;
   let translationLanguageService: TranslationLanguageService;
+  
   let explorationState1 = {
     Introduction: {
       content: {
@@ -1312,6 +1374,7 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
+  
   let explorationState2 = {
     Introduction: {
       content: {
@@ -1375,12 +1438,15 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
+  
   let refreshStateTranslationEmitter = new EventEmitter();
+  
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
+  
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -1427,9 +1493,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
+  
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
+    
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
@@ -1442,6 +1510,7 @@ describe('State translation component', () => {
     );
     routerService = TestBed.inject(RouterService);
     explorationStatesService.init(explorationState1, false);
+    
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
     entityTranslationsService.entityTranslation =
@@ -1452,6 +1521,7 @@ describe('State translation component', () => {
         language_code: 'hi',
         translations: {},
       });
+    
     spyOnProperty(
       stateEditorService,
       'onRefreshStateTranslation'
@@ -1467,15 +1537,20 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
+    
     explorationStatesService.init(explorationState2, false);
+    
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
     component.ngOnInit();
+    
     fixture.detectChanges();
   });
+  
   afterEach(() => {
     component.ngOnDestroy();
   });
+  
   it('should cover all translatable objects', () => {
     Object.keys(DEFAULT_OBJECT_VALUES).forEach(objName => {
       if (
@@ -1492,12 +1567,14 @@ describe('State translation component', () => {
       }).not.toThrowError();
     });
   });
+  
   it('should update correct translation with updateTranslatedContent', () => {
     component.activeTranslatedContent = new TranslatedContent();
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated HTML', 'html', true),
       });
+    
     translationTabActiveModeService.isVoiceoverModeActive = jasmine
       .createSpy()
       .and.returnValue(false);
@@ -1505,11 +1582,14 @@ describe('State translation component', () => {
       translationTabActiveContentIdService,
       'getActiveContentId'
     ).and.returnValue('content_0');
+    
     component.updateTranslatedContent();
+    
     expect(component.activeTranslatedContent.translation).toBe(
       'Translated HTML'
     );
   });
+  
   it('should format TranslatableSetOfNormalizedString values', () => {
     expect(
       component.getHumanReadableRuleInputValues(
@@ -1518,6 +1598,7 @@ describe('State translation component', () => {
       )
     ).toEqual('[input1, input2]');
   });
+  
   it('should format TranslatableSetOfUnicodeString values', () => {
     expect(
       component.getHumanReadableRuleInputValues(
@@ -1526,32 +1607,40 @@ describe('State translation component', () => {
       )
     ).toEqual('[input1, input2]');
   });
+  
   it('should throw an error on invalid type', () => {
     expect(() => {
       component.getHumanReadableRuleInputValues(null, 'InvalidType');
     }).toThrowError('The InvalidType type is not implemented.');
   });
+  
   it('should correctly navigate to the given state', () => {
     spyOn(routerService, 'navigateToMainTab').and.callFake(() => {});
     component.navigateToState('new_state');
     expect(routerService.navigateToMainTab).toHaveBeenCalledWith('new_state');
   });
+  
   it('should return original html when translation tab is active', () => {
     spyOn(
       translationTabActiveModeService,
       'isTranslationModeActive'
     ).and.returnValue(true);
+    
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
+    
     expect(htmlData).toBe('<p>HTML data</p>');
   });
+  
   it('should return null when translation not available', () => {
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
+    
     expect(htmlData).toBeNull();
   });
+  
   it('should return unicode when translation tab is active', () => {
     spyOn(
       translationTabActiveModeService,
@@ -1564,16 +1653,20 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBe('This is the unicode');
   });
+  
   it('should return translation html when translation available', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated HTML', 'html', true),
       });
+    
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
+    
     expect(htmlData).toBe('Translated HTML');
   });
+  
   it('should return null when translation is empty in voiceover mode', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
@@ -1586,16 +1679,20 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBeNull();
   });
+  
   it('should return null when translation no available', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_1: new TranslatedContent('Translated HTML', 'html', true),
       });
+    
     const htmlData = component.getRequiredHtml(
       new SubtitledHtml('<p>HTML data</p>', 'content_0')
     );
+    
     expect(htmlData).toBeNull();
   });
+  
   it('should return translated unicode in voiceover mode when translation exist', () => {
     entityTranslationsService.languageCodeToLatestEntityTranslations.en =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
@@ -1608,6 +1705,7 @@ describe('State translation component', () => {
     const unicodeData = component.getRequiredUnicode(subtitledObject);
     expect(unicodeData).toBe('Translated UNICODE');
   });
+  
   describe('when rules input tab is accessed but with no rules', () => {
     it('should throw an error when there are no rules', () => {
       spyOn(component, 'isDisabled').and.returnValue(false);
@@ -1619,6 +1717,7 @@ describe('State translation component', () => {
         'Accessed rule input translation tab when there are no rules'
       );
     });
+    
     it('should throw an error when there are no rules', () => {
       component.interactionRuleTranslatableContents = [];
       expect(() => {
@@ -1628,6 +1727,7 @@ describe('State translation component', () => {
       );
     });
   });
+  
   describe('when state has default outcome and no answer groups', () => {
     it(
       'should activate feedback tab with default outcome when' +
@@ -1643,6 +1743,7 @@ describe('State translation component', () => {
       }
     );
   });
+  
   describe('when initContentId and initTabName are provided', () => {
     const mockStateAnswerGroups = [
       {
@@ -1703,6 +1804,7 @@ describe('State translation component', () => {
         trainingData: [],
       },
     ];
+    
     const mockStateHints = [
       {
         hintContent: {
@@ -1720,6 +1822,7 @@ describe('State translation component', () => {
         },
       },
     ];
+    
     const mockinteractionCustomizationArgTranslatableContent = [
       {
         name: 'demo',
@@ -1740,59 +1843,76 @@ describe('State translation component', () => {
         },
       },
     ];
+    
     it('should return correct index for card of type feedback', () => {
       component.stateAnswerGroups =
         mockStateAnswerGroups as unknown as AnswerGroup[];
       component.activeTab = 'feedback';
       component.initActiveContentId = 'feedback_29';
+      
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'feedback_29'
       );
+      
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(2);
     });
+    
     it('should return correct index for card of type hint', () => {
       component.stateHints = mockStateHints as unknown as Hint[];
       component.activeTab = 'hint';
       component.initActiveContentId = 'hint_2';
+      
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'hint_2'
       );
+      
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(1);
     });
+    
     it('should return correct index for card of type custom args', () => {
       component.interactionCustomizationArgTranslatableContent =
         mockinteractionCustomizationArgTranslatableContent;
       component.activeTab = 'ca';
       component.initActiveContentId = 'ca_1';
+      
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'ca_1'
       );
+      
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(0);
     });
+    
     it('should return 0 as index for unknown tabs', () => {
       component.activeTab = 'unknown';
       component.initActiveContentId = 'unknown_1';
+      
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'ca_1'
       );
+      
       const index = component.getIndexOfActiveCard();
       expect(index).toEqual(0);
     });
+    
     it('should return correct active tab name', () => {
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(
         'content_29'
       );
+      
       expect(component.getActiveTab()).toBe('content');
     });
+    
     it('should return active tab name as null when contentId is null', () => {
       spyOn(stateEditorService, 'getInitActiveContentId').and.returnValue(null);
+      
       expect(component.getActiveTab()).toBe(null);
     });
   });
 });
+
 describe('State translation component', () => {
   let component: StateTranslationComponent;
   let fixture: ComponentFixture<StateTranslationComponent>;
@@ -1921,6 +2041,7 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
+  
   let explorationState4 = {
     Introduction: {
       classifier_model_id: null,
@@ -1953,12 +2074,15 @@ describe('State translation component', () => {
       solicit_answer_details: false,
     },
   } as StateObjectsBackendDict;
+  
   let refreshStateTranslationEmitter = new EventEmitter();
+  
   class MockPageContextService {
     getExplorationId() {
       return 'expId';
     }
   }
+  
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -2006,9 +2130,11 @@ describe('State translation component', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
+  
   beforeEach(() => {
     fixture = TestBed.createComponent(StateTranslationComponent);
     component = fixture.componentInstance;
+    
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
     explorationStatesService = TestBed.inject(ExplorationStatesService);
@@ -2041,6 +2167,7 @@ describe('State translation component', () => {
       translationTabActiveModeService,
       'isVoiceoverModeActive'
     ).and.returnValue(true);
+    
     explorationStatesService.init(explorationState4, false);
     // Because the customization arguments we are passing for testing are
     // invalid, we will skip getInteractionHtml(), which would error
@@ -2065,12 +2192,15 @@ describe('State translation component', () => {
     });
     component.isTranslationTabBusy = false;
     component.stateName = 'Introduction';
+    
     component.ngOnInit();
     fixture.detectChanges();
   });
+  
   afterEach(() => {
     component.ngOnDestroy();
   });
+  
   describe(
     'when state has a multiple choice interaction with no hints, ' +
       'solution or outcome',
@@ -2078,27 +2208,34 @@ describe('State translation component', () => {
       it('should evaluate feedback tab as disabled', () => {
         expect(component.isDisabled('feedback')).toBe(true);
       });
+      
       it('should evaluate hint tab as disabled', () => {
         expect(component.isDisabled('hint')).toBe(true);
       });
+      
       it('should evaluate solution tab as disabled', () => {
         expect(component.isDisabled('solution')).toBe(true);
       });
+      
       it('should change active customization argument index', () => {
         component.onTabClick('ca');
         spyOn(translationTabActiveContentIdService, 'setActiveContent');
+        
         component.changeActiveCustomizationArgContentIndex(1);
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('ca_1', 'html');
+        
         component.changeActiveCustomizationArgContentIndex(0);
         expect(
           translationTabActiveContentIdService.setActiveContent
         ).toHaveBeenCalledWith('ca_0', 'unicode');
       });
+      
       it('should isDisabled return true when stateinteractionId is null', () => {
         component.TAB_ID_CONTENT = 'some_id';
         component.stateInteractionId = null;
+        
         expect(component.isDisabled('any')).toBeTrue();
       });
     }

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -73,6 +73,35 @@ class MockNgbModal {
   }
 }
 
+class MockPlatformFeatureService {
+  // Add any methods your component calls, e.g.
+  isFeatureEnabled() {
+    return false;
+  }
+}
+
+class MockTranslationStatusService {
+  getTranslationStatus() {
+    return {};
+  }
+
+  getActiveStateComponentStatusColor(contentId: string): string {
+    return '#D14836';
+  }
+
+  getActiveStateComponentNeedsUpdateStatus(contentId: string): boolean {
+    return false;
+  }
+
+  getActiveStateContentIdNeedsUpdateStatus(contentId: string): boolean {
+    return false;
+  }
+
+  getActiveStateContentIdStatusColor(contentId: string): string {
+    return '#808080';
+  }
+}
+
 @Pipe({name: 'parameterizeRuleDescriptionPipe'})
 class MockParameterizeRuleDescriptionPipe {
   transform(
@@ -84,7 +113,9 @@ class MockParameterizeRuleDescriptionPipe {
   }
 }
 class MockExplorationLanguageCodeService {
-  displayed = 'en';
+  get displayed() {
+    return 'en';
+  }
 }
 @Pipe({name: 'wrapTextWithEllipsis'})
 class MockWrapTextWithEllipsisPipe {
@@ -118,7 +149,6 @@ describe('State translation component', () => {
   let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
-  let explorationLanguageCodeService: ExplorationLanguageCodeService;
 
   let explorationState1 = {
     Introduction: {
@@ -736,20 +766,16 @@ describe('State translation component', () => {
         ).toBe('[] Feedback Text');
       });
 
-      it(
-        'should get summary default outcome when answer group count' +
-          ' is greater than 0',
-        () => {
-          expect(
-            component.summarizeDefaultOutcome(
-              Outcome.createNew('unused', '1', 'Feedback Text', []),
-              'TextInput',
-              1,
-              'true'
-            )
-          ).toBe('[] Feedback Text');
-        }
-      );
+      it('should get summary default outcome when outcome is linear', () => {
+        expect(
+          component.summarizeDefaultOutcome(
+            Outcome.createNew('unused', '1', 'Feedback Text', []),
+            'Continue',
+            0,
+            'true'
+          )
+        ).toBe('[When the button is clicked] Feedback Text');
+      });
 
       it(
         'should get summary default outcome when answer group count' +
@@ -762,7 +788,7 @@ describe('State translation component', () => {
               0,
               'true'
             )
-          ).toBe('[] Feedback Text');
+          ).toBe('[All other answers] Feedback Text');
         }
       );
 
@@ -786,63 +812,64 @@ describe('State translation component', () => {
             null,
             true
           )
-        ).toBe('[] Feedback text');
+        ).toBe('[All other answers] Feedback Text');
+      });
+
+      it('should return null for missing translation in non-original language', () => {
+        spyOn(
+          translationLanguageService,
+          'getActiveLanguageCode'
+        ).and.returnValue('es');
+        // ExplorationLanguageCodeService.displayed is 'en' by mock default.
+
+        let subtitledObject = SubtitledHtml.createFromBackendDict({
+          content_id: 'content_1',
+          html: 'Original Content',
+        });
+
+        // Entity translations for 'es' are missing/empty.
+        expect(component.getRequiredHtml(subtitledObject)).toBeNull();
+      });
+
+      it('should return original content for original language in voiceover mode', () => {
+        spyOn(
+          translationLanguageService,
+          'getActiveLanguageCode'
+        ).and.returnValue('en');
+        let subtitledObject = SubtitledHtml.createFromBackendDict({
+          content_id: 'content_1',
+          html: 'Original Content',
+        });
+
+        expect(component.getRequiredHtml(subtitledObject)).toBe(
+          'Original Content'
+        );
+      });
+
+      it('should return correct empty content message for original language', () => {
+        spyOn(
+          translationLanguageService,
+          'getActiveLanguageCode'
+        ).and.returnValue('en');
+        // ExplorationLanguageCodeService.displayed is 'en'.
+
+        expect(component.getEmptyContentMessage()).toBe(
+          'There is no text available to voiceover.'
+        );
+      });
+
+      it('should check if original content is present', () => {
+        let subtitledObject = SubtitledHtml.createFromBackendDict({
+          content_id: 'content_1',
+          html: 'Content',
+        });
+        expect(component.hasOriginalContent(subtitledObject)).toBe(true);
+
+        subtitledObject.html = '';
+        expect(component.hasOriginalContent(subtitledObject)).toBe(false);
       });
     }
   );
-});
-
-    it('should return null for missing translation in non-original language', () => {
-      (translationLanguageService.getActiveLanguageCode as any).and.returnValue('es');
-      // explorationLanguageCodeService.displayed is 'en' by mock default.
-
-      let subtitledObject = SubtitledHtml.createFromBackendDict({
-        content_id: 'content_1',
-        html: 'Original Content',
-      });
-
-      // Entity translations for 'es' are missing/empty.
-      expect(component.getRequiredHtml(subtitledObject)).toBeNull();
-    });
-
-    it('should return original content for original language in voiceover mode', () => {
-      spyOn(translationLanguageService, 'getActiveLanguageCode').and.returnValue('en');
-      // The following lines appear to be misplaced code from a different context.
-      // They are commented out to maintain syntactical correctness of the test file.
-      // console.log('Lang Code:', langCode);
-      // // @ts-ignore
-      // console.log('Displayed Lang:', this.explorationLanguageCodeService.displayed);
-      //
-      // if (langCode === this.explorationLanguageCodeService.displayed) {
-      //   return subtitledHtml.html;
-      // }
-      let subtitledObject = SubtitledHtml.createFromBackendDict({
-        content_id: 'content_1',
-        html: 'Original Content',
-      });
-
-      expect(component.getRequiredHtml(subtitledObject)).toBe('Original Content');
-    });
-
-    it('should return correct empty content message for original language', () => {
-      (translationLanguageService.getActiveLanguageCode as any).and.returnValue('en');
-      // explorationLanguageCodeService.displayed is 'en'.
-
-      expect(component.getEmptyContentMessage()).toBe(
-        'There is no text available to voiceover.'
-      );
-    });
-
-    it('should check if original content is present', () => {
-      let subtitledObject = SubtitledHtml.createFromBackendDict({
-        content_id: 'content_1',
-        html: 'Content',
-      });
-      expect(component.hasOriginalContent(subtitledObject)).toBe(true);
-
-      subtitledObject.html = '';
-      expect(component.hasOriginalContent(subtitledObject)).toBe(false);
-    });
 });
 
 describe('State translation component', () => {
@@ -1937,6 +1964,7 @@ describe('State translation component', () => {
   let stateEditorService: StateEditorService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
+  let translationLanguageService: TranslationLanguageService;
   let explorationHtmlFormatterService: ExplorationHtmlFormatterService;
   let explorationState1 = {
     Introduction: {

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -43,6 +43,7 @@ import {AngularNameService} from 'pages/exploration-editor-page/services/angular
 import {ExplorationStatesService} from 'pages/exploration-editor-page/services/exploration-states.service';
 import {StateEditorRefreshService} from 'pages/exploration-editor-page/services/state-editor-refresh.service';
 import {PageContextService} from 'services/page-context.service';
+import {ExplorationLanguageCodeService} from 'pages/exploration-editor-page/services/exploration-language-code.service';
 import {EntityTranslationsService} from 'services/entity-translations.services';
 import {ExplorationHtmlFormatterService} from 'services/exploration-html-formatter.service';
 import {ExplorationImprovementsTaskRegistryService} from 'services/exploration-improvements-task-registry.service';
@@ -76,6 +77,9 @@ class MockParameterizeRuleDescriptionPipe {
   ): string {
     return '';
   }
+}
+class MockExplorationLanguageCodeService {
+  displayed = 'en';
 }
 @Pipe({name: 'wrapTextWithEllipsis'})
 class MockWrapTextWithEllipsisPipe {
@@ -139,6 +143,7 @@ describe('State translation component', () => {
   let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
+  let explorationLanguageCodeService: ExplorationLanguageCodeService;
   let explorationState1 = {
     Introduction: {
       content: {
@@ -333,6 +338,9 @@ describe('State translation component', () => {
     );
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
+    );
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
     );
     explorationStatesService.init(explorationState1, false);
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
@@ -742,6 +750,58 @@ describe('State translation component', () => {
       });
     }
   );
+  it('should return null for missing translation in non-original language', () => {
+    it('should return null for missing translation in non-original language', () => {
+      (translationLanguageService.getActiveLanguageCode as any).and.returnValue('es');
+      // explorationLanguageCodeService.displayed is 'en' by mock default.
+
+      let subtitledObject = SubtitledHtml.createFromBackendDict({
+        content_id: 'content_1',
+        html: 'Original Content',
+      });
+
+      // Entity translations for 'es' are missing/empty.
+      expect(component.getRequiredHtml(subtitledObject)).toBeNull();
+    });
+
+    it('should return original content for original language in voiceover mode', () => {
+      spyOn(translationLanguageService, 'getActiveLanguageCode').and.returnValue('en');
+      // The following lines appear to be misplaced code from a different context.
+      // They are commented out to maintain syntactical correctness of the test file.
+      // console.log('Lang Code:', langCode);
+      // // @ts-ignore
+      // console.log('Displayed Lang:', this.explorationLanguageCodeService.displayed);
+      //
+      // if (langCode === this.explorationLanguageCodeService.displayed) {
+      //   return subtitledHtml.html;
+      // }
+      let subtitledObject = SubtitledHtml.createFromBackendDict({
+        content_id: 'content_1',
+        html: 'Original Content',
+      });
+
+      expect(component.getRequiredHtml(subtitledObject)).toBe('Original Content');
+    });
+
+    it('should return correct empty content message for original language', () => {
+      (translationLanguageService.getActiveLanguageCode as any).and.returnValue('en');
+      // explorationLanguageCodeService.displayed is 'en'.
+
+      expect(component.getEmptyContentMessage()).toBe(
+        'There is no text available to voiceover.'
+      );
+    });
+
+    it('should check if original content is present', () => {
+      let subtitledObject = SubtitledHtml.createFromBackendDict({
+        content_id: 'content_1',
+        html: 'Content',
+      });
+      expect(component.hasOriginalContent(subtitledObject)).toBe(true);
+
+      subtitledObject.html = '';
+      expect(component.hasOriginalContent(subtitledObject)).toBe(false);
+    });
 });
 describe('State translation component', () => {
   let component: StateTranslationComponent;

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
@@ -136,9 +136,7 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
     }
 
     let langCode = this.translationLanguageService.getActiveLanguageCode();
-    console.log('getRequiredHtml - LangCode:', langCode);
-    console.log('getRequiredHtml - Displayed:', this.explorationLanguageCodeService.displayed);
-
+    
     if (langCode === this.explorationLanguageCodeService.displayed) {
       return subtitledHtml.html;
     }

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
@@ -35,6 +35,7 @@ import {
   StateEditorService,
 } from 'components/state-editor/state-editor-properties-services/state-editor.service';
 import {ExplorationStatesService} from 'pages/exploration-editor-page/services/exploration-states.service';
+import {ExplorationLanguageCodeService} from 'pages/exploration-editor-page/services/exploration-language-code.service';
 import {RouterService} from 'pages/exploration-editor-page/services/router.service';
 import {ExplorationHtmlFormatterService} from 'services/exploration-html-formatter.service';
 import {TranslationStatusService} from '../services/translation-status.service';
@@ -109,6 +110,7 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
     private ckEditorCopyContentService: CkEditorCopyContentService,
     private explorationHtmlFormatterService: ExplorationHtmlFormatterService,
     private explorationStatesService: ExplorationStatesService,
+    private explorationLanguageCodeService: ExplorationLanguageCodeService,
     private routerService: RouterService,
     private stateEditorService: StateEditorService,
     private entityTranslationsService: EntityTranslationsService,
@@ -128,18 +130,24 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
     return this.translationTabActiveModeService.isVoiceoverModeActive();
   }
 
-  getRequiredHtml(subtitledHtml: SubtitledHtml): string {
+  getRequiredHtml(subtitledHtml: SubtitledHtml): string | null {
     if (this.translationTabActiveModeService.isTranslationModeActive()) {
       return subtitledHtml.html;
     }
 
     let langCode = this.translationLanguageService.getActiveLanguageCode();
+    console.log('getRequiredHtml - LangCode:', langCode);
+    console.log('getRequiredHtml - Displayed:', this.explorationLanguageCodeService.displayed);
+
+    if (langCode === this.explorationLanguageCodeService.displayed) {
+      return subtitledHtml.html;
+    }
     if (
       !this.entityTranslationsService.languageCodeToLatestEntityTranslations.hasOwnProperty(
         langCode
       )
     ) {
-      return subtitledHtml.html;
+      return null;
     }
 
     let translationContent =
@@ -147,24 +155,27 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
         langCode
       ].getWrittenTranslation(subtitledHtml.contentId);
     if (!translationContent) {
-      return subtitledHtml.html;
+      return null;
     }
 
     return translationContent.translation as string;
   }
 
-  getRequiredUnicode(SubtitledUnicode: SubtitledUnicode): string {
+  getRequiredUnicode(SubtitledUnicode: SubtitledUnicode): string | null {
     if (this.translationTabActiveModeService.isTranslationModeActive()) {
       return SubtitledUnicode.unicode;
     }
 
     let langCode = this.translationLanguageService.getActiveLanguageCode();
+    if (langCode === this.explorationLanguageCodeService.displayed) {
+      return SubtitledUnicode.unicode;
+    }
     if (
       !this.entityTranslationsService.languageCodeToLatestEntityTranslations.hasOwnProperty(
         langCode
       )
     ) {
-      return SubtitledUnicode.unicode;
+      return null;
     }
 
     let translationContent =
@@ -172,7 +183,7 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
         langCode
       ].getWrittenTranslation(SubtitledUnicode.contentId);
     if (!translationContent) {
-      return SubtitledUnicode.unicode;
+      return null;
     }
 
     return translationContent.translation as string;
@@ -180,15 +191,28 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
 
   getEmptyContentMessage(): string {
     if (this.translationTabActiveModeService.isVoiceoverModeActive()) {
+      let langCode = this.translationLanguageService.getActiveLanguageCode();
+      if (langCode === this.explorationLanguageCodeService.displayed) {
+        return 'There is no text available to voiceover.';
+      } else {
       return (
         'The translation for this section has not been created yet. ' +
         'Switch to translation mode to add a text translation.'
       );
+     }
     } else {
       return 'There is no text available to translate.';
     }
   }
-
+  hasOriginalContent(
+    subtitledContent: SubtitledHtml | SubtitledUnicode
+  ): boolean {
+    if (subtitledContent instanceof SubtitledHtml) {
+      return subtitledContent.html !== '';
+    } else if (subtitledContent instanceof SubtitledUnicode) {
+      return subtitledContent.unicode !== '';
+    }
+  }
   isActive(tabId: string): boolean {
     return this.activatedTabId === tabId;
   }


### PR DESCRIPTION
## Overview

1. This PR fixes part of #20088.
2. This PR does the following: 

- This PR fixes multiple issues in the Exploration Editor Translation Tab, where:
- Cards corresponding to empty original (English) content were still shown.
- In voiceover mode, missing translations in non-original languages incorrectly fell back to English text.
- Empty content was incorrectly counted as “missing translation” in the translation status indicators.

3. The original bug occurred because: 

- The translation tab did not distinguish between empty original content and missing translations.
- In voiceover mode, getRequiredHtml and getRequiredUnicode fell back to original content even when a translation was missing.
- Translation status calculations included empty content IDs, causing incorrect progress indicators.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Proof 1: Missing translations do not fall back to English (Voiceover mode)

When the active language is non-English, and a translation is missing, the Translation Tab shows the placeholder text instead of falling back to the original English content.

This confirms that getRequiredHtml / getRequiredUnicode return null for missing translations in non-original languages.

📽️ Screen recording:

https://github.com/user-attachments/assets/fcc58e59-ed95-4593-92ba-4bb53635153c

Proof 2: Original language shows original content in Voiceover mode

When the active language is English (original language), the Translation Tab correctly displays the original English content.

No placeholder is shown when original content exists.

📸 Screenshot: 
<img width="1512" height="982" alt="original language in english" src="https://github.com/user-attachments/assets/aa19064f-9c59-45c0-a475-660830bc55c1" />

Proof 3: Cards with empty original content are hidden

Cards corresponding to empty original (English) content do not appear in the Translation Tab.

In the example below, Interaction, Feedback, Hints, and Solution have empty original content, so only the Content tab is rendered.

📸 Screenshot: 

<img width="1512" height="982" alt="Missing translation in non-English" src="https://github.com/user-attachments/assets/4b32b9ec-8c3d-4577-a201-1e7ef1ac1fbd" />

#### Proof of changes on desktop with slow/throttled network

Manually verified on desktop. No UI or performance issues observed.

#### Proof of changes on mobile phone

Not applicable. Translation Tab is not optimized for mobile usage.

#### Proof of changes in Arabic language

<img width="1512" height="982" alt="Screenshot 2026-02-05 at 11 02 36 PM" src="https://github.com/user-attachments/assets/05c9f347-ba5a-4f1e-8e17-c74ea944a8b9" />

Note: The Exploration Overview panel remains fixed on the right as per the existing editor layout.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
