### PR TITLE
Fix 24206 typos in blog services and creator dashboard files

### DIFF
--- a/core/domain/blog_services.py
+++ b/core/domain/blog_services.py
@@ -459,7 +459,7 @@ def does_blog_post_with_url_fragment_exist(url_fragment: str) -> bool:
         url_fragment: str. The url fragment for the blog post.
 
     Returns:
-        bool. Whether the the url fragment for the blog post exists.
+        bool. Whether the url fragment for the blog post exists.
 
     Raises:
         Exception. Blog Post URL fragment is not a string.

--- a/core/domain/blog_services_test.py
+++ b/core/domain/blog_services_test.py
@@ -421,7 +421,7 @@ class BlogServicesUnitTests(test_utils.GenericTestBase):
         assert blog_post is not None
         self.assertEqual(blog_post.to_dict(), expected_blog_post.to_dict())
 
-    def test_get_blog_posy_by_invalid_url(self) -> None:
+    def test_get_blog_post_by_invalid_url(self) -> None:
         # TODO(#13059): Here we use MyPy ignore because after we fully type the
         # codebase we plan to get rid of the tests that intentionally test wrong
         # inputs that we can normally catch by typing.

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.spec.ts
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.spec.ts
@@ -148,7 +148,7 @@ describe('Creator Dashboard Page Component', () => {
   });
 
   it(
-    'should get complete thumbail icon path corresponding to a given' +
+    'should get complete thumbnail icon path corresponding to a given' +
       ' relative path',
     () => {
       expect(component.getCompleteThumbnailIconUrl('/path/to/icon.png')).toBe(


### PR DESCRIPTION
##Overview
This pull request is fixing three minor typos in the blog services tests and the creator dashboard spec file. This was needed for better clarity and overall consistency. There were no tricky parts. See the screenshots below for the observed changes:

##Proof
<img width="845" height="289" alt="Screenshot 2026-02-17 at 4 56 00 PM" src="https://github.com/user-attachments/assets/eb31a713-956a-4916-9cc7-2e25cad3b6fe" />
<img width="840" height="281" alt="Screenshot 2026-02-17 at 4 58 10 PM" src="https://github.com/user-attachments/assets/b9847c5b-06e4-415a-9dcb-e036ba307bd4" />
<img width="844" height="282" alt="Screenshot 2026-02-17 at 4 58 53 PM" src="https://github.com/user-attachments/assets/fd56d6cc-ba65-47e4-a201-4f9e2c6c4ab6" />
##Checklist
-My PR addresses one issue only
-I followed Oppia’s code style
-All tests pass
-I filled out the PR template
-I included screenshots (if needed)
-My commit message is clear and formatted
-I pushed the latest code
-I’m ready to respond to reviews promptly