### PR TITLE
Add input validation in feedback section of creator dashboard

### DIFF
--- a/core/templates/pages/exploration-editor-page/feedback-tab/templates/create-feedback-thread-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/feedback-tab/templates/create-feedback-thread-modal.component.html
@@ -18,10 +18,10 @@
 
     <!-- Error Messages -->
     <span class="text-danger" *ngIf="subjectInput.invalid && subjectInput.touched">
-      <span *ngIf="subjectInput.errors?.['required']">
+      <span *ngIf="subjectInput.errors?.required">
         Subject is required.
       </span>
-      <span *ngIf="subjectInput.errors?.['minlength']">
+      <span *ngIf="subjectInput.errors?.minlength">
         Subject must be at least 5 characters long.
       </span>
     </span>
@@ -43,10 +43,10 @@
 
     <!-- Error Messages -->
     <span class="text-danger" *ngIf="messageInput.invalid && messageInput.touched">
-      <span *ngIf="messageInput.errors?.['required']">
+      <span *ngIf="messageInput.errors?.required">
         Message cannot be empty.
       </span>
-      <span *ngIf="messageInput.errors?.['minlength']">
+      <span *ngIf="messageInput.errors?.minlength">
         Message must be at least 10 characters long.
       </span>
     </span>

--- a/core/templates/pages/exploration-editor-page/feedback-tab/templates/create-feedback-thread-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/feedback-tab/templates/create-feedback-thread-modal.component.html
@@ -3,21 +3,87 @@
 </div>
 
 <div class="modal-body">
-  <p>Thread subject: <input aria-label="Thread subject" class="oppia-feedback-modal-input oppia-autofocus" type="text" [(ngModel)]="newThreadSubject"></p>
-  <p>Message text <textarea aria-label="Message text" class="oppia-feedback-modal-textarea" [(ngModel)]="newThreadText" rows="6"></textarea></p>
+
+  <!-- THREAD SUBJECT -->
+  <p>
+    Thread subject:
+    <input aria-label="Thread subject"
+           class="oppia-feedback-modal-input oppia-autofocus"
+           type="text"
+           name="threadSubject"
+           required minlength="5"
+           maxlength="200"
+           #subjectInput="ngModel"
+           [(ngModel)]="newThreadSubject">
+
+    <!-- Error Messages -->
+    <span class="text-danger" *ngIf="subjectInput.invalid && subjectInput.touched">
+      <span *ngIf="subjectInput.errors?.['required']">
+        Subject is required.
+      </span>
+      <span *ngIf="subjectInput.errors?.['minlength']">
+        Subject must be at least 5 characters long.
+      </span>
+    </span>
+  </p>
+
+  <!-- MESSAGE TEXT -->
+  <p>
+    Message text
+    <textarea aria-label="Message text"
+              class="oppia-feedback-modal-textarea"
+              name="threadMessage"
+              required
+              minlength="10"
+              maxlength="5000"
+              rows="6"
+              #messageInput="ngModel"
+              [(ngModel)]="newThreadText">
+    </textarea>
+
+    <!-- Error Messages -->
+    <span class="text-danger" *ngIf="messageInput.invalid && messageInput.touched">
+      <span *ngIf="messageInput.errors?.['required']">
+        Message cannot be empty.
+      </span>
+      <span *ngIf="messageInput.errors?.['minlength']">
+        Message must be at least 10 characters long.
+      </span>
+    </span>
+  </p>
+
 </div>
 
 <div class="modal-footer">
-  <button class="btn btn-secondary e2e-test-cancel-new-feedback-btn" (click)="cancel()">Cancel</button>
-  <button class="btn btn-success e2e-test-create-new-feedback-btn" (click)="create(newThreadSubject, newThreadText)" [disabled]="!newThreadSubject || !newThreadText">Create Thread</button>
+  <button class="btn btn-secondary e2e-test-cancel-new-feedback-btn" (click)="cancel()">
+    Cancel
+  </button>
+
+  <button class="btn btn-success e2e-test-create-new-feedback-btn"
+          (click)="create(newThreadSubject?.trim(), newThreadText?.trim())"
+          [disabled]="
+          subjectInput.invalid ||
+          messageInput.invalid ||
+          !newThreadSubject?.trim() ||
+          !newThreadText?.trim()
+  ">
+    Create Thread
+  </button>
 </div>
 
 <style>
   .oppia-feedback-modal-input {
     min-height: 35px;
   }
+
   .oppia-feedback-modal-textarea {
     margin-top: 5px;
     min-height: 175px;
+  }
+
+  .text-danger {
+    display: block;
+    font-size: 13px;
+    margin-top: 4px;
   }
 </style>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes  #25087.
2. This PR does the following: 
- This PR introduces validation of the input field in the feedback form in the creator dashboard.
3. (For bug-fixing PRs only) The original bug occurred because there was no input validation before.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

Before:-
[Screencast from 2026-02-28 18-43-05.webm](https://github.com/user-attachments/assets/e24b8616-e7c2-4b41-9966-525426b95a0f)


After:-
[Screencast from 2026-02-28 18-37-43.webm](https://github.com/user-attachments/assets/54e2dcf1-5ec6-446b-ba8f-debbbeb12645)



#### Proof of changes on desktop with slow/throttled network

[Screencast from 2026-02-28 20-09-58.webm](https://github.com/user-attachments/assets/c67d0840-b102-4fe9-ad0d-ed6c5882ac53)

#### Proof of changes on mobile phone
No changes

#### Proof of changes in Arabic language
No UI change.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
