### PR TITLE
Fix #24512: Correct contributor avatar alignment in lesson information card

### DIFF
--- a/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.css
@@ -173,6 +173,7 @@
 .oppia-lesson-exploration-progress-info .oppia-contributors-icon {
   cursor: default;
   margin-right: 0.3125rem;
+  width: 24px;
 }
 
 .oppia-lesson-info-card .row.center {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/24512.
2. This PR corrects the misalignment of contributor avatars in the lesson information card modal. The issue was caused by the Material icon expanding beyond its intended width, which disrupted the flex layout and shifted the visual center. Constraining the icon width ensures consistent spacing and properly aligns the contributor avatars with the other metric icons.
3. The original bug occurred because the Material icon did not have a fixed width, allowing it to stretch within the flex container and create uneven layout geometry.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Before : 
<img width="1912" height="964" alt="Screenshot 2026-02-06 104831" src="https://github.com/user-attachments/assets/a1abab4d-489e-4731-9bb9-1c6bb5d6a104" />

After : 
<img width="1914" height="961" alt="Screenshot 2026-02-06 105116" src="https://github.com/user-attachments/assets/581d48ba-e707-42b4-aada-353cecdfa305" />
<img width="1915" height="964" alt="Screenshot 2026-02-06 105439" src="https://github.com/user-attachments/assets/a38e9940-eeee-4b86-b9af-6a24d87500c2" />
<img width="1919" height="966" alt="Screenshot 2026-02-06 105603" src="https://github.com/user-attachments/assets/89024b49-dbfc-4303-a572-15d8bc5bbe81" />


#### Proof of changes on mobile phone
<img width="1369" height="962" alt="image" src="https://github.com/user-attachments/assets/fe4e0698-6a68-4182-aa98-3b774c5b014a" />

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
