### PR TITLE
Fix #18876: Fix concept card modal z-index and restore entity context after save

### DIFF
--- a/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.spec.ts
+++ b/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.spec.ts
@@ -27,6 +27,7 @@ import {
 import {CkEditorCopyContentService} from 'components/ck-editor-helpers/ck-editor-copy-content.service';
 import {HtmlEscaperService} from 'services/html-escaper.service';
 import {NoninteractiveSkillreview} from './oppia-noninteractive-skillreview.component';
+import {OppiaNoninteractiveSkillreviewConceptCardModalComponent} from './oppia-noninteractive-skillreview-concept-card-modal.component';
 import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {PageContextService} from 'services/page-context.service';
 import {SimpleChanges} from '@angular/core';
@@ -126,6 +127,14 @@ describe('NoninteractiveSkillreview', () => {
     component.openConceptCard(e);
 
     expect(modalSpy).toHaveBeenCalled();
+    expect(modalSpy).toHaveBeenCalledWith(
+      OppiaNoninteractiveSkillreviewConceptCardModalComponent,
+      {
+        backdrop: true,
+        backdropClass: 'forced-modal-backdrop-stack-over',
+        windowClass: 'forced-modal-stack-over',
+      }
+    );
     expect(pageContextService.removeCustomEntityContext).not.toHaveBeenCalled();
   });
 
@@ -260,4 +269,42 @@ describe('NoninteractiveSkillreview', () => {
 
     expect(component.linkText).toBe('new text');
   });
+
+  it(
+    'should restore entity context after concept card modal is' +
+      ' successfully closed',
+    fakeAsync(() => {
+      spyOn(pageContextService, 'setCustomEntityContext');
+      spyOn(pageContextService, 'getEntityId').and.returnValue('entityId');
+      spyOn(pageContextService, 'getEntityType').and.returnValue('entityType');
+      spyOn(pageContextService, 'removeCustomEntityContext');
+
+      let e = {
+        currentTarget: {
+          offsetParent: {
+            dataset: {
+              ckeWidgetId: false,
+            },
+          },
+        },
+      } as unknown as MouseEvent;
+
+      ckEditorCopyContentService.copyModeActive = false;
+      spyOn(ngbModal, 'open').and.callFake((dlg, opt) => {
+        return {
+          componentInstance: MockNgbModalRef,
+          result: Promise.resolve(),
+        } as NgbModalRef;
+      });
+
+      component.openConceptCard(e);
+      tick();
+
+      expect(pageContextService.removeCustomEntityContext).toHaveBeenCalled();
+      expect(pageContextService.setCustomEntityContext).toHaveBeenCalledWith(
+        'entityType',
+        'entityId'
+      );
+    })
+  );
 });

--- a/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.ts
+++ b/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.ts
@@ -40,12 +40,12 @@ import {
   OnInit,
   SimpleChanges,
 } from '@angular/core';
-import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
-import {AppConstants} from 'app.constants';
-import {PageContextService} from 'services/page-context.service';
-import {CkEditorCopyContentService} from 'components/ck-editor-helpers/ck-editor-copy-content.service';
-import {HtmlEscaperService} from 'services/html-escaper.service';
-import {OppiaNoninteractiveSkillreviewConceptCardModalComponent} from './oppia-noninteractive-skillreview-concept-card-modal.component';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { AppConstants } from 'app.constants';
+import { PageContextService } from 'services/page-context.service';
+import { CkEditorCopyContentService } from 'components/ck-editor-helpers/ck-editor-copy-content.service';
+import { HtmlEscaperService } from 'services/html-escaper.service';
+import { OppiaNoninteractiveSkillreviewConceptCardModalComponent } from './oppia-noninteractive-skillreview-concept-card-modal.component';
 
 @Component({
   selector: 'oppia-noninteractive-skillreview',
@@ -67,7 +67,7 @@ export class NoninteractiveSkillreview implements OnInit, OnChanges {
     private pageContextService: PageContextService,
     private htmlEscaperService: HtmlEscaperService,
     private ngbModal: NgbModal
-  ) {}
+  ) { }
 
   private _updateViewOnNewSkillSelected(): void {
     if (!this.skillIdWithValue || !this.textWithValue) {
@@ -118,11 +118,23 @@ export class NoninteractiveSkillreview implements OnInit, OnChanges {
 
     const modalRef = this.ngbModal.open(
       OppiaNoninteractiveSkillreviewConceptCardModalComponent,
-      {backdrop: true}
+      {
+        backdrop: true,
+        backdropClass: 'forced-modal-backdrop-stack-over',
+        windowClass: 'forced-modal-stack-over',
+      }
     );
     modalRef.componentInstance.skillId = this.skillId;
     modalRef.result.then(
-      () => {},
+      () => {
+        this.pageContextService.removeCustomEntityContext();
+        if (this.entityId && this.entityType) {
+          this.pageContextService.setCustomEntityContext(
+            this.entityType,
+            this.entityId
+          );
+        }
+      },
       res => {
         this.pageContextService.removeCustomEntityContext();
         // Restore the entity context to that of the state before the concept card


### PR DESCRIPTION
## Overview

Closes #18876

This PR fixes two bugs in the concept card modal in the question submission dashboard:
1. The concept card modal appears behind the question editor on the first click
2. After selecting and saving a concept card, it disappears from the text block

**Root Cause:**
Using `git bisect`, the bug was traced to commit `f012535` (PR #12294 —
"Migrate all oppia-non-interactive-*"). During the AngularJS → Angular migration,
`NgbModal.open()` was set with only `{backdrop: true}` and no z-index override,
causing the concept card modal to render at the same z-index (~1050) as the
parent question editor modal.

Additionally, the `modalRef.result.then()` resolve callback was empty, meaning
entity context was never restored after a successful save — causing the concept
card to disappear.

**Fix:**
- Added `backdropClass: 'forced-modal-backdrop-stack-over'` and
  `windowClass: 'forced-modal-stack-over'` following the existing pattern used
  in `question-misconception-editor.component.ts` with CSS classes already
  defined in `oppia.css`
- Added entity context restoration in the previously empty resolve callback

## Proof that changes are correct


https://github.com/user-attachments/assets/55e1360d-d28d-4489-8efc-1b1d38f9d7ab



1. **Before fix:** Concept card modal appears behind question editor on first click
2. **After fix:** Concept card modal appears in front on first click ✅
3. **After fix:** Concept card persists after saving the text block ✅

All 9 unit tests passing:

<img width="1474" height="709" alt="Screenshot 2026-02-24 212705" src="https://github.com/user-attachments/assets/4800a90b-9fd1-44d5-9114-108c34422f89" />


## Checklist

- [ ] The PR title starts with "Fix #issuenum: " or "feat #issuenum: "
- [ ] The PR explanation clearly describes the problem and the fix
- [ ] The linter/lint checks are passing
- [ ] The unit tests are passing
- [ ] The e2e/acceptance tests are passing (if applicable)
- [ ] I have read and followed the [Oppia contribution guidelines](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia)
- [ ] I have added/updated unit tests for the changes I made
- [ ] I have updated the [wiki](https://github.com/oppia/oppia/wiki) if applicable
- [ ] The PR is assigned to me
- [ ] I have requested a review from the appropriate reviewer