### PR TITLE
Fix part of #21970: Add domain object and validate() for DeletedUsernameModel

### DIFF
--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1859,6 +1859,7 @@ class DeletedUsername:
         self.username_hash = username_hash
 
     def validate(self) -> None:
+        """Validates the username_hash."""
         if not isinstance(self.username_hash, str):
             raise utils.ValidationError(
                 'Expected username_hash to be a string, received %s'

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1871,7 +1871,7 @@ class DeletedUsername:
             raise utils.ValidationError(
                 'username_hash must be at most 32 characters long.'
             )
-        if not re.match(r'^[A-Za-z0-9abc]+$', self.username_hash):
+        if not re.match(r'^[A-Za-z0-9]+$', self.username_hash):
             raise utils.ValidationError(
                 'username_hash must be a valid hash string.'
             )

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1867,11 +1867,11 @@ class DeletedUsername:
             )
         if not self.username_hash:
             raise utils.ValidationError('username_hash cannot be empty.')
-        if len(self.username_hash) != 32:
+        if len(self.username_hash) > 32 or len(self.username_hash) == 0:
             raise utils.ValidationError(
-                'username_hash must be 32 characters long.'
+                'username_hash must be at most 32 characters long.'
             )
         if not re.match(r'^[A-Za-z0-9abc]+$', self.username_hash):
             raise utils.ValidationError(
-                'username_hash must be a valid base64-encoded string.'
+                'username_hash must be a valid hash string.'
             )

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1862,15 +1862,17 @@ class DeletedUsername:
         """Validates the username_hash."""
         if not isinstance(self.username_hash, str):
             raise utils.ValidationError(
-                'Expected username_hash to be a string, received %s'
-                % self.username_hash
+                f'Expected username_hash to be a string, received {self.username_hash}'
             )
-        if not self.username_hash:
+
+        if len(self.username_hash) == 0:
             raise utils.ValidationError('username_hash cannot be empty.')
-        if len(self.username_hash) > 32 or len(self.username_hash) == 0:
+
+        if len(self.username_hash) > 32:
             raise utils.ValidationError(
                 'username_hash must be at most 32 characters long.'
             )
+
         if not re.match(r'^[A-Za-z0-9]+$', self.username_hash):
             raise utils.ValidationError(
                 'username_hash must be a valid hash string.'

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1859,23 +1859,18 @@ class DeletedUsername:
         self.username_hash = username_hash
 
     def validate(self) -> None:
-        """Validates the username_hash."""
-
         if not isinstance(self.username_hash, str):
             raise utils.ValidationError(
                 'Expected username_hash to be a string, received %s'
                 % self.username_hash
             )
-
         if not self.username_hash:
             raise utils.ValidationError('username_hash cannot be empty.')
-
         if len(self.username_hash) != 32:
             raise utils.ValidationError(
                 'username_hash must be 32 characters long.'
             )
-
-        if not re.match(r'^[a-f0-9]{32}$', self.username_hash):
+        if not re.match(r'^[A-Za-z0-9abc]+$', self.username_hash):
             raise utils.ValidationError(
-                'username_hash must be a valid hexadecimal string.'
+                'username_hash must be a valid base64-encoded string.'
             )

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1850,3 +1850,32 @@ class TranslationCoordinatorStats:
             'coordinator_ids': self.coordinator_ids,
             'coordinators_count': self.coordinators_count,
         }
+
+
+class DeletedUsername:
+    """Domain object for DeletedUsernameModel."""
+
+    def __init__(self, username_hash: str) -> None:
+        self.username_hash = username_hash
+
+    def validate(self) -> None:
+        """Validates the username_hash."""
+
+        if not isinstance(self.username_hash, str):
+            raise utils.ValidationError(
+                'Expected username_hash to be a string, received %s'
+                % self.username_hash
+            )
+
+        if not self.username_hash:
+            raise utils.ValidationError('username_hash cannot be empty.')
+
+        if len(self.username_hash) != 32:
+            raise utils.ValidationError(
+                'username_hash must be 32 characters long.'
+            )
+
+        if not re.match(r'^[a-f0-9]{32}$', self.username_hash):
+            raise utils.ValidationError(
+                'username_hash must be a valid hexadecimal string.'
+            )

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import datetime
 import logging
 
+from typing import cast
 from core import feconf, utils
 from core.constants import constants
 from core.domain import auth_services, user_domain, user_services
@@ -1981,6 +1982,8 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
             deleted_username.validate()
 
     def test_validate_with_non_string(self) -> None:
-        deleted_username = user_domain.DeletedUsername(username_hash=123)
+        deleted_username = user_domain.DeletedUsername(
+            username_hash=cast(str, 123)
+        )
         with self.assertRaisesRegex(utils.ValidationError, 'string'):
             deleted_username.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -26,6 +26,7 @@ from core.constants import constants
 from core.domain import auth_services, user_domain, user_services
 from core.platform import models
 from core.tests import test_utils
+from core.storage.user import gae_models as user_models
 
 from typing import List, Optional, TypedDict, cast
 
@@ -1988,3 +1989,37 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
         )
         with self.assertRaisesRegex(utils.ValidationError, 'string'):
             deleted_username.validate()
+
+
+class DeletedUsernameServicesTests(test_utils.GenericTestBase):
+
+    def test_get_deleted_username_from_model(self):
+        model = user_models.DeletedUsernameModel(id='a' * 32)
+        obj = user_services.get_deleted_username_from_model(model)
+
+        self.assertIsInstance(obj, user_domain.DeletedUsername)
+        self.assertEqual(obj.username_hash, 'a' * 32)
+        self.assertTrue(obj.username_hash.isalnum())
+        obj.validate()
+
+    def test_get_model_from_domain_object(self):
+        domain_obj = user_domain.DeletedUsername(username_hash='a' * 32)
+
+        model = user_services.get_deleted_username_model_from_domain_object(
+            domain_obj
+        )
+
+        self.assertEqual(model.id, 'a' * 32)
+
+    def test_save_deleted_username(self):
+        normalized_username = 'testuser'
+
+        user_services.save_deleted_username(normalized_username)
+
+        model = user_models.DeletedUsernameModel.get_by_id(
+            utils.convert_to_hash(
+                normalized_username, user_models.DeletedUsernameModel.ID_LENGTH
+            )
+        )
+
+        self.assertIsNotNone(model)

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1993,7 +1993,7 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
 
 class DeletedUsernameServicesTests(test_utils.GenericTestBase):
 
-    def test_get_deleted_username_from_model(self):
+    def test_get_deleted_username_from_model(self) -> None:
         model = user_models.DeletedUsernameModel(id='a' * 32)
         obj = user_services.get_deleted_username_from_model(model)
 
@@ -2002,7 +2002,7 @@ class DeletedUsernameServicesTests(test_utils.GenericTestBase):
         self.assertTrue(obj.username_hash.isalnum())
         obj.validate()
 
-    def test_get_model_from_domain_object(self):
+    def test_get_model_from_domain_object(self) -> None:
         domain_obj = user_domain.DeletedUsername(username_hash='a' * 32)
 
         model = user_services.get_deleted_username_model_from_domain_object(
@@ -2011,7 +2011,7 @@ class DeletedUsernameServicesTests(test_utils.GenericTestBase):
 
         self.assertEqual(model.id, 'a' * 32)
 
-    def test_save_deleted_username(self):
+    def test_save_deleted_username(self) -> None:
         normalized_username = 'testuser'
 
         user_services.save_deleted_username(normalized_username)

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1981,7 +1981,8 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
             deleted_username.validate()
 
     def test_validate_with_non_string(self) -> None:
-        # Here use cast because we intentionally pass a non-string value to test validation.
+        # Here we use cast because we intentionally pass a non-string value
+        # to test validation logic for incorrect types.
         deleted_username = user_domain.DeletedUsername(
             username_hash=cast(str, 123)
         )

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1981,10 +1981,9 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
             deleted_username.validate()
 
     def test_validate_with_non_string(self) -> None:
+        # Here use cast because we intentionally pass a non-string value to test validation.
         deleted_username = user_domain.DeletedUsername(
-            username_hash=cast(
-                str, 123
-            )  # Here use cast because we intentionally pass a non-string value to test validation.
+            username_hash=cast(str, 123)
         )
         with self.assertRaisesRegex(utils.ValidationError, 'string'):
             deleted_username.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1981,9 +1981,10 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
             deleted_username.validate()
 
     def test_validate_with_non_string(self) -> None:
-        # Here use cast because we intentionally pass a non-string value to test validation.
         deleted_username = user_domain.DeletedUsername(
-            username_hash=cast(str, 123)
+            username_hash=cast(
+                str, 123
+            )  # Here use cast because we intentionally pass a non-string value to test validation.
         )
         with self.assertRaisesRegex(utils.ValidationError, 'string'):
             deleted_username.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -21,14 +21,13 @@ from __future__ import annotations
 import datetime
 import logging
 
-from typing import cast
 from core import feconf, utils
 from core.constants import constants
 from core.domain import auth_services, user_domain, user_services
 from core.platform import models
 from core.tests import test_utils
 
-from typing import List, Optional, TypedDict
+from typing import List, Optional, TypedDict, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -1982,6 +1981,7 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
             deleted_username.validate()
 
     def test_validate_with_non_string(self) -> None:
+        # Here use cast because we intentionally pass a non-string value to test validation.
         deleted_username = user_domain.DeletedUsername(
             username_hash=cast(str, 123)
         )

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1971,13 +1971,13 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
             deleted_username.validate()
 
     def test_validate_with_invalid_length(self) -> None:
-        deleted_username = user_domain.DeletedUsername(username_hash='abc123')
+        deleted_username = user_domain.DeletedUsername(username_hash='a' * 33)
         with self.assertRaisesRegex(utils.ValidationError, '32'):
             deleted_username.validate()
 
     def test_validate_with_invalid_characters(self) -> None:
-        deleted_username = user_domain.DeletedUsername(username_hash='z' * 32)
-        with self.assertRaisesRegex(utils.ValidationError, 'hexadecimal'):
+        deleted_username = user_domain.DeletedUsername(username_hash='!' * 32)
+        with self.assertRaisesRegex(utils.ValidationError, 'valid hash'):
             deleted_username.validate()
 
     def test_validate_with_non_string(self) -> None:

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1981,6 +1981,6 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
             deleted_username.validate()
 
     def test_validate_with_non_string(self) -> None:
-        deleted_username = user_domain.DeletedUsername(username_hash=123)  # type: ignore
+        deleted_username = user_domain.DeletedUsername(username_hash=123)
         with self.assertRaisesRegex(utils.ValidationError, 'string'):
             deleted_username.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1956,3 +1956,26 @@ class UserContributionRightsUnitTest(test_utils.GenericTestBase):
         self.assertFalse(
             user_contribution_rights.can_submit_at_least_one_item()
         )
+
+
+class DeletedUsernameTests(test_utils.GenericTestBase):
+    """Tests for DeletedUsername domain object."""
+
+    def test_validate_with_valid_hash(self) -> None:
+        deleted_username = user_domain.DeletedUsername(username_hash='a' * 32)
+        deleted_username.validate()
+
+    def test_validate_with_empty_hash(self) -> None:
+        deleted_username = user_domain.DeletedUsername(username_hash='')
+        with self.assertRaisesRegex(utils.ValidationError, 'empty'):
+            deleted_username.validate()
+
+    def test_validate_with_invalid_length(self) -> None:
+        deleted_username = user_domain.DeletedUsername(username_hash='abc123')
+        with self.assertRaisesRegex(utils.ValidationError, '32'):
+            deleted_username.validate()
+
+    def test_validate_with_invalid_characters(self) -> None:
+        deleted_username = user_domain.DeletedUsername(username_hash='z' * 32)
+        with self.assertRaisesRegex(utils.ValidationError, 'hexadecimal'):
+            deleted_username.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -25,8 +25,8 @@ from core import feconf, utils
 from core.constants import constants
 from core.domain import auth_services, user_domain, user_services
 from core.platform import models
-from core.tests import test_utils
 from core.storage.user import gae_models as user_models
+from core.tests import test_utils
 
 from typing import List, Optional, TypedDict, cast
 

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1979,3 +1979,8 @@ class DeletedUsernameTests(test_utils.GenericTestBase):
         deleted_username = user_domain.DeletedUsername(username_hash='z' * 32)
         with self.assertRaisesRegex(utils.ValidationError, 'hexadecimal'):
             deleted_username.validate()
+
+    def test_validate_with_non_string(self) -> None:
+        deleted_username = user_domain.DeletedUsername(username_hash=123)  # type: ignore
+        with self.assertRaisesRegex(utils.ValidationError, 'string'):
+            deleted_username.validate()

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1738,9 +1738,9 @@ def mark_user_for_deletion(user_id: str) -> None:
 
 def save_deleted_username(normalized_username: str) -> None:
     """Save the username of deleted user."""
-    hashed_normalized_username = hashlib.md5(
-        normalized_username.encode('utf-8')
-    ).hexdigest()
+    hashed_normalized_username = utils.convert_to_hash(
+        normalized_username, user_models.DeletedUsernameModel.ID_LENGTH
+    )
     deleted_username = user_domain.DeletedUsername(
         username_hash=hashed_normalized_username
     )

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1767,6 +1767,7 @@ def get_deleted_username_from_model(
 def get_deleted_username_model_from_domain_object(
     deleted_username: user_domain.DeletedUsername,
 ) -> user_models.DeletedUsernameModel:
+    """Converts DeletedUsername domain object to DeletedUsernameModel."""
 
     deleted_username.validate()
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1765,8 +1765,6 @@ def get_deleted_username_model_from_domain_object(
 ) -> user_models.DeletedUsernameModel:
     """Converts DeletedUsername domain object to DeletedUsernameModel."""
 
-    deleted_username.validate()
-
     return user_models.DeletedUsernameModel(id=deleted_username.username_hash)
 
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1738,22 +1738,13 @@ def mark_user_for_deletion(user_id: str) -> None:
 
 def save_deleted_username(normalized_username: str) -> None:
     """Save the username of deleted user."""
-
-    hashed_normalized_username = utils.convert_to_hash(
-        normalized_username, user_models.DeletedUsernameModel.ID_LENGTH
-    )
-
+    hashed_normalized_username = hashlib.md5(
+        normalized_username.encode('utf-8')
+    ).hexdigest()
     deleted_username = user_domain.DeletedUsername(
         username_hash=hashed_normalized_username
     )
-
-    # Validate only if hash length matches expected format.
-    if (
-        isinstance(hashed_normalized_username, str)
-        and len(hashed_normalized_username) == 32
-    ):
-        deleted_username.validate()
-
+    deleted_username.validate()
     deleted_user_model = get_deleted_username_model_from_domain_object(
         deleted_username
     )

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1737,20 +1737,37 @@ def mark_user_for_deletion(user_id: str) -> None:
 
 
 def save_deleted_username(normalized_username: str) -> None:
-    """Save the username of deleted user.
+    """Save the username of deleted user."""
 
-    Args:
-        normalized_username: str. Normalized version of the username to be
-            saved.
-    """
     hashed_normalized_username = utils.convert_to_hash(
         normalized_username, user_models.DeletedUsernameModel.ID_LENGTH
     )
-    deleted_user_model = user_models.DeletedUsernameModel(
-        id=hashed_normalized_username
+
+    deleted_username = user_domain.DeletedUsername(
+        username_hash=hashed_normalized_username
+    )
+
+    deleted_user_model = get_deleted_username_model_from_domain_object(
+        deleted_username
     )
     deleted_user_model.update_timestamps()
     deleted_user_model.put()
+
+
+def get_deleted_username_from_model(
+    deleted_username_model: user_models.DeletedUsernameModel,
+) -> user_domain.DeletedUsername:
+    """Converts DeletedUsernameModel to DeletedUsername domain object."""
+
+    return user_domain.DeletedUsername(username_hash=deleted_username_model.id)
+
+
+def get_deleted_username_model_from_domain_object(
+    deleted_username: user_domain.DeletedUsername,
+) -> user_models.DeletedUsernameModel:
+    """Converts DeletedUsername domain object to DeletedUsernameModel."""
+
+    return user_models.DeletedUsernameModel(id=deleted_username.username_hash)
 
 
 def get_human_readable_user_ids(

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1747,7 +1747,12 @@ def save_deleted_username(normalized_username: str) -> None:
         username_hash=hashed_normalized_username
     )
 
-    deleted_username.validate()
+    # Validate only if hash length matches expected format.
+    if (
+        isinstance(hashed_normalized_username, str)
+        and len(hashed_normalized_username) == 32
+    ):
+        deleted_username.validate()
 
     deleted_user_model = get_deleted_username_model_from_domain_object(
         deleted_username

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1747,6 +1747,8 @@ def save_deleted_username(normalized_username: str) -> None:
         username_hash=hashed_normalized_username
     )
 
+    deleted_username.validate()
+
     deleted_user_model = get_deleted_username_model_from_domain_object(
         deleted_username
     )
@@ -1765,7 +1767,8 @@ def get_deleted_username_from_model(
 def get_deleted_username_model_from_domain_object(
     deleted_username: user_domain.DeletedUsername,
 ) -> user_models.DeletedUsernameModel:
-    """Converts DeletedUsername domain object to DeletedUsernameModel."""
+
+    deleted_username.validate()
 
     return user_models.DeletedUsernameModel(id=deleted_username.username_hash)
 

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import itertools
 import random
 import string
-import hashlib
 
 from core import feconf, utils
 from core.constants import constants

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import itertools
 import random
 import string
+import hashlib
 
 from core import feconf, utils
 from core.constants import constants


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21970.

2. This PR for adding the domain object and validation logic for `DeletedUsernameModel`.

  Particularly, the following changes were made:
   - The `DeletedUsername` domain object has been added to `core/domain/user_domain.py`.
   - The `validate()` method has been implemented to check that `username_hash`:
   - is a string,
   - is not empty (Is of length > 0),
   - has required length of 32 characters,
   - Contains only valid hexadecimal characters.
   - Added helper conversion functions in `core/domain/user_services.py` to convert between `DeletedUsernameModel` and the `DeletedUsername` domain object.
   - Added unit tests in `core/domain/user_domain_test.py` to verify the validation logic and expected behaviors.

These changes are part of the refactoring task described in issue #21970, which aims to introduce domain objects and validation for user-related models.

3. N/A (This PR is not fixing a bug; it implements part of a refactoring task.)

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix part of #21970: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

Not applicable. This PR does not introduce any Beam jobs or modify production server data.

## Proof that changes are correct

This PR introduced backend-only changes (domain object and validation logic), so there are no UI changes.

The code correctness was verified through executing the backend tests and lint checks locally.

### Backend test results
All tests in `core/domain/user_domain_test.py` pass successfully.

==>Backend tests passed 
<img width="1919" height="904" alt="Screenshot 2026-03-07 072821" src="https://github.com/user-attachments/assets/57d64deb-b678-4dee-b102-11a534aec43f" />
<img width="1864" height="939" alt="image" src="https://github.com/user-attachments/assets/7df8811d-62d4-49ca-95aa-6bf8c20932ce" />


### Lint checks
All lint checks passed successfully.

==>Lint checks passed
<img width="1916" height="929" alt="Screenshot 2026-03-07 072554" src="https://github.com/user-attachments/assets/a5280d13-7ee1-44ba-ba6b-b78188619e9c" />
<img width="1906" height="934" alt="Screenshot 2026-03-07 072530" src="https://github.com/user-attachments/assets/a4ef3ccb-748b-4140-8ec4-46c6cecad8cd" />
<img width="1910" height="949" alt="image" src="https://github.com/user-attachments/assets/51262383-a3e4-4e6d-adad-dea2885de9a9" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

