### PR TITLE
Add customization args validation for MusicNotesInput

### DIFF
--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
@@ -57,9 +57,19 @@ describe('MusicNotesInputValidationService', () => {
       missing_prerequisite_skill_id: null,
     });
     goodAnswerGroups = [AnswerGroup.createNew([], goodDefaultOutcome, [], '')];
+
+    // Initialize customizationArgs with valid values
+    customizationArgs = {
+      sequenceToGuess: {
+        value: [['C4', 'quarter']],
+      },
+      initialSequence: {
+        value: [['C4', 'quarter']],
+      },
+    };
   });
 
-  it('should be able to perform basic validation', () => {
+  it('should return critical warning when initialSequence is empty', () => {
     var warnings = validatorService.getAllWarnings(
       currentState,
       {
@@ -73,6 +83,30 @@ describe('MusicNotesInputValidationService', () => {
       goodAnswerGroups,
       goodDefaultOutcome
     );
+
+    expect(warnings).toEqual([
+      {
+        type: AppConstants.WARNING_TYPES.CRITICAL,
+        message: 'Initial sequence should not be empty.',
+      },
+    ]);
+  });
+
+  it('should return no warnings when initialSequence is not empty', () => {
+    var warnings = validatorService.getAllWarnings(
+      currentState,
+      {
+        sequenceToGuess: {
+          value: [['C4', 'quarter']],
+        },
+        initialSequence: {
+          value: [['C4', 'quarter']], // Non-empty array with a note
+        },
+      },
+      goodAnswerGroups,
+      goodDefaultOutcome
+    );
+
     expect(warnings).toEqual([]);
   });
 
@@ -100,7 +134,7 @@ describe('MusicNotesInputValidationService', () => {
 
     var warnings = validatorService.getAllWarnings(
       currentState,
-      customizationArgs,
+      customizationArgs, // Now this is properly initialized in beforeEach
       answerGroups,
       goodDefaultOutcome
     );

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
@@ -57,8 +57,7 @@ describe('MusicNotesInputValidationService', () => {
       missing_prerequisite_skill_id: null,
     });
     goodAnswerGroups = [AnswerGroup.createNew([], goodDefaultOutcome, [], '')];
-
-    // Initialize customizationArgs with valid values
+    // Initialize customizationArgs with valid values.
     customizationArgs = {
       sequenceToGuess: {
         value: [['C4', 'quarter']],
@@ -69,6 +68,7 @@ describe('MusicNotesInputValidationService', () => {
     };
   });
 
+  // Test for empty initialSequence.
   it('should return critical warning when initialSequence is empty', () => {
     var warnings = validatorService.getAllWarnings(
       currentState,
@@ -92,6 +92,7 @@ describe('MusicNotesInputValidationService', () => {
     ]);
   });
 
+  // Test for non-empty initialSequence.
   it('should return no warnings when initialSequence is not empty', () => {
     var warnings = validatorService.getAllWarnings(
       currentState,
@@ -100,7 +101,7 @@ describe('MusicNotesInputValidationService', () => {
           value: [['C4', 'quarter']],
         },
         initialSequence: {
-          value: [['C4', 'quarter']], // Non-empty array with a note
+          value: [['C4', 'quarter']], // Non-empty array with a note.
         },
       },
       goodAnswerGroups,
@@ -110,6 +111,7 @@ describe('MusicNotesInputValidationService', () => {
     expect(warnings).toEqual([]);
   });
 
+  // Test for invalid rule.
   it('should throw error when rule HasLengthInclusivelyBetween is invalid', () => {
     var answerGroup = AnswerGroup.createNew(
       [
@@ -134,7 +136,7 @@ describe('MusicNotesInputValidationService', () => {
 
     var warnings = validatorService.getAllWarnings(
       currentState,
-      customizationArgs, // Now this is properly initialized in beforeEach
+      customizationArgs, // Now this is properly initialized in beforeEach.
       answerGroups,
       goodDefaultOutcome
     );

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
@@ -24,9 +24,11 @@ import {Outcome} from 'domain/exploration/outcome.model';
 
 import {AppConstants} from 'app.constants';
 import {Rule} from 'domain/exploration/rule.model';
-import {MusicNotesInputCustomizationArgs, ReadableMusicNote} from 'extensions/interactions/customization-args-defs';
+import {
+  MusicNotesInputCustomizationArgs,
+  ReadableMusicNote,
+} from 'extensions/interactions/customization-args-defs';
 import cloneDeep from 'lodash/cloneDeep';
-
 
 describe('MusicNotesInputValidationService', () => {
   let validatorService: MusicNotesInputValidationService;
@@ -61,16 +63,20 @@ describe('MusicNotesInputValidationService', () => {
     // Initialize customizationArgs with valid values.
     customizationArgs = {
       sequenceToGuess: {
-        value: [{
-          readableNoteName: 'C4',
-          noteDuration: { num: 1, den: 4 }
-        }],
+        value: [
+          {
+            readableNoteName: 'C4',
+            noteDuration: {num: 1, den: 4},
+          },
+        ],
       },
       initialSequence: {
-        value: [{
-          readableNoteName: 'C4',
-          noteDuration: { num: 1, den: 4 }
-        }],
+        value: [
+          {
+            readableNoteName: 'C4',
+            noteDuration: {num: 1, den: 4},
+          },
+        ],
       },
     };
   });
@@ -105,16 +111,20 @@ describe('MusicNotesInputValidationService', () => {
       currentState,
       {
         sequenceToGuess: {
-          value: [{
-          readableNoteName: 'C4',
-          noteDuration: { num: 1, den: 4 }
-        }],
+          value: [
+            {
+              readableNoteName: 'C4',
+              noteDuration: {num: 1, den: 4},
+            },
+          ],
         },
         initialSequence: {
-          value: [{
-          readableNoteName: 'C4',
-          noteDuration: { num: 1, den: 4 }
-        }], // Non-empty array with a note.
+          value: [
+            {
+              readableNoteName: 'C4',
+              noteDuration: {num: 1, den: 4},
+            },
+          ], // Non-empty array with a note.
         },
       },
       goodAnswerGroups,

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
@@ -24,8 +24,9 @@ import {Outcome} from 'domain/exploration/outcome.model';
 
 import {AppConstants} from 'app.constants';
 import {Rule} from 'domain/exploration/rule.model';
-import {MusicNotesInputCustomizationArgs} from 'extensions/interactions/customization-args-defs';
+import {MusicNotesInputCustomizationArgs, ReadableMusicNote} from 'extensions/interactions/customization-args-defs';
 import cloneDeep from 'lodash/cloneDeep';
+
 
 describe('MusicNotesInputValidationService', () => {
   let validatorService: MusicNotesInputValidationService;
@@ -60,10 +61,16 @@ describe('MusicNotesInputValidationService', () => {
     // Initialize customizationArgs with valid values.
     customizationArgs = {
       sequenceToGuess: {
-        value: [['C4', 'quarter']],
+        value: [{
+          readableNoteName: 'C4',
+          noteDuration: { num: 1, den: 4 }
+        }],
       },
       initialSequence: {
-        value: [['C4', 'quarter']],
+        value: [{
+          readableNoteName: 'C4',
+          noteDuration: { num: 1, den: 4 }
+        }],
       },
     };
   });
@@ -98,10 +105,16 @@ describe('MusicNotesInputValidationService', () => {
       currentState,
       {
         sequenceToGuess: {
-          value: [['C4', 'quarter']],
+          value: [{
+          readableNoteName: 'C4',
+          noteDuration: { num: 1, den: 4 }
+        }],
         },
         initialSequence: {
-          value: [['C4', 'quarter']], // Non-empty array with a note.
+          value: [{
+          readableNoteName: 'C4',
+          noteDuration: { num: 1, den: 4 }
+        }], // Non-empty array with a note.
         },
       },
       goodAnswerGroups,

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
@@ -38,7 +38,7 @@ export class MusicNotesInputValidationService {
   getCustomizationArgsWarnings(
     customizationArgs: MusicNotesInputCustomizationArgs
   ): Warning[] {
-    // TODO(#20442): Implement customization args validations.
+    // Validation implemented for initialSequence. Add validation for sequenceToGuess if needed.
     const warningsList: Warning[] = [];
     if (customizationArgs.initialSequence.value.length === 0) {
       warningsList.push({

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
@@ -39,7 +39,14 @@ export class MusicNotesInputValidationService {
     customizationArgs: MusicNotesInputCustomizationArgs
   ): Warning[] {
     // TODO(#20442): Implement customization args validations.
-    return [];
+    const warningsList: Warning[] = [];
+    if (customizationArgs.initialSequence.value.length === 0) {
+      warningsList.push({
+        type: AppConstants.WARNING_TYPES.CRITICAL, // CHANGED: ERROR -> CRITICAL
+        message: 'Initial sequence should not be empty.',
+      });
+    }
+    return warningsList;
   }
 
   getAllWarnings(
@@ -63,7 +70,7 @@ export class MusicNotesInputValidationService {
         if (rule.type === 'HasLengthInclusivelyBetween') {
           if (rule.inputs.a > rule.inputs.b) {
             partialWarningsList.push({
-              type: AppConstants.WARNING_TYPES.ERROR,
+              type: AppConstants.WARNING_TYPES.ERROR, // CHANGED: CRITICAL -> ERROR
               message:
                 `The rule in response group ${groupId} is invalid -- ` +
                 `${rule.inputs.a} is more than ${rule.inputs.b}`,

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
@@ -42,7 +42,7 @@ export class MusicNotesInputValidationService {
     const warningsList: Warning[] = [];
     if (customizationArgs.initialSequence.value.length === 0) {
       warningsList.push({
-        type: AppConstants.WARNING_TYPES.CRITICAL, // CHANGED: ERROR -> CRITICAL
+        type: AppConstants.WARNING_TYPES.CRITICAL,
         message: 'Initial sequence should not be empty.',
       });
     }
@@ -70,7 +70,7 @@ export class MusicNotesInputValidationService {
         if (rule.type === 'HasLengthInclusivelyBetween') {
           if (rule.inputs.a > rule.inputs.b) {
             partialWarningsList.push({
-              type: AppConstants.WARNING_TYPES.ERROR, // CHANGED: CRITICAL -> ERROR
+              type: AppConstants.WARNING_TYPES.ERROR,
               message:
                 `The rule in response group ${groupId} is invalid -- ` +
                 `${rule.inputs.a} is more than ${rule.inputs.b}`,


### PR DESCRIPTION
## Overview
This PR adds validation for the MusicNotesInput interaction to prevent saving when the initialSequence is empty. It adds a CRITICAL warning that blocks the exploration from being saved with an invalid configuration.

### Files changed:
- `extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts`: Added validation check for empty initialSequence returning CRITICAL warning
- `extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts`: Added tests for empty and non-empty initialSequence


Fixes part of #20442

## Essential Checklist
- I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- I have written tests for my code.
- The PR title starts with "Fix part of [BUG]: TODO(juansaba): Implement customization args validations. #20442: ", followed by a short, clear summary of the changes.
- I have assigned the correct reviewers to this PR.

## Proof that changes are correct
This change was verified locally in the exploration editor.

**Before the change:**
- The MusicNotesInput interaction could be saved with an empty initialSequence (starting notes on the staff), resulting in an invalid configuration.

**After the change:**
- An error warning is shown when initialSequence is empty, preventing the exploration from being saved.
- No warning is shown once initialSequence is properly configured.
- A frontend unit test has been added to validate this behavior.

## Demo
Screen recording demonstrating the editor warning when initialSequence is left empty.
https://github.com/user-attachments/assets/124d72c9-981b-41fa-8b8a-65755956f0c4

Screen recording demonstrating normal behavior when initialSequence is configured.
https://github.com/user-attachments/assets/f9e9c76b-8ac8-46ea-8df0-9d34fe2527f9

