### PR TITLE
Fix #25156: Resolve ExpressionChangedAfterItHasBeenCheckedError in HomeTabComponent

### DIFF
--- a/core/templates/pages/learner-dashboard-page/home-tab.component.ts
+++ b/core/templates/pages/learner-dashboard-page/home-tab.component.ts
@@ -17,7 +17,13 @@
  */
 
 import {AppConstants} from 'app.constants';
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {CollectionSummary} from 'domain/collection/collection-summary.model';
 import {LearnerTopicSummary} from 'domain/topic/learner-topic-summary.model';
 import {LearnerExplorationSummary} from 'domain/summary/learner-exploration-summary.model';
@@ -76,6 +82,7 @@ export class HomeTabComponent {
   loadingMessage: string = 'Loading';
 
   constructor(
+    private changeDetectorRef: ChangeDetectorRef,
     private i18nLanguageCodeService: I18nLanguageCodeService,
     private loaderService: LoaderService,
     private windowDimensionService: WindowDimensionsService,
@@ -168,6 +175,10 @@ export class HomeTabComponent {
       this.allCardsLoaded = true;
       this.loadingMessage = '';
       this.loaderService.hideLoadingScreen();
+      // Explicitly trigger change detection so that Angular's
+      // verification pass sees the updated value of allCardsLoaded,
+      // preventing an ExpressionChangedAfterItHasBeenCheckedError.
+      this.changeDetectorRef.detectChanges();
     } else {
       setTimeout(() => {
         if (!this.allCardsLoaded) {


### PR DESCRIPTION
**### Overview**

This PR fixes #25156.
This PR does the following: It resolves the ExpressionChangedAfterItHasBeenCheckedError that appears in the browser console when loading the New Learner Dashboard (Home tab) with the show_redesigned_learner_dashboard feature flag enabled. The fix imports ChangeDetectorRef into HomeTabComponent and calls detectChanges() immediately after synchronously setting allCardsLoaded to true in the zero-cards path within ngOnInit(). This ensures Angular's verification pass sees the final, consistent value of the *ngIf="!allCardsLoaded" expression, preventing the mismatch error.
(For bug-fixing PRs only) The original bug occurred because: In HomeTabComponent, the property allCardsLoaded is initialised to false, which causes the *ngIf="!allCardsLoaded" expression in the template (home-tab.component.html, line 88) to evaluate to true during Angular's first change detection cycle. However, during ngOnInit(), when totalLessonCards === 0, allCardsLoaded is immediately set to true synchronously. This causes the *ngIf expression to flip from true to false before Angular's dev-mode verification pass completes, triggering the ExpressionChangedAfterItHasBeenCheckedError. The bug was likely introduced when the redesigned learner dashboard loading logic was added, which introduced the allCardsLoaded flag and *ngIf="!allCardsLoaded" loading indicator.

### **Essential Checklist**
 

- [ ✓] I have linked the issue that this PR fixes in the "Development" section of the sidebar.

 

- [ ✓] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.

 

- [ ✓] I have written tests for my code.

- [ ✓]  The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.

 

- [ ✓] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

- [✓ ] Testing doc (for PRs with Beam jobs that modify production server data)


Proof that changes are correct
What changed

### **File modified:** 

core/templates/pages/learner-dashboard-page/home-tab.component.ts

Imported ChangeDetectorRef from @angular/core.
Injected ChangeDetectorRef into the component constructor.
Called this.changeDetectorRef.detectChanges() immediately after synchronously setting allCardsLoaded = true in the totalLessonCards === 0 branch of ngOnInit().

### **How to verify**

1. Log in as a learner.
2. Go to the Admin page and grant yourself Release Coordinator rights.
3. Navigate to http://localhost:8181/release-coordinator.
4. Enable the feature flag: show_redesigned_learner_dashboard.
5. Navigate to http://localhost:8181/learner-dashboard.
6. Open the browser DevTools Console.
7. Refresh the page.
8. Before the fix: The console shows:
`ERROR Error: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: 'ngIf: true'. Current value: 'ngIf: false'. at HomeTabComponent.html`
9. After the fix: The Learner Dashboard loads without the ExpressionChangedAfterItHasBeenCheckedError in the console.

**### Unit tests**
All 23 existing unit tests in home-tab.component.spec.ts pass successfully with zero modifications required.

