### PR TITLE
Fix navigation wait strategy in LoggedInUser class for improved relia…

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
@@ -901,7 +901,7 @@ export class LoggedInUser extends BaseUser {
       await this.clickOnElementWithSelector(agreeToTermsCheckbox);
       await this.page.waitForSelector(registerNewUserButton);
       await Promise.all([
-        this.page.waitForNavigation({waitUntil: 'networkidle0'}),
+        this.page.waitForNavigation({waitUntil: 'networkidle2'}),
         this.clickOnElementWithText(LABEL_FOR_SUBMIT_BUTTON),
       ]);
 
@@ -932,8 +932,10 @@ export class LoggedInUser extends BaseUser {
       invalidEmailErrorContainer
     );
     if (!invalidEmailErrorContainerElement) {
-      await this.clickOnElementWithText('Sign In');
-      await this.page.waitForNavigation({waitUntil: 'networkidle0'});
+      await Promise.all([
+        this.page.waitForNavigation({waitUntil: 'networkidle2'}),
+        this.clickOnElementWithText('Sign In'),
+      ]);
 
       // Post Check: Check if the login page is closed. We can't check if user
       // is redirected to the home page it is dependent to "redirects" in URL.


### PR DESCRIPTION
## Overview

1. This PR fixes  **#21572**.

2. This PR does the following: 
- Fixes random `TimeoutError (30000 ms exceeded)` during sign-in acceptance tests.  
- Solves a race condition where `waitForNavigation()` was called after clicking "Sign In", causing Puppeteer to miss fast navigation.  
- Properly synchronizes the click action with navigation to prevent timeouts.  
- Replaces `networkidle0` with `networkidle2` to avoid timeouts caused by background network requests.  
- Makes the sign-in tests more stable and reliable.  
 3. The original bug occurred because: 
 - The bug happened because `waitForNavigation()` was set **after** clicking "Sign In", so if the page loaded quickly, Puppeteer missed it and waited until timeout (race condition).  

- The test used `networkidle0`, which waits for **zero network requests**, but Firebase auth makes background requests, so the page never became fully idle and timed out.  

- The issue became worse with the Firebase emulator flow (multiple async auth calls), especially on slow CI machines, making the tests flaky.  


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<img width="1919" height="1080" alt="Screenshot from 2026-02-12 23-32-57" src="https://github.com/user-attachments/assets/4b0d1c85-dad1-4011-843c-555f679b5fc5" />

Stress Testing : 

https://github.com/kishansinghifs1/oppia/actions/runs/21984752488 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4ba3ddde-7a5e-4fc6-887b-1df5fd572c9e" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
