### PR TITLE
Fix(#24953): Add character limit validation for SetInput button text

### DIFF
--- a/extensions/interactions/SetInput/directives/set-input-validation.service.spec.ts
+++ b/extensions/interactions/SetInput/directives/set-input-validation.service.spec.ts
@@ -127,6 +127,30 @@ describe('SetInputValidationService', () => {
         },
       ]);
     });
+
+    it('should generate errors when buttonText exceeds 20 characters', () => {
+      let badCustomizationArgs = {
+        buttonText: {
+          value: new SubtitledUnicode(
+            '123456789012345678901',
+            'ca_buttonText'
+          ),
+        },
+      };
+
+      let warnings = validatorService.getAllWarnings(
+        currentState,
+        badCustomizationArgs,
+        goodAnswerGroups,
+        goodDefaultOutcome
+      );
+      expect(warnings).toEqual([
+        {
+          type: WARNING_TYPES.ERROR,
+          message: 'The button text should be at most 20 characters.',
+        },
+      ]);
+    });
   });
 
   describe('.getRedundantRuleWarnings', () => {

--- a/extensions/interactions/SetInput/directives/set-input-validation.service.spec.ts
+++ b/extensions/interactions/SetInput/directives/set-input-validation.service.spec.ts
@@ -131,10 +131,7 @@ describe('SetInputValidationService', () => {
     it('should generate errors when buttonText exceeds 20 characters', () => {
       let badCustomizationArgs = {
         buttonText: {
-          value: new SubtitledUnicode(
-            '123456789012345678901',
-            'ca_buttonText'
-          ),
+          value: new SubtitledUnicode('123456789012345678901', 'ca_buttonText'),
         },
       };
 

--- a/extensions/interactions/SetInput/directives/set-input-validation.service.ts
+++ b/extensions/interactions/SetInput/directives/set-input-validation.service.ts
@@ -105,6 +105,11 @@ export class SetInputValidationService {
         message: 'Label for this button should not be empty',
         type: AppConstants.WARNING_TYPES.ERROR,
       });
+    } else if (buttonText.unicode.length > 20) {
+      warningsList.push({
+        type: AppConstants.WARNING_TYPES.ERROR,
+        message: 'The button text should be at most 20 characters.',
+      });
     }
 
     return warningsList;


### PR DESCRIPTION
## Overview

Fixes #24953 by adding character limit validation for the "Label for the 'Add Item' button" field in the SetInput interaction.

Currently, users can enter an unlimited amount of text in the "Add Item" button label field, which causes errors when attempting to save the interaction. This PR adds a 20-character limit validation to prevent this issue and provide clear feedback to users.

## Essential Checklist

- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] Any changes to scripts in the scripts/ directory have an associated PR that updates the contributor setup instructions on the oppia/oppia wiki.
- [x] The linter/Karma presubmit checks all pass.
- [x] The PR follows the style guide.
- [x] The PR does not contain any unnecessary code changes from automated linters.
- [x] The PR is made from a branch that is up to date with "develop".
- [x] The PR is **assigned** to the appropriate reviewers.

## For UI changes only

If your PR makes UI changes, your reviewer will ask you to attach screenshots/videos in the PR showing the before and after state of your feature. Please be prepared to provide them.

- [ ] There are screenshot(s)/video(s) attached to show the changes working correctly. The screenshot(s) should be taken in "Guest mode" (when not logged in) where possible.
- [x] The PR is **assigned** to a UI owner.

## Proof that changes are correct

### Manual Testing
1. Navigate to `/creator-dashboard` and click "Create Exploration"
2. Click "Add Interaction" and select "Set Input" from the Math tab
3. In the "Label for the 'Add Item' button" field, enter exactly 20 characters (e.g., "12345678901234567890") - this should work fine
4. Now enter 21 characters (e.g., "123456789012345678901") - this should show the error: "The button text should be at most 20 characters."
5. Attempt to save the interaction with >20 characters - it should be prevented until the text is shortened

### Unit Testing
- Added comprehensive unit test in `set-input-validation.service.spec.ts` that verifies the 20-character limit validation
- The test creates a button text with 21 characters and confirms it generates the appropriate error message
- All existing tests continue to pass, ensuring no regression

### Code Changes
- **File**: `extensions/interactions/SetInput/directives/set-input-validation.service.ts`
  - Added validation check: `buttonText.unicode.length > 20`
  - Error message: "The button text should be at most 20 characters."
  - Consistent with existing Continue interaction validation

- **File**: `extensions/interactions/SetInput/directives/set-input-validation.service.spec.ts`
  - Added test case: "should generate errors when buttonText exceeds 20 characters"
  - Uses 21-character string to verify the limit is enforced

This fix ensures consistency across interactions (Continue already has the same 20-character limit) and prevents the error that occurred when users entered excessively long button text.