### PR TITLE
Fix #25125: Update acceptance to explicitly wait for welcome modal and fail if isn't present.

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/edit-the-profile.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/edit-the-profile.spec.ts
@@ -42,7 +42,9 @@ describe('Logged-In Learner', function () {
 
     await explorationEditor.createAndPublishExplorationWithCards(
       'Solving problems without calculator',
-      'Algebra'
+      'Algebra',
+      2,
+      true
     );
   });
 

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/edit-avatar-and-view-exploration-from-profile-page.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/edit-avatar-and-view-exploration-from-profile-page.spec.ts
@@ -78,7 +78,6 @@ describe('Logged-in User', function () {
       await loggedInUser.openExplorationInExplorationEditor(
         TEST_EXPLORATION.title
       );
-      await loggedInUser.dismissWelcomeModal();
       await loggedInUser.navigateToSettingsTab();
       await loggedInUser.updateTitleTo(TEST_EXPLORATION.editedTitle);
 

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/manage-exploration-progress-in-learner-dashboard.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-user/manage-exploration-progress-in-learner-dashboard.spec.ts
@@ -63,7 +63,7 @@ describe('Logged-in User', function () {
       'loggedInUser1',
       'logged_in_user1@example.com'
     );
-  }, 480000);
+  }, 600000);
 
   /**
    * TODO(#22493): Add tests for home tab. Interactions involving in-progress lessons

--- a/core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-commits.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-commits.spec.ts
@@ -55,7 +55,6 @@ describe('Site Moderator', function () {
 
     await explorationEditor.navigateToCreatorDashboardPage();
     await explorationEditor.navigateToExplorationEditorFromCreatorDashboard();
-    await explorationEditor.dismissWelcomeModal();
     await explorationEditor.createMinimalExploration(
       'Test Exploration 2',
       'End Exploration'

--- a/core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-feedback-messages.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-feedback-messages.spec.ts
@@ -58,7 +58,6 @@ describe('Site Moderator', function () {
 
     await explorationEditor.navigateToCreatorDashboardPage();
     await explorationEditor.navigateToExplorationEditorFromCreatorDashboard();
-    await explorationEditor.dismissWelcomeModal();
     await explorationEditor.createMinimalExploration(
       'Test Exploration 2',
       'End Exploration'

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -43,7 +43,9 @@ describe('Topic Manager', function () {
     // Create two simple explorations.
     explorationId1 =
       await curriculumAdmin.createAndPublishAMinimalExplorationWithTitle(
-        'Exploring Quadratic Equations'
+        'Exploring Quadratic Equations',
+        'Algebra',
+        true
       );
 
     explorationId2 =

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -56,7 +56,6 @@ describe('Topic Manager', function () {
     // Create an exploration with Code Editor.
     await curriculumAdmin.navigateToCreatorDashboardPage();
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
-    await curriculumAdmin.dismissWelcomeModal();
 
     // Create an exlporation unsupported by mobile.
     explorationId3 = await curriculumAdmin.createSimpleProgrammingExploration();

--- a/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/filter-the-translations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/filter-the-translations.spec.ts
@@ -62,7 +62,7 @@ describe('Translation Reviewer', function () {
     const explorationId =
       await curriculumAdm.createAndPublishAMinimalExplorationWithTitle(
         'Exploration 1',
-        'Algrbra',
+        'Algebra',
         true
       );
     const explorationId2 =

--- a/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/filter-the-translations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/filter-the-translations.spec.ts
@@ -61,7 +61,9 @@ describe('Translation Reviewer', function () {
     // Create translation opportunity.
     const explorationId =
       await curriculumAdm.createAndPublishAMinimalExplorationWithTitle(
-        'Exploration 1'
+        'Exploration 1',
+        'Algrbra',
+        true
       );
     const explorationId2 =
       await curriculumAdm.createAndPublishAMinimalExplorationWithTitle(

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/exploration-editor.ts
@@ -1,0 +1,66 @@
+// Copyright 2025 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Utility class to interact with Exploration Editor.
+ */
+
+import {BaseUser} from './puppeteer-utils';
+import {showMessage} from './show-message';
+
+const dismissWelcomeModalSelector = 'button.e2e-test-dismiss-welcome-modal';
+
+export class ExplorationEditorModal {
+  userInstance: BaseUser;
+
+  constructor(userInstance: BaseUser) {
+    this.userInstance = userInstance;
+  }
+
+  /**
+   * Function to dismiss exploration editor welcome modal.
+   * @param failIfMissing - Whether to fail if the welcome modal is not found.
+   */
+  async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
+    try {
+      await this.userInstance.page.waitForSelector(
+        dismissWelcomeModalSelector,
+        {
+          visible: true,
+          // If we know the modal should appear, we can wait longer.
+          timeout: failIfMissing ? 20000 : 5000,
+        }
+      );
+      await this.userInstance.clickOnElementWithSelector(
+        dismissWelcomeModalSelector
+      );
+      await this.userInstance.expectElementToBeVisible(
+        dismissWelcomeModalSelector,
+        false
+      );
+      showMessage('Tutorial pop-up closed successfully.');
+    } catch (error) {
+      if (!failIfMissing) {
+        showMessage(
+          'Welcome Modal not found, but test can be continued.\n' +
+            `Error: ${error.message}`
+        );
+        return;
+      }
+      throw new Error(
+        'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
+      );
+    }
+  }
+}

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -131,6 +131,7 @@ export class BaseUser {
           TestToModulesMatcher.registerPuppeteerBrowser(browser);
         }
         this.page = await browser.newPage();
+        this.attachNavigationLogs(this.page);
         this.pages.push(this.page);
 
         if (mobile) {
@@ -403,6 +404,7 @@ export class BaseUser {
         )
       ).page()) ?? (await this.browserObject.newPage());
     this.page = newPage;
+    this.attachNavigationLogs(this.page);
     this.setupDebugTools();
   }
 
@@ -1246,6 +1248,7 @@ export class BaseUser {
 
     await newPage.bringToFront();
     this.page = newPage;
+    this.attachNavigationLogs(this.page);
     return newPage;
   }
 
@@ -2162,6 +2165,15 @@ export class BaseUser {
     await this.expectElementToBeVisible(hideOSKButtonSelector);
     await this.clickOnElementWithSelector(hideOSKButtonSelector);
     await this.expectElementToBeVisible(hideOSKButtonSelector, false);
+  }
+
+  /**
+   * Logs every navigation event on the page.
+   */
+  attachNavigationLogs(page: Page): void {
+    page.on('framenavigated', frame => {
+      showMessage('NAVIGATED: ' + frame.url());
+    });
   }
 }
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -21,6 +21,7 @@ import {showMessage} from '../common/show-message';
 import {TopicManager} from './topic-manager';
 import puppeteer from 'puppeteer';
 import {ElementHandle} from 'puppeteer';
+import {ExplorationEditorModal} from '../common/exploration-editor';
 
 const curriculumAdminThumbnailImage =
   testConstants.data.curriculumAdminThumbnailImage;
@@ -42,8 +43,6 @@ const uploadPhotoButton = 'button.e2e-test-photo-upload-submit';
 const photoUploadModal = 'edit-thumbnail-modal';
 const removeQuestionConfirmationButton =
   '.e2e-test-remove-question-confirmation-button';
-
-const dismissWelcomeModalSelector = 'button.e2e-test-dismiss-welcome-modal';
 
 const topicsTab = 'a.e2e-test-topics-tab';
 const desktopTopicSelector = 'a.e2e-test-topic-name';
@@ -1702,33 +1701,10 @@ export class CurriculumAdmin extends TopicManager {
   /**
    * Function to dismiss exploration editor welcome modal.
    * @param failIfMissing - Whether to fail if the welcome modal is not found.
-   *
-   * TODO(#22539): This function has a duplicates in other files.
-   * To avoid unexpected behavior, ensure that any modifications here are also
-   * made in topic-manager.ts.
    */
   async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
-    try {
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        visible: true,
-        // If we know the modal should appear, we can wait longer.
-        timeout: failIfMissing ? 20000 : 5000,
-      });
-      await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-      await this.expectElementToBeVisible(dismissWelcomeModalSelector, false);
-      showMessage('Tutorial pop-up closed successfully.');
-    } catch (error) {
-      if (!failIfMissing) {
-        showMessage(
-          'Welcome Modal not found, but test can be continued.\n' +
-            `Error: ${error.message}`
-        );
-      } else {
-        throw new Error(
-          'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
-        );
-      }
-    }
+    const explorationEditor = new ExplorationEditorModal(this);
+    await explorationEditor.dismissWelcomeModal(failIfMissing);
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -1700,22 +1700,34 @@ export class CurriculumAdmin extends TopicManager {
   }
 
   /**
-   * Function to dismiss welcome modal
+   * Function to dismiss exploration editor welcome modal.
+   * @param failIfMissing - Whether to fail if the welcome modal is not found.
+   *
+   * TODO(#22539): This function has a duplicates in other files.
+   * To avoid unexpected behavior, ensure that any modifications here are also
+   * made in topic-manager.ts.
    */
-  async dismissWelcomeModal(): Promise<void> {
+  async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
     try {
-      await this.page.waitForNetworkIdle();
       await this.page.waitForSelector(dismissWelcomeModalSelector, {
         visible: true,
-        timeout: 10000,
+        // If we know the modal should appear, we can wait longer.
+        timeout: failIfMissing ? 20000 : 5000,
       });
       await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        hidden: true,
-      });
+      await this.expectElementToBeVisible(dismissWelcomeModalSelector, false);
       showMessage('Tutorial pop-up closed successfully.');
     } catch (error) {
-      showMessage(`welcome modal not found: ${error.message}`);
+      if (!failIfMissing) {
+        showMessage(
+          'Welcome Modal not found, but test can be continued.\n' +
+            `Error: ${error.message}`
+        );
+      } else {
+        throw new Error(
+          'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
+        );
+      }
     }
   }
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -4700,13 +4700,11 @@ export class ExplorationEditor extends BaseUser {
   async createAndPublishAMinimalExplorationWithTitle(
     title: string,
     category: string = 'Algebra',
-    flag: boolean = true
+    flag: boolean = false
   ): Promise<string> {
     await this.navigateToCreatorDashboardPage();
     await this.navigateToExplorationEditorFromCreatorDashboard();
-    if (flag) {
-      await this.dismissWelcomeModal();
-    }
+    await this.dismissWelcomeModal(flag);
     await this.createMinimalExploration(
       'Exploration intro text',
       'End Exploration'

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -4786,11 +4786,12 @@ export class ExplorationEditor extends BaseUser {
   async createAndPublishExplorationWithCards(
     explorationTitle: string,
     category: string = 'Mathematics',
-    numberOfCards: number = 2
+    numberOfCards: number = 2,
+    expectedWelcomeModal: boolean = false
   ): Promise<string> {
     await this.navigateToCreatorDashboardPage();
     await this.navigateToExplorationEditorFromCreatorDashboard();
-    await this.dismissWelcomeModal();
+    await this.dismissWelcomeModal(expectedWelcomeModal);
 
     for (let i = 0; i < numberOfCards - 1; i++) {
       await this.updateCardContent(`Content ${i}`);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -27,6 +27,7 @@ import path from 'path';
 import {GraphViz} from '../common/interactions/graph-viz';
 import {PencilCode} from '../common/interactions/pencil-code';
 import {ImageAreaSelection} from '../common/interactions/image-area-selection';
+import {ExplorationEditorModal} from '../common/exploration-editor';
 
 const creatorDashboardPage = testConstants.URLs.CreatorDashboard;
 const baseUrl = testConstants.URLs.BaseURL;
@@ -34,7 +35,6 @@ const imageToUpload = testConstants.data.curriculumAdminThumbnailImage;
 
 const createExplorationButtonSelector =
   'button.e2e-test-create-new-exploration-button';
-const dismissWelcomeModalSelector = 'button.e2e-test-dismiss-welcome-modal';
 const dropdownToggleIcon = '.e2e-test-mobile-options-dropdown';
 const saveContentButton = 'button.e2e-test-save-state-content';
 const addInteractionButton = 'button.e2e-test-open-add-interaction-modal';
@@ -2769,33 +2769,10 @@ export class ExplorationEditor extends BaseUser {
   /**
    * Function to dismiss exploration editor welcome modal.
    * @param failIfMissing - Whether to fail if the welcome modal is not found.
-   *
-   * TODO(#22539): This function has a duplicates in other files.
-   * To avoid unexpected behavior, ensure that any modifications here are also
-   * made in topic-manager.ts.
    */
   async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
-    try {
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        visible: true,
-        // If we know the modal should appear, we can wait longer.
-        timeout: failIfMissing ? 20000 : 5000,
-      });
-      await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-      await this.expectElementToBeVisible(dismissWelcomeModalSelector, false);
-      showMessage('Tutorial pop-up closed successfully.');
-    } catch (error) {
-      if (!failIfMissing) {
-        showMessage(
-          'Welcome Modal not found, but test can be continued.\n' +
-            `Error: ${error.message}`
-        );
-      } else {
-        throw new Error(
-          'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
-        );
-      }
-    }
+    const explorationEditor = new ExplorationEditorModal(this);
+    await explorationEditor.dismissWelcomeModal(failIfMissing);
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -2769,8 +2769,12 @@ export class ExplorationEditor extends BaseUser {
   /**
    * Function to dismiss exploration editor welcome modal.
    * @param failIfMissing - Whether to fail if the welcome modal is not found.
+   *
+   * TODO(#22539): This function has a duplicates in other files.
+   * To avoid unexpected behavior, ensure that any modifications here are also
+   * made in topic-manager.ts.
    */
-  async dismissWelcomeModal(failIfMissing: boolean = false): Promise<void> {
+  async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
     try {
       await this.page.waitForSelector(dismissWelcomeModalSelector, {
         visible: true,
@@ -2803,7 +2807,7 @@ export class ExplorationEditor extends BaseUser {
     // The existing dismissWelcomeModal() in this class already handles the
     // case where the modal is not present (via try/catch), so we just
     // delegate to it.
-    await this.dismissWelcomeModal();
+    await this.dismissWelcomeModal(false);
   }
 
   /**
@@ -2854,9 +2858,6 @@ export class ExplorationEditor extends BaseUser {
    * @param {string} content - The content to be added to the card.
    */
   async updateCardContent(content: string): Promise<void> {
-    // Dismiss the welcome modal if it appears (handles race condition where
-    // modal appears after previous dismissWelcomeModal call).
-    await this.dismissWelcomeModalIfPresent();
     await this.page.waitForSelector(stateEditSelector, {
       visible: true,
     });
@@ -6586,9 +6587,6 @@ export class ExplorationEditor extends BaseUser {
     imageDescription: string,
     imageCaption: string | null
   ): Promise<void> {
-    // Dismiss the welcome modal if it appears (handles race condition where
-    // modal appears after previous dismissWelcomeModal call).
-    await this.dismissWelcomeModalIfPresent();
     await this.expectElementToBeVisible(stateEditSelector);
     await this.clickOnElementWithSelector(stateEditSelector);
     await this.addImageRTE(imageFilePath, imageDescription, imageCaption);
@@ -6602,9 +6600,6 @@ export class ExplorationEditor extends BaseUser {
    * Block Quote, Image, Math Formula, and Concept Card.
    */
   async addExplorationDescriptionContainingBasicRTEComponents(): Promise<void> {
-    // Dismiss the welcome modal if it appears (handles race condition where
-    // modal appears after previous dismissWelcomeModal call).
-    await this.dismissWelcomeModalIfPresent();
     // Click on RTE.
     await this.page.waitForSelector(stateEditSelector, {visible: true});
     await this.clickOnElementWithSelector(stateEditSelector);
@@ -6690,9 +6685,6 @@ export class ExplorationEditor extends BaseUser {
    * Updates an exploration description containing all RTE elements.
    */
   async addExplorationDescriptionContainingAllRTEComponents(): Promise<void> {
-    // Dismiss the welcome modal if it appears (handles race condition where
-    // modal appears after previous dismissWelcomeModal call).
-    await this.dismissWelcomeModalIfPresent();
     // Click on RTE.
     await this.page.waitForSelector(stateEditSelector, {visible: true});
     await this.clickOnElementWithSelector(stateEditSelector);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
@@ -20,6 +20,7 @@ import {BaseUser} from '../common/puppeteer-utils';
 import testConstants from '../common/test-constants';
 import {showMessage} from '../common/show-message';
 import puppeteer from 'puppeteer';
+import {ExplorationEditorModal} from '../common/exploration-editor';
 
 const profilePageUrlPrefix = testConstants.URLs.ProfilePagePrefix;
 const WikiPrivilegesToFirebaseAccount =
@@ -143,7 +144,6 @@ const contributorDashboardMenuLink =
 const profileMenuLink = '.e2e-test-profile-link';
 const preferencesMenuLink = '.e2e-test-preferences-link';
 const createExplorationButton = 'button.e2e-test-create-new-exploration-button';
-const dismissWelcomeModalSelector = 'button.e2e-test-dismiss-welcome-modal';
 const saveContentButton = 'button.e2e-test-save-state-content';
 const addInteractionButton = 'button.e2e-test-open-add-interaction-modal';
 const saveInteractionButton = 'button.e2e-test-save-interaction';
@@ -2404,33 +2404,10 @@ export class LoggedInUser extends BaseUser {
   /**
    * Function to dismiss exploration editor welcome modal.
    * @param failIfMissing - Whether to fail if the welcome modal is not found.
-   *
-   * TODO(#22539): This function has a duplicates in other files.
-   * To avoid unexpected behavior, ensure that any modifications here are also
-   * made in topic-manager.ts.
    */
   async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
-    try {
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        visible: true,
-        // If we know the modal should appear, we can wait longer.
-        timeout: failIfMissing ? 20000 : 5000,
-      });
-      await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-      await this.expectElementToBeVisible(dismissWelcomeModalSelector, false);
-      showMessage('Tutorial pop-up closed successfully.');
-    } catch (error) {
-      if (!failIfMissing) {
-        showMessage(
-          'Welcome Modal not found, but test can be continued.\n' +
-            `Error: ${error.message}`
-        );
-      } else {
-        throw new Error(
-          'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
-        );
-      }
-    }
+    const explorationEditor = new ExplorationEditorModal(this);
+    await explorationEditor.dismissWelcomeModal(failIfMissing);
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
@@ -2403,21 +2403,33 @@ export class LoggedInUser extends BaseUser {
 
   /**
    * Function to dismiss exploration editor welcome modal.
+   * @param failIfMissing - Whether to fail if the welcome modal is not found.
+   *
+   * TODO(#22539): This function has a duplicates in other files.
+   * To avoid unexpected behavior, ensure that any modifications here are also
+   * made in topic-manager.ts.
    */
-  async dismissWelcomeModal(): Promise<void> {
+  async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
     try {
-      await this.page.waitForNetworkIdle();
       await this.page.waitForSelector(dismissWelcomeModalSelector, {
         visible: true,
-        timeout: 10000,
+        // If we know the modal should appear, we can wait longer.
+        timeout: failIfMissing ? 20000 : 5000,
       });
       await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        hidden: true,
-      });
+      await this.expectElementToBeVisible(dismissWelcomeModalSelector, false);
       showMessage('Tutorial pop-up closed successfully.');
     } catch (error) {
-      showMessage(`welcome modal not found: ${(error as Error).message}`);
+      if (!failIfMissing) {
+        showMessage(
+          'Welcome Modal not found, but test can be continued.\n' +
+            `Error: ${error.message}`
+        );
+      } else {
+        throw new Error(
+          'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
+        );
+      }
     }
   }
 
@@ -2684,11 +2696,12 @@ export class LoggedInUser extends BaseUser {
    */
   async createAndPublishAMinimalExplorationWithTitle(
     title: string,
-    category: string = 'Algebra'
+    category: string = 'Algebra',
+    expectedWelcomeModal: boolean = false
   ): Promise<string | null> {
     await this.navigateToCreatorDashboardPage();
     await this.navigateToExplorationEditorPageFromCreatorDashboard();
-    await this.dismissWelcomeModal();
+    await this.dismissWelcomeModal(expectedWelcomeModal);
     await this.createMinimalExploration(
       'Exploration intro text',
       'End Exploration'

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/voiceover-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/voiceover-admin.ts
@@ -19,11 +19,10 @@
 import {BaseUser} from '../common/puppeteer-utils';
 import testConstants from '../common/test-constants';
 import {showMessage} from '../common/show-message';
+import {ExplorationEditorModal} from '../common/exploration-editor';
 
 const baseURL = testConstants.URLs.BaseURL;
 const voiceoverAdminURL = testConstants.URLs.VoiceoverAdmin;
-
-const dismissWelcomeModalSelector = 'button.e2e-test-dismiss-welcome-modal';
 
 const editVoiceoverArtistButton = 'span.e2e-test-edit-voice-artist-roles';
 const voiceArtistUsernameInputBox = 'input#newVoicAartistUsername';
@@ -135,33 +134,10 @@ export class VoiceoverAdmin extends BaseUser {
   /**
    * Function to dismiss exploration editor welcome modal.
    * @param failIfMissing - Whether to fail if the welcome modal is not found.
-   *
-   * TODO(#22539): This function has a duplicates in other files.
-   * To avoid unexpected behavior, ensure that any modifications here are also
-   * made in topic-manager.ts.
    */
   async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
-    try {
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        visible: true,
-        // If we know the modal should appear, we can wait longer.
-        timeout: failIfMissing ? 20000 : 5000,
-      });
-      await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-      await this.expectElementToBeVisible(dismissWelcomeModalSelector, false);
-      showMessage('Tutorial pop-up closed successfully.');
-    } catch (error) {
-      if (!failIfMissing) {
-        showMessage(
-          'Welcome Modal not found, but test can be continued.\n' +
-            `Error: ${error.message}`
-        );
-      } else {
-        throw new Error(
-          'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
-        );
-      }
-    }
+    const explorationEditor = new ExplorationEditorModal(this);
+    await explorationEditor.dismissWelcomeModal(failIfMissing);
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/voiceover-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/voiceover-admin.ts
@@ -133,18 +133,35 @@ export class VoiceoverAdmin extends BaseUser {
   }
 
   /**
-   * Function to dismiss welcome modal.
+   * Function to dismiss exploration editor welcome modal.
+   * @param failIfMissing - Whether to fail if the welcome modal is not found.
+   *
+   * TODO(#22539): This function has a duplicates in other files.
+   * To avoid unexpected behavior, ensure that any modifications here are also
+   * made in topic-manager.ts.
    */
-  async dismissWelcomeModal(): Promise<void> {
-    await this.page.waitForSelector(dismissWelcomeModalSelector, {
-      visible: true,
-    });
-    await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-    await this.page.waitForSelector(dismissWelcomeModalSelector, {
-      hidden: true,
-    });
-
-    showMessage('Tutorial pop-up is closed.');
+  async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
+    try {
+      await this.page.waitForSelector(dismissWelcomeModalSelector, {
+        visible: true,
+        // If we know the modal should appear, we can wait longer.
+        timeout: failIfMissing ? 20000 : 5000,
+      });
+      await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
+      await this.expectElementToBeVisible(dismissWelcomeModalSelector, false);
+      showMessage('Tutorial pop-up closed successfully.');
+    } catch (error) {
+      if (!failIfMissing) {
+        showMessage(
+          'Welcome Modal not found, but test can be continued.\n' +
+            `Error: ${error.message}`
+        );
+      } else {
+        throw new Error(
+          'Welcome Modal not found.\n' + 'Actual Error:\n' + error.message
+        );
+      }
+    }
   }
 
   /**
@@ -153,22 +170,10 @@ export class VoiceoverAdmin extends BaseUser {
    * already been dismissed earlier in the test flow.
    */
   async dismissWelcomeModalIfPresent(): Promise<void> {
-    const MODAL_CHECK_TIMEOUT_MS = 2000;
-    try {
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        visible: true,
-        timeout: MODAL_CHECK_TIMEOUT_MS,
-      });
-      await this.clickOnElementWithSelector(dismissWelcomeModalSelector);
-      await this.page.waitForSelector(dismissWelcomeModalSelector, {
-        hidden: true,
-      });
-      showMessage('Tutorial pop-up was present and has been closed.');
-    } catch {
-      // Modal is not present, which is fine - it may have already been
-      // dismissed or not appeared yet.
-      showMessage('Tutorial pop-up was not present, continuing.');
-    }
+    // The existing dismissWelcomeModal() in this class already handles the
+    // case where the modal is not present (via try/catch), so we just
+    // delegate to it.
+    await this.dismissWelcomeModal(false);
   }
 
   /**
@@ -300,7 +305,7 @@ export class VoiceoverAdmin extends BaseUser {
     voiceArtistUsername: string
   ): Promise<void> {
     await this.navigateToExplorationEditor(explorationId);
-    await this.dismissWelcomeModal();
+    await this.dismissWelcomeModal(false);
     await this.navigateToExplorationSettingsTab();
     await this.addVoiceoverArtistsToExploration([voiceArtistUsername]);
   }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #25125
2. This PR does the following:
    - Updates an acceptance test (`logged-in-learner/edit-the-profile`) to wait for welcome modal explicitly, instead of try it. This ensures that test proceeds correctly.
    - Adds navigation logs to debug other test failures and flakes.
4. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct
### Before
Mobile: 1/20 (5%)  
Desktop: 0/20 (All passed)  
Link: https://github.com/jayam04/oppia/actions/runs/22562768205  
<img width="1024" height="288" alt="image" src="https://github.com/user-attachments/assets/e17255af-bbf5-471d-8340-004e9429c798" />

### After Fix
Mobile: 0/100  
Desktop: 0/100   
Link: https://github.com/jayam04/oppia/actions/runs/22565056679  
<img width="1024" height="288" alt="image" src="https://github.com/user-attachments/assets/c9d08697-6f15-4695-942a-ee3502d02651" />

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
