### PR TITLE
Fix #24510: Resolve horizontal overflow in Practice Tab on small screens

### DIFF
--- a/core/templates/pages/topic-viewer-page/practice-tab/practice-tab.component.css
+++ b/core/templates/pages/topic-viewer-page/practice-tab/practice-tab.component.css
@@ -121,17 +121,20 @@
 
 @media (max-width: 1024px) {
   .practice-tab .oppia-practice-tab-container .oppia-page-card {
-    width: 60vw;
+    box-sizing: border-box;
+    max-width: 550px;
+    width: 100%;
   }
 }
 
 @media (max-width: 500px) {
   .practice-tab .oppia-practice-tab-container .oppia-page-card {
     padding: 15px 24px 64px 24px;
-    width: 90vw;
   }
   .practice-tab .practice-tab-for-learner-dashboard .oppia-page-card {
-    width: 69vw;
+    box-sizing: border-box;
+    max-width: 550px;
+    width: 100%;
   }
   .practice-tab .practice-tab-for-learner-dashboard .capsule-progress {
     height: 13px;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/24510.
2. This PR resolves a horizontal overflow issue in the Practice Tab card on smaller screen sizes. The card previously used fixed/viewport-based widths which caused the layout to extend beyond its parent container. The fix makes the card responsive by using width: 100%, max-width, and box-sizing: border-box, ensuring proper rendering across mobile, tablet, and desktop screens while keeping the change scoped to the practice-tab component.
3. The original bug occurred because the card width was constrained using viewport units and fixed pixel values within responsive breakpoints, which did not properly adapt to very narrow screens.
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## Before : 

https://github.com/user-attachments/assets/1faa72a7-f81f-4a46-9cbb-9eeff8feb371

## After : 


https://github.com/user-attachments/assets/bd4e1e6e-4c82-4239-80c9-df7c70e98ea1



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
