### PR TITLE
Fix: Prevent username overlapping in profile dropdown (#22725)

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -536,6 +536,14 @@
   border: 2px solid transparent;
 }
 
+.oppia-top-navigation-bar .e2e-test-profile-link {
+  display: block;
+  max-width: 200px; /* Constrains the width so it forces the ellipsis */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media screen and (max-width : 1212px) {
 
   .oppia-top-navigation-bar .learn-dropdown-menu .nav-item-left {


### PR DESCRIPTION
## Overview

1. This PR fixes #22725.
2. This PR does the following: It prevents long, continuous usernames from overflowing or stretching the profile dropdown menu in the top navigation bar. I applied standard CSS text truncation (`white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis`) and a `max-width` constraint (`200px`) to the `.e2e-test-profile-link` class within `top-navigation-bar.component.css`. This ensures the text gracefully truncates with an ellipsis (...) while maintaining the dropdown's intended structural layout.
3. The original bug occurred because: The `<strong>` and `<a>` tags wrapping the username inside the dropdown lacked explicit width constraints or overflow handling. Since continuous strings (without spaces) do not naturally wrap to a new line, excessively long usernames forced the parent container to stretch beyond its designed bounds, causing UI overlap.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code. *(Note: Pure CSS change, visually tested)*
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network
![WhatsApp Image 2026-02-28 at 10 08 36](https://github.com/user-attachments/assets/4ac4177b-f7c5-470a-9ec6-79285a164f45)



#### Proof of changes on mobile phone
![WhatsApp Image 2026-02-28 at 10 08 35](https://github.com/user-attachments/assets/53a72fa3-0f5c-420c-9c21-28d5bbafce0a)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.