### PR TITLE
Fix #23472 Skill preview search to update results while typing

### DIFF
--- a/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.html
+++ b/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.html
@@ -8,9 +8,9 @@
           <div *ngIf="questionsFetched">
             <div class="question-filters">
               <input type="text"
-                    class="e2e-test-question-text-input"
-                    [(ngModel)]="questionTextFilter"
-                    (input)="applyFilters()">
+                     class="e2e-test-question-text-input"
+                     [(ngModel)]="questionTextFilter"
+                     (ngModelChange)="applyFilters()">
               <select [(ngModel)]="interactionFilter"
                       class="form-select"
                       (change)="applyFilters()">

--- a/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.html
+++ b/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.html
@@ -8,9 +8,9 @@
           <div *ngIf="questionsFetched">
             <div class="question-filters">
               <input type="text"
-                     class="e2e-test-question-text-input"
-                     [(ngModel)]="questionTextFilter"
-                     (change)="applyFilters()">
+                    class="e2e-test-question-text-input"
+                    [(ngModel)]="questionTextFilter"
+                    (input)="applyFilters()">
               <select [(ngModel)]="interactionFilter"
                       class="form-select"
                       (change)="applyFilters()">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #23472 
2. This PR does the following: This PR updates the Skill Preview tab search to filter questions in real time as the user types. Previously, users had to click outside the input field to trigger the search results, which was unintuitive. The change binds the search field to the input event so filtering happens automatically on each keystroke, improving UX while keeping the implementation minimal.
3. (For bug-fixing PRs only) The original bug occurred because: The search field was using the (change) event, which only fires when the input loses focus. As a result, Angular did not run the filtering logic during typing, and results appeared only after an additional click triggered change detection.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before

- Typing in the search box did not update results immediately.

- Results only appeared after clicking elsewhere on the screen (blur event).


https://github.com/user-attachments/assets/b39eca06-d41a-4d5a-94fa-4246921b2c42


After

- Results update instantly while typing in the search field.

- No extra click is required; filtering now behaves like a standard live search.

https://github.com/user-attachments/assets/8a52f9c2-a30b-4219-8c5a-a98a9c0f068e

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

@mon4our  PTAL