### PR TITLE
Fixes #15897 : Carousal view broken on RTL languages

### DIFF
--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -93,8 +93,13 @@ class MockTranslateService {
   }
 }
 
+// Browser engines report RTL scroll offsets in different modes:
+// - 'default': positive values increase from left to right.
+// - 'negative': values are non-positive and become more negative rightward.
+// - 'reverse': positive values increase from right to left.
 type RtlScrollType = 'default' | 'negative' | 'reverse';
 
+// This interface is used by tests to access private RTL scroll helpers.
 interface LibraryPageComponentPrivateMethods {
   getRtlScrollType: () => RtlScrollType;
   getNormalizedScrollLeft: (carouselElement: HTMLElement) => number;

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -102,6 +102,7 @@ interface LibraryPageComponentPrivateMethods {
     carouselElement: HTMLElement,
     normalizedScrollLeft: number
   ) => void;
+  rtlScrollType: RtlScrollType | null;
 }
 
 describe('Library Page Component', () => {
@@ -1111,7 +1112,7 @@ describe('Library Page Component', () => {
   it('should return cached rtl scroll type if already computed', () => {
     const privateMethods =
       componentInstance as unknown as LibraryPageComponentPrivateMethods;
-    (componentInstance as any).rtlScrollType = 'negative';
+    privateMethods.rtlScrollType = 'negative';
 
     const result = privateMethods.getRtlScrollType();
 
@@ -1121,7 +1122,7 @@ describe('Library Page Component', () => {
   it('should detect default rtl scroll type when scrollLeft is positive', () => {
     const privateMethods =
       componentInstance as unknown as LibraryPageComponentPrivateMethods;
-    (componentInstance as any).rtlScrollType = null;
+    privateMethods.rtlScrollType = null;
 
     const mockContainer = document.createElement('div');
     const mockDummy = document.createElement('div');
@@ -1147,7 +1148,7 @@ describe('Library Page Component', () => {
   it('should detect negative rtl scroll type when scrollLeft is 0 after setting to 1', () => {
     const privateMethods =
       componentInstance as unknown as LibraryPageComponentPrivateMethods;
-    (componentInstance as any).rtlScrollType = null;
+    privateMethods.rtlScrollType = null;
 
     const mockContainer = document.createElement('div');
     const mockDummy = document.createElement('div');
@@ -1181,7 +1182,7 @@ describe('Library Page Component', () => {
   it('should detect reverse rtl scroll type when scrollLeft is non-zero after setting to 1', () => {
     const privateMethods =
       componentInstance as unknown as LibraryPageComponentPrivateMethods;
-    (componentInstance as any).rtlScrollType = null;
+    privateMethods.rtlScrollType = null;
 
     const mockContainer = document.createElement('div');
     const mockDummy = document.createElement('div');

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -1107,4 +1107,254 @@ describe('Library Page Component', () => {
 
     expect(componentInstance.leftmostCardIndices[ind]).toBe(2);
   });
+
+  it('should return cached rtl scroll type if already computed', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    (componentInstance as any).rtlScrollType = 'negative';
+
+    const result = privateMethods.getRtlScrollType();
+
+    expect(result).toBe('negative');
+  });
+
+  it('should detect default rtl scroll type when scrollLeft is positive', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    (componentInstance as any).rtlScrollType = null;
+
+    const mockContainer = document.createElement('div');
+    const mockDummy = document.createElement('div');
+    let appendChildCalled = false;
+
+    spyOn(document, 'createElement').and.callFake((tagName: string) => {
+      if (!appendChildCalled) {
+        appendChildCalled = true;
+        return mockDummy;
+      }
+      return mockContainer;
+    });
+
+    spyOnProperty(mockContainer, 'scrollLeft', 'get').and.returnValue(1);
+    spyOn(document.body, 'appendChild');
+    spyOn(document.body, 'removeChild');
+
+    const result = privateMethods.getRtlScrollType();
+
+    expect(result).toBe('default');
+  });
+
+  it('should detect negative rtl scroll type when scrollLeft is 0 after setting to 1', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    (componentInstance as any).rtlScrollType = null;
+
+    const mockContainer = document.createElement('div');
+    const mockDummy = document.createElement('div');
+    let appendChildCalled = false;
+    let scrollLeftValue = 0;
+
+    spyOn(document, 'createElement').and.callFake((tagName: string) => {
+      if (!appendChildCalled) {
+        appendChildCalled = true;
+        return mockDummy;
+      }
+      return mockContainer;
+    });
+
+    spyOnProperty(mockContainer, 'scrollLeft', 'get').and.returnValue(
+      scrollLeftValue
+    );
+    spyOnProperty(mockContainer, 'scrollLeft', 'set').and.callFake(
+      (value: number) => {
+        scrollLeftValue = 0;
+      }
+    );
+    spyOn(document.body, 'appendChild');
+    spyOn(document.body, 'removeChild');
+
+    const result = privateMethods.getRtlScrollType();
+
+    expect(result).toBe('negative');
+  });
+
+  it('should detect reverse rtl scroll type when scrollLeft is non-zero after setting to 1', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    (componentInstance as any).rtlScrollType = null;
+
+    const mockContainer = document.createElement('div');
+    const mockDummy = document.createElement('div');
+    let appendChildCalled = false;
+    let scrollLeftValue = 0;
+
+    spyOn(document, 'createElement').and.callFake((tagName: string) => {
+      if (!appendChildCalled) {
+        appendChildCalled = true;
+        return mockDummy;
+      }
+      return mockContainer;
+    });
+
+    spyOnProperty(mockContainer, 'scrollLeft', 'get').and.callFake(
+      () => scrollLeftValue
+    );
+    spyOnProperty(mockContainer, 'scrollLeft', 'set').and.callFake(
+      (value: number) => {
+        scrollLeftValue = 1;
+      }
+    );
+    spyOn(document.body, 'appendChild');
+    spyOn(document.body, 'removeChild');
+
+    const result = privateMethods.getRtlScrollType();
+
+    expect(result).toBe('reverse');
+  });
+
+  it('should normalize scroll left for ltr mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: 100,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      false
+    );
+
+    const result = privateMethods.getNormalizedScrollLeft(mockElement);
+
+    expect(result).toBe(100);
+  });
+
+  it('should normalize scroll left for rtl negative mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: -200,
+      scrollWidth: 1000,
+      clientWidth: 300,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('negative');
+
+    const result = privateMethods.getNormalizedScrollLeft(mockElement);
+
+    expect(result).toBe(200);
+  });
+
+  it('should normalize scroll left for rtl reverse mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: 150,
+      scrollWidth: 1000,
+      clientWidth: 300,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('reverse');
+
+    const result = privateMethods.getNormalizedScrollLeft(mockElement);
+
+    expect(result).toBe(550);
+  });
+
+  it('should normalize scroll left for rtl default mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: 75,
+      scrollWidth: 1000,
+      clientWidth: 300,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('default');
+
+    const result = privateMethods.getNormalizedScrollLeft(mockElement);
+
+    expect(result).toBe(75);
+  });
+
+  it('should set normalized scroll left for ltr mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: 0,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      false
+    );
+
+    privateMethods.setNormalizedScrollLeft(mockElement, 250);
+
+    expect(mockElement.scrollLeft).toBe(250);
+  });
+
+  it('should set normalized scroll left for rtl negative mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: 0,
+      scrollWidth: 1000,
+      clientWidth: 300,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('negative');
+
+    privateMethods.setNormalizedScrollLeft(mockElement, 150);
+
+    expect(mockElement.scrollLeft).toBe(-150);
+  });
+
+  it('should set normalized scroll left for rtl reverse mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: 0,
+      scrollWidth: 900,
+      clientWidth: 300,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('reverse');
+
+    privateMethods.setNormalizedScrollLeft(mockElement, 200);
+
+    expect(mockElement.scrollLeft).toBe(400);
+  });
+
+  it('should set normalized scroll left for rtl default mode', () => {
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
+    const mockElement = {
+      scrollLeft: 0,
+      scrollWidth: 900,
+      clientWidth: 300,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('default');
+
+    privateMethods.setNormalizedScrollLeft(mockElement, 180);
+
+    expect(mockElement.scrollLeft).toBe(180);
+  });
 });

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -93,6 +93,17 @@ class MockTranslateService {
   }
 }
 
+type RtlScrollType = 'default' | 'negative' | 'reverse';
+
+interface LibraryPageComponentPrivateMethods {
+  getRtlScrollType: () => RtlScrollType;
+  getNormalizedScrollLeft: (carouselElement: HTMLElement) => number;
+  setNormalizedScrollLeft: (
+    carouselElement: HTMLElement,
+    normalizedScrollLeft: number
+  ) => void;
+}
+
 describe('Library Page Component', () => {
   let fixture: ComponentFixture<LibraryPageComponent>;
   let componentInstance: LibraryPageComponent;
@@ -971,17 +982,16 @@ describe('Library Page Component', () => {
       scrollWidth: 0,
       clientWidth: 0,
     } as HTMLElement;
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
 
     spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
       true
     );
-    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
-      'negative'
-    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('negative');
 
-    const normalizedScrollLeft = (
-      componentInstance as any
-    ).getNormalizedScrollLeft(mockCarouselElement);
+    const normalizedScrollLeft =
+      privateMethods.getNormalizedScrollLeft(mockCarouselElement);
     expect(normalizedScrollLeft).toBe(250);
   });
 
@@ -991,17 +1001,16 @@ describe('Library Page Component', () => {
       scrollWidth: 1000,
       clientWidth: 400,
     } as HTMLElement;
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
 
     spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
       true
     );
-    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
-      'reverse'
-    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('reverse');
 
-    const normalizedScrollLeft = (
-      componentInstance as any
-    ).getNormalizedScrollLeft(mockCarouselElement);
+    const normalizedScrollLeft =
+      privateMethods.getNormalizedScrollLeft(mockCarouselElement);
     expect(normalizedScrollLeft).toBe(400);
   });
 
@@ -1011,18 +1020,15 @@ describe('Library Page Component', () => {
       scrollWidth: 0,
       clientWidth: 0,
     } as HTMLElement;
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
 
     spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
       true
     );
-    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
-      'negative'
-    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('negative');
 
-    (componentInstance as any).setNormalizedScrollLeft(
-      mockCarouselElement,
-      300
-    );
+    privateMethods.setNormalizedScrollLeft(mockCarouselElement, 300);
     expect(mockCarouselElement.scrollLeft).toBe(-300);
   });
 
@@ -1032,18 +1038,15 @@ describe('Library Page Component', () => {
       scrollWidth: 900,
       clientWidth: 300,
     } as HTMLElement;
+    const privateMethods =
+      componentInstance as unknown as LibraryPageComponentPrivateMethods;
 
     spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
       true
     );
-    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
-      'reverse'
-    );
+    spyOn(privateMethods, 'getRtlScrollType').and.returnValue('reverse');
 
-    (componentInstance as any).setNormalizedScrollLeft(
-      mockCarouselElement,
-      250
-    );
+    privateMethods.setNormalizedScrollLeft(mockCarouselElement, 250);
     expect(mockCarouselElement.scrollLeft).toBe(350);
   });
 

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -965,6 +965,88 @@ describe('Library Page Component', () => {
     flush();
   }));
 
+  it('should normalize scrollLeft for RTL negative mode', () => {
+    const mockCarouselElement = {
+      scrollLeft: -250,
+      scrollWidth: 0,
+      clientWidth: 0,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
+      'negative'
+    );
+
+    const normalizedScrollLeft = (
+      componentInstance as any
+    ).getNormalizedScrollLeft(mockCarouselElement);
+    expect(normalizedScrollLeft).toBe(250);
+  });
+
+  it('should normalize scrollLeft for RTL reverse mode', () => {
+    const mockCarouselElement = {
+      scrollLeft: 200,
+      scrollWidth: 1000,
+      clientWidth: 400,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
+      'reverse'
+    );
+
+    const normalizedScrollLeft = (
+      componentInstance as any
+    ).getNormalizedScrollLeft(mockCarouselElement);
+    expect(normalizedScrollLeft).toBe(400);
+  });
+
+  it('should set normalized scrollLeft for RTL negative mode', () => {
+    const mockCarouselElement = {
+      scrollLeft: 0,
+      scrollWidth: 0,
+      clientWidth: 0,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
+      'negative'
+    );
+
+    (componentInstance as any).setNormalizedScrollLeft(
+      mockCarouselElement,
+      300
+    );
+    expect(mockCarouselElement.scrollLeft).toBe(-300);
+  });
+
+  it('should set normalized scrollLeft for RTL reverse mode', () => {
+    const mockCarouselElement = {
+      scrollLeft: 0,
+      scrollWidth: 900,
+      clientWidth: 300,
+    } as HTMLElement;
+
+    spyOn(i18nLanguageCodeService, 'isCurrentLanguageRTL').and.returnValue(
+      true
+    );
+    spyOn<any>(componentInstance, 'getRtlScrollType').and.returnValue(
+      'reverse'
+    );
+
+    (componentInstance as any).setNormalizedScrollLeft(
+      mockCarouselElement,
+      250
+    );
+    expect(mockCarouselElement.scrollLeft).toBe(350);
+  });
+
   it('should not scroll if activity count is too small to allow scrolling', () => {
     const ind = 0;
     const shouldScrollLeft = false;

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -49,6 +49,8 @@ interface MobileLibraryGroupProperties {
   buttonText: string;
 }
 
+type RtlScrollType = 'default' | 'negative' | 'reverse';
+
 @Component({
   selector: 'oppia-library-page',
   templateUrl: './library-page.component.html',
@@ -102,6 +104,7 @@ export class LibraryPageComponent {
   currentCardIndex: number = 0;
   cardsToShow: number = 3;
   dots: number[] = [];
+  rtlScrollType: RtlScrollType | null = null;
 
   constructor(
     private loggerService: LoggerService,
@@ -128,6 +131,79 @@ export class LibraryPageComponent {
 
   clearActiveGroup(): void {
     this.activeGroupIndex = null;
+  }
+
+  private getRtlScrollType(): RtlScrollType {
+    if (this.rtlScrollType !== null) {
+      return this.rtlScrollType;
+    }
+
+    const dummy = document.createElement('div');
+    const container = document.createElement('div');
+
+    container.dir = 'rtl';
+    container.style.width = '4px';
+    container.style.height = '1px';
+    container.style.overflow = 'scroll';
+    container.style.position = 'absolute';
+    container.style.top = '-1000px';
+
+    dummy.style.width = '10px';
+    dummy.style.height = '1px';
+    container.appendChild(dummy);
+    document.body.appendChild(container);
+
+    if (container.scrollLeft > 0) {
+      this.rtlScrollType = 'default';
+    } else {
+      container.scrollLeft = 1;
+      this.rtlScrollType = container.scrollLeft === 0 ? 'negative' : 'reverse';
+    }
+
+    document.body.removeChild(container);
+    return this.rtlScrollType;
+  }
+
+  private getNormalizedScrollLeft(carouselElement: HTMLElement): number {
+    const scrollLeft = carouselElement.scrollLeft;
+    if (!this.i18nLanguageCodeService.isCurrentLanguageRTL()) {
+      return scrollLeft;
+    }
+
+    const rtlScrollType = this.getRtlScrollType();
+    if (rtlScrollType === 'negative') {
+      return -scrollLeft;
+    }
+    if (rtlScrollType === 'reverse') {
+      return (
+        carouselElement.scrollWidth - carouselElement.clientWidth - scrollLeft
+      );
+    }
+    return scrollLeft;
+  }
+
+  private setNormalizedScrollLeft(
+    carouselElement: HTMLElement,
+    normalizedScrollLeft: number
+  ): void {
+    if (!this.i18nLanguageCodeService.isCurrentLanguageRTL()) {
+      carouselElement.scrollLeft = normalizedScrollLeft;
+      return;
+    }
+
+    const rtlScrollType = this.getRtlScrollType();
+    if (rtlScrollType === 'negative') {
+      carouselElement.scrollLeft = -normalizedScrollLeft;
+      return;
+    }
+    if (rtlScrollType === 'reverse') {
+      carouselElement.scrollLeft =
+        carouselElement.scrollWidth -
+        carouselElement.clientWidth -
+        normalizedScrollLeft;
+      return;
+    }
+    carouselElement.scrollLeft = normalizedScrollLeft;
   }
 
   initCarousels(): void {
@@ -170,7 +246,12 @@ export class LibraryPageComponent {
     for (let i = 0; i < this.libraryGroups.length; i++) {
       const carouselTileElem = carouselTileElems[i] as HTMLElement;
       if (carouselTileElem) {
-        const scrollLeft = carouselTileElem.scrollLeft;
+        const currentLeftmostIndex = this.leftmostCardIndices[i] || 0;
+        this.setNormalizedScrollLeft(
+          carouselTileElem,
+          currentLeftmostIndex * AppConstants.LIBRARY_TILE_WIDTH_PX
+        );
+        const scrollLeft = this.getNormalizedScrollLeft(carouselTileElem);
         const index = Math.ceil(
           scrollLeft / AppConstants.LIBRARY_TILE_WIDTH_PX
         );
@@ -194,7 +275,7 @@ export class LibraryPageComponent {
     }
 
     const direction = isLeftScroll ? -1 : 1;
-    let scrollLeft = carouselElement.scrollLeft;
+    let scrollLeft = this.getNormalizedScrollLeft(carouselElement);
 
     if (
       this.libraryGroups[ind].activity_summary_dicts.length <=
@@ -203,7 +284,11 @@ export class LibraryPageComponent {
       return;
     }
 
-    scrollLeft = Math.max(0, scrollLeft);
+    const maxScrollPx = Math.max(
+      0,
+      carouselElement.scrollWidth - carouselElement.clientWidth
+    );
+    scrollLeft = Math.max(0, Math.min(scrollLeft, maxScrollPx));
 
     if (isLeftScroll) {
       this.leftmostCardIndices[ind] = Math.max(
@@ -219,12 +304,17 @@ export class LibraryPageComponent {
       );
     }
 
-    const newScrollPositionPx =
-      scrollLeft +
-      this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX * direction;
+    const newScrollPositionPx = Math.max(
+      0,
+      Math.min(
+        maxScrollPx,
+        scrollLeft +
+          this.tileDisplayCount * AppConstants.LIBRARY_TILE_WIDTH_PX * direction
+      )
+    );
 
     const duration = 800;
-    const start = carouselElement.scrollLeft;
+    const start = scrollLeft;
     const distance = newScrollPositionPx - start;
     const startTime = performance.now();
 
@@ -236,7 +326,7 @@ export class LibraryPageComponent {
           ? 2 * progress * progress
           : -1 + (4 - 2 * progress) * progress;
 
-      carouselElement.scrollLeft = start + distance * ease;
+      this.setNormalizedScrollLeft(carouselElement, start + distance * ease);
 
       if (progress < 1) {
         requestAnimationFrame(animateScroll);
@@ -354,6 +444,7 @@ export class LibraryPageComponent {
     this.translateSubscription = this.translateService.onLangChange.subscribe(
       () => {
         this.setPageTitle();
+        this.initCarousels();
       }
     );
 

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -49,6 +49,10 @@ interface MobileLibraryGroupProperties {
   buttonText: string;
 }
 
+// Browser engines report RTL scroll offsets in different modes:
+// - 'default': positive values increase from left to right.
+// - 'negative': values are non-positive and become more negative rightward.
+// - 'reverse': positive values increase from right to left.
 type RtlScrollType = 'default' | 'negative' | 'reverse';
 
 @Component({


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #15897 
2. This PR does the following: fixes carousel behavior on /community-library for RTL languages (e.g. Arabic).
3. The original bug occurred because: RTL scrolling used raw scrollLeft assumptions that only work reliably in LTR

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #15897: " followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
[Screencast from 2026-02-12 12-10-44.webm](https://github.com/user-attachments/assets/095b209d-f17c-4852-81af-f552bf29f1d6)

[Screencast from 2026-03-02 12-46-14.webm](https://github.com/user-attachments/assets/b4e5cbbd-6105-4ebf-8a60-648b17d0957a)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.