### PR TITLE
Fix #24839: Restrict search results to title and objective fields

### DIFF
--- a/core/platform/search/elastic_search_services.py
+++ b/core/platform/search/elastic_search_services.py
@@ -327,6 +327,7 @@ def search(
             {
                 'multi_match': {
                     'query': query_string,
+                    'fields': ['title', 'objective']
                 }
             }
         ]

--- a/core/platform/search/elastic_search_services.py
+++ b/core/platform/search/elastic_search_services.py
@@ -413,6 +413,7 @@ def blog_post_summaries_search(
             {
                 'multi_match': {
                     'query': query_string,
+                    'fields': ['title']
                 }
             }
         ]

--- a/core/platform/search/elastic_search_services_test.py
+++ b/core/platform/search/elastic_search_services_test.py
@@ -215,7 +215,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 {
                     'query': {
                         'bool': {
-                            'must': [{'multi_match': {'query': 'query'}}],
+                            'must': [{'multi_match': {'query': 'query', 'fields': ['title', 'objective']}}],
                             'filter': [
                                 {
                                     'match': {
@@ -385,7 +385,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 {
                     'query': {
                         'bool': {
-                            'must': [{'multi_match': {'query': 'query'}}],
+                            'must': [{'multi_match': {'query': 'query', 'fields': ['title']}}],
                             'filter': [
                                 {
                                     'match': {

--- a/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
+++ b/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
@@ -6,18 +6,19 @@
     <div class="topic-preview-nav">
       <div class="topic-preview-navbar-tabs">
         <div class="topic-preview-navbar-tab e2e-test-preview-subtab"
-          [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'story'}"
-          (click)="changePreviewTab('story')">
+             [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'story'}"
+             (click)="changePreviewTab('story')">
           <div class="topic-preview-icon">
-            <img alt="" class="tab-icon" [src]="getStaticImageUrl('/icons/play_icon_24px.svg')">
+            <img alt="" class="tab-icon"
+                 [src]="getStaticImageUrl('/icons/play_icon_24px.svg')">
           </div>
           <div class="topic-preview-text">
             Learn
           </div>
         </div>
         <div class="topic-preview-navbar-tab e2e-test-preview-subtab"
-          [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'practice'}"
-          (click)="changePreviewTab('practice')">
+             [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'practice'}"
+             (click)="changePreviewTab('practice')">
           <div class="topic-preview-icon">
             <img alt="" class="tab-icon" [src]="getStaticImageUrl('/icons/train_icon_24px.svg')">
           </div>
@@ -26,10 +27,11 @@
           </div>
         </div>
         <div class="topic-preview-navbar-tab e2e-test-preview-subtab"
-          [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'subtopic'}"
-          (click)="changePreviewTab('subtopic')">
+             [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'subtopic'}"
+             (click)="changePreviewTab('subtopic')">
           <div class="topic-preview-icon">
-            <img alt="" class="tab-icon" [src]="getStaticImageUrl('/icons/review_icon_24px.svg')">
+            <img alt="" class="tab-icon"
+                 [src]="getStaticImageUrl('/icons/review_icon_24px.svg')">
           </div>
           <div class="topic-preview-text">
             Study
@@ -38,19 +40,29 @@
       </div>
     </div>
     <div *ngIf="activeTab === 'story'">
-      <stories-list [topicName]="topic.getName()" [topicId]="topic.getId()" [topicDescription]="topic.getDescription()"
-        [canonicalStorySummaries]="canonicalStorySummaries" [classroomUrlFragment]="classroomUrlFragment"
-        [classroomName]="classroomName" [topicUrlFragment]="topicUrlFragment">
+      <stories-list
+                    [topicName]="topic.getName()"
+                    [topicId]="topic.getId()"
+                    [topicDescription]="topic.getDescription()"
+                    [canonicalStorySummaries]="canonicalStorySummaries"
+                    [classroomUrlFragment]="classroomUrlFragment"
+                    [classroomName]="classroomName"
+                    [topicUrlFragment]="topicUrlFragment">
       </stories-list>
     </div>
     <div *ngIf="activeTab === 'subtopic'">
-      <subtopics-list [classroomUrlFragment]="classroomUrlFragment" [subtopicsList]="subtopics"
-        [topicId]="topic.getId()" [topicName]="topicName" [topicUrlFragment]="topicUrlFragment">
+      <subtopics-list [classroomUrlFragment]="''"
+                      [subtopicsList]="subtopics"
+                      [topicId]="topic.getId()"
+                      [topicName]="topicName"
+                      [topicUrlFragment]="''">
       </subtopics-list>
     </div>
-    <div *ngIf="activeTab === 'practice'">
-      <practice-tab *ngIf="isPracticeTabEnabled()" [subtopicsList]="subtopics" [topicName]="topicName"
-        [topicUrlFragment]="topicUrlFragment" [classroomUrlFragment]="classroomUrlFragment">
+    <div  *ngIf="activeTab === 'practice'">
+      <practice-tab *ngIf="isPracticeTabEnabled()" [subtopicsList]="subtopics"
+                    [topicName]="topicName"
+                    [topicUrlFragment]="topicUrlFragment"
+                    [classroomUrlFragment]="classroomUrlFragment">
       </practice-tab>
       <mat-card dir="auto" *ngIf="!isPracticeTabEnabled()" class="oppia-page-card practice-tab-not-available-card">
         <h2 class="coming-soon-title" [innerHTML]="'I18N_TOPIC_VIEWER_COMING_SOON' | translate">
@@ -66,29 +78,25 @@
     background-color: #fff;
     margin: 0 auto;
     position: relative;
+    top: 50px;
     width: 50%;
   }
-
   .topic-preview-parent {
     margin-top: -40px;
   }
-
   .topic-preview-nav {
     background-color: #00645c;
     box-shadow: 0 2px 8px #000000cf;
     margin-bottom: 12px;
   }
-
   .topic-preview-navbar-tabs {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
   }
-
   .topic-preview-nav-active {
     border-bottom: 4px solid #fff;
   }
-
   .topic-preview-navbar-tab {
     cursor: pointer;
     display: inline-block;
@@ -97,11 +105,9 @@
     padding: 20px 0;
     text-align: center;
   }
-
   .topic-preview-icon img {
     height: 40px;
   }
-
   .topic-preview-text {
     color: #fff;
     font-family: Capriola, Roboto, Arial, sans-serif;
@@ -109,32 +115,26 @@
     margin-top: 4px;
     text-transform: uppercase;
   }
-
   .topic-preview-container mat-card {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 0 rgba(0, 0, 0, 0.24);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 0 rgba(0,0,0,0.24);
     margin-top: 0;
   }
-
   .topic-preview-parent .topic-preview-container mat-card {
     box-shadow: none;
   }
-
   @media screen and (max-width: 1000px) {
     .topic-preview-container {
       width: 70%;
-    }
+   }
   }
-
   @media screen and (max-width: 800px) {
     .topic-preview-container {
       width: 80%;
     }
-
     .topic-preview-parent .background-banner-position {
       top: 30px;
     }
   }
-
   @media screen and (max-width: 650px) {
     .topic-preview-container {
       margin-top: 80px;

--- a/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
+++ b/core/templates/pages/topic-editor-page/preview-tab/topic-preview-tab.component.html
@@ -6,19 +6,18 @@
     <div class="topic-preview-nav">
       <div class="topic-preview-navbar-tabs">
         <div class="topic-preview-navbar-tab e2e-test-preview-subtab"
-             [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'story'}"
-             (click)="changePreviewTab('story')">
+          [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'story'}"
+          (click)="changePreviewTab('story')">
           <div class="topic-preview-icon">
-            <img alt="" class="tab-icon"
-                 [src]="getStaticImageUrl('/icons/play_icon_24px.svg')">
+            <img alt="" class="tab-icon" [src]="getStaticImageUrl('/icons/play_icon_24px.svg')">
           </div>
           <div class="topic-preview-text">
             Learn
           </div>
         </div>
         <div class="topic-preview-navbar-tab e2e-test-preview-subtab"
-             [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'practice'}"
-             (click)="changePreviewTab('practice')">
+          [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'practice'}"
+          (click)="changePreviewTab('practice')">
           <div class="topic-preview-icon">
             <img alt="" class="tab-icon" [src]="getStaticImageUrl('/icons/train_icon_24px.svg')">
           </div>
@@ -27,11 +26,10 @@
           </div>
         </div>
         <div class="topic-preview-navbar-tab e2e-test-preview-subtab"
-             [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'subtopic'}"
-             (click)="changePreviewTab('subtopic')">
+          [ngClass]="{'topic-preview-nav-active e2e-test-active-tab': activeTab === 'subtopic'}"
+          (click)="changePreviewTab('subtopic')">
           <div class="topic-preview-icon">
-            <img alt="" class="tab-icon"
-                 [src]="getStaticImageUrl('/icons/review_icon_24px.svg')">
+            <img alt="" class="tab-icon" [src]="getStaticImageUrl('/icons/review_icon_24px.svg')">
           </div>
           <div class="topic-preview-text">
             Study
@@ -40,29 +38,19 @@
       </div>
     </div>
     <div *ngIf="activeTab === 'story'">
-      <stories-list
-                    [topicName]="topic.getName()"
-                    [topicId]="topic.getId()"
-                    [topicDescription]="topic.getDescription()"
-                    [canonicalStorySummaries]="canonicalStorySummaries"
-                    [classroomUrlFragment]="classroomUrlFragment"
-                    [classroomName]="classroomName"
-                    [topicUrlFragment]="topicUrlFragment">
+      <stories-list [topicName]="topic.getName()" [topicId]="topic.getId()" [topicDescription]="topic.getDescription()"
+        [canonicalStorySummaries]="canonicalStorySummaries" [classroomUrlFragment]="classroomUrlFragment"
+        [classroomName]="classroomName" [topicUrlFragment]="topicUrlFragment">
       </stories-list>
     </div>
     <div *ngIf="activeTab === 'subtopic'">
-      <subtopics-list [classroomUrlFragment]="''"
-                      [subtopicsList]="subtopics"
-                      [topicId]="topic.getId()"
-                      [topicName]="topicName"
-                      [topicUrlFragment]="''">
+      <subtopics-list [classroomUrlFragment]="classroomUrlFragment" [subtopicsList]="subtopics"
+        [topicId]="topic.getId()" [topicName]="topicName" [topicUrlFragment]="topicUrlFragment">
       </subtopics-list>
     </div>
-    <div  *ngIf="activeTab === 'practice'">
-      <practice-tab *ngIf="isPracticeTabEnabled()" [subtopicsList]="subtopics"
-                    [topicName]="topicName"
-                    [topicUrlFragment]="topicUrlFragment"
-                    [classroomUrlFragment]="classroomUrlFragment">
+    <div *ngIf="activeTab === 'practice'">
+      <practice-tab *ngIf="isPracticeTabEnabled()" [subtopicsList]="subtopics" [topicName]="topicName"
+        [topicUrlFragment]="topicUrlFragment" [classroomUrlFragment]="classroomUrlFragment">
       </practice-tab>
       <mat-card dir="auto" *ngIf="!isPracticeTabEnabled()" class="oppia-page-card practice-tab-not-available-card">
         <h2 class="coming-soon-title" [innerHTML]="'I18N_TOPIC_VIEWER_COMING_SOON' | translate">
@@ -78,25 +66,29 @@
     background-color: #fff;
     margin: 0 auto;
     position: relative;
-    top: 50px;
     width: 50%;
   }
+
   .topic-preview-parent {
     margin-top: -40px;
   }
+
   .topic-preview-nav {
     background-color: #00645c;
     box-shadow: 0 2px 8px #000000cf;
     margin-bottom: 12px;
   }
+
   .topic-preview-navbar-tabs {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
   }
+
   .topic-preview-nav-active {
     border-bottom: 4px solid #fff;
   }
+
   .topic-preview-navbar-tab {
     cursor: pointer;
     display: inline-block;
@@ -105,9 +97,11 @@
     padding: 20px 0;
     text-align: center;
   }
+
   .topic-preview-icon img {
     height: 40px;
   }
+
   .topic-preview-text {
     color: #fff;
     font-family: Capriola, Roboto, Arial, sans-serif;
@@ -115,26 +109,32 @@
     margin-top: 4px;
     text-transform: uppercase;
   }
+
   .topic-preview-container mat-card {
-    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 0 rgba(0,0,0,0.24);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 0 rgba(0, 0, 0, 0.24);
     margin-top: 0;
   }
+
   .topic-preview-parent .topic-preview-container mat-card {
     box-shadow: none;
   }
+
   @media screen and (max-width: 1000px) {
     .topic-preview-container {
       width: 70%;
-   }
+    }
   }
+
   @media screen and (max-width: 800px) {
     .topic-preview-container {
       width: 80%;
     }
+
     .topic-preview-parent .background-banner-position {
       top: 30px;
     }
   }
+
   @media screen and (max-width: 650px) {
     .topic-preview-container {
       margin-top: 80px;


### PR DESCRIPTION
## Overview

1. This PR fixes #24839.
2. This PR restricts the Community Library search results to matches in the `title` and `objective` fields only. This prevents explorations from appearing in search results when the search term is not present in their title or objective (e.g., when the term matches internal fields like `id` or `category`).
3. (For bug-fixing PRs only) The original bug occurred because the `multi_match` query in `elastic_search_services.py` did not specify the `fields` parameter. By default, ElasticSearch searches across all fields in the document, which led to irrelevant matches.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #24839: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR.

## Proof of correctness

No proof of changes needed because this is a backend-only logic change and was verified by passing all 18 relevant backend tests. Output: [Ran 18 tests in 1.1s OK].

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.