### PR TITLE
Fix #23658: Ensure Pencil Code interaction loads correctly by waiting for script 

### DIFF
--- a/extensions/interactions/PencilCodeEditor/directives/oppia-interactive-pencil-code-editor.component.ts
+++ b/extensions/interactions/PencilCodeEditor/directives/oppia-interactive-pencil-code-editor.component.ts
@@ -29,6 +29,10 @@ import {PencilCodeEditorCustomizationArgs} from 'interactions/customization-args
 import {PencilCodeEditorRulesService} from './pencil-code-editor-rules.service';
 import {PencilCodeResetConfirmation} from './pencil-code-reset-confirmation.component';
 import {PlayerPositionService} from 'pages/exploration-player-page/services/player-position.service';
+import {
+  InsertScriptService,
+  KNOWN_SCRIPTS,
+} from 'services/insert-script.service';
 import {Subscription} from 'rxjs';
 
 @Component({
@@ -56,7 +60,8 @@ export class PencilCodeEditor implements OnInit, OnDestroy {
     private interactionAttributesExtractorService: InteractionAttributesExtractorService,
     private ngbModal: NgbModal,
     private playerPositionService: PlayerPositionService,
-    private pencilCodeEditorRulesService: PencilCodeEditorRulesService
+    private pencilCodeEditorRulesService: PencilCodeEditorRulesService,
+    private insertScriptService: InsertScriptService
   ) {}
 
   private _getAttributes() {
@@ -100,176 +105,180 @@ export class PencilCodeEditor implements OnInit, OnDestroy {
       })
     );
 
-    // The iframe may not be immediately available due to asynchronous rendering.
-    // To handle this, we retry checking for its presence up to `maxRetries` times.
-    // If the iframe does not appear within the retry limit, we display an error message.
+    this.insertScriptService.loadScript(KNOWN_SCRIPTS.PENCILCODE, () => {
+      // The iframe may not be immediately available due to asynchronous rendering.
+      // To handle this, we retry checking for its presence up to `maxRetries` times.
+      // If the iframe does not appear within the retry limit, we display an error message.
 
-    const maxRetries = 10;
-    let retryCount = 0;
+      const maxRetries = 10;
+      let retryCount = 0;
 
-    const checkIframe = () => {
-      let iframeElements = this.elementRef.nativeElement.querySelectorAll(
-        '.pencil-code-editor-iframe'
-      );
+      const checkIframe = () => {
+        let iframeElements = this.elementRef.nativeElement.querySelectorAll(
+          '.pencil-code-editor-iframe'
+        );
 
-      if (iframeElements.length > 0) {
-        this.iframeDiv = iframeElements[0] as HTMLElement;
-        this.pce = new PencilCodeEmbed(this.iframeDiv);
-      } else if (retryCount < maxRetries) {
-        retryCount++;
-        setTimeout(checkIframe, 200);
-      } else {
-        this.pencilCodeEditorIsLoaded = true;
-      }
-    };
+        if (iframeElements.length > 0) {
+          this.iframeDiv = iframeElements[0] as HTMLElement;
+          this.pce = new PencilCodeEmbed(this.iframeDiv);
+        } else if (retryCount < maxRetries) {
+          retryCount++;
+          setTimeout(checkIframe, 200);
+          return;
+        } else {
+          this.pencilCodeEditorIsLoaded = true;
+          return;
+        }
 
-    checkIframe();
+        this.interactionIsActive = this.lastAnswer === null;
 
-    this.interactionIsActive = this.lastAnswer === null;
+        const {initialCode} =
+          this.interactionAttributesExtractorService.getValuesFromAttributes(
+            'PencilCodeEditor',
+            this._getAttributes()
+          ) as PencilCodeEditorCustomizationArgs;
+        this.someInitialCode = this.interactionIsActive
+          ? initialCode.value
+          : this.lastAnswer?.code || '';
 
-    const {initialCode} =
-      this.interactionAttributesExtractorService.getValuesFromAttributes(
-        'PencilCodeEditor',
-        this._getAttributes()
-      ) as PencilCodeEditorCustomizationArgs;
-    this.someInitialCode = this.interactionIsActive
-      ? initialCode.value
-      : this.lastAnswer?.code || '';
+        this.pce.beginLoad(this.someInitialCode);
+        this.pce.on('load', () => {
+          // Hides the error console at the bottom right, and prevents it
+          // from showing up even if the code has an error. Also, hides the
+          // turtle, and redefines say() to also write the text on the
+          // screen.
+          this.pce.setupScript([
+            {
+              code: [
+                'window.onerror = function() {',
+                '  return true;',
+                '};',
+                'debug.hide();',
+                'window.removeEventListener("error", debug)',
+                '',
+                'ht();',
+                '',
+                'oldsay = window.say',
+                'say = function(x) {',
+                '  write(x);',
+                '  oldsay(x);',
+                '};',
+              ].join('\n'),
+              type: 'text/javascript',
+            },
+          ]);
 
-    this.pce.beginLoad(this.someInitialCode);
-    this.pce.on('load', () => {
-      // Hides the error console at the bottom right, and prevents it
-      // from showing up even if the code has an error. Also, hides the
-      // turtle, and redefines say() to also write the text on the
-      // screen.
-      this.pce.setupScript([
-        {
-          code: [
-            'window.onerror = function() {',
-            '  return true;',
-            '};',
-            'debug.hide();',
-            'window.removeEventListener("error", debug)',
-            '',
-            'ht();',
-            '',
-            'oldsay = window.say',
-            'say = function(x) {',
-            '  write(x);',
-            '  oldsay(x);',
-            '};',
-          ].join('\n'),
-          type: 'text/javascript',
-        },
-      ]);
-
-      this.pce.showEditor();
-      this.pce.hideToggleButton();
-      if (this.interactionIsActive) {
-        this.pce.setEditable();
-      } else {
-        this.pce.hideMiddleButton();
-        this.pce.setReadOnly();
-      }
-
-      // Pencil Code automatically takes the focus on load, so we clear
-      // it.
-      this.focusManagerService.clearFocus();
-    });
-
-    let errorIsHappening = false;
-    let hasSubmittedAnswer = false;
-
-    this.pce.on('startExecute', () => {
-      hasSubmittedAnswer = false;
-    });
-
-    // Handles submission of the user's code execution result.
-    // Used in both 'execute' and 'registerCurrentInteraction()' to ensure consistency.
-    let submitInteractionAnswer = () => {
-      // Prevents submission if an error has occurred or an answer has already been submitted.
-      if (errorIsHappening || hasSubmittedAnswer) {
-        return;
-      }
-
-      // Evaluates the code inside the Pencil Code iframe's context.
-      // The first argument 'document.body.innerHTML' retrieves the current
-      // HTML output generated by the user's code execution.
-      // PencilCode sanitizes user input, ensuring security.
-      this.pce.eval(
-        'document.body.innerHTML', // disable-bad-pattern-check
-        (pencilCodeHtml: string) => {
-          // Normalize the user's inputted code (e.g., replace tabs with spaces).
-          let normalizedCode = this.getNormalizedCode();
-
-          // Extract all div elements from the executed output to get the textual content.
-          let temp = document.createElement('div');
-
-          // `pencilCodeHtml` is a string representing the raw HTML content inside
-          // the output frame. We convert it into an element to access and extract
-          // textual content from all the `div` elements present.
-          // eslint-disable-next-line oppia/no-inner-html
-          temp.innerHTML = pencilCodeHtml;
-
-          let output: string = '';
-          let htmlObject = temp.querySelectorAll('div');
-
-          // Loop through each div element to extract its inner text.
-          for (let i = 0; i < htmlObject.length; i++) {
-            // eslint-disable-next-line oppia/no-inner-html
-            output += htmlObject[i].innerHTML + '\n';
+          this.pce.showEditor();
+          this.pce.hideToggleButton();
+          if (this.interactionIsActive) {
+            this.pce.setEditable();
+          } else {
+            this.pce.hideMiddleButton();
+            this.pce.setReadOnly();
           }
 
-          // Mark the answer as submitted to prevent duplicate submissions.
+          // Pencil Code automatically takes the focus on load, so we clear
+          // it.
+          this.focusManagerService.clearFocus();
+        });
+
+        let errorIsHappening = false;
+        let hasSubmittedAnswer = false;
+
+        this.pce.on('startExecute', () => {
+          hasSubmittedAnswer = false;
+        });
+
+        // Handles submission of the user's code execution result.
+        // Used in both 'execute' and 'registerCurrentInteraction()' to ensure consistency.
+        let submitInteractionAnswer = () => {
+          // Prevents submission if an error has occurred or an answer has already been submitted.
+          if (errorIsHappening || hasSubmittedAnswer) {
+            return;
+          }
+
+          // Evaluates the code inside the Pencil Code iframe's context.
+          // The first argument 'document.body.innerHTML' retrieves the current
+          // HTML output generated by the user's code execution.
+          // PencilCode sanitizes user input, ensuring security.
+          this.pce.eval(
+            'document.body.innerHTML', // disable-bad-pattern-check
+            (pencilCodeHtml: string) => {
+              // Normalize the user's inputted code (e.g., replace tabs with spaces).
+              let normalizedCode = this.getNormalizedCode();
+
+              // Extract all div elements from the executed output to get the textual content.
+              let temp = document.createElement('div');
+
+              // `pencilCodeHtml` is a string representing the raw HTML content inside
+              // the output frame. We convert it into an element to access and extract
+              // textual content from all the `div` elements present.
+              // eslint-disable-next-line oppia/no-inner-html
+              temp.innerHTML = pencilCodeHtml;
+
+              let output: string = '';
+              let htmlObject = temp.querySelectorAll('div');
+
+              // Loop through each div element to extract its inner text.
+              for (let i = 0; i < htmlObject.length; i++) {
+                // eslint-disable-next-line oppia/no-inner-html
+                output += htmlObject[i].innerHTML + '\n';
+              }
+
+              // Mark the answer as submitted to prevent duplicate submissions.
+              hasSubmittedAnswer = true;
+
+              // Submit the extracted code and its output to the current interaction service,
+              // which handles storing the response and validating it against rules.
+              this.currentInteractionService.onSubmit(
+                {
+                  code: normalizedCode,
+                  output: output || '',
+                  evaluation: '',
+                  error: '',
+                },
+                this.pencilCodeEditorRulesService
+              );
+            },
+            // Execute evaluation within the iframe context.
+            true
+          );
+        };
+
+        this.pce.on('execute', submitInteractionAnswer);
+
+        this.pce.on('error', (error: {message: string}) => {
+          if (hasSubmittedAnswer) {
+            return;
+          }
+          let normalizedCode = this.getNormalizedCode();
+
+          errorIsHappening = true;
           hasSubmittedAnswer = true;
 
-          // Submit the extracted code and its output to the current interaction service,
-          // which handles storing the response and validating it against rules.
           this.currentInteractionService.onSubmit(
             {
               code: normalizedCode,
-              output: output || '',
+              output: '',
               evaluation: '',
-              error: '',
+              error: error.message,
             },
             this.pencilCodeEditorRulesService
           );
-        },
-        // Execute evaluation within the iframe context.
-        true
-      );
-    };
 
-    this.pce.on('execute', submitInteractionAnswer);
+          setTimeout(() => {
+            errorIsHappening = false;
+          }, 1000);
+        });
 
-    this.pce.on('error', (error: {message: string}) => {
-      if (hasSubmittedAnswer) {
-        return;
-      }
-      let normalizedCode = this.getNormalizedCode();
+        this.currentInteractionService.registerCurrentInteraction(
+          submitInteractionAnswer,
+          null
+        );
+      };
 
-      errorIsHappening = true;
-      hasSubmittedAnswer = true;
-
-      this.currentInteractionService.onSubmit(
-        {
-          code: normalizedCode,
-          output: '',
-          evaluation: '',
-          error: error.message,
-        },
-        this.pencilCodeEditorRulesService
-      );
-
-      setTimeout(() => {
-        errorIsHappening = false;
-      }, 1000);
+      checkIframe();
     });
-
-    this.currentInteractionService.registerCurrentInteraction(
-      submitInteractionAnswer,
-      null
-    );
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes: #23658 and #22688.
2. This PR does the following: 
Updates the Pencil Code interaction to load the external **pencilcodeembed.js** script using **InsertScriptService** and initializes the editor only after the script has finished loading.
This ensures the interaction loads reliably without vendoring the library locally.
4. (For bug-fixing PRs only) The original bug occurred because:
The PencilCodeEditor component attempted to access the global **PencilCodeEmbed** object during **ngOnInit**, while the external script defining it was still loading asynchronously.
This caused a race condition, leading to **_ReferenceError: PencilCodeEmbed_** is not defined and resulting in an empty or broken interaction.
### Note
This PR replaces #24723 to provide a clean history without force-pushes.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
Video: Publish exploration + learner playthrough
This video shows:

- Creating an exploration with the Pencil Code interaction
- Publishing the exploration
- Playing it as a learner in the Player view

The interaction loads correctly and works as expected, with no console errors, including under throttled network conditions.

**Before:**

[Pencil-code_bug.webm](https://github.com/user-attachments/assets/bdfe9037-e0f7-441c-a930-66781159f2d0)


**After:**

[Learner_verify.webm](https://github.com/user-attachments/assets/299cbd4c-deb3-4a8a-baa7-70dc96fa850b)

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->
N/A — no UI changes were made, and the fix is platform-agnostic.

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->
N/A — no UI or layout changes were introduced.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
