### PR TITLE
Fix(#24953): Add character limit validation for SetInput button text

### DIFF
--- a/extensions/interactions/SetInput/directives/set-input-validation.service.spec.ts
+++ b/extensions/interactions/SetInput/directives/set-input-validation.service.spec.ts
@@ -127,6 +127,30 @@ describe('SetInputValidationService', () => {
         },
       ]);
     });
+
+    it('should generate errors when buttonText exceeds 20 characters', () => {
+      let badCustomizationArgs = {
+        buttonText: {
+          value: new SubtitledUnicode(
+            '123456789012345678901',
+            'ca_buttonText'
+          ),
+        },
+      };
+
+      let warnings = validatorService.getAllWarnings(
+        currentState,
+        badCustomizationArgs,
+        goodAnswerGroups,
+        goodDefaultOutcome
+      );
+      expect(warnings).toEqual([
+        {
+          type: WARNING_TYPES.ERROR,
+          message: 'The button text should be at most 20 characters.',
+        },
+      ]);
+    });
   });
 
   describe('.getRedundantRuleWarnings', () => {

--- a/extensions/interactions/SetInput/directives/set-input-validation.service.ts
+++ b/extensions/interactions/SetInput/directives/set-input-validation.service.ts
@@ -105,6 +105,11 @@ export class SetInputValidationService {
         message: 'Label for this button should not be empty',
         type: AppConstants.WARNING_TYPES.ERROR,
       });
+    } else if (buttonText.unicode.length > 20) {
+      warningsList.push({
+        type: AppConstants.WARNING_TYPES.ERROR,
+        message: 'The button text should be at most 20 characters.',
+      });
     }
 
     return warningsList;


### PR DESCRIPTION
## What does this PR do?

Fixes issue #24953 by adding character limit validation for the "Label for the 'Add Item' button" field in the SetInput interaction.

## What is the fix?

- Added validation to enforce a 20-character limit for the button text in SetInput interaction
- Added corresponding unit test to verify the validation works correctly
- Made validation consistent with the existing character limit in the Continue interaction

## How to test the fix?

1. Go to `/creator-dashboard` and click "Create Exploration"
2. Add a "Set Input" interaction from the Math tab
3. Try entering more than 20 characters in the "Label for the 'Add Item' button" field
4. Attempt to save - you should now see an error message: "The button text should be at most 20 characters."

## Before this fix:
- Users could enter unlimited characters causing errors when saving
- No validation feedback provided to users

## After this fix:
- Character limit enforced with clear error message
- Prevents save until text is within the 20-character limit

Fixes #24953