### PR TITLE
Fail fast in merge queue and set max parallelization

### DIFF
--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     strategy:
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         shard: [1, 2, 3, 4, 5]
     steps:

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -46,7 +46,7 @@ jobs:
     needs: generate-job-strategy-matrix
     runs-on: ubuntu-22.04
     strategy:
-      max-parallel: 15
+      max-parallel: 25
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         num_runs: ${{ fromJson(needs.generate-job-strategy-matrix.outputs.job-strategy-matrix) }}

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -46,10 +46,10 @@ jobs:
     needs: generate-job-strategy-matrix
     runs-on: ubuntu-22.04
     strategy:
-      max-parallel: 25
+      max-parallel: 15
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         num_runs: ${{ fromJson(needs.generate-job-strategy-matrix.outputs.job-strategy-matrix) }}
-      fail-fast: false
     steps:
       - name: Checkout repository so that local actions can be used
         uses: actions/checkout@v4

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -84,7 +84,6 @@ jobs:
     if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).e2e.count > 0 }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).e2e.suites }}
     name: E2E (${{ matrix.suite.name }})
@@ -181,7 +180,6 @@ jobs:
     strategy:
       # Fast fail only if it's a merge queue.
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.suites }}
     name: Acceptance (${{ matrix.suite.name }})
@@ -305,7 +303,6 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_accessibility.suites }}
     name: Lighthouse a11y (shard ${{ matrix.suite.name }})
@@ -335,7 +332,6 @@ jobs:
     if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_performance.count > 0 }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_performance.suites }}
     name: Lighthouse perf (shard ${{ matrix.suite.name }})

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -83,7 +83,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).e2e.count > 0 }}
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
+      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).e2e.suites }}
     name: E2E (${{ matrix.suite.name }})
@@ -180,6 +181,7 @@ jobs:
     strategy:
       # Fast fail only if it's a merge queue.
       fail-fast: ${{ github.event_name == 'merge_group' }}
+      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.suites }}
     name: Acceptance (${{ matrix.suite.name }})
@@ -302,6 +304,8 @@ jobs:
     if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_accessibility.count > 0 }}
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: ${{ github.event_name == 'merge_group' }}
+      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_accessibility.suites }}
     name: Lighthouse a11y (shard ${{ matrix.suite.name }})
@@ -330,6 +334,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_performance.count > 0 }}
     strategy:
+      fail-fast: ${{ github.event_name == 'merge_group' }}
+      max-parallel: 15
       matrix:
         suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_performance.suites }}
     name: Lighthouse perf (shard ${{ matrix.suite.name }})


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: Enables fast-failing in the merge queue for all CI workflows that use a matrix strategy to spawn jobs. This should reduce CI runner usage.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

The changes made here are already in use in some of our workflows. This fix is urgently needed to speed up CI checks so that PRs don't time out in the merge queue, so we're skipping full testing.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
