### PR TITLE
Add regression test: unpublish removes exploration from summaries endpoint

### DIFF
--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -900,6 +900,64 @@ class ExplorationSummariesHandlerTests(test_utils.GenericTestBase):
         self.assertEqual(summaries[0]['status'], 'public')
 
         self.logout()
+        
+    def test_unpublish_removes_exploration_from_summaries(self) -> None:
+        """Regression test: unpublishing an exploration must remove it
+        from the summaries endpoint so it is no longer visible to learners.
+        """
+        # Sign up a moderator who has unpublish permission.
+        self.signup(self.MODERATOR_EMAIL, self.MODERATOR_USERNAME)
+        self.set_moderators([self.MODERATOR_USERNAME])
+        moderator_id = self.get_user_id_from_email(self.MODERATOR_EMAIL)
+        moderator = user_services.get_user_actions_info(moderator_id)
+
+        # Before unpublish: PUBLIC_EXP_ID_EDITOR should appear in summaries.
+        self.login(self.VIEWER_EMAIL)
+
+        response_dict = self.get_json(
+            feconf.EXPLORATION_SUMMARIES_DATA_URL,
+            params={
+                'stringified_exp_ids': json.dumps(
+                    [self.PUBLIC_EXP_ID_EDITOR]
+                )
+            },
+        )
+        summaries = response_dict['summaries']
+        summary_ids = [s['id'] for s in summaries]
+        self.assertIn(self.PUBLIC_EXP_ID_EDITOR, summary_ids)
+
+        self.logout()
+
+        # Unpublish the exploration as moderator.
+        rights_manager.unpublish_exploration(
+            moderator, self.PUBLIC_EXP_ID_EDITOR
+        )
+
+        # After unpublish: exploration should NOT appear in summaries.
+        self.login(self.VIEWER_EMAIL)
+
+        response_dict = self.get_json(
+            feconf.EXPLORATION_SUMMARIES_DATA_URL,
+            params={
+                'stringified_exp_ids': json.dumps(
+                    [self.PUBLIC_EXP_ID_EDITOR]
+                )
+            },
+        )
+        summaries_after = response_dict['summaries']
+        summary_ids_after = [s['id'] for s in summaries_after]
+        self.assertNotIn(
+            self.PUBLIC_EXP_ID_EDITOR,
+            summary_ids_after,
+            msg=(
+                'Unpublished exploration %s should not appear in '
+                'public summaries.' % self.PUBLIC_EXP_ID_EDITOR
+            )
+        )
+
+        self.logout()
+
+  
 
     def test_can_get_editable_private_exploration_summaries(self) -> None:
         self.login(self.VIEWER_EMAIL)

--- a/docs/reviews/PR-1-self-review.md
+++ b/docs/reviews/PR-1-self-review.md
@@ -1,0 +1,30 @@
+# Self-Review: PR-1 — Unpublish removes exploration from summaries endpoint
+
+## What changed and why?
+Added `test_unpublish_removes_exploration_from_summaries` to
+`ExplorationSummariesHandlerTests` in `core/controllers/library_test.py`.
+
+The test publishes an exploration (done in setUp), confirms it appears in
+`EXPLORATION_SUMMARIES_DATA_URL`, calls `rights_manager.unpublish_exploration`
+as a moderator, then asserts the exploration is gone from the same endpoint.
+This closes the regression gap in Issue #1 — previously there was zero test
+coverage for the unpublish path in the library controller.
+
+## Why is this the right test layer?
+Integration — the test exercises the real `rights_manager.unpublish_exploration`
+domain call, the real datastore emulator, and the real library HTTP handler
+end-to-end. No mocks are needed. A unit test would not catch a bug where the
+summary index fails to update after a rights change, which is exactly the
+regression risk this test protects against.
+
+## What could still break / what's not covered?
+- Only checks the public summaries endpoint (include_private_explorations=False)
+- Does not test re-publishing after unpublishing (round-trip)
+- Does not test the case where a moderator unpublishes someone else's exploration
+  vs. the owner unpublishing their own
+
+## What risks or follow-ups remain?
+- The Error -11 datastore emulator crash on first attempt is a known Mac/Java
+  infrastructure issue unrelated to the test logic. The test passes on retry.
+- Follow-up: add a test verifying re-publishing after unpublish restores the
+  exploration to summaries.


### PR DESCRIPTION
## Overview

## Summary
Adds test_unpublish_removes_exploration_from_summaries to
ExplorationSummariesHandlerTests in core/controllers/library_test.py.

## What changed
- One new test method in ExplorationSummariesHandlerTests
- Self-review doc at docs/reviews/PR-1-self-review.md

## How to run
python -m scripts.run_backend_tests --test_targets=core.controllers.library_test.ExplorationSummariesHandlerTests.test_unpublish_removes_exploration_from_summaries

## What behavior is now protected
Without this test, a refactor to rights_manager.unpublish_exploration,
the summary update logic, or the library handler query could silently
leave unpublished explorations visible to learners with no automated signal.

## Evidence of gap (before this PR)
grep -n "unpublish" core/controllers/library_test.py
(no results before this change)




<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
