### PR TITLE
Fix #22289: Ignore quoted PTAL comments and prevent self-assignment in workflow

### DIFF
--- a/.github/workflows/assign_reviewer_on_ptal.yml
+++ b/.github/workflows/assign_reviewer_on_ptal.yml
@@ -47,6 +47,12 @@ jobs:
               core.setFailed(`Invalid repo (${repo}) or owner (${owner})`);
               return;
             }
+            const rawComment = (context.payload.comment?.body || '');
+            const comment = rawComment
+                       .split('\n')
+                       .filter(line => !line.trim().startsWith('>'))
+                       .join('\n')
+                       .trim();
             const comment = (context.payload.comment?.body || '').trim();
             const reviewerPattern = /((?:@[\w-]+[\s,]*)+)\s+(ptal|take\s+a\s+pass|please\s+review)\b/i;
             const match = comment.match(reviewerPattern);
@@ -73,6 +79,9 @@ jobs:
               core.setFailed('Issue is not a PR');
               return;
             }
+            reviewers = reviewers.filter(
+                r => r !== context.payload.comment.user.login
+            );
             await github.rest.issues.addAssignees({
               owner,
               repo,
@@ -108,3 +117,4 @@ jobs:
         with:
           message: "Failed to assign reviewers in PR workflow"
           webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}
+

--- a/.github/workflows/assign_reviewer_on_ptal.yml
+++ b/.github/workflows/assign_reviewer_on_ptal.yml
@@ -117,4 +117,3 @@ jobs:
         with:
           message: "Failed to assign reviewers in PR workflow"
           webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}
-


### PR DESCRIPTION
## Overview

1. This PR fixes #22289.
2. This PR updates the PTAL workflow to:

   * Ignore quoted lines (lines starting with '>') before matching PTAL patterns.
   * Prevent self-assignment by filtering out the commenter from the extracted reviewer list.
3. The original bug occurred because the workflow applied the PTAL regex to the entire comment body without filtering quoted lines, and it did not remove the commenter from the extracted reviewer list before attempting assignment.


## Essential Checklist

* [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [ ] I have written tests for my code.
* [x] The PR title starts with "Fix #22289: ".
* [x] I will assign the correct reviewers to this PR.


## Proof that changes are correct

This workflow was tested in a forked repository using a dummy PR.

### Case 1: Quoted PTAL

* Comment: `> PTAL @SIRILEKKALA`
* Expected behavior: Quoted lines should be ignored.
* Result: Workflow ran successfully, and no reviewer or assignee was added.
<img width="1494" height="600" alt="image" src="https://github.com/user-attachments/assets/5cb6295c-9dd0-4289-93a1-a27246757814" />
=> with > PTAL @SIRILEKKALA 
<img width="1830" height="723" alt="image" src="https://github.com/user-attachments/assets/a962dcb7-31cb-47f0-a556-d37c0d6e8e71" />
=> Workflow ran successfully and no reviewer was assigned.
<img width="1835" height="669" alt="image" src="https://github.com/user-attachments/assets/8843e4d0-6521-4c6f-a659-238858d34bc7" />


### Case 2: Normal PTAL with Self Mention

* Comment: `PTAL @SIRILEKKALA`
* Expected behavior: PTAL pattern should be detected, but self-assignment should be prevented.
* Result: Workflow ran successfully, and no reviewer was assigned (commenter was filtered out).
<img width="1410" height="307" alt="image" src="https://github.com/user-attachments/assets/8c878d1d-7857-457c-9331-df7d944b33c1" />
=> with PTAL @SIRILEKKALA 
<img width="1811" height="718" alt="image" src="https://github.com/user-attachments/assets/773bb15d-2b1e-4928-a96d-48c4532ee12c" />
=>Workflow ran successfully and no reviewer was assigned (commenter was filtered out).
<img width="1839" height="793" alt="image" src="https://github.com/user-attachments/assets/20f92716-c6da-4a5d-b43a-1e04437136fc" />

### Case 3: Valid PTAL Pattern Handling

* The workflow continues to detect valid PTAL patterns correctly.
* Reviewer extraction logic remains intact after filtering quoted lines and removing the commenter.

Screenshots demonstrating these cases (workflow runs and assignment results) are attached.


## PR Pointers

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: [https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve](https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve)
* Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the [["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR)](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
* See the [[Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers)](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.



