### PR TITLE
Fix #18729: Regenerate contributor stats when lessons/assignments change

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1611,6 +1611,9 @@ def delete_explorations(
         feconf.ENTITY_TYPE_EXPLORATION, exploration_ids
     )
 
+    if exploration_ids:
+        suggestion_services.regenerate_contributor_stats()
+
     # Remove from subscribers.
     taskqueue_services.defer(
         feconf.FUNCTION_ID_TO_FUNCTION_NAME_FOR_DEFERRED_JOBS[

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -705,6 +705,16 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
         exp_services.delete_explorations(self.owner_id, [])
         self.process_and_flush_pending_tasks()
 
+    def test_delete_explorations_regenerates_contributor_stats(self) -> None:
+        self.save_new_default_exploration(self.EXP_0_ID, self.owner_id)
+
+        with self.swap_with_call_counter(
+            suggestion_services, 'regenerate_contributor_stats'
+        ) as (regenerate_contributor_stats):
+            exp_services.delete_explorations(self.owner_id, [self.EXP_0_ID])
+
+        self.assertEqual(regenerate_contributor_stats.times_called, 1)
+
     def test_soft_deletion_of_multiple_explorations(self) -> None:
         """Test that soft deletion of explorations works correctly."""
         # TODO(sll): Add tests for deletion of states and version snapshots.

--- a/core/domain/story_services.py
+++ b/core/domain/story_services.py
@@ -903,6 +903,10 @@ def update_story(
     suggestion_services.auto_reject_translation_suggestions_for_exp_ids(
         exp_ids_removed_from_story
     )
+    if story_is_published and (
+        exp_ids_removed_from_story or exp_ids_added_to_story
+    ):
+        suggestion_services.regenerate_contributor_stats()
 
     exp_models.ExplorationContextModel.delete_multi(
         exploration_context_models_to_be_deleted
@@ -971,6 +975,7 @@ def delete_story(
     opportunity_services.delete_exp_opportunities_corresponding_to_story(
         story_id
     )
+    suggestion_services.regenerate_contributor_stats()
 
     # Delete references of the story from all related learner groups.
     learner_group_services.remove_story_reference_from_learner_groups(story_id)

--- a/core/domain/story_services_test.py
+++ b/core/domain/story_services_test.py
@@ -30,6 +30,7 @@ from core.domain import (
     story_domain,
     story_fetchers,
     story_services,
+    suggestion_services,
     topic_domain,
     topic_fetchers,
     topic_services,
@@ -854,7 +855,12 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(orig_story_dict, new_story_dict)
 
     def test_delete_story(self) -> None:
-        story_services.delete_story(self.USER_ID, self.STORY_ID)
+        with self.swap_with_call_counter(
+            suggestion_services, 'regenerate_contributor_stats'
+        ) as (regenerate_contributor_stats):
+            story_services.delete_story(self.USER_ID, self.STORY_ID)
+
+        self.assertEqual(regenerate_contributor_stats.times_called, 1)
         self.assertEqual(
             story_fetchers.get_story_by_id(self.STORY_ID, strict=False), None
         )
@@ -862,6 +868,46 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             story_fetchers.get_story_summary_by_id(self.STORY_ID, strict=False),
             None,
         )
+
+    def test_update_story_with_changed_exploration_links_regenerates_stats(
+        self,
+    ) -> None:
+        self.save_new_valid_exploration(
+            'exp_2',
+            self.user_id_admin,
+            title='Title 2',
+            category='Mathematics',
+            language_code='en',
+        )
+        self.publish_exploration(self.user_id_admin, 'exp_2')
+        topic_services.publish_story(
+            self.TOPIC_ID, self.STORY_ID, self.user_id_admin
+        )
+        change_list = [
+            story_domain.StoryChange(
+                {
+                    'cmd': story_domain.CMD_UPDATE_STORY_NODE_PROPERTY,
+                    'property_name': (
+                        story_domain.STORY_NODE_PROPERTY_EXPLORATION_ID
+                    ),
+                    'node_id': self.NODE_ID_1,
+                    'old_value': self.EXP_ID,
+                    'new_value': 'exp_2',
+                }
+            )
+        ]
+
+        with self.swap_with_call_counter(
+            suggestion_services, 'regenerate_contributor_stats'
+        ) as (regenerate_contributor_stats):
+            story_services.update_story(
+                self.USER_ID,
+                self.STORY_ID,
+                change_list,
+                'Updated story node.',
+            )
+
+        self.assertEqual(regenerate_contributor_stats.times_called, 1)
 
     def test_cannot_get_story_from_model_with_invalid_schema_version(
         self,

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -2719,6 +2719,216 @@ def get_all_contributor_stats(
     )
 
 
+def _get_all_suggestion_models_of_type(
+    suggestion_type: str,
+) -> List[suggestion_models.GeneralSuggestionModel]:
+    """Gets all suggestion models corresponding to the supplied type.
+
+    Args:
+        suggestion_type: str. The type of suggestion.
+
+    Returns:
+        list(GeneralSuggestionModel). Suggestion models corresponding to the
+        supplied type.
+    """
+    query = suggestion_models.GeneralSuggestionModel.get_all().filter(
+        suggestion_models.GeneralSuggestionModel.suggestion_type
+        == suggestion_type
+    )
+
+    suggestion_models_of_type: List[
+        suggestion_models.GeneralSuggestionModel
+    ] = []
+    offset = 0
+    while True:
+        current_batch = query.fetch(
+            feconf.DEFAULT_SUGGESTION_QUERY_LIMIT, offset=offset
+        )
+        if len(current_batch) == 0:
+            break
+        suggestion_models_of_type.extend(current_batch)
+        offset += len(current_batch)
+
+    return suggestion_models_of_type
+
+
+def _delete_all_contributor_stats_models() -> None:
+    """Deletes all contributor stats models."""
+    translation_contribution_stats_models = (
+        suggestion_models.TranslationContributionStatsModel.get_all().fetch()
+    )
+    suggestion_models.TranslationContributionStatsModel.delete_multi(
+        list(translation_contribution_stats_models)
+    )
+
+    translation_review_stats_models = (
+        suggestion_models.TranslationReviewStatsModel.get_all().fetch()
+    )
+    suggestion_models.TranslationReviewStatsModel.delete_multi(
+        list(translation_review_stats_models)
+    )
+
+    question_contribution_stats_models = (
+        suggestion_models.QuestionContributionStatsModel.get_all().fetch()
+    )
+    suggestion_models.QuestionContributionStatsModel.delete_multi(
+        list(question_contribution_stats_models)
+    )
+
+    question_review_stats_models = (
+        suggestion_models.QuestionReviewStatsModel.get_all().fetch()
+    )
+    suggestion_models.QuestionReviewStatsModel.delete_multi(
+        list(question_review_stats_models)
+    )
+
+    translation_submitter_total_model_cls = (
+        suggestion_models.TranslationSubmitterTotalContributionStatsModel
+    )
+    translation_submitter_total_stats_models = (
+        translation_submitter_total_model_cls.get_all().fetch()
+    )
+    translation_submitter_total_model_cls.delete_multi(
+        list(translation_submitter_total_stats_models)
+    )
+
+    translation_reviewer_total_model_cls = (
+        suggestion_models.TranslationReviewerTotalContributionStatsModel
+    )
+    translation_reviewer_total_stats_models = (
+        translation_reviewer_total_model_cls.get_all().fetch()
+    )
+    translation_reviewer_total_model_cls.delete_multi(
+        list(translation_reviewer_total_stats_models)
+    )
+
+    question_submitter_total_model_cls = (
+        suggestion_models.QuestionSubmitterTotalContributionStatsModel
+    )
+    question_submitter_total_stats_models = (
+        question_submitter_total_model_cls.get_all().fetch()
+    )
+    question_submitter_total_model_cls.delete_multi(
+        list(question_submitter_total_stats_models)
+    )
+
+    question_reviewer_total_model_cls = (
+        suggestion_models.QuestionReviewerTotalContributionStatsModel
+    )
+    question_reviewer_total_stats_models = (
+        question_reviewer_total_model_cls.get_all().fetch()
+    )
+    question_reviewer_total_model_cls.delete_multi(
+        list(question_reviewer_total_stats_models)
+    )
+
+
+def _get_suggestion_submission_datetime(
+    suggestion_model: suggestion_models.GeneralSuggestionModel,
+) -> datetime.datetime:
+    """Returns the datetime when the suggestion was submitted.
+
+    Args:
+        suggestion_model: GeneralSuggestionModel. The suggestion model to fetch
+            the submission datetime from.
+
+    Returns:
+        datetime.datetime. The suggestion submission datetime.
+    """
+    return (
+        suggestion_model.created_on
+        if suggestion_model.created_on is not None
+        else suggestion_model.last_updated
+    )
+
+
+def regenerate_contributor_stats() -> None:
+    """Recreates contributor stats based on current opportunities/assignments.
+
+    This deletes all contributor stats models and rebuilds them by replaying
+    suggestion submissions and reviews in chronological order.
+    """
+    _delete_all_contributor_stats_models()
+
+    translation_suggestion_models = _get_all_suggestion_models_of_type(
+        feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT
+    )
+    question_suggestion_models = _get_all_suggestion_models_of_type(
+        feconf.SUGGESTION_TYPE_ADD_QUESTION
+    )
+
+    for suggestion_model in sorted(
+        translation_suggestion_models, key=_get_suggestion_submission_datetime
+    ):
+        suggestion = get_suggestion_from_model(suggestion_model)
+        # Narrowing down the type from BaseSuggestion to
+        # SuggestionTranslateContent.
+        assert isinstance(
+            suggestion, suggestion_registry.SuggestionTranslateContent
+        )
+        if opportunity_services.get_exploration_opportunity_summary_by_id(
+            suggestion.target_id
+        ) is None:
+            continue
+        suggestion.last_updated = _get_suggestion_submission_datetime(
+            suggestion_model
+        )
+        update_translation_contribution_stats_at_submission(suggestion)
+
+    for suggestion_model in sorted(
+        question_suggestion_models, key=_get_suggestion_submission_datetime
+    ):
+        suggestion = get_suggestion_from_model(suggestion_model)
+        # Narrowing down the type from BaseSuggestion to
+        # SuggestionAddQuestion.
+        assert isinstance(
+            suggestion, suggestion_registry.SuggestionAddQuestion
+        )
+        suggestion.last_updated = _get_suggestion_submission_datetime(
+            suggestion_model
+        )
+        update_question_contribution_stats_at_submission(suggestion)
+
+    reviewed_statuses = [
+        suggestion_models.STATUS_ACCEPTED,
+        suggestion_models.STATUS_REJECTED,
+    ]
+
+    for suggestion_model in sorted(
+        translation_suggestion_models, key=lambda model: model.last_updated
+    ):
+        if suggestion_model.status not in reviewed_statuses:
+            continue
+        suggestion = get_suggestion_from_model(suggestion_model)
+        # Narrowing down the type from BaseSuggestion to
+        # SuggestionTranslateContent.
+        assert isinstance(
+            suggestion, suggestion_registry.SuggestionTranslateContent
+        )
+        if suggestion.final_reviewer_id is None:
+            continue
+        if opportunity_services.get_exploration_opportunity_summary_by_id(
+            suggestion.target_id
+        ) is None:
+            continue
+        update_translation_review_stats(suggestion)
+
+    for suggestion_model in sorted(
+        question_suggestion_models, key=lambda model: model.last_updated
+    ):
+        if suggestion_model.status not in reviewed_statuses:
+            continue
+        suggestion = get_suggestion_from_model(suggestion_model)
+        # Narrowing down the type from BaseSuggestion to
+        # SuggestionAddQuestion.
+        assert isinstance(
+            suggestion, suggestion_registry.SuggestionAddQuestion
+        )
+        if suggestion.final_reviewer_id is None:
+            continue
+        update_question_review_stats(suggestion)
+
+
 def _update_translation_contribution_stats_models(
     translation_contribution_stats: List[
         suggestion_registry.TranslationContributionStats

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -2741,8 +2741,8 @@ def _get_all_suggestion_models_of_type(
     ] = []
     offset = 0
     while True:
-        current_batch = query.fetch(
-            feconf.DEFAULT_SUGGESTION_QUERY_LIMIT, offset=offset
+        current_batch: Sequence[suggestion_models.GeneralSuggestionModel] = (
+            query.fetch(feconf.DEFAULT_SUGGESTION_QUERY_LIMIT, offset=offset)
         )
         if len(current_batch) == 0:
             break
@@ -2754,30 +2754,30 @@ def _get_all_suggestion_models_of_type(
 
 def _delete_all_contributor_stats_models() -> None:
     """Deletes all contributor stats models."""
-    translation_contribution_stats_models = (
-        suggestion_models.TranslationContributionStatsModel.get_all().fetch()
-    )
+    translation_contribution_stats_models: Sequence[
+        suggestion_models.TranslationContributionStatsModel
+    ] = suggestion_models.TranslationContributionStatsModel.get_all().fetch()
     suggestion_models.TranslationContributionStatsModel.delete_multi(
         list(translation_contribution_stats_models)
     )
 
-    translation_review_stats_models = (
-        suggestion_models.TranslationReviewStatsModel.get_all().fetch()
-    )
+    translation_review_stats_models: Sequence[
+        suggestion_models.TranslationReviewStatsModel
+    ] = suggestion_models.TranslationReviewStatsModel.get_all().fetch()
     suggestion_models.TranslationReviewStatsModel.delete_multi(
         list(translation_review_stats_models)
     )
 
-    question_contribution_stats_models = (
-        suggestion_models.QuestionContributionStatsModel.get_all().fetch()
-    )
+    question_contribution_stats_models: Sequence[
+        suggestion_models.QuestionContributionStatsModel
+    ] = suggestion_models.QuestionContributionStatsModel.get_all().fetch()
     suggestion_models.QuestionContributionStatsModel.delete_multi(
         list(question_contribution_stats_models)
     )
 
-    question_review_stats_models = (
-        suggestion_models.QuestionReviewStatsModel.get_all().fetch()
-    )
+    question_review_stats_models: Sequence[
+        suggestion_models.QuestionReviewStatsModel
+    ] = suggestion_models.QuestionReviewStatsModel.get_all().fetch()
     suggestion_models.QuestionReviewStatsModel.delete_multi(
         list(question_review_stats_models)
     )
@@ -2785,9 +2785,9 @@ def _delete_all_contributor_stats_models() -> None:
     translation_submitter_total_model_cls = (
         suggestion_models.TranslationSubmitterTotalContributionStatsModel
     )
-    translation_submitter_total_stats_models = (
-        translation_submitter_total_model_cls.get_all().fetch()
-    )
+    translation_submitter_total_stats_models: Sequence[
+        suggestion_models.TranslationSubmitterTotalContributionStatsModel
+    ] = translation_submitter_total_model_cls.get_all().fetch()
     translation_submitter_total_model_cls.delete_multi(
         list(translation_submitter_total_stats_models)
     )
@@ -2795,9 +2795,9 @@ def _delete_all_contributor_stats_models() -> None:
     translation_reviewer_total_model_cls = (
         suggestion_models.TranslationReviewerTotalContributionStatsModel
     )
-    translation_reviewer_total_stats_models = (
-        translation_reviewer_total_model_cls.get_all().fetch()
-    )
+    translation_reviewer_total_stats_models: Sequence[
+        suggestion_models.TranslationReviewerTotalContributionStatsModel
+    ] = translation_reviewer_total_model_cls.get_all().fetch()
     translation_reviewer_total_model_cls.delete_multi(
         list(translation_reviewer_total_stats_models)
     )
@@ -2805,9 +2805,9 @@ def _delete_all_contributor_stats_models() -> None:
     question_submitter_total_model_cls = (
         suggestion_models.QuestionSubmitterTotalContributionStatsModel
     )
-    question_submitter_total_stats_models = (
-        question_submitter_total_model_cls.get_all().fetch()
-    )
+    question_submitter_total_stats_models: Sequence[
+        suggestion_models.QuestionSubmitterTotalContributionStatsModel
+    ] = question_submitter_total_model_cls.get_all().fetch()
     question_submitter_total_model_cls.delete_multi(
         list(question_submitter_total_stats_models)
     )
@@ -2815,9 +2815,9 @@ def _delete_all_contributor_stats_models() -> None:
     question_reviewer_total_model_cls = (
         suggestion_models.QuestionReviewerTotalContributionStatsModel
     )
-    question_reviewer_total_stats_models = (
-        question_reviewer_total_model_cls.get_all().fetch()
-    )
+    question_reviewer_total_stats_models: Sequence[
+        suggestion_models.QuestionReviewerTotalContributionStatsModel
+    ] = question_reviewer_total_model_cls.get_all().fetch()
     question_reviewer_total_model_cls.delete_multi(
         list(question_reviewer_total_stats_models)
     )
@@ -2835,11 +2835,29 @@ def _get_suggestion_submission_datetime(
     Returns:
         datetime.datetime. The suggestion submission datetime.
     """
-    return (
-        suggestion_model.created_on
-        if suggestion_model.created_on is not None
-        else suggestion_model.last_updated
-    )
+    submission_datetime = suggestion_model.created_on
+    if submission_datetime is None:
+        submission_datetime = suggestion_model.last_updated
+
+    assert isinstance(submission_datetime, datetime.datetime)
+    return submission_datetime
+
+
+def _get_suggestion_last_updated_datetime(
+    suggestion_model: suggestion_models.GeneralSuggestionModel,
+) -> datetime.datetime:
+    """Returns the datetime when the suggestion was last updated.
+
+    Args:
+        suggestion_model: GeneralSuggestionModel. The suggestion model to fetch
+            the last updated datetime from.
+
+    Returns:
+        datetime.datetime. The suggestion last updated datetime.
+    """
+    last_updated = suggestion_model.last_updated
+    assert isinstance(last_updated, datetime.datetime)
+    return last_updated
 
 
 def regenerate_contributor_stats() -> None:
@@ -2866,9 +2884,12 @@ def regenerate_contributor_stats() -> None:
         assert isinstance(
             suggestion, suggestion_registry.SuggestionTranslateContent
         )
-        if opportunity_services.get_exploration_opportunity_summary_by_id(
-            suggestion.target_id
-        ) is None:
+        if (
+            opportunity_services.get_exploration_opportunity_summary_by_id(
+                suggestion.target_id
+            )
+            is None
+        ):
             continue
         suggestion.last_updated = _get_suggestion_submission_datetime(
             suggestion_model
@@ -2881,9 +2902,7 @@ def regenerate_contributor_stats() -> None:
         suggestion = get_suggestion_from_model(suggestion_model)
         # Narrowing down the type from BaseSuggestion to
         # SuggestionAddQuestion.
-        assert isinstance(
-            suggestion, suggestion_registry.SuggestionAddQuestion
-        )
+        assert isinstance(suggestion, suggestion_registry.SuggestionAddQuestion)
         suggestion.last_updated = _get_suggestion_submission_datetime(
             suggestion_model
         )
@@ -2895,7 +2914,8 @@ def regenerate_contributor_stats() -> None:
     ]
 
     for suggestion_model in sorted(
-        translation_suggestion_models, key=lambda model: model.last_updated
+        translation_suggestion_models,
+        key=_get_suggestion_last_updated_datetime,
     ):
         if suggestion_model.status not in reviewed_statuses:
             continue
@@ -2907,23 +2927,25 @@ def regenerate_contributor_stats() -> None:
         )
         if suggestion.final_reviewer_id is None:
             continue
-        if opportunity_services.get_exploration_opportunity_summary_by_id(
-            suggestion.target_id
-        ) is None:
+        if (
+            opportunity_services.get_exploration_opportunity_summary_by_id(
+                suggestion.target_id
+            )
+            is None
+        ):
             continue
         update_translation_review_stats(suggestion)
 
     for suggestion_model in sorted(
-        question_suggestion_models, key=lambda model: model.last_updated
+        question_suggestion_models,
+        key=_get_suggestion_last_updated_datetime,
     ):
         if suggestion_model.status not in reviewed_statuses:
             continue
         suggestion = get_suggestion_from_model(suggestion_model)
         # Narrowing down the type from BaseSuggestion to
         # SuggestionAddQuestion.
-        assert isinstance(
-            suggestion, suggestion_registry.SuggestionAddQuestion
-        )
+        assert isinstance(suggestion, suggestion_registry.SuggestionAddQuestion)
         if suggestion.final_reviewer_id is None:
             continue
         update_question_review_stats(suggestion)

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -5197,7 +5197,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
             'regenerate_contributor_stats',
             lambda: None,
         ):
-            topic_services.remove_uncategorized_skill(
+            topic_services.delete_uncategorized_skill(
                 self.admin_id, topic_id_1, skill_id_1
             )
             topic_services.add_uncategorized_skill(
@@ -5229,8 +5229,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
         )
         assert question_submitter_total_stats_model is not None
         topic_ids_with_question_submissions = (
-            question_submitter_total_stats_model
-            .topic_ids_with_question_submissions
+            question_submitter_total_stats_model.topic_ids_with_question_submissions
         )
         self.assertEqual(
             topic_ids_with_question_submissions,

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -27,6 +27,7 @@ from core.domain import (
     exp_fetchers,
     exp_services,
     feedback_services,
+    opportunity_services,
     question_domain,
     rights_domain,
     rights_manager,
@@ -5117,6 +5118,123 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
         )
         self.assertEqual(
             question_submitter_total_stats_model.overall_accuracy, 100.0
+        )
+
+    def test_regenerate_stats_skips_translations_without_opportunities(
+        self,
+    ) -> None:
+        change_dict = self._set_up_topics_and_stories_for_translations()
+        translation_suggestion = suggestion_services.create_suggestion(
+            feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+            feconf.ENTITY_TYPE_EXPLORATION,
+            '0',
+            1,
+            self.author_id,
+            change_dict,
+            'description',
+        )
+        suggestion_services.update_translation_contribution_stats_at_submission(
+            translation_suggestion
+        )
+
+        self.assertIsNotNone(
+            suggestion_models.TranslationContributionStatsModel.get(
+                'hi', self.author_id, '0'
+            )
+        )
+
+        opportunity_services.delete_exploration_opportunities(['0'])
+        suggestion_services.regenerate_contributor_stats()
+
+        self.assertIsNone(
+            suggestion_models.TranslationContributionStatsModel.get(
+                'hi', self.author_id, '0'
+            )
+        )
+        translation_submitter_total_model_cls = (
+            suggestion_models.TranslationSubmitterTotalContributionStatsModel
+        )
+        self.assertIsNone(
+            translation_submitter_total_model_cls.get('hi', self.author_id)
+        )
+
+    def test_regenerate_stats_updates_question_topic_assignments(
+        self,
+    ) -> None:
+        skill_id_1 = self._create_skill()
+        skill_id_2 = self._create_skill()
+        skill_id_3 = self._create_skill()
+
+        topic_id_1 = self._create_topic(skill_id_1, skill_id_2)
+        topic_id_2 = topic_fetchers.get_new_topic_id()
+        self.save_new_topic(
+            topic_id_2,
+            'topic_admin',
+            name='Topic2',
+            abbreviated_name='topic-two',
+            url_fragment='topic-two',
+            description='Description',
+            canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[skill_id_3],
+            subtopics=[],
+            next_subtopic_id=1,
+        )
+
+        question_suggestion = self._create_question_suggestion(skill_id_1)
+        suggestion_services.update_question_contribution_stats_at_submission(
+            question_suggestion
+        )
+
+        self.assertIsNotNone(
+            suggestion_models.QuestionContributionStatsModel.get(
+                self.author_id, topic_id_1
+            )
+        )
+
+        with self.swap(
+            suggestion_services,
+            'regenerate_contributor_stats',
+            lambda: None,
+        ):
+            topic_services.remove_uncategorized_skill(
+                self.admin_id, topic_id_1, skill_id_1
+            )
+            topic_services.add_uncategorized_skill(
+                self.admin_id, topic_id_2, skill_id_1
+            )
+
+        suggestion_services.regenerate_contributor_stats()
+
+        self.assertIsNone(
+            suggestion_models.QuestionContributionStatsModel.get(
+                self.author_id, topic_id_1
+            )
+        )
+        question_contribution_stats_model = (
+            suggestion_models.QuestionContributionStatsModel.get(
+                self.author_id, topic_id_2
+            )
+        )
+        assert question_contribution_stats_model is not None
+        self.assertEqual(
+            question_contribution_stats_model.submitted_questions_count, 1
+        )
+
+        question_submitter_total_stats_model_cls = (
+            suggestion_models.QuestionSubmitterTotalContributionStatsModel
+        )
+        question_submitter_total_stats_model = (
+            question_submitter_total_stats_model_cls.get_by_id(self.author_id)
+        )
+        assert question_submitter_total_stats_model is not None
+        topic_ids_with_question_submissions = (
+            question_submitter_total_stats_model
+            .topic_ids_with_question_submissions
+        )
+        self.assertEqual(
+            topic_ids_with_question_submissions,
+            [topic_id_2],
         )
 
     def generate_random_string(self, length: int) -> str:

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -57,6 +57,48 @@ if MYPY:  # pragma: no cover
 
 (topic_models,) = models.Registry.import_models([models.Names.TOPIC])
 
+TOPIC_COMMANDS_THAT_REQUIRE_CONTRIBUTOR_STATS_REGENERATION = [
+    topic_domain.CMD_ADD_CANONICAL_STORY,
+    topic_domain.CMD_DELETE_CANONICAL_STORY,
+    topic_domain.CMD_ADD_ADDITIONAL_STORY,
+    topic_domain.CMD_DELETE_ADDITIONAL_STORY,
+    topic_domain.CMD_ADD_UNCATEGORIZED_SKILL_ID,
+    topic_domain.CMD_REMOVE_UNCATEGORIZED_SKILL_ID,
+]
+
+
+def _should_regenerate_contributor_stats(
+    change_list: Sequence[change_domain.BaseChange],
+) -> bool:
+    """Returns whether contributor stats should be regenerated.
+
+    Args:
+        change_list: list(BaseChange). The list of topic/subtopic changes.
+
+    Returns:
+        bool. Whether contributor stats should be regenerated.
+    """
+    for change in change_list:
+        if not isinstance(change, topic_domain.TopicChange):
+            continue
+
+        if (
+            change.cmd
+            in TOPIC_COMMANDS_THAT_REQUIRE_CONTRIBUTOR_STATS_REGENERATION
+        ):
+            return True
+        if (
+            change.cmd == topic_domain.CMD_UPDATE_TOPIC_PROPERTY
+            and change.property_name
+            in [
+                topic_domain.TOPIC_PROPERTY_CANONICAL_STORY_REFERENCES,
+                topic_domain.TOPIC_PROPERTY_ADDITIONAL_STORY_REFERENCES,
+            ]
+        ):
+            return True
+
+    return False
+
 
 def _create_topic(
     committer_id: str,
@@ -1172,6 +1214,9 @@ def update_topic_and_subtopic_pages(
             updated_topic.id, updated_topic.name
         )
 
+    if _should_regenerate_contributor_stats(change_list):
+        suggestion_services.regenerate_contributor_stats()
+
 
 def delete_uncategorized_skill(
     user_id: str, topic_id: str, uncategorized_skill_id: str
@@ -1324,6 +1369,7 @@ def publish_story(topic_id: str, story_id: str, committer_id: str) -> None:
     opportunity_services.add_new_exploration_opportunities(
         story_id, linked_exp_ids
     )
+    suggestion_services.regenerate_contributor_stats()
 
 
 def unpublish_story(topic_id: str, story_id: str, committer_id: str) -> None:
@@ -1400,6 +1446,7 @@ def unpublish_story(topic_id: str, story_id: str, committer_id: str) -> None:
     exp_ids = story.story_contents.get_all_linked_exp_ids()
     opportunity_services.delete_exploration_opportunities(exp_ids)
     suggestion_services.auto_reject_translation_suggestions_for_exp_ids(exp_ids)
+    suggestion_services.regenerate_contributor_stats()
 
 
 def delete_canonical_story(user_id: str, topic_id: str, story_id: str) -> None:

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -1291,6 +1291,78 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(topic_summary.canonical_story_count, 0)
         self.assertEqual(topic_summary.additional_story_count, 0)
 
+    def test_publish_story_regenerates_contributor_stats(self) -> None:
+        with self.swap_with_call_counter(
+            suggestion_services, 'regenerate_contributor_stats'
+        ) as (regenerate_contributor_stats):
+            topic_services.publish_story(
+                self.TOPIC_ID, self.story_id_1, self.user_id_admin
+            )
+
+        self.assertEqual(regenerate_contributor_stats.times_called, 1)
+
+    def test_unpublish_story_regenerates_contributor_stats(self) -> None:
+        topic_services.publish_story(
+            self.TOPIC_ID, self.story_id_1, self.user_id_admin
+        )
+
+        with self.swap_with_call_counter(
+            suggestion_services, 'regenerate_contributor_stats'
+        ) as (regenerate_contributor_stats):
+            topic_services.unpublish_story(
+                self.TOPIC_ID, self.story_id_1, self.user_id_admin
+            )
+
+        self.assertEqual(regenerate_contributor_stats.times_called, 1)
+
+    def test_update_topic_regenerates_stats_for_assignment_change(self) -> None:
+        changelist = [
+            topic_domain.TopicChange(
+                {
+                    'cmd': topic_domain.CMD_REMOVE_UNCATEGORIZED_SKILL_ID,
+                    'uncategorized_skill_id': self.skill_id_1,
+                }
+            )
+        ]
+
+        with self.swap_with_call_counter(
+            suggestion_services, 'regenerate_contributor_stats'
+        ) as (regenerate_contributor_stats):
+            topic_services.update_topic_and_subtopic_pages(
+                self.user_id_admin,
+                self.TOPIC_ID,
+                changelist,
+                'Removed skill from topic.',
+            )
+
+        self.assertEqual(regenerate_contributor_stats.times_called, 1)
+
+    def test_update_topic_does_not_regenerate_stats_for_metadata_changes(
+        self,
+    ) -> None:
+        changelist = [
+            topic_domain.TopicChange(
+                {
+                    'cmd': topic_domain.CMD_UPDATE_TOPIC_PROPERTY,
+                    'property_name': topic_domain.TOPIC_PROPERTY_DESCRIPTION,
+                    'old_value': 'Description',
+                    'new_value': 'Updated description.',
+                }
+            )
+        ]
+
+        with self.swap_with_call_counter(
+            suggestion_services, 'regenerate_contributor_stats'
+        ) as (regenerate_contributor_stats):
+            topic_services.update_topic_and_subtopic_pages(
+                self.user_id_admin,
+                self.TOPIC_ID,
+                changelist,
+                'Updated topic description.',
+            )
+
+        self.assertEqual(regenerate_contributor_stats.times_called, 0)
+
     def test_invalid_publish_and_unpublish_story(self) -> None:
         with self.assertRaisesRegex(
             Exception,


### PR DESCRIPTION
## Overview

1. This PR fixes #18729.
2. This PR does the following:
   - Adds `suggestion_services.regenerate_contributor_stats()` to rebuild contributor stats from existing suggestions using current lesson/topic assignments.
   - Triggers stats regeneration when lessons/topic assignment mappings change:
     - exploration deletion (`exp_services.delete_explorations`)
     - published story lesson-link updates and story deletion (`story_services`)
     - story publish/unpublish and topic assignment changes (`topic_services`)
   - Adds regression tests across `exp_services_test`, `story_services_test`, `topic_services_test`, and `suggestion_services_test`.
3. (For bug-fixing PRs only) The original bug occurred because contributor stats were only updated incrementally at suggestion submission/review time, but not recomputed when lesson/opportunity mappings or skill-topic assignments changed later.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a backend-only services/tests change with no UI surface.

## Additional Notes

- Local backend test execution is currently blocked in this environment by missing App Engine SDK path expected by Oppia scripts (`oppia_tools/google-cloud-sdk-500.0.0/.../google_appengine`).
- Added/updated unit tests:
  - `core/domain/exp_services_test.py`
  - `core/domain/story_services_test.py`
  - `core/domain/topic_services_test.py`
  - `core/domain/suggestion_services_test.py`

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
