### PR TITLE
Fix #21285: Assert only stdout in start_subprocess_for_result tests

### DIFF
--- a/scripts/common_test.py
+++ b/scripts/common_test.py
@@ -1299,9 +1299,8 @@ class CommonTests(test_utils.GenericTestBase):
         popen_swap = self.swap(subprocess, 'Popen', mock_popen)
 
         with popen_swap:
-            self.assertEqual(
-                common.start_subprocess_for_result(['cmd']), (b'test\n', b'')
-            )
+            result = common.start_subprocess_for_result(['cmd'])
+            self.assertEqual(result[0], b'test\n')
 
     def test_workflow_permissions_set_to_read_all(self) -> None:
         workflows_dir = os.path.join(os.getcwd(), '.github', 'workflows')

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -239,10 +239,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             return process
 
         with self.swap(subprocess, 'Popen', mock_popen):
-            self.assertEqual(
-                pre_commit_hook.start_subprocess_for_result(['cmd']),
-                (b'test\n', b''),
-            )
+            result = pre_commit_hook.start_subprocess_for_result(['cmd'])
+            self.assertEqual(result[0], b'test\n')
 
     def test_does_diff_include_package_lock_file_with_package_lock_in_diff(
         self,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #21285.
2. This PR does the following: Updates the `test_start_subprocess_for_result` tests in both `scripts/pre_commit_hook_test.py` and `scripts/common_test.py` to assert only `stdout` (`result[0]`) instead of the full `(stdout, stderr)` tuple. Under CI resource pressure, gRPC background threads (from Cloud Datastore emulator libraries) can write errors like `pthread_create failed: Resource temporarily unavailable` to `stderr` of the forked process, causing the assertion on `stderr == b''` to fail. By asserting only `stdout`, we eliminate this source of flakiness while preserving the test's original intent: verifying that `start_subprocess_for_result` correctly invokes `Popen` and calls `communicate()`.
3. (For bug-fixing PRs only) The original bug occurred because: The test created a real `subprocess.Popen(['echo', 'test'])` before the `Popen` mock was applied, then asserted the exact tuple `(b'test\n', b'')`. Under CI resource pressure, gRPC background threads could write error messages to `stderr`, making `stderr != b''` and causing the assertion to fail intermittently.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a test-only fix that addresses flaky CI behavior caused by gRPC background threads writing to stderr under resource pressure. There are no UI or user-facing changes.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
