### PR TITLE
Fix part of #20088: Hide empty translation cards and correct voiceover fallback

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.spec.ts
@@ -17,6 +17,7 @@
  */
 
 import {TestBed} from '@angular/core/testing';
+import {SubtitledHtml} from 'domain/exploration/subtitled-html.model';
 import {ExplorationDataService} from 'pages/exploration-editor-page/services/exploration-data.service';
 import {ExplorationStatesService} from 'pages/exploration-editor-page/services/exploration-states.service';
 import {TranslationLanguageService} from 'pages/exploration-editor-page/translation-tab/services/translation-language.service';
@@ -428,13 +429,13 @@ describe('Translation status service', () => {
       ttams.activateVoiceoverMode();
       var explorationAudioRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationAudioRequiredCount).toBe(8);
+      expect(explorationAudioRequiredCount).toBe(5);
 
       ttams.activateTranslationMode();
       tls.setActiveLanguageCode('hi');
       var explorationTranslationsRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationTranslationsRequiredCount).toBe(8);
+      expect(explorationTranslationsRequiredCount).toBe(5);
 
       // To test changes after adding a new state.
       ess.addState('Fourth', () => {});
@@ -446,14 +447,14 @@ describe('Translation status service', () => {
       tls.setActiveLanguageCode('en');
       var explorationAudioRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationAudioRequiredCount).toBe(9);
+      expect(explorationAudioRequiredCount).toBe(5);
 
       ttams.activateTranslationMode();
       tls.setActiveLanguageCode('hi');
 
       var explorationTranslationsRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationTranslationsRequiredCount).toBe(9);
+      expect(explorationTranslationsRequiredCount).toBe(5);
     }
   );
 
@@ -496,12 +497,12 @@ describe('Translation status service', () => {
 
     ttams.activateVoiceoverMode();
 
-    expect(tss.getExplorationContentRequiredCount()).toBe(8);
+    expect(tss.getExplorationContentRequiredCount()).toBe(5);
 
     entityVoiceoversService.setActiveLanguageAccentCode('en-US');
 
     tss.refresh();
-    expect(tss.getExplorationContentNotAvailableCount()).toEqual(7);
+    expect(tss.getExplorationContentNotAvailableCount()).toEqual(4);
     let color = tss.getActiveStateContentIdStatusColor('content_0');
     expect(tss.NO_ASSETS_AVAILABLE_COLOR).toEqual(color);
 
@@ -512,7 +513,7 @@ describe('Translation status service', () => {
     } as FeatureStatusChecker);
 
     tss.refresh();
-    expect(tss.getExplorationContentNotAvailableCount()).toEqual(6);
+    expect(tss.getExplorationContentNotAvailableCount()).toEqual(3);
     color = tss.getActiveStateContentIdStatusColor('content_0');
     expect(tss.ALL_ASSETS_AVAILABLE_COLOR).toEqual(color);
 
@@ -521,7 +522,7 @@ describe('Translation status service', () => {
 
     entityVoiceoversService.setActiveLanguageAccentCode('en-IN');
     tss.refresh();
-    expect(tss.getExplorationContentNotAvailableCount()).toEqual(8);
+    expect(tss.getExplorationContentNotAvailableCount()).toEqual(5);
   });
 
   it('should return a correct count of audio not available in an exploration', () => {
@@ -531,6 +532,10 @@ describe('Translation status service', () => {
     expect(explorationAudioNotAvailableCount).toBe(0);
 
     ess.addState('Fourth', () => {});
+    ess.saveStateContent(
+      'Fourth',
+      SubtitledHtml.createDefault('Fourth content', 'content_9')
+    );
     ess.saveInteractionId('Third', 'MultipleChoiceInput');
     ess.saveInteractionId('Fourth', 'EndExploration');
     tss.refresh();
@@ -549,9 +554,13 @@ describe('Translation status service', () => {
       tss.refresh();
       var explorationTranslationNotAvailableCount =
         tss.getExplorationContentNotAvailableCount();
-      expect(explorationTranslationNotAvailableCount).toBe(7);
+      expect(explorationTranslationNotAvailableCount).toBe(4);
 
       ess.addState('Fourth', () => {});
+      ess.saveStateContent(
+        'Fourth',
+        SubtitledHtml.createDefault('Fourth content', 'content_9')
+      );
       ess.saveInteractionId('Third', 'MultipleChoiceInput');
       ess.saveInteractionId('Fourth', 'EndExploration');
 
@@ -559,7 +568,7 @@ describe('Translation status service', () => {
       tss.refresh();
       explorationTranslationNotAvailableCount =
         tss.getExplorationContentNotAvailableCount();
-      expect(explorationTranslationNotAvailableCount).toBe(8);
+      expect(explorationTranslationNotAvailableCount).toBe(5);
     }
   );
 

--- a/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
@@ -28,6 +28,7 @@ import {EntityTranslationsService} from 'services/entity-translations.services';
 import {StateEditorService} from 'components/state-editor/state-editor-properties-services/state-editor.service';
 import {InteractionSpecsKey} from 'pages/interaction-specs.constants';
 import {TranslatedContent} from 'domain/exploration/translated-content.model';
+import {BaseTranslatableObject} from 'domain/objects/BaseTranslatableObject.model';
 import {PlatformFeatureService} from 'services/platform-feature.service';
 import {EntityVoiceoversService} from 'services/entity-voiceovers.services';
 
@@ -163,8 +164,25 @@ export class TranslationStatusService implements OnInit {
         let noTranslationCount = 0;
         let noVoiceoverCount = 0;
 
-        let allContentIds =
-          this.explorationStatesService.getAllContentIdsByStateName(stateName);
+        let state = this.explorationStatesService.getState(stateName);
+        let allContentIds = state
+          .getAllContents()
+          .filter(content => {
+            let value = BaseTranslatableObject.getContentValue(content);
+            if (Array.isArray(value)) {
+              if (value.length === 0) {
+                return false;
+              }
+              return value.some(
+                val =>
+                  (val || '').trim() !== '' && (val || '').trim() !== '<p></p>'
+              );
+            }
+            let strValue = (value as string) || '';
+            return strValue.trim() !== '' && strValue.trim() !== '<p></p>';
+          })
+          .map(content => content.contentId as string);
+
         let interactionId =
           this.explorationStatesService.getInteractionIdMemento(stateName);
         // This is used to prevent users from adding unwanted hints audio, as

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -57,7 +57,10 @@ import {RouterService} from 'pages/exploration-editor-page/services/router.servi
 import {TranslatedContent} from 'domain/exploration/translated-content.model';
 import {Hint} from 'domain/exploration/hint-object.model';
 import {AnswerGroup} from 'domain/exploration/answer-group.model';
-
+import {TruncatePipe} from 'filters/string-utility-filters/truncate.pipe';
+import {FormatRtePreviewPipe} from 'filters/format-rte-preview.pipe';
+import {PlatformFeatureService} from 'services/platform-feature.service';
+import {ExplorationLanguageCodeService} from 'pages/exploration-editor-page/services/exploration-language-code.service';
 const DEFAULT_OBJECT_VALUES = require('objects/object_defaults.json');
 
 class MockNgbModal {
@@ -290,6 +293,9 @@ describe('State translation component', () => {
 
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
+    );
     explorationStatesService = TestBed.inject(ExplorationStatesService);
     translationLanguageService = TestBed.inject(TranslationLanguageService);
     translationTabActiveContentIdService = TestBed.inject(
@@ -648,7 +654,7 @@ describe('State translation component', () => {
             0,
             'true'
           )
-        ).toBe('[] Feedback Text');
+        ).toBe('[When the button is clicked] Feedback Text');
       });
 
       it(
@@ -662,7 +668,7 @@ describe('State translation component', () => {
               1,
               'true'
             )
-          ).toBe('[] Feedback Text');
+          ).toBe('[All other answers] Feedback Text');
         }
       );
 
@@ -677,7 +683,7 @@ describe('State translation component', () => {
               0,
               'true'
             )
-          ).toBe('[] Feedback Text');
+          ).toBe('[All answers] Feedback Text');
         }
       );
 
@@ -701,7 +707,7 @@ describe('State translation component', () => {
             null,
             true
           )
-        ).toBe('[] Feedback text');
+        ).toBe('[Answer] Feedback text');
       });
     }
   );
@@ -712,6 +718,7 @@ describe('State translation component', () => {
   let fixture: ComponentFixture<StateTranslationComponent>;
   let ckEditorCopyContentService: CkEditorCopyContentService;
   let entityTranslationsService: EntityTranslationsService;
+  let explorationLanguageCodeService: ExplorationLanguageCodeService;
   let explorationStatesService: ExplorationStatesService;
   let stateEditorService: StateEditorService;
   let translationLanguageService: TranslationLanguageService;
@@ -903,6 +910,9 @@ describe('State translation component', () => {
     );
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
+    );
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
     );
     explorationStatesService.init(explorationState1, false);
 
@@ -2020,6 +2030,7 @@ describe('State translation component', () => {
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
     );
+
     explorationStatesService.init(explorationState1, false);
     explorationHtmlFormatterService = TestBed.inject(
       ExplorationHtmlFormatterService

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -54,6 +54,7 @@ import {TranslationTabActiveContentIdService} from '../services/translation-tab-
 import {TranslationTabActiveModeService} from '../services/translation-tab-active-mode.service';
 import {StateTranslationComponent} from './state-translation.component';
 import {RouterService} from 'pages/exploration-editor-page/services/router.service';
+import {ExplorationLanguageCodeService} from 'pages/exploration-editor-page/services/exploration-language-code.service';
 import {TranslatedContent} from 'domain/exploration/translated-content.model';
 import {Hint} from 'domain/exploration/hint-object.model';
 import {AnswerGroup} from 'domain/exploration/answer-group.model';
@@ -80,7 +81,7 @@ class MockParameterizeRuleDescriptionPipe {
 @Pipe({name: 'wrapTextWithEllipsis'})
 class MockWrapTextWithEllipsisPipe {
   transform(input: string, characterCount: number): string {
-    return '';
+    return input;
   }
 }
 
@@ -108,6 +109,7 @@ describe('State translation component', () => {
   let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
+  let explorationLanguageCodeService: ExplorationLanguageCodeService;
 
   let explorationState1 = {
     Introduction: {
@@ -297,7 +299,11 @@ describe('State translation component', () => {
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
     );
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
+    );
     explorationStatesService.init(explorationState1, false);
+    explorationLanguageCodeService.displayed = 'en';
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
     entityTranslationsService.entityTranslation =
@@ -633,8 +639,7 @@ describe('State translation component', () => {
           ' been added yet',
         () => {
           expect(component.getEmptyContentMessage()).toBe(
-            'The translation for this section has not been created yet.' +
-              ' Switch to translation mode to add a text translation.'
+            'There is no content available for voiceover.'
           );
         }
       );
@@ -716,6 +721,7 @@ describe('State translation component', () => {
   let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
+  let explorationLanguageCodeService: ExplorationLanguageCodeService;
 
   let explorationState1 = {
     Introduction: {
@@ -870,6 +876,7 @@ describe('State translation component', () => {
         ReadOnlyExplorationBackendApiService,
         StateEditorService,
         TranslationLanguageService,
+        ExplorationLanguageCodeService,
         TranslationTabActiveContentIdService,
         TranslationTabActiveModeService,
         {
@@ -903,7 +910,11 @@ describe('State translation component', () => {
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
     );
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
+    );
     explorationStatesService.init(explorationState1, false);
+    explorationLanguageCodeService.displayed = 'en';
 
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
@@ -1128,6 +1139,7 @@ describe('State translation component', () => {
   let translationLanguageService: TranslationLanguageService;
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
+  let explorationLanguageCodeService: ExplorationLanguageCodeService;
   let routerService: RouterService;
 
   let explorationState1 = {
@@ -1346,6 +1358,7 @@ describe('State translation component', () => {
         ReadOnlyExplorationBackendApiService,
         StateEditorService,
         TranslationLanguageService,
+        ExplorationLanguageCodeService,
         TranslationTabActiveContentIdService,
         TranslationTabActiveModeService,
         {
@@ -1379,8 +1392,13 @@ describe('State translation component', () => {
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
     );
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
+    );
     routerService = TestBed.inject(RouterService);
     explorationStatesService.init(explorationState1, false);
+    explorationLanguageCodeService.displayed = 'en';
+    explorationLanguageCodeService.displayed = 'en';
 
     entityTranslationsService = TestBed.inject(EntityTranslationsService);
     entityTranslationsService.init('exp1', 'exploration', 5);
@@ -1528,7 +1546,10 @@ describe('State translation component', () => {
   });
 
   it('should return translation html when translation available', () => {
-    entityTranslationsService.languageCodeToLatestEntityTranslations.en =
+    (translationLanguageService.getActiveLanguageCode as any).and.returnValue(
+      'hi'
+    );
+    entityTranslationsService.languageCodeToLatestEntityTranslations.hi =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_0: new TranslatedContent('Translated HTML', 'html', true),
       });
@@ -1567,7 +1588,10 @@ describe('State translation component', () => {
   });
 
   it('should return translated unicode in voiceover mode when translation exist', () => {
-    entityTranslationsService.languageCodeToLatestEntityTranslations.en =
+    (translationLanguageService.getActiveLanguageCode as any).and.returnValue(
+      'hi'
+    );
+    entityTranslationsService.languageCodeToLatestEntityTranslations.hi =
       new EntityTranslation('entityId', 'entityType', 'entityVersion', 'hi', {
         content_1: new TranslatedContent('Translated UNICODE', 'unicode', true),
       });
@@ -1797,6 +1821,7 @@ describe('State translation component', () => {
   let translationTabActiveContentIdService: TranslationTabActiveContentIdService;
   let translationTabActiveModeService: TranslationTabActiveModeService;
   let explorationHtmlFormatterService: ExplorationHtmlFormatterService;
+  let explorationLanguageCodeService: ExplorationLanguageCodeService;
   let explorationState1 = {
     Introduction: {
       content: {
@@ -1986,6 +2011,7 @@ describe('State translation component', () => {
         ReadOnlyExplorationBackendApiService,
         StateEditorService,
         TranslationLanguageService,
+        ExplorationLanguageCodeService,
         TranslationTabActiveContentIdService,
         TranslationTabActiveModeService,
         {
@@ -2019,8 +2045,11 @@ describe('State translation component', () => {
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
     );
-
+    explorationLanguageCodeService = TestBed.inject(
+      ExplorationLanguageCodeService
+    );
     explorationStatesService.init(explorationState1, false);
+    explorationLanguageCodeService.displayed = 'en';
     explorationHtmlFormatterService = TestBed.inject(
       ExplorationHtmlFormatterService
     );

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -57,10 +57,6 @@ import {RouterService} from 'pages/exploration-editor-page/services/router.servi
 import {TranslatedContent} from 'domain/exploration/translated-content.model';
 import {Hint} from 'domain/exploration/hint-object.model';
 import {AnswerGroup} from 'domain/exploration/answer-group.model';
-import {TruncatePipe} from 'filters/string-utility-filters/truncate.pipe';
-import {FormatRtePreviewPipe} from 'filters/format-rte-preview.pipe';
-import {PlatformFeatureService} from 'services/platform-feature.service';
-import {ExplorationLanguageCodeService} from 'pages/exploration-editor-page/services/exploration-language-code.service';
 const DEFAULT_OBJECT_VALUES = require('objects/object_defaults.json');
 
 class MockNgbModal {
@@ -293,9 +289,6 @@ describe('State translation component', () => {
 
     ckEditorCopyContentService = TestBed.inject(CkEditorCopyContentService);
     stateEditorService = TestBed.inject(StateEditorService);
-    explorationLanguageCodeService = TestBed.inject(
-      ExplorationLanguageCodeService
-    );
     explorationStatesService = TestBed.inject(ExplorationStatesService);
     translationLanguageService = TestBed.inject(TranslationLanguageService);
     translationTabActiveContentIdService = TestBed.inject(
@@ -718,7 +711,6 @@ describe('State translation component', () => {
   let fixture: ComponentFixture<StateTranslationComponent>;
   let ckEditorCopyContentService: CkEditorCopyContentService;
   let entityTranslationsService: EntityTranslationsService;
-  let explorationLanguageCodeService: ExplorationLanguageCodeService;
   let explorationStatesService: ExplorationStatesService;
   let stateEditorService: StateEditorService;
   let translationLanguageService: TranslationLanguageService;
@@ -910,9 +902,6 @@ describe('State translation component', () => {
     );
     translationTabActiveModeService = TestBed.inject(
       TranslationTabActiveModeService
-    );
-    explorationLanguageCodeService = TestBed.inject(
-      ExplorationLanguageCodeService
     );
     explorationStatesService.init(explorationState1, false);
 

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
@@ -55,6 +55,7 @@ import {EntityTranslationsService} from 'services/entity-translations.services';
 import {TranslatedContent} from 'domain/exploration/translated-content.model';
 import {TranslationLanguageService} from '../services/translation-language.service';
 import {PlatformFeatureService} from 'services/platform-feature.service';
+import {ExplorationLanguageCodeService} from 'pages/exploration-editor-page/services/exploration-language-code.service';
 
 @Component({
   selector: 'oppia-state-translation',
@@ -121,58 +122,71 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
     private truncatePipe: TruncatePipe,
     private wrapTextWithEllipsisPipe: WrapTextWithEllipsisPipe,
     private parameterizeRuleDescriptionPipe: ParameterizeRuleDescriptionPipe,
-    private platformFeatureService: PlatformFeatureService
+    private platformFeatureService: PlatformFeatureService,
+    private explorationLanguageCodeService: ExplorationLanguageCodeService
   ) {}
 
   isVoiceoverModeActive(): boolean {
     return this.translationTabActiveModeService.isVoiceoverModeActive();
   }
 
-  getRequiredHtml(subtitledHtml: SubtitledHtml): string {
+  getRequiredHtml(subtitledHtml: SubtitledHtml): string | null {
     if (this.translationTabActiveModeService.isTranslationModeActive()) {
       return subtitledHtml.html;
     }
 
     let langCode = this.translationLanguageService.getActiveLanguageCode();
+
+    // If viewing in the exploration's original language, return the original.
+    if (langCode === this.explorationLanguageCodeService.displayed) {
+      return subtitledHtml.html;
+    }
+
     if (
       !this.entityTranslationsService.languageCodeToLatestEntityTranslations.hasOwnProperty(
         langCode
       )
     ) {
-      return subtitledHtml.html;
+      return null;
     }
 
     let translationContent =
       this.entityTranslationsService.languageCodeToLatestEntityTranslations[
         langCode
       ].getWrittenTranslation(subtitledHtml.contentId);
-    if (!translationContent) {
-      return subtitledHtml.html;
+    if (!translationContent || !translationContent.translation) {
+      return null;
     }
 
     return translationContent.translation as string;
   }
 
-  getRequiredUnicode(SubtitledUnicode: SubtitledUnicode): string {
+  getRequiredUnicode(SubtitledUnicode: SubtitledUnicode): string | null {
     if (this.translationTabActiveModeService.isTranslationModeActive()) {
       return SubtitledUnicode.unicode;
     }
 
     let langCode = this.translationLanguageService.getActiveLanguageCode();
+
+    // If viewing in the exploration's original language, return the original.
+    if (langCode === this.explorationLanguageCodeService.displayed) {
+      return SubtitledUnicode.unicode;
+    }
+
     if (
       !this.entityTranslationsService.languageCodeToLatestEntityTranslations.hasOwnProperty(
         langCode
       )
     ) {
-      return SubtitledUnicode.unicode;
+      return null;
     }
 
     let translationContent =
       this.entityTranslationsService.languageCodeToLatestEntityTranslations[
         langCode
       ].getWrittenTranslation(SubtitledUnicode.contentId);
-    if (!translationContent) {
-      return SubtitledUnicode.unicode;
+    if (!translationContent || !translationContent.translation) {
+      return null;
     }
 
     return translationContent.translation as string;
@@ -180,6 +194,10 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
 
   getEmptyContentMessage(): string {
     if (this.translationTabActiveModeService.isVoiceoverModeActive()) {
+      let langCode = this.translationLanguageService.getActiveLanguageCode();
+      if (langCode === this.explorationLanguageCodeService.displayed) {
+        return 'There is no content available for voiceover.';
+      }
       return (
         'The translation for this section has not been created yet. ' +
         'Switch to translation mode to add a text translation.'

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.ts
@@ -362,7 +362,7 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
     let outcome = answerGroup.outcome;
     let hasFeedback = outcome.hasNonemptyFeedback();
 
-    if (answerGroup.rules) {
+    if (answerGroup.rules && answerGroup.rules.length > 0) {
       let firstRule = this.ConvertToPlainTextPipe.transform(
         this.parameterizeRuleDescriptionPipe.transform(
           answerGroup.rules[0],
@@ -379,6 +379,8 @@ export class StateTranslationComponent implements OnInit, OnDestroy {
         );
       }
       summary = '[' + summary + '] ';
+    } else {
+      summary = '[Answer] ';
     }
 
     if (hasFeedback) {


### PR DESCRIPTION
## Overview

1. This PR fixes part of #20088.
2. This PR does the following: 

- Fixes an issue where missing non-English translations in the Translation Tab incorrectly fell back to displaying the original English content.

- Ensures that when a non-English translation is missing, the placeholder message is shown instead of falling back to English.

- Ensures empty original content cards are not rendered in the Translation Tab.

- Updates the translation status logic so empty content is not counted as “missing translation.”

3. The original bug occurred because: 

- In voiceover mode, getRequiredHtml and getRequiredUnicode fell back to original content even when a non-English translation was missing.

- The component did not distinguish between empty original content and missing translations.

- Translation status calculations included empty content IDs, leading to incorrect progress indicators.

## Essential Checklist

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Missing translations do not fall back to English (Voiceover mode)
When the active language is non-English, and a translation is missing, the Translation Tab shows the placeholder text instead of falling back to the original English content.
This confirms that getRequiredHtml / getRequiredUnicode return null for missing translations in non-original languages.


https://github.com/user-attachments/assets/6480fc83-e23f-4be2-9d4c-a956718f5d51

#### Proof of changes on desktop with slow/throttled network
Manually verified on desktop. No UI or performance issues observed.

#### Proof of changes on mobile phone

Not applicable. Translation Tab is not optimized for mobile usage.

#### Proof of changes in Arabic language

<img width="1512" height="982" alt="oppia after rtl" src="https://github.com/user-attachments/assets/b3b0eed5-a697-47aa-833a-d71bb822b5ed" />

Note: The Exploration Overview panel remains fixed on the right as per the existing editor layout.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
