### PR TITLE
Fix #24219: Fix flake in exploration editor save-draft-publish-and-discard-the-changes test

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -3613,6 +3613,9 @@ export class ExplorationEditor extends BaseUser {
         visible: true,
       });
       await this.clickOnElementWithSelector(mobileChangesDropdownSelector);
+      await this.page.waitForSelector(
+        `${mobileDiscardButtonSelector}:not(.disabled)`
+      );
       await this.clickOnElementWithSelector(mobileDiscardButtonSelector);
     } else {
       await this.page.waitForSelector(discardDraftDropdownSelector, {
@@ -3622,6 +3625,9 @@ export class ExplorationEditor extends BaseUser {
       await this.page.waitForSelector(desktopDiscardDraftButton, {
         visible: true,
       });
+      await this.page.waitForSelector(
+        `${desktopDiscardDraftButton}:not(.disabled)`
+      );
       await this.clickOnElementWithSelector(desktopDiscardDraftButton);
     }
     await this.page.waitForSelector(confirmDiscardButton, {


### PR DESCRIPTION
## Overview

1. This PR fixes #24219 .
2. This PR does the following: Fixes a flaky E2E test in the exploration-editor/save-draft-publish-and-discard-the-changes suite. It introduces synchronization logic to discardCurrentChanges() in exploration-editor.ts to prevent race conditions.
3. (For bug-fixing PRs only) The original bug occurred because:The test was clicking the "Discard Changes" button while it was momentarily disabled during an autosave, causing the click to be ignored and the subsequent waitForSelector for the modal to timeout.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
The Stress Tests passed with a success rate of 299/300. The single fail was due to some other flaky reason.


https://github.com/user-attachments/assets/37559d56-8b4f-4afb-bb2b-8314f1b28eb8


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
