### PR TITLE
Fix #23981: Resolve newsletter acceptance test flake on external links

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/interested-parent/sign-up-for-oppias-newsletter.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/interested-parent/sign-up-for-oppias-newsletter.spec.ts
@@ -36,15 +36,10 @@ describe('Interested Parent', function () {
     );
     // Check for Thanks Message.
     await interestedParent.expectNewsletterSubscriptionThanksMessage();
-    // Finds the Watch a video button then clicks it.
-    await interestedParent.clickWatchAVideoButton();
-    // Navigate to the home page.
-    await interestedParent.navigateToHome();
-    await interestedParent.submitEmailForNewsletter(
-      'example.abc@domain.xyz.mn'
-    );
-    // Finds the Read Blog button then clicks it.
-    await interestedParent.clickReadBlogButton();
+    // Finds the Watch a video button and checks its link.
+    await interestedParent.expectWatchAVideoButtonToHaveCorrectLink();
+    // Finds the Read Blog button and checks its link.
+    await interestedParent.expectReadBlogButtonToHaveCorrectLink();
   });
 
   afterAll(async function () {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -3508,56 +3508,23 @@ export class LoggedOutUser extends BaseUser {
   /**
    * Function to verify the Watch a Video button after subscribing to newsletter.
    */
-  async clickWatchAVideoButton(): Promise<void> {
-    await this.page.waitForSelector(watchAVideoButtonInThanksForSubscribe);
-    const buttonText = await this.page.$eval(
+  async expectWatchAVideoButtonToHaveCorrectLink(): Promise<void> {
+    await this.openExternalLink(
       watchAVideoButtonInThanksForSubscribe,
-      element => (element as HTMLElement).innerText
+      'https://youtu.be/OConyxG7HaM'
     );
-    if (buttonText !== 'Watch a video') {
-      throw new Error('The Watch A Video button does not exist!');
-    }
-    await this.clickAndWaitForNavigation(
-      watchAVideoButtonInThanksForSubscribe,
-      true
-    );
-    await this.waitForPageToFullyLoad();
-
-    const url = this.page.url();
-    if (!url.includes(testConstants.OppiaSocials.YouTube.Domain)) {
-      throw new Error(
-        `The Watch A Video button should open the right page,
-          but it opens ${url} instead.`
-      );
-    }
-    showMessage('The Watch A Video button opens the right page.');
+    showMessage('The Watch a Video button has the right link.');
   }
 
   /**
    * Function to verify the Read Blog button after subscribing to newsletter.
    */
-  async clickReadBlogButton(): Promise<void> {
-    await this.page.waitForSelector(readOurBlogButtonInThanksForSubscribe);
-    const buttonText = await this.page.$eval(
+  async expectReadBlogButtonToHaveCorrectLink(): Promise<void> {
+    await this.openExternalLink(
       readOurBlogButtonInThanksForSubscribe,
-      element => (element as HTMLElement).innerText
+      readBlogUrl
     );
-    if (buttonText !== 'Read our blog') {
-      throw new Error('The Read Our Blog button does not exist!');
-    }
-    await this.clickAndWaitForNavigation(
-      readOurBlogButtonInThanksForSubscribe,
-      true
-    );
-
-    if (this.page.url() !== readBlogUrl) {
-      throw new Error(
-        `The Read Our Blog button should open the Blog page,
-          but it opens ${this.page.url()} instead.`
-      );
-    } else {
-      showMessage('The Read Our Blog button opens the Blog page.');
-    }
+    showMessage('The Read our blog button has the right link.');
   }
   /**
    * Function to verify that the user is on the login page.


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #23981.
2. This PR does the following: Prevents the `sign-up-for-oppias-newsletter` Acceptance Test from failing randomly on CI by replacing [clickAndWaitForNavigation](cci:1://file:///home/rohan/Documents/open_source/oppia/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts:641:2-664:3) on the YouTube and Medium buttons with [openExternalLink](cci:1://file:///home/rohan/Documents/open_source/oppia/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts:789:2-805:3). This avoids navigating off-page to external domains and relying on external network speeds, making the test far faster and removing the timeout flake.
3. (For bug-fixing PRs only) The original bug occurred because: The test used Puppeteer's `waitForNavigation` (which waits for `networkidle2`) after clicking buttons pointing to heavy external sites (Medium and YouTube). On limited GitHub CI runner bandwidth, resolving trackers and media frequently exceeded the 30000ms delay limit, failing the Acceptance test randomly.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**N/A** (This is an Acceptance Test-only logic fix to prevent CI test timeouts. No Oppia UI/Frontend or backend application logic is altered in this PR.)

**Verification via Automated Tests:**
This was verified by running the `interested-parent/sign-up-for-oppias-newsletter` test suite and confirming it executes flawlessly and efficiently without actually clicking to external websites and timing out.

**Test Logs:**
```
[test-log] 16:29.849: Subscribed to newsletter successfully [test-log] 16:29.923: The Watch a Video button has the right link. [test-log] 16:29.997: The Read our blog button has the right link. ... PASS core/tests/puppeteer-acceptance-tests/specs/interested-parent/sign-up-for-oppias-newsletter.spec.ts (41.43 s) Interested Parent ✓ should be able to sign up for the Oppia's newletter (1975 ms)

Test Suites: 1 passed, 1 total
```

#### Proof of changes on mobile phone
N/A (Test-only fix, no mobile-specific application changes.)

#### Proof of changes in Arabic language
N/A (No UI text or layout changes.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.