### PR TITLE
Fix #23694: Fix account deletion crash caused by invalid parsing of MailChimpError

### DIFF
--- a/core/platform/bulk_email/mailchimp_bulk_email_services.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-
 import hashlib
 import logging
 

--- a/core/platform/bulk_email/mailchimp_bulk_email_services.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-import ast
+
 import hashlib
 import logging
 
@@ -130,7 +130,7 @@ def _create_user_in_mailchimp_db(
             mailchimp_audience_id, subscribed_mailchimp_data
         )
     except mailchimpclient.MailChimpError as error:
-        error_message = ast.literal_eval(str(error))
+        error_message = error.args[0]
         # This is the specific error message returned for the case where the
         # user was permanently deleted from the Mailchimp database earlier.
         # This was found by experimenting with the MailChimp API. Note that the
@@ -177,14 +177,7 @@ def permanently_delete_user_from_list(user_email: str) -> None:
             mailchimp_audience_id, subscriber_hash
         )
     except mailchimpclient.MailChimpError as error:
-        # This has to be done since the message can only be accessed from
-        # MailChimpError by error.message in Python2, but this is deprecated in
-        # Python3.
-        # In Python3, the message can be accessed directly by KeyError
-        # (https://github.com/VingtCinq/python-mailchimp/pull/65), so as a
-        # workaround for Python2, the 'message' attribute is obtained by
-        # str() and then it is converted to dict. This works in Python3 as well.
-        error_message = ast.literal_eval(str(error))
+        error_message = error.args[0]
         # Ignore if the error corresponds to "User does not exist".
         if error_message['status'] != 404:
             raise Exception(error_message['detail']) from error
@@ -316,14 +309,7 @@ def add_or_update_user_status(
                     unsubscribed_mailchimp_data,
                 )
         except mailchimpclient.MailChimpError as mailchimp_err:
-            # This has to be done since the message can only be accessed from
-            # MailChimpError by error.message in Python2, but this is deprecated
-            # in Python3.  In Python3, the message can be accessed directly by
-            # KeyError (https://github.com/VingtCinq/python-mailchimp/pull/65),
-            # so as a workaround for Python2, the 'message' attribute is
-            # obtained by str() and then it is converted to dict. This works in
-            # Python3 as well.
-            error_message = ast.literal_eval(str(mailchimp_err))
+            error_message = mailchimp_err.args[0]
             # Error 404 corresponds to 'User does not exist'.
             if error_message['status'] == 404:
                 if can_receive_email_updates:

--- a/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
+++ b/core/platform/bulk_email/mailchimp_bulk_email_services_test.py
@@ -23,6 +23,7 @@ from core.platform import models
 from core.platform.bulk_email import mailchimp_bulk_email_services
 from core.tests import test_utils
 
+import requests
 from mailchimp3 import mailchimpclient
 from typing import Dict, List
 
@@ -114,14 +115,24 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
                         dict. The updated status dict for users.
                     """
                     if not self.users_data:
+                        mock_response = requests.Response()
+                        mock_response.status_code = 401
                         raise mailchimpclient.MailChimpError(
-                            {'status': 401, 'detail': 'Server Error'}
+                            {
+                                'status': 401,
+                                'detail': 'Server Error',
+                                'response': mock_response,
+                            }
                         )
                     for user in self.users_data:
                         if user['email_hash'] == subscriber_hash:
                             return user
 
-                    raise mailchimpclient.MailChimpError({'status': 404})
+                    mock_response = requests.Response()
+                    mock_response.status_code = 404
+                    raise mailchimpclient.MailChimpError(
+                        {'status': 404, 'response': mock_response}
+                    )
 
                 def update(
                     self,
@@ -161,18 +172,24 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
                             }
                         )
                     elif data['email_address'] == 'test4@example.com':
+                        mock_response = requests.Response()
+                        mock_response.status_code = 400
                         raise mailchimpclient.MailChimpError(
                             {
                                 'status': 400,
                                 'title': 'Forgotten Email Not Subscribed',
+                                'response': mock_response,
                             }
                         )
                     else:
+                        mock_response = requests.Response()
+                        mock_response.status_code = 404
                         raise mailchimpclient.MailChimpError(
                             {
                                 'status': 404,
                                 'title': 'Invalid email',
                                 'detail': 'Server Issue',
+                                'response': mock_response,
                             }
                         )
 
@@ -389,12 +406,11 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
                 mailchimp_bulk_email_services.add_or_update_user_status(
                     self.user_email_1, {}, 'Web', can_receive_email_updates=True
                 )
-                self.assertItemsEqual(
-                    [
-                        'Mailchimp error prevented email signup: '
-                        '{\'status\': 401, \'detail\': \'Server Error\'}'
-                    ],
-                    logs,
+                self.assertEqual(len(logs), 1)
+                self.assertRegex(
+                    logs[0],
+                    r'Mailchimp error prevented email signup: '
+                    r'\{\'status\': 401, \'detail\': \'Server Error\', \'response\': <Response \[401\]>\}',
                 )
 
     @test_utils.set_platform_parameters(
@@ -470,9 +486,10 @@ class MailchimpServicesUnitTests(test_utils.GenericTestBase):
                     'Web',
                     can_receive_email_updates=True,
                 )
-                self.assertItemsEqual(
-                    ['Mailchimp error prevented email signup: Server Issue'],
-                    logs,
+                self.assertEqual(len(logs), 1)
+                self.assertRegex(
+                    logs[0],
+                    r'Mailchimp error prevented email signup: Server Issue',
                 )
 
     @test_utils.set_platform_parameters(


### PR DESCRIPTION
## Overview

1. This PR fixes #23694.
2. This PR does the following: 
   * Modifies `mailchimp_bulk_email_services.py` to replace all three occurrences of `ast.literal_eval(str(error))` with `error.args[0]`. This safely accesses the original error dictionary directly without going through string conversion.
   * Removes the unused `import ast`.
   * Updates `mailchimp_bulk_email_services_test.py` to include a `'response': 'mock_response'` key in the mocked `MailChimpError` dictionaries, ensuring the tests accurately mimic the real library's behavior and catch this scenario.
3. The original bug occurred because: The `python-mailchimp` library constructs its `MailChimpError` using a dictionary that contains a raw `requests.Response` object. When `str(error)` is called, it outputs something like `{'response': <Response [404]>, 'status': 404}`. The `<Response [404]>` part is not valid Python syntax, causing `ast.literal_eval()` to crash with a `SyntaxError`. This resulted in a 500 Internal Server Error, halting the account deletion process on the test server when the Mailchimp API returned an error.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

*(As requested by @NITISH084 , @HardikGoyal2003 , a testing doc has been created to verify this fix on the backup/test servers since local dev uses emulator mode).*

- [x] A testing doc has been written: https://docs.google.com/document/d/1Q8p2gHERMnNCS4KTkbqAsPtxmp8-NkGJ3NSpbrn97oQ/edit?usp=sharing
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

**Local Reproduction & Verification Strategy:**
Because the local dev server uses `dev_mode_bulk_email_services.py`, the real Mailchimp errors don't trigger locally. To reproduce the 500 error and verify the fix, I temporarily modified the local dev file to throw the exact `MailChimpError` containing the raw `<Response [404]>` object. 

Here are the temporary changes made to `dev_mode_bulk_email_services.py` strictly to record the "Before" and "After" videos below:

```python
import ast
import requests
from mailchimp3 import mailchimpclient

def permanently_delete_user_from_list(user_email: str) -> None:
    
    # We use a real Response object to mimic the production Mailchimp API return
    mock_response = requests.Response()
    mock_response.status_code = 404
    
    mock_error_data = {
        'status': 404,
        'detail': 'User does not exist',
        'instance': mock_response  # <--- Causes ast.literal_eval to crash
    }
    try:
        raise mailchimpclient.MailChimpError(mock_error_data)
    except mailchimpclient.MailChimpError as error:
        # BEFORE (Crashes with 500 SyntaxError due to unquoted <Response [404]>):
        # error_message = ast.literal_eval(str(error)) 
        
        # AFTER (Completes successfully by grabbing the dict directly):
        error_message = error.args[0]
        
        if error_message['status'] != 404:
            raise Exception(error_message['detail']) from error
```
**Before Fix :**
(The 500 Internal Server Error triggered by ast.literal_eval)


https://github.com/user-attachments/assets/6a231b84-0137-4632-b7ad-a9d01c807b83





**After Fix :**
(The deletion completes successfully using error.args[0])


https://github.com/user-attachments/assets/d5462fa1-e47a-45f9-9273-376ada16ea8c





#### Proof of changes on desktop with slow/throttled network

Not Applicable - Purely a backend server error fix.

#### Proof of changes on mobile phone

Not Applicable - Purely a backend server error fix.

#### Proof of changes in Arabic language

Not Applicable - Purely a backend server error fix.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
