### PR TITLE
Fix 25015 : Added link to direct the user to the active "Developing Secure Softwa…

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -126,4 +126,4 @@ If you wish to add more context or information, we recommend adding it after the
 
 ## References
 
-This document was developed with the help of the [OSS Vulnerability Guide](https://github.com/ossf/oss-vulnerability-guide) and the [Secure Software Development Fundamentals course](https://github.com/ossf/secure-sw-dev-fundamentals/blob/main/secure_software_development_fundamentals.md) by the [Open Source Security Foundation](https://openssf.org/).
+This document was developed with the help of the [OSS Vulnerability Guide](https://github.com/ossf/oss-vulnerability-guide) and the [Secure Software Development Fundamentals course](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/?utm_source=chatgpt.com) by the [Open Source Security Foundation](https://openssf.org/).


### PR DESCRIPTION
Fixes #25015 

## Overview

The link should direct the user to the active "Developing Secure Software" training content provided by OpenSSF. This allows contributors to learn the necessary security protocols for working on the Oppia codebase.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [✔️ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [✔️ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ❌] I have written tests for my code.
- [✔️ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ✔️] I have assigned the correct reviewers to this PR 


Before: 
![Image 26-02-26 at 15 09](https://github.com/user-attachments/assets/fb0fb3f9-58eb-4c16-871b-20df047095f9)


After:

![Image 26-02-26 at 15 10](https://github.com/user-attachments/assets/c550251f-8bfc-455c-8844-c345019b4c7e)


@prathx-365 PTAL