### PR TITLE
Cancel workflows after merge queue failure

### DIFF
--- a/.github/workflows/all_lint_checks.yml
+++ b/.github/workflows/all_lint_checks.yml
@@ -2,7 +2,9 @@ name: Lint checks
 permissions: read-all
 on:
   merge_group:
-    types: [checks_requested]
+    types:
+      - checks_requested
+      - destroyed
   push:
     branches:
       - develop
@@ -13,12 +15,15 @@ on:
       - release-*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+         github.event.pull_request.number || github.event.merge_group.head_ref
+         || github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   backend_lint:
     name: Backend
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4
@@ -39,6 +44,7 @@ jobs:
   frontend_lint:
     name: Custom ESLint checks
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4
@@ -56,6 +62,7 @@ jobs:
   frontend_formatter:
     name: Frontend formatting with prettier
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4
@@ -75,6 +82,7 @@ jobs:
   black_formatter:
     name: Frontend formatting with prettier
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4

--- a/.github/workflows/all_type_checks.yml
+++ b/.github/workflows/all_type_checks.yml
@@ -2,7 +2,9 @@ name: Type checks
 permissions: read-all
 on:
   merge_group:
-    types: [checks_requested]
+    types:
+      - checks_requested
+      - destroyed
   push:
     branches:
       - develop
@@ -13,12 +15,15 @@ on:
       - release-*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+         github.event.pull_request.number || github.event.merge_group.head_ref
+         || github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   backend_type_checks:
     name: Backend
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4
@@ -35,6 +40,7 @@ jobs:
   frontend_type_checks:
     name: Frontend
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4

--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -2,7 +2,9 @@ name: Backend unit tests
 permissions: read-all
 on:
   merge_group:
-    types: [checks_requested]
+    types:
+      - checks_requested
+      - destroyed
   push:
     branches:
       - develop
@@ -13,12 +15,15 @@ on:
       - release-*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+         github.event.pull_request.number || github.event.merge_group.head_ref
+         || github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   run_backend_associated_test_file_checks:
     name: Verify associated test files
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4
@@ -35,6 +40,7 @@ jobs:
   run_tests:
     name: Shard ${{ matrix.shard }}
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     strategy:
       matrix:
         shard: [1, 2, 3, 4, 5]

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -2,7 +2,9 @@ name: Frontend unit tests
 permissions: read-all
 on:
   merge_group:
-    types: [checks_requested]
+    types:
+      - checks_requested
+      - destroyed
   push:
     branches:
       - develop
@@ -13,12 +15,15 @@ on:
       - release-*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+         github.event.pull_request.number || github.event.merge_group.head_ref
+         || github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   generate-job-strategy-matrix:
     name: Generate job strategy matrix
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     outputs:
       job-strategy-matrix: ${{ steps.generate.outputs.job-strategy-matrix }}
     steps:

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -2,7 +2,9 @@ name: Full-stack tests
 permissions: read-all
 on:
   merge_group:
-    types: [checks_requested]
+    types:
+      - checks_requested
+      - destroyed
   push:
     branches:
       - develop
@@ -13,12 +15,15 @@ on:
       - release-*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+         github.event.pull_request.number || github.event.merge_group.head_ref
+         || github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   e2e_and_acceptance_coverage:
     name: Verify all e2e/acceptance tests are included
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4
@@ -35,6 +40,7 @@ jobs:
   check_test_suites_to_run:
     name: Compute which tests to run
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     outputs:
       TEST_SUITES_TO_RUN: ${{ steps.compute_test_suites.outputs.TEST_SUITES_TO_RUN }}
     steps:

--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -2,7 +2,9 @@ name: Oppiabot
 
 on:
   merge_group:
-    types: [checks_requested]
+    types:
+      - checks_requested
+      - destroyed
   issues:
     types:
       - labeled
@@ -12,15 +14,22 @@ on:
       - release-*
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+         github.event.pull_request.number || github.event.merge_group.head_ref
+         || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   oppiabot:
     name: Verify CLA
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     permissions:
-      issues: write          
-      pull-requests: write   
-      checks: write 
-      statuses: write        
+      issues: write
+      pull-requests: write
+      checks: write
+      statuses: write
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: Enables stale workflow cancelation for workflows triggered by the merge queue.

Currently, we cancel workflow runs triggered by previous commits when new commits are pushed, but not for runs triggered by the merge queue, leading to unnecessary CI runs. This PR extends obsolete workflow cancellation to the merge queue as follows:

1. Handle the `destroyed` action type of the merge group triggering event so that when a PR gets bumped out of the merge queue due to a test failure or timeout, another workflow run is created.
2. Set the concurrency key to `${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref || github.run_id }}` so that:
   * If the workflow was triggered by a push, cancel any older runs of this workflow on the same branch (because of github.ref).
   * If the workflow was triggered by a PR, cancel any older runs of this workflow for the same PR (because of github.event.pull_request.number).
   * If the workflow was triggered by the creation of a merge group in the merge queue, cancel any older runs of this workflow for the same merge group (because of github.event.merge_group.head_ref, which is structured like this: `refs/heads/gh-readonly-queue/main/pr-[PR NUM]-[SHA OF POST-MERGE COMMIT]`).
   * If none of the above, fall back to the run ID, which is unique, so nothing gets canceled.
3. Add an `if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}` to the jobs so that the workflow runs triggered by merge group destruction don't actually do anything.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

I tested this approach in a sandbox repository:

* The job run initially created to test the PR in the merge queue: https://github.com/golden-sunrise/actions-sandbox/actions/runs/22290705347
* The no-op job run created upon merge group destruction (I removed the PR from the queue): https://github.com/golden-sunrise/actions-sandbox/actions/runs/22290780676

Note that the no-op job does nothing, and the original job run is canceled early.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
