### PR TITLE
Fix#24050 Add debounced autosave to state content editor

### DIFF
--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
@@ -181,4 +181,103 @@ describe('StateHintsEditorComponent', () => {
 
     expect(result).toBeFalse();
   });
+
+  it('should return false when preview card is not found', () => {
+    spyOn(document, 'querySelector').and.returnValue(null);
+
+    expect(component.isCardHeightLimitReached()).toBeFalse();
+  });
+
+  it('should return false when card height is within limit', () => {
+    const mockEl = document.createElement('div');
+    spyOnProperty(mockEl, 'offsetHeight').and.returnValue(500);
+    spyOn(document, 'querySelector').and.returnValue(mockEl);
+
+    expect(component.isCardHeightLimitReached()).toBeFalse();
+  });
+
+  it('should return true when card height exceeds limit', () => {
+    const mockEl = document.createElement('div');
+    spyOnProperty(mockEl, 'offsetHeight').and.returnValue(700);
+    spyOn(document, 'querySelector').and.returnValue(mockEl);
+
+    expect(component.isCardHeightLimitReached()).toBeTrue();
+  });
+
+  it('should update cardHeightLimitReached after view check', () => {
+    spyOn(component, 'isCardHeightLimitReached').and.returnValue(true);
+    const cdRef = TestBed.inject(ChangeDetectorRef);
+    spyOn(cdRef, 'detectChanges');
+
+    component.ngAfterViewChecked();
+
+    expect(component.cardHeightLimitReached).toBeTrue();
+  });
+
+  it('should not autosave when editor is closed', () => {
+    component['contentEditorIsOpen'] = false;
+    component['autosaveInitialized'] = true;
+
+    component['detectContentChangeAndAutosave']();
+
+    expect(component['autosaveTimer']).toBeNull();
+  });
+
+  it('should not autosave when html is unchanged', () => {
+    component['contentEditorIsOpen'] = true;
+    component['autosaveInitialized'] = true;
+
+    component['lastSavedHtml'] = 'same';
+    stateContentService.displayed.html = 'same';
+
+    component['detectContentChangeAndAutosave']();
+
+    expect(component['autosaveTimer']).toBeNull();
+  });
+
+  it('should schedule autosave when html changes', () => {
+    jasmine.clock().install();
+
+    component['contentEditorIsOpen'] = true;
+    component['autosaveInitialized'] = true;
+    component['lastSavedHtml'] = 'old';
+
+    stateContentService.displayed.html = 'new';
+
+    spyOn<any>(component, 'autoSaveContent');
+
+    component['detectContentChangeAndAutosave']();
+
+    jasmine.clock().tick(1500);
+
+    expect(component['autoSaveContent']).toHaveBeenCalledWith('new');
+
+    jasmine.clock().uninstall();
+  });
+
+  it('should not auto save if editor closed during timer', () => {
+    component['contentEditorIsOpen'] = false;
+
+    component['autoSaveContent']('html');
+
+    expect(component['lastSavedHtml']).not.toBe('html');
+  });
+
+  it('should save when external save is triggered', () => {
+    spyOn(component, 'saveContent');
+
+    component.contentEditorIsOpen = true;
+    externalSaveService.onExternalSave.emit();
+
+    expect(component.saveContent).toHaveBeenCalled();
+  });
+
+  it('should clear autosave timer on destroy', () => {
+    component['autosaveTimer'] = setTimeout(() => {}, 1000);
+    spyOn(window, 'clearTimeout');
+
+    component.ngOnDestroy();
+
+    expect(clearTimeout).toHaveBeenCalled();
+  });
 });

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.spec.ts
@@ -162,26 +162,6 @@ describe('StateHintsEditorComponent', () => {
     expect(component.saveStateContent.emit).toHaveBeenCalled();
   });
 
-  it('should update when card height limit is reached', () => {
-    component.cardHeightLimitReached = false;
-    spyOn(component, 'isCardHeightLimitReached').and.returnValue(
-      !component.cardHeightLimitReached
-    );
-
-    component.ngAfterViewChecked();
-
-    expect(component.cardHeightLimitReached).toBeTrue();
-    expect(component.isCardHeightLimitReached).toHaveBeenCalled();
-  });
-
-  it('should return false if shadow preview card is not present', () => {
-    spyOn(document, 'querySelector').and.returnValue(null);
-
-    const result = component.isCardHeightLimitReached();
-
-    expect(result).toBeFalse();
-  });
-
   it('should return false when preview card is not found', () => {
     spyOn(document, 'querySelector').and.returnValue(null);
 
@@ -204,14 +184,18 @@ describe('StateHintsEditorComponent', () => {
     expect(component.isCardHeightLimitReached()).toBeTrue();
   });
 
-  it('should update cardHeightLimitReached after view check', () => {
+  it('should call detectChanges when card height state changes', () => {
+    component.cardHeightLimitReached = false;
+
     spyOn(component, 'isCardHeightLimitReached').and.returnValue(true);
-    const cdRef = TestBed.inject(ChangeDetectorRef);
+
+    const cdRef = (component as any).changeDetectorRef;
     spyOn(cdRef, 'detectChanges');
 
     component.ngAfterViewChecked();
 
     expect(component.cardHeightLimitReached).toBeTrue();
+    expect(cdRef.detectChanges).toHaveBeenCalled();
   });
 
   it('should not autosave when editor is closed', () => {
@@ -279,5 +263,30 @@ describe('StateHintsEditorComponent', () => {
     component.ngOnDestroy();
 
     expect(clearTimeout).toHaveBeenCalled();
+  });
+
+  it('should not call detectChanges if card height state did not change', () => {
+    component.cardHeightLimitReached = true;
+
+    spyOn(component, 'isCardHeightLimitReached').and.returnValue(true);
+
+    const cdRef = (component as any).changeDetectorRef;
+    spyOn(cdRef, 'detectChanges');
+
+    component.ngAfterViewChecked();
+
+    expect(component.cardHeightLimitReached).toBeTrue();
+    expect(cdRef.detectChanges).not.toHaveBeenCalled();
+  });
+
+  it('should call detectContentChangeAndAutosave during ngAfterViewChecked', () => {
+    spyOn(component as any, 'detectContentChangeAndAutosave');
+    spyOn(component, 'isCardHeightLimitReached').and.returnValue(false);
+
+    component.ngAfterViewChecked();
+
+    expect(
+      (component as any).detectContentChangeAndAutosave
+    ).toHaveBeenCalled();
   });
 });

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.ts
@@ -19,6 +19,8 @@
 import {
   Component,
   OnInit,
+  AfterViewChecked,
+  OnDestroy,
   ChangeDetectorRef,
   Input,
   Output,
@@ -47,7 +49,9 @@ interface HTMLSchema {
   selector: 'oppia-state-content-editor',
   templateUrl: './state-content-editor.component.html',
 })
-export class StateContentEditorComponent implements OnInit {
+export class StateContentEditorComponent
+  implements OnInit, AfterViewChecked, OnDestroy
+{
   @Output() intialize: EventEmitter<void> = new EventEmitter();
   @Output() saveStateContent = new EventEmitter<SubtitledHtml>();
 
@@ -119,6 +123,7 @@ export class StateContentEditorComponent implements OnInit {
       this.cardHeightLimitReached = cardHeightLimitReached;
       this.changeDetectorRef.detectChanges();
     }
+    this.detectContentChangeAndAutosave();
   }
 
   hideCardHeightLimitWarning(): void {
@@ -126,15 +131,23 @@ export class StateContentEditorComponent implements OnInit {
   }
 
   saveContent(): void {
+    if (this.autosaveTimer) {
+      clearTimeout(this.autosaveTimer);
+    }
     this.stateContentService.saveDisplayedValue();
     this.saveStateContent.emit(this.stateContentService.displayed);
     this.contentEditorIsOpen = false;
     this.intialize.emit();
+    this.autosaveInitialized = false;
   }
 
   openStateContentEditor(): void {
     this.editorFirstTimeEventsService.registerFirstOpenContentBoxEvent();
     this.contentEditorIsOpen = true;
+    this.lastSavedHtml = this.stateContentService.displayed.html;
+    setTimeout(() => {
+      this.autosaveInitialized = true;
+    });
   }
 
   onSaveContentButtonClicked(): void {
@@ -143,8 +156,12 @@ export class StateContentEditorComponent implements OnInit {
   }
 
   cancelEdit(): void {
+    if (this.autosaveTimer) {
+      clearTimeout(this.autosaveTimer);
+    }
     this.stateContentService.restoreFromMemento();
     this.contentEditorIsOpen = false;
+    this.autosaveInitialized = false;
   }
 
   isContentEditable(): boolean {
@@ -153,5 +170,41 @@ export class StateContentEditorComponent implements OnInit {
 
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
+    if (this.autosaveTimer) {
+      clearTimeout(this.autosaveTimer);
+    }
+  }
+
+  private autosaveTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly AUTOSAVE_DELAY_MS = 1500;
+  private lastSavedHtml: string = '';
+  private autosaveInitialized: boolean = false;
+  private detectContentChangeAndAutosave(): void {
+    if (!this.contentEditorIsOpen || !this.autosaveInitialized) {
+      return;
+    }
+    const currentHtml = this.stateContentService.displayed.html;
+    if (currentHtml === this.lastSavedHtml) {
+      return;
+    }
+    this.scheduleAutosave(currentHtml);
+  }
+
+  private scheduleAutosave(newHtml: string): void {
+    if (this.autosaveTimer) {
+      clearTimeout(this.autosaveTimer);
+    }
+    this.autosaveTimer = setTimeout(() => {
+      this.autoSaveContent(newHtml);
+    }, this.AUTOSAVE_DELAY_MS);
+  }
+
+  private autoSaveContent(newHtml: string): void {
+    if (!this.contentEditorIsOpen) {
+      return;
+    }
+    this.lastSavedHtml = newHtml;
+    this.stateContentService.saveDisplayedValue();
+    this.saveStateContent.emit(this.stateContentService.displayed);
   }
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #24050.
2. This PR does the following:

- Adds autosave support to the State Content Editor so that changes are saved automatically without requiring the user to click “Save Content.”

- Aligns the behavior of this editor with other exploration editor fields that already support autosave.

- Improves UX consistency and reduces the risk of losing unsaved edits.

- Integrates with the existing save/change-detection flow to ensure content persists correctly after refresh.

3. (For bug-fixing PRs only) The original bug occurred because: 

- The State Content Editor relied on a manual save trigger, unlike other editors that used the platform’s autosave mechanism.

- This created inconsistent behavior and could lead to accidental data loss if users navigated away without clicking “Save Content.”

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before:

- Users had to manually click “Save Content.”

- Unsaved edits could be lost on refresh or navigation.

https://github.com/user-attachments/assets/5abc9605-c563-468c-ad7b-90b3ebae5058



After:

- Content is automatically saved as changes are made.

- Changes persist after page refresh, confirming successful autosave integration.

- Behavior is now consistent with other autosaving editor fields.

https://github.com/user-attachments/assets/0d69b877-26a1-468f-b596-2987a4270db9


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

@{{reviewer_username}} PTAL

