### PR TITLE
docs: add clarification comment to exploration player root component

### DIFF
--- a/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-root.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-root.component.html
@@ -1,3 +1,9 @@
+<!--
+  Documentation improvement:
+  This root component renders the Exploration Player interface used in
+  learner mode. The structure below defines navbar, navigation options,
+  main lesson content, and footer sections.
+-->
 <oppia-angular-root>
   <oppia-base-content>
     <navbar-breadcrumb>


### PR DESCRIPTION
## Overview
Adds a documentation comment explaining the structure of the
Exploration Player root component to improve readability for
contributors working on the Lesson Player area.

## This PR does the following
- Adds a clarification comment to the exploration player root component.
- Improves contributor readability.
- Documentation-only change.

## Proof that changes are correct
This change only adds a documentation comment and does not modify
application logic or UI behavior.

## Essential Checklist
- [x] I have reviewed the files changed.
- [x] This is a documentation-only change.
- [x] The change does not affect functionality.