### PR TITLE
Fix #23347: Correct RTL breadcrumb spacing and selector typo

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1029,17 +1029,11 @@ textarea {
 }
 
 .oppia-navbar-breadcrumb-separator {
-  margin-right: 8px;
+  display: inline-block;
+  margin-inline: 8px;
 }
 .oppia-navbar-breadcrumb-separator:after {
   content: ">";
-}
-
-.oppia-navbar-breadcrumb-rtl-separator {
-  margin-left: 8px;
-}
-.oppia-navbar-breadcrumb-rtl-separator:after {
-  content: "<";
 }
 
 .oppia-activity-summary-tile.oppia-dashboard-collection-tile a:hover {
@@ -2544,6 +2538,10 @@ div#ng-curtain {
   color: white;
   font-size: 20px;
   padding: 6px;
+  -moz-transform: scaleX(1) /*rtl:scaleX(-1)*/;
+  -o-transform: scaleX(1) /*rtl:scaleX(-1)*/;
+  -webkit-transform: scaleX(1) /*rtl:scaleX(-1)*/;
+  transform: scaleX(1) /*rtl:scaleX(-1)*/;
 }
 
 .oppia-navbar-tabs {

--- a/core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.css
+++ b/core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.css
@@ -132,7 +132,7 @@ oppia-blog-author-page .blog-post-card {
 
 @media (max-width: 570px) {
   .blog-author-page-breadcrumb .oppia-author-page-back-button {
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
 }
 
@@ -150,7 +150,7 @@ oppia-blog-author-page .blog-post-card {
 .blog-author-page-breadcrumb .oppia-navbar-breadcrumb {
   display: -webkit-inline-box;
   flex-flow: column;
-  margin-left: -10px;
+  margin-inline-start: -10px;
   overflow-wrap: break-word;
   padding-top: 3px;
 }

--- a/core/templates/pages/blog-post-page/blog-post-page.component.css
+++ b/core/templates/pages/blog-post-page/blog-post-page.component.css
@@ -10,8 +10,8 @@ button:focus {
 
 
 @media (max-width: 570px) {
-  .blog-post-page-breadcrumb .oppia-blog-post-page-back-button {
-    margin-left: -10px;
+  .blog-post-page-breadcrumb .oppia-blog-post-back-button {
+    margin-inline-start: -10px;
   }
 }
 
@@ -29,7 +29,7 @@ button:focus {
 .blog-post-page-breadcrumb .oppia-navbar-breadcrumb {
   display: -webkit-inline-box;
   flex-flow: column;
-  margin-left: -10px;
+  margin-inline-start: -10px;
   overflow-wrap: break-word;
   padding-top: 3px;
 }

--- a/core/templates/pages/profile-page/profile-page-navbar.component.css
+++ b/core/templates/pages/profile-page/profile-page-navbar.component.css
@@ -5,9 +5,9 @@
 */
 
 .oppia-username-text {
-  margin-left: 8px;
+  margin-inline-start: 8px;
 }
 
 .oppia-navbar-breadcrumb-separator {
-  margin-right: 8px;
+  margin-inline-end: 8px;
 }


### PR DESCRIPTION
## Overview

1. This PR fixes #23347.
2. This PR does the following: Fixes breadcrumb separator spacing inconsistencies in RTL vs LTR by switching breadcrumb spacing to logical CSS properties (`margin-inline*`) so spacing around the separator is direction-safe and visually consistent. It also fixes a blog post breadcrumb back-button selector typo and replaces direction-specific margins with logical margins in related breadcrumb CSS.
3. (For bug-fixing PRs only) The original bug occurred because breadcrumb spacing used hardcoded `margin-left`/`margin-right` rules, which produced inconsistent spacing in RTL layouts. There was also a selector typo in blog post breadcrumb CSS (`.oppia-blog-post-page-back-button` instead of `.oppia-blog-post-back-button`) that prevented the intended style rule from applying.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct


#### Proof of changes in Arabic language

- Added Arabic screenshots showing corrected breadcrumb separator spacing and direction behavior.
- Verified spacing between `Oppia`, separator, and Arabic page title is visually consistent with English.
before
<img width="1470" height="269" alt="Screenshot 2026-02-24 at 1 02 04 AM" src="https://github.com/user-attachments/assets/a9eb28d8-9d4b-45d4-a417-a0723373ebe9" />

after 
<img width="1470" height="86" alt="553696486-a9f4ec0e-0416-4638-99ef-a692d05e1bf1" src="https://github.com/user-attachments/assets/4fb59663-903b-4abf-ad0e-a8868002a8ab" />

