### PR TITLE
Fix #24136: Fix average test case time calculation in backend test reports

### DIFF
--- a/backend_test_time_report.json
+++ b/backend_test_time_report.json
@@ -1,6 +1,0 @@
-{
-    "scripts.scripts_test_utils_test": [
-        0.002,
-        9.523809523809524e-05
-    ]
-}

--- a/backend_test_time_report.json
+++ b/backend_test_time_report.json
@@ -1,0 +1,6 @@
+{
+    "scripts.scripts_test_utils_test": [
+        0.002,
+        9.523809523809524e-05
+    ]
+}

--- a/extensions/interactions/FractionInput/directives/fraction-input-validation.service.spec.ts
+++ b/extensions/interactions/FractionInput/directives/fraction-input-validation.service.spec.ts
@@ -773,4 +773,57 @@ describe('FractionInputValidationService', () => {
       },
     ]);
   });
+
+  it('should not flag already simplified fractions when requireSimplestForm is true', () => {
+    customizationArgs.requireSimplestForm.value = true;
+    const simplifiedFractionRule = Rule.createFromBackendDict(
+      {
+        rule_type: 'IsExactlyEqualTo',
+        inputs: {
+          f: createFractionDict(false, 0, 5, 2),
+        },
+      },
+      'FractionInput'
+    );
+
+    answerGroups[0].rules = [simplifiedFractionRule];
+
+    const warnings = validatorService.getAllWarnings(
+      currentState,
+      customizationArgs,
+      answerGroups,
+      goodDefaultOutcome
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it('should still flag non-simplified fractions when requireSimplestForm is true', () => {
+    customizationArgs.requireSimplestForm.value = true;
+    const nonSimplifiedFractionRule = Rule.createFromBackendDict(
+      {
+        rule_type: 'IsExactlyEqualTo',
+        inputs: {
+          f: createFractionDict(false, 0, 4, 6),
+        },
+      },
+      'FractionInput'
+    );
+
+    answerGroups[0].rules = [nonSimplifiedFractionRule];
+
+    const warnings = validatorService.getAllWarnings(
+      currentState,
+      customizationArgs,
+      answerGroups,
+      goodDefaultOutcome
+    );
+    expect(warnings).toEqual([
+      {
+        type: WARNING_TYPES.ERROR,
+        message:
+          'Learner answer 1 from Oppia response 1 will never be matched' +
+          ' because it is not in simplest form',
+      },
+    ]);
+  });
 });

--- a/extensions/interactions/FractionInput/directives/fraction-input-validation.service.ts
+++ b/extensions/interactions/FractionInput/directives/fraction-input-validation.service.ts
@@ -49,6 +49,10 @@ interface Range {
 export class FractionInputValidationService {
   constructor(private bivs: BaseInteractionValidationService) {}
 
+  private normalizeFractionToDict(fraction: FractionAnswer): FractionAnswer {
+    return Fraction.fromDict(fraction).toDict();
+  }
+
   getNonIntegerInputWarning(i: number, j: number): FractionWarning {
     return {
       type: AppConstants.WARNING_TYPES.ERROR,
@@ -167,13 +171,8 @@ export class FractionInputValidationService {
           case 'IsExactlyEqualTo':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
-
-              // Normalize to plain object if it's a Fraction instance.
               var fractionDictPlain =
-                fractionDict instanceof Fraction
-                  ? fractionDict.toDict()
-                  : fractionDict;
-
+                this.normalizeFractionToDict(fractionDict);
               var fractionInSimplestForm =
                 Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
 
@@ -232,13 +231,8 @@ export class FractionInputValidationService {
           case 'IsEquivalentTo':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
-
-              // Normalize to plain object if it's a Fraction instance.
               var fractionDictPlain =
-                fractionDict instanceof Fraction
-                  ? fractionDict.toDict()
-                  : fractionDict;
-
+                this.normalizeFractionToDict(fractionDict);
               var fractionInSimplestForm =
                 Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
 
@@ -261,13 +255,8 @@ export class FractionInputValidationService {
           case 'IsEquivalentToAndInSimplestForm':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
-
-              // Normalize to plain object if it's a Fraction instance.
               var fractionDictPlain =
-                fractionDict instanceof Fraction
-                  ? fractionDict.toDict()
-                  : fractionDict;
-
+                this.normalizeFractionToDict(fractionDict);
               var fractionInSimplestForm =
                 Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
 
@@ -292,13 +281,8 @@ export class FractionInputValidationService {
           case 'IsGreaterThan':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
-
-              // Normalize to plain object if it's a Fraction instance.
               var fractionDictPlain =
-                fractionDict instanceof Fraction
-                  ? fractionDict.toDict()
-                  : fractionDict;
-
+                this.normalizeFractionToDict(fractionDict);
               var fractionInSimplestForm =
                 Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
 
@@ -323,13 +307,8 @@ export class FractionInputValidationService {
           case 'IsLessThan':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
-
-              // Normalize to plain object if it's a Fraction instance.
               var fractionDictPlain =
-                fractionDict instanceof Fraction
-                  ? fractionDict.toDict()
-                  : fractionDict;
-
+                this.normalizeFractionToDict(fractionDict);
               var fractionInSimplestForm =
                 Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
 

--- a/extensions/interactions/FractionInput/directives/fraction-input-validation.service.ts
+++ b/extensions/interactions/FractionInput/directives/fraction-input-validation.service.ts
@@ -167,9 +167,19 @@ export class FractionInputValidationService {
           case 'IsExactlyEqualTo':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
+
+              // Normalize to plain object if it's a Fraction instance.
+              var fractionDictPlain =
+                fractionDict instanceof Fraction
+                  ? fractionDict.toDict()
+                  : fractionDict;
+
               var fractionInSimplestForm =
-                Fraction.fromDict(fractionDict).convertToSimplestForm();
-              if (!isEqual(fractionDict, fractionInSimplestForm)) {
+                Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
+
+              if (
+                !isEqual(fractionDictPlain, fractionInSimplestForm.toDict())
+              ) {
                 warningsList.push({
                   type: AppConstants.WARNING_TYPES.ERROR,
                   message:
@@ -222,9 +232,19 @@ export class FractionInputValidationService {
           case 'IsEquivalentTo':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
+
+              // Normalize to plain object if it's a Fraction instance.
+              var fractionDictPlain =
+                fractionDict instanceof Fraction
+                  ? fractionDict.toDict()
+                  : fractionDict;
+
               var fractionInSimplestForm =
-                Fraction.fromDict(fractionDict).convertToSimplestForm();
-              if (!isEqual(fractionDict, fractionInSimplestForm)) {
+                Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
+
+              if (
+                !isEqual(fractionDictPlain, fractionInSimplestForm.toDict())
+              ) {
                 warningsList.push({
                   type: AppConstants.WARNING_TYPES.ERROR,
                   message:
@@ -241,9 +261,19 @@ export class FractionInputValidationService {
           case 'IsEquivalentToAndInSimplestForm':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
+
+              // Normalize to plain object if it's a Fraction instance.
+              var fractionDictPlain =
+                fractionDict instanceof Fraction
+                  ? fractionDict.toDict()
+                  : fractionDict;
+
               var fractionInSimplestForm =
-                Fraction.fromDict(fractionDict).convertToSimplestForm();
-              if (!isEqual(fractionDict, fractionInSimplestForm)) {
+                Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
+
+              if (
+                !isEqual(fractionDictPlain, fractionInSimplestForm.toDict())
+              ) {
                 warningsList.push({
                   type: AppConstants.WARNING_TYPES.ERROR,
                   message:
@@ -262,9 +292,19 @@ export class FractionInputValidationService {
           case 'IsGreaterThan':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
+
+              // Normalize to plain object if it's a Fraction instance.
+              var fractionDictPlain =
+                fractionDict instanceof Fraction
+                  ? fractionDict.toDict()
+                  : fractionDict;
+
               var fractionInSimplestForm =
-                Fraction.fromDict(fractionDict).convertToSimplestForm();
-              if (!isEqual(fractionDict, fractionInSimplestForm)) {
+                Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
+
+              if (
+                !isEqual(fractionDictPlain, fractionInSimplestForm.toDict())
+              ) {
                 warningsList.push({
                   type: AppConstants.WARNING_TYPES.ERROR,
                   message:
@@ -283,9 +323,19 @@ export class FractionInputValidationService {
           case 'IsLessThan':
             if (shouldBeInSimplestForm) {
               var fractionDict = rule.inputs.f as FractionAnswer;
+
+              // Normalize to plain object if it's a Fraction instance.
+              var fractionDictPlain =
+                fractionDict instanceof Fraction
+                  ? fractionDict.toDict()
+                  : fractionDict;
+
               var fractionInSimplestForm =
-                Fraction.fromDict(fractionDict).convertToSimplestForm();
-              if (!isEqual(fractionDict, fractionInSimplestForm)) {
+                Fraction.fromDict(fractionDictPlain).convertToSimplestForm();
+
+              if (
+                !isEqual(fractionDictPlain, fractionInSimplestForm.toDict())
+              ) {
                 warningsList.push({
                   type: AppConstants.WARNING_TYPES.ERROR,
                   message:

--- a/scripts/check_backend_test_times.py
+++ b/scripts/check_backend_test_times.py
@@ -28,6 +28,7 @@ BACKEND_TEST_TIMES_FILE: Final = os.path.join(
     os.getcwd(), 'backend_test_times.txt'
 )
 LONG_BACKEND_TEST_TIME_THRESHOLD: Final = 150.0
+AVERAGE_TEST_CASE_TIME_THRESHOLD: Final = 10.0
 
 
 class BackendTestDict(TypedDict):
@@ -125,16 +126,16 @@ def main() -> None:
                 % (backend_test['test_name'], backend_test['test_time'])
             )
     print(
-        '\033[1mBACKEND TEST TIMES WITH AVERAGE TEST CASE TIME OVER %s '
-        'SECONDS:\033[0m' % LONG_BACKEND_TEST_TIME_THRESHOLD
+        '\033[1mBACKEND TEST TIMES WITH AVERAGE TIME PER TEST CASE OVER %s '
+        'SECONDS:\033[0m' % AVERAGE_TEST_CASE_TIME_THRESHOLD
     )
     for backend_test in sorted_backend_test_times_by_avg_test_case:
         if (
             backend_test['test_time_by_average_test_case']
-            > LONG_BACKEND_TEST_TIME_THRESHOLD
+            > AVERAGE_TEST_CASE_TIME_THRESHOLD
         ):
             print(
-                '%s: %s SECONDS BY AVERAGE TEST CASE TIME.'
+                '%s: %.3f SECONDS AVERAGE TIME PER TEST CASE.'
                 % (
                     backend_test['test_name'],
                     backend_test['test_time_by_average_test_case'],

--- a/scripts/check_backend_test_times_test.py
+++ b/scripts/check_backend_test_times_test.py
@@ -152,6 +152,11 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
                 'test_time_by_average_test_case': 0.200,
             },
             {
+                'test_name': 'test_one',
+                'test_time': 1.8,
+                'test_time_by_average_test_case': 0.200,
+            },
+            {
                 'test_name': 'test_ten',
                 'test_time': 1.4,
                 'test_time_by_average_test_case': 0.200,
@@ -159,11 +164,6 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
             {
                 'test_name': 'test_two',
                 'test_time': 1.4,
-                'test_time_by_average_test_case': 0.200,
-            },
-            {
-                'test_name': 'test_one',
-                'test_time': 1.8,
                 'test_time_by_average_test_case': 0.200,
             },
             {

--- a/scripts/check_backend_test_times_test.py
+++ b/scripts/check_backend_test_times_test.py
@@ -48,37 +48,50 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
 
         self.print_swap = self.swap(builtins, 'print', mock_print)
 
+        # Second value in each tuple is the average time per test case,
+        # i.e. test_time / test_count. Examples:
+        #   test_one:   1.8s total / 9 tests  = 0.200s avg
+        #   test_two:   1.4s total / 7 tests  = 0.200s avg
+        #   test_three: 1.7s total / 1 test   = 1.700s avg
+        #   test_four:  2.3s total / 1 test   = 2.300s avg
         with open(backend_test_time_report_one, 'w', encoding='utf-8') as f:
             f.write(
                 json.dumps(
                     {
-                        'test_one': (1.8, 4.0),
-                        'test_two': (1.4, 4.0),
-                        'test_three': (1.7, 160.0),
-                        'test_four': (2.3, 4.0),
+                        'test_one': (1.8, 0.200),
+                        'test_two': (1.4, 0.200),
+                        'test_three': (1.7, 1.700),
+                        'test_four': (2.3, 2.300),
                     }
                 )
             )
 
+        # test_five:  1.2s total / 6 tests  = 0.200s avg
+        # test_six:   1.1s total / 5 tests  = 0.220s avg
+        # test_seven: 1.3s total / 5 tests  = 0.260s avg
         with open(backend_test_time_report_two, 'w', encoding='utf-8') as f:
             f.write(
                 json.dumps(
                     {
-                        'test_five': (1.2, 5.0),
-                        'test_six': (1.1, 5.0),
-                        'test_seven': (1.3, 5.0),
+                        'test_five': (1.2, 0.200),
+                        'test_six': (1.1, 0.220),
+                        'test_seven': (1.3, 0.260),
                     }
                 )
             )
 
+        # test_eight:  1.5s total / 6 tests   = 0.250s avg
+        # test_nine:  33.0s total / 3 tests   = 11.000s avg  (> 10s threshold)
+        # test_ten:    1.4s total / 7 tests   = 0.200s avg
+        # test_eleven: 164.4s total / 12 tests = 13.700s avg (> 10s threshold, > 150s total)
         with open(backend_test_time_report_three, 'w', encoding='utf-8') as f:
             f.write(
                 json.dumps(
                     {
-                        'test_eight': (1.5, 6.0),
-                        'test_nine': (1.6, 170.0),
-                        'test_ten': (1.4, 6.0),
-                        'test_eleven': (164.4, 200.0),
+                        'test_eight': (1.5, 0.250),
+                        'test_nine': (33.0, 11.000),
+                        'test_ten': (1.4, 0.200),
+                        'test_eleven': (164.4, 13.700),
                     }
                 )
             )
@@ -92,114 +105,114 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
             {
                 'test_name': 'test_six',
                 'test_time': 1.1,
-                'test_time_by_average_test_case': 5.0,
+                'test_time_by_average_test_case': 0.220,
             },
             {
                 'test_name': 'test_five',
                 'test_time': 1.2,
-                'test_time_by_average_test_case': 5.0,
+                'test_time_by_average_test_case': 0.200,
             },
             {
                 'test_name': 'test_seven',
                 'test_time': 1.3,
-                'test_time_by_average_test_case': 5.0,
+                'test_time_by_average_test_case': 0.260,
             },
             {
                 'test_name': 'test_ten',
                 'test_time': 1.4,
-                'test_time_by_average_test_case': 6.0,
+                'test_time_by_average_test_case': 0.200,
             },
             {
                 'test_name': 'test_two',
                 'test_time': 1.4,
-                'test_time_by_average_test_case': 4.0,
+                'test_time_by_average_test_case': 0.200,
             },
             {
                 'test_name': 'test_eight',
                 'test_time': 1.5,
-                'test_time_by_average_test_case': 6.0,
-            },
-            {
-                'test_name': 'test_nine',
-                'test_time': 1.6,
-                'test_time_by_average_test_case': 170.0,
+                'test_time_by_average_test_case': 0.250,
             },
             {
                 'test_name': 'test_three',
                 'test_time': 1.7,
-                'test_time_by_average_test_case': 160.0,
+                'test_time_by_average_test_case': 1.700,
             },
             {
                 'test_name': 'test_one',
                 'test_time': 1.8,
-                'test_time_by_average_test_case': 4.0,
+                'test_time_by_average_test_case': 0.200,
             },
             {
                 'test_name': 'test_four',
                 'test_time': 2.3,
-                'test_time_by_average_test_case': 4.0,
+                'test_time_by_average_test_case': 2.300,
+            },
+            {
+                'test_name': 'test_nine',
+                'test_time': 33.0,
+                'test_time_by_average_test_case': 11.000,
             },
             {
                 'test_name': 'test_eleven',
                 'test_time': 164.4,
-                'test_time_by_average_test_case': 200.0,
+                'test_time_by_average_test_case': 13.700,
             },
         ]
         self.sorted_backend_test_times_by_avg_test_case = [
             {
-                'test_name': 'test_four',
-                'test_time': 2.3,
-                'test_time_by_average_test_case': 4.0,
-            },
-            {
-                'test_name': 'test_one',
-                'test_time': 1.8,
-                'test_time_by_average_test_case': 4.0,
-            },
-            {
-                'test_name': 'test_two',
-                'test_time': 1.4,
-                'test_time_by_average_test_case': 4.0,
-            },
-            {
                 'test_name': 'test_five',
                 'test_time': 1.2,
-                'test_time_by_average_test_case': 5.0,
-            },
-            {
-                'test_name': 'test_seven',
-                'test_time': 1.3,
-                'test_time_by_average_test_case': 5.0,
-            },
-            {
-                'test_name': 'test_six',
-                'test_time': 1.1,
-                'test_time_by_average_test_case': 5.0,
-            },
-            {
-                'test_name': 'test_eight',
-                'test_time': 1.5,
-                'test_time_by_average_test_case': 6.0,
+                'test_time_by_average_test_case': 0.200,
             },
             {
                 'test_name': 'test_ten',
                 'test_time': 1.4,
-                'test_time_by_average_test_case': 6.0,
+                'test_time_by_average_test_case': 0.200,
+            },
+            {
+                'test_name': 'test_two',
+                'test_time': 1.4,
+                'test_time_by_average_test_case': 0.200,
+            },
+            {
+                'test_name': 'test_one',
+                'test_time': 1.8,
+                'test_time_by_average_test_case': 0.200,
+            },
+            {
+                'test_name': 'test_six',
+                'test_time': 1.1,
+                'test_time_by_average_test_case': 0.220,
+            },
+            {
+                'test_name': 'test_eight',
+                'test_time': 1.5,
+                'test_time_by_average_test_case': 0.250,
+            },
+            {
+                'test_name': 'test_seven',
+                'test_time': 1.3,
+                'test_time_by_average_test_case': 0.260,
             },
             {
                 'test_name': 'test_three',
                 'test_time': 1.7,
-                'test_time_by_average_test_case': 160.0,
+                'test_time_by_average_test_case': 1.700,
+            },
+            {
+                'test_name': 'test_four',
+                'test_time': 2.3,
+                'test_time_by_average_test_case': 2.300,
             },
             {
                 'test_name': 'test_nine',
-                'test_time': 1.6,
-                'test_time_by_average_test_case': 170.0,
+                'test_time': 33.0,
+                'test_time_by_average_test_case': 11.000,
             },
             {
                 'test_name': 'test_eleven',
                 'test_time': 164.4,
-                'test_time_by_average_test_case': 200.0,
+                'test_time_by_average_test_case': 13.700,
             },
         ]
 
@@ -277,18 +290,17 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
             'test_ten: 1.4 SECONDS.',
             'test_two: 1.4 SECONDS.',
             'test_eight: 1.5 SECONDS.',
-            'test_nine: 1.6 SECONDS.',
             'test_three: 1.7 SECONDS.',
             'test_one: 1.8 SECONDS.',
             'test_four: 2.3 SECONDS.',
+            'test_nine: 33.0 SECONDS.',
             'test_eleven: 164.4 SECONDS.',
             '\033[1mBACKEND TEST TIMES OVER 150.0 SECONDS:\033[0m',
             'test_eleven: 164.4 SECONDS.',
-            '\033[1mBACKEND TEST TIMES WITH AVERAGE TEST CASE TIME '
-            'OVER 150.0 SECONDS:\033[0m',
-            'test_three: 160.0 SECONDS BY AVERAGE TEST CASE TIME.',
-            'test_nine: 170.0 SECONDS BY AVERAGE TEST CASE TIME.',
-            'test_eleven: 200.0 SECONDS BY AVERAGE TEST CASE TIME.',
+            '\033[1mBACKEND TEST TIMES WITH AVERAGE TIME PER TEST CASE '
+            'OVER 10.0 SECONDS:\033[0m',
+            'test_nine: 11.000 SECONDS AVERAGE TIME PER TEST CASE.',
+            'test_eleven: 13.700 SECONDS AVERAGE TIME PER TEST CASE.',
         ]
         self.assertEqual(sorted_backend_test_times_message, self.print_arr)
         backend_test_times_temp_file.close()

--- a/scripts/check_backend_test_times_test.py
+++ b/scripts/check_backend_test_times_test.py
@@ -48,12 +48,6 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
 
         self.print_swap = self.swap(builtins, 'print', mock_print)
 
-        # Second value in each tuple is the average time per test case,
-        # i.e. test_time / test_count. Examples:
-        #   test_one:   1.8s total / 9 tests  = 0.200s avg
-        #   test_two:   1.4s total / 7 tests  = 0.200s avg
-        #   test_three: 1.7s total / 1 test   = 1.700s avg
-        #   test_four:  2.3s total / 1 test   = 2.300s avg
         with open(backend_test_time_report_one, 'w', encoding='utf-8') as f:
             f.write(
                 json.dumps(
@@ -66,9 +60,6 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
                 )
             )
 
-        # test_five:  1.2s total / 6 tests  = 0.200s avg
-        # test_six:   1.1s total / 5 tests  = 0.220s avg
-        # test_seven: 1.3s total / 5 tests  = 0.260s avg
         with open(backend_test_time_report_two, 'w', encoding='utf-8') as f:
             f.write(
                 json.dumps(
@@ -80,10 +71,6 @@ class CheckBackendTestTimesTests(test_utils.GenericTestBase):
                 )
             )
 
-        # test_eight:  1.5s total / 6 tests   = 0.250s avg
-        # test_nine:  33.0s total / 3 tests   = 11.000s avg  (> 10s threshold)
-        # test_ten:    1.4s total / 7 tests   = 0.200s avg
-        # test_eleven: 164.4s total / 12 tests = 13.700s avg (> 10s threshold, > 150s total)
         with open(backend_test_time_report_three, 'w', encoding='utf-8') as f:
             f.write(
                 json.dumps(

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -89,7 +89,6 @@ _LOAD_TESTS_DIR: Final = os.path.join(
 TIME_REPORT_PATH: Final = os.path.join(
     os.getcwd(), 'backend_test_time_report.json'
 )
-AVERAGE_TEST_CASE_TIME: Final = 2
 
 # Error code indicating a segmentation fault, which can occur transiently due to
 # instability in gRPC (a dependency of apache-beam[gcp]). This error was first
@@ -427,9 +426,7 @@ def check_test_results(
                     )
                 test_count = int(tests_run_regex_match.group(1))
                 test_time = float(tests_run_regex_match.group(2))
-                test_time_by_average_test_case = (
-                    test_count * AVERAGE_TEST_CASE_TIME
-                )
+                test_time_by_average_test_case = test_time / test_count
                 time_report[spec.test_target] = (
                     test_time,
                     test_time_by_average_test_case,

--- a/scripts/run_backend_tests_test.py
+++ b/scripts/run_backend_tests_test.py
@@ -467,7 +467,7 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
                 tasks, task_to_taskspec
             )
 
-        # Check first values match exactly
+        # Check first values match exactly.
         self.assertEqual(
             time_report['scripts.new_script_one_test.py'][0], 1.234
         )
@@ -475,7 +475,7 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
             time_report['scripts.new_script_two_test.py'][0], 2.542
         )
 
-        # Check second values (averages) match with tolerance
+        # Check second values (averages) match with tolerance.
         self.assertAlmostEqual(
             time_report['scripts.new_script_one_test.py'][1],
             1.234 / 9,

--- a/scripts/run_backend_tests_test.py
+++ b/scripts/run_backend_tests_test.py
@@ -467,13 +467,26 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
                 tasks, task_to_taskspec
             )
 
+        # Check first values match exactly
         self.assertEqual(
-            time_report,
-            {
-                'scripts.new_script_one_test.py': (1.234, 0.137),
-                'scripts.new_script_two_test.py': (2.542, 0.282),
-            },
+            time_report['scripts.new_script_one_test.py'][0], 1.234
         )
+        self.assertEqual(
+            time_report['scripts.new_script_two_test.py'][0], 2.542
+        )
+
+        # Check second values (averages) match with tolerance
+        self.assertAlmostEqual(
+            time_report['scripts.new_script_one_test.py'][1],
+            1.234 / 9,
+            places=5,
+        )
+        self.assertAlmostEqual(
+            time_report['scripts.new_script_two_test.py'][1],
+            2.542 / 9,
+            places=5,
+        )
+
         self.assertIn(
             'SUCCESS   %s: 9 tests (1.2 secs)' % test1_target, self.print_arr
         )
@@ -483,8 +496,8 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
 
     def test_successful_test_run_with_generate_time_report_flag(self) -> None:
         expected_time_report = {
-            'scripts.new_script_one_test.py': [1.234, 0.137],
-            'scripts.new_script_two_test.py': [2.542, 0.282],
+            'scripts.new_script_one_test.py': [1.234, 1.234 / 9],
+            'scripts.new_script_two_test.py': [2.542, 2.542 / 9],
         }
         swap_check_results = self.swap(
             run_backend_tests,

--- a/scripts/run_backend_tests_test.py
+++ b/scripts/run_backend_tests_test.py
@@ -462,9 +462,7 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
             task2_target, True
         )
 
-        with self.print_swap, self.swap(
-            run_backend_tests, 'AVERAGE_TEST_CASE_TIME', 1
-        ):
+        with self.print_swap:
             _, _, _, time_report = run_backend_tests.check_test_results(
                 tasks, task_to_taskspec
             )
@@ -472,8 +470,8 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
         self.assertEqual(
             time_report,
             {
-                'scripts.new_script_one_test.py': (1.234, 9),
-                'scripts.new_script_two_test.py': (2.542, 9),
+                'scripts.new_script_one_test.py': (1.234, 0.137),
+                'scripts.new_script_two_test.py': (2.542, 0.282),
             },
         )
         self.assertIn(
@@ -485,8 +483,8 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
 
     def test_successful_test_run_with_generate_time_report_flag(self) -> None:
         expected_time_report = {
-            'scripts.new_script_one_test.py': [1.234, 9],
-            'scripts.new_script_two_test.py': [2.542, 9],
+            'scripts.new_script_one_test.py': [1.234, 0.137],
+            'scripts.new_script_two_test.py': [2.542, 0.282],
         }
         swap_check_results = self.swap(
             run_backend_tests,
@@ -512,9 +510,7 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
         with self.swap_execute_task, swap_check_coverage:
             with self.swap_cloud_datastore_emulator, swap_check_results:
                 with swap_time_report_path, self.swap_redis_server:
-                    with self.swap(
-                        run_backend_tests, 'AVERAGE_TEST_CASE_TIME', 1
-                    ), self.print_swap:
+                    with self.print_swap:
                         run_backend_tests.main(args=['--generate_time_report'])
         loaded_time_report = json.loads(time_report_temp_file.read())
         self.assertEqual(loaded_time_report, expected_time_report)


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #24136 .
2. This PR does the following:  The third section of the backend test times report was displaying incorrect "average test case time" values because it was computing test_count * 2 instead of total_time / test_count. This fix corrects the calculation to show actual average time per test case and updates the threshold from 150 seconds to 10 seconds as specified in the issue.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

### Before:
Ran a test file with time reporting:
```
> python -m scripts.run_backend_tests --test_targets=scripts.scripts_test_utils_test --generate_time_report

+------------------+
| SUMMARY OF TESTS |
+------------------+

SUCCESS   scripts.scripts_test_utils_test: 21 tests (0.0 secs)

Ran 21 tests in 1 test class.
All tests passed.


Done!

> cat backend_test_time_report.json
{
    "scripts.scripts_test_utils_test": [
        0.002,
        42
    ]
```
The old broken code is showing 42.0 as the second value (21 × 2).
### After:

``` 
> python -m scripts.run_backend_tests --test_targets=scripts.scripts_test_utils_test --generate_time_report

+------------------+
| SUMMARY OF TESTS |
+------------------+

SUCCESS   scripts.scripts_test_utils_test: 21 tests (0.0 secs)

Ran 21 tests in 1 test class.
All tests passed.


Done!

> cat backend_test_time_report.json
{
    "scripts.scripts_test_utils_test": [
        0.002,
        9.523809523809524e-05
    ]
}
```
This correctly shows:

Total time: 0.002 seconds
Average per test: 0.000095 seconds (for 21 tests: 0.002 / 21 ≈ 9.523809523809524e-05) 
<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
