### PR TITLE
Fix #24107 : Remove redundant search button and simplify blog search UI

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page.component.css
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.css
@@ -252,3 +252,33 @@ oppia-blog-home-page .blog-post-card {
   color: inherit;
   text-decoration: none;
 }
+
+.blog-search-input-wrapper {
+  width: 100%;
+}
+
+.blog-search-input {
+  width: 100%;
+  height: 48px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid #d6d9dc;
+  background-color: #ffffff;
+  font-size: 15px;
+  box-shadow: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.blog-search-input:hover {
+  border-color: #aab0b6;
+}
+
+.blog-search-input:focus {
+  outline: none;
+  border-color: #0d7a5f;
+  box-shadow: 0 0 0 2px rgba(13, 122, 95, 0.15);
+}
+
+.blog-search-input::placeholder {
+  color: #8f9aa3;
+}

--- a/core/templates/pages/blog-home-page/blog-home-page.component.html
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.html
@@ -109,22 +109,14 @@
             {{ 'I18N_BLOG_HOME_PAGE_QUERY_SEARCH_HEADING' | translate }}
           </h4>
           <form class="navbar-form oppia-search-bar-form ps-0 e2e-test-search-field" role="search">
-            <div class="mb-3 d-flex">
+            <div class="mb-3 d-flex blog-search-input-wrapper">
               <input type="text"
-                     class="form-control oppia-search-bar-input oppia-search-bar-text-input e2e-test-search-input"
-                     [(ngModel)]="searchQuery"
-                     [ngModelOptions]="{ updateOn: 'change', standalone: 'true' }"
-                     aria-label="Search bar"
-                     (keydown.enter)="onSearchQueryChangeExec()">
-              <div class="input-group oppia-input-group">
-                <div class="input-group-text oppia-search-bar-icon" [ngClass]="{'d-block': isSmallScreenViewActive()}">
-                  <i class="fas fa-search material-icons oppia-translate-icon-down md-18" *ngIf="!isSearchInProgress()">
-                  </i>
-                  <span *ngIf="isSearchInProgress()">
-                    <i class="fas fa-sync material-icons md-18 oppia-animate-spin"></i>
-                  </span>
-                </div>
-              </div>
+                    class="form-control oppia-search-bar-input oppia-search-bar-text-input e2e-test-search-input blog-search-input"
+                    [(ngModel)]="searchQuery"
+                    [ngModelOptions]="{ updateOn: 'change', standalone: 'true' }"
+                    aria-label="Search bar"
+                    placeholder="Search blog posts..."
+                    (keydown.enter)="onSearchQueryChangeExec()">
             </div>
           </form>
           <h4 class="d-flex flex-grow-1 search-heading">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #24107 
2. This PR does the following: This PR removes the redundant search button from the blog page and simplifies the search UI to use a single input field. The search functionality remains unchanged and is still triggered via the Enter key. Scoped CSS was added to properly style the standalone input after removing the old input-group layout dependency.
3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because the page contained two UI elements (a search input and a separate button/icon group) that both triggered the same search function, resulting in duplicated functionality and a confusing user experience. The styling was also tightly coupled to the removed button structure

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before:
<img width="858" height="849" alt="Screenshot 2026-02-17 at 09 48 02" src="https://github.com/user-attachments/assets/09579a7d-7a20-4e96-9538-8a622c1e95ec" />

After:

https://github.com/user-attachments/assets/ef5f4ca4-1d95-4908-aac7-735d6005aef8



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

@mosin74 PTAL