### PR TITLE
Fix #10278 Topic and skills dashboard total count label

### DIFF
--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.spec.ts
@@ -410,13 +410,14 @@ describe('Topics and skills dashboard page component', () => {
   });
 
   it('should get total count value for skills', () => {
+    componentInstance.totalSkillCount = 32;
     componentInstance.skillSummaries = [
       new SkillSummary('', '', '', 2, 3, 4, 6, 7),
     ];
     componentInstance.itemsPerPage = 0;
-    expect(componentInstance.getTotalCountValueForSkills()).toEqual('many');
+    expect(componentInstance.getTotalCountValueForSkills()).toEqual(32);
     componentInstance.itemsPerPage = 2;
-    expect(componentInstance.getTotalCountValueForSkills()).toEqual(1);
+    expect(componentInstance.getTotalCountValueForSkills()).toEqual(32);
   });
 
   it('should refresh pagination', () => {

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.ts
@@ -368,12 +368,8 @@ export class TopicsAndSkillsDashboardPageComponent {
     );
   }
 
-  getTotalCountValueForSkills(): number | string {
-    if (this.skillSummaries.length > this.itemsPerPage) {
-      return 'many';
-    }
-
-    return this.skillSummaries.length;
+  getTotalCountValueForSkills(): number {
+    return this.totalSkillCount;
   }
 
   refreshPagination(): void {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #10278
2. This PR does the following: the skills pagination header on the Topics and Skills Dashboard so it shows the numeric total skill count instead of ` many`
3. (For bug-fixing PRs only) The original bug occurred because: It returned "many" whenever skillSummaries.length > itemsPerPage, instead of using totalSkillCount, So once more than one page of skills existed, the label switched to "many"

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [x] A testing doc has been written: ... (ADD LINK) ...
- [x] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->


before: 
![](https://user-images.githubusercontent.com/19878639/89962539-fcfa3700-dc12-11ea-9336-79b176f2616d.png)


after:
<img width="1457" height="667" alt="Screenshot 2026-03-02 at 1 16 05 PM" src="https://github.com/user-attachments/assets/5d76d5a6-f1f4-4dd6-aee3-ac3c680181b3" />
<img width="1457" height="558" alt="Screenshot 2026-03-02 at 2 40 21 PM" src="https://github.com/user-attachments/assets/156f1892-95c6-4408-88ab-f6668e0a75a9" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
