### PR TITLE
Fix part of #23496: Enable strict checks for Group 2 files

### DIFF
--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -117,7 +117,7 @@ export class CkEditor4RteComponent
     private renderer: Renderer2
   ) {
     this.rteHelperService =
-      OppiaAngularRootComponent.rteHelperService as RteHelperService;
+      OppiaAngularRootComponent.rteHelperService as unknown as RteHelperService;
     this.subscriptions = new Subscription();
   }
 

--- a/core/templates/components/common-layout-directives/common-elements/sharing-links.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/sharing-links.component.spec.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {ExplorationEmbedButtonModalComponent} from 'components/button-directives/exploration-embed-button-modal.component';
@@ -57,7 +56,6 @@ describe('SharingLinksComponent', () => {
   beforeEach(waitForAsync(() => {
     windowRef = new MockWindowRef();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       declarations: [SharingLinksComponent],
       providers: [{provide: WindowRef, useValue: windowRef}],
     }).compileComponents();

--- a/core/templates/components/entity-creation-services/collection-creation.service.spec.ts
+++ b/core/templates/components/entity-creation-services/collection-creation.service.spec.ts
@@ -26,20 +26,6 @@ import {CollectionCreationService} from 'components/entity-creation-services/col
 import {LoaderService} from 'services/loader.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {UserService} from 'services/user.service';
-import {UserInfo} from 'domain/user/user-info.model';
-
-class MockUserService {
-  isLoggedIn(): boolean {
-    return false;
-  }
-
-  getUserInfoAsync(): Promise<UserInfo> {
-    return Promise.resolve({
-      isLoggedIn: () => true,
-    } as UserInfo);
-  }
-}
 
 describe('Collection Creation service', () => {
   let collectionCreationService: CollectionCreationService;
@@ -53,12 +39,6 @@ describe('Collection Creation service', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [
-        {
-          provide: UserService,
-          useClass: MockUserService,
-        },
-      ],
     });
 
     collectionCreationService = TestBed.inject(CollectionCreationService);

--- a/core/templates/components/forms/custom-forms-directives/object-editor.directive.ts
+++ b/core/templates/components/forms/custom-forms-directives/object-editor.directive.ts
@@ -39,7 +39,10 @@ import {
   SimpleChange,
   SimpleChanges,
   ViewContainerRef,
+  ComponentRef,
+  Type,
 } from '@angular/core';
+
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -48,48 +51,50 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import {AlgebraicExpressionEditorComponent} from 'objects/templates/algebraic-expression-editor.component';
-import {BooleanEditorComponent} from 'objects/templates/boolean-editor.component';
-import {CodeStringEditorComponent} from 'objects/templates/code-string-editor.component';
-import {CoordTwoDimEditorComponent} from 'objects/templates/coord-two-dim-editor.component';
-import {AllowedVariablesEditorComponent} from 'objects/templates/allowed-variables-editor.component';
-import {DragAndDropPositiveIntEditorComponent} from 'objects/templates/drag-and-drop-positive-int-editor.component';
-import {FilepathEditorComponent} from 'objects/templates/filepath-editor.component';
-import {FractionEditorComponent} from 'objects/templates/fraction-editor.component';
-import {GraphEditorComponent} from 'objects/templates/graph-editor.component';
-import {HtmlEditorComponent} from 'objects/templates/html-editor.component';
-import {ImageWithRegionsEditorComponent} from 'objects/templates/image-with-regions-editor.component';
-import {ListOfSetsOfTranslatableHtmlContentIdsEditorComponent} from 'objects/templates/list-of-sets-of-translatable-html-content-ids-editor.component';
-import {ListOfTabsEditorComponent} from 'objects/templates/list-of-tabs-editor.component';
-import {ListOfUnicodeStringEditorComponent} from 'objects/templates/list-of-unicode-string-editor.component';
-import {MathEquationEditorComponent} from 'objects/templates/math-equation-editor.component';
-import {MathExpressionContentEditorComponent} from 'objects/templates/math-expression-content-editor.component';
-import {MusicPhraseEditorComponent} from 'objects/templates/music-phrase-editor.component';
-import {NonnegativeIntEditorComponent} from 'objects/templates/nonnegative-int-editor.component';
-import {NormalizedStringEditorComponent} from 'objects/templates/normalized-string-editor.component';
-import {NumberWithUnitsEditorComponent} from 'objects/templates/number-with-units-editor.component';
-import {NumericExpressionEditorComponent} from 'objects/templates/numeric-expression-editor.component';
-import {ParameterNameEditorComponent} from 'objects/templates/parameter-name-editor.component';
-import {PositionOfTermsEditorComponent} from 'objects/templates/position-of-terms-editor.component';
-import {PositiveIntEditorComponent} from 'objects/templates/positive-int-editor.component';
-import {RatioExpressionEditorComponent} from 'objects/templates/ratio-expression-editor.component';
-import {RealEditorComponent} from 'objects/templates/real-editor.component';
-import {SanitizedUrlEditorComponent} from 'objects/templates/sanitized-url-editor.component';
-import {SetOfAlgebraicIdentifierEditorComponent} from 'objects/templates/set-of-algebraic-identifier-editor.component';
-import {SetOfTranslatableHtmlContentIdsEditorComponent} from 'objects/templates/set-of-translatable-html-content-ids-editor.component';
-import {SetOfUnicodeStringEditorComponent} from 'objects/templates/set-of-unicode-string-editor.component';
-import {SkillSelectorEditorComponent} from 'objects/templates/skill-selector-editor.component';
-import {SubtitledHtmlEditorComponent} from 'objects/templates/subtitled-html-editor.component';
-import {SubtitledUnicodeEditorComponent} from 'objects/templates/subtitled-unicode-editor.component';
-import {SvgEditorComponent} from 'objects/templates/svg-editor.component';
-import {TranslatableHtmlContentIdEditorComponent} from 'objects/templates/translatable-html-content-id.component';
-import {TranslatableSetOfNormalizedStringEditorComponent} from 'objects/templates/translatable-set-of-normalized-string-editor.component';
-import {TranslatableSetOfUnicodeStringEditorComponent} from 'objects/templates/translatable-set-of-unicode-string-editor.component';
-import {UnicodeStringEditorComponent} from 'objects/templates/unicode-string-editor.component';
-import {IntEditorComponent} from 'objects/templates/int-editor.component';
-import {LoggerService} from 'services/contextual/logger.service';
-import {ComponentRef} from '@angular/core';
+
 import {Subscription} from 'rxjs';
+
+import {AlgebraicExpressionEditorComponent} from 'extensions/objects/templates/algebraic-expression-editor.component';
+import {BooleanEditorComponent} from 'extensions/objects/templates/boolean-editor.component';
+import {CodeStringEditorComponent} from 'extensions/objects/templates/code-string-editor.component';
+import {CoordTwoDimEditorComponent} from 'extensions/objects/templates/coord-two-dim-editor.component';
+import {AllowedVariablesEditorComponent} from 'extensions/objects/templates/allowed-variables-editor.component';
+import {DragAndDropPositiveIntEditorComponent} from 'extensions/objects/templates/drag-and-drop-positive-int-editor.component';
+import {FilepathEditorComponent} from 'extensions/objects/templates/filepath-editor.component';
+import {FractionEditorComponent} from 'extensions/objects/templates/fraction-editor.component';
+import {GraphEditorComponent} from 'extensions/objects/templates/graph-editor.component';
+import {HtmlEditorComponent} from 'extensions/objects/templates/html-editor.component';
+import {ImageWithRegionsEditorComponent} from 'extensions/objects/templates/image-with-regions-editor.component';
+import {ListOfSetsOfTranslatableHtmlContentIdsEditorComponent} from 'extensions/objects/templates/list-of-sets-of-translatable-html-content-ids-editor.component';
+import {ListOfTabsEditorComponent} from 'extensions/objects/templates/list-of-tabs-editor.component';
+import {ListOfUnicodeStringEditorComponent} from 'extensions/objects/templates/list-of-unicode-string-editor.component';
+import {MathEquationEditorComponent} from 'extensions/objects/templates/math-equation-editor.component';
+import {MathExpressionContentEditorComponent} from 'extensions/objects/templates/math-expression-content-editor.component';
+import {MusicPhraseEditorComponent} from 'extensions/objects/templates/music-phrase-editor.component';
+import {NonnegativeIntEditorComponent} from 'extensions/objects/templates/nonnegative-int-editor.component';
+import {NormalizedStringEditorComponent} from 'extensions/objects/templates/normalized-string-editor.component';
+import {NumberWithUnitsEditorComponent} from 'extensions/objects/templates/number-with-units-editor.component';
+import {NumericExpressionEditorComponent} from 'extensions/objects/templates/numeric-expression-editor.component';
+import {ParameterNameEditorComponent} from 'extensions/objects/templates/parameter-name-editor.component';
+import {PositionOfTermsEditorComponent} from 'extensions/objects/templates/position-of-terms-editor.component';
+import {PositiveIntEditorComponent} from 'extensions/objects/templates/positive-int-editor.component';
+import {RatioExpressionEditorComponent} from 'extensions/objects/templates/ratio-expression-editor.component';
+import {RealEditorComponent} from 'extensions/objects/templates/real-editor.component';
+import {SanitizedUrlEditorComponent} from 'extensions/objects/templates/sanitized-url-editor.component';
+import {SetOfAlgebraicIdentifierEditorComponent} from 'extensions/objects/templates/set-of-algebraic-identifier-editor.component';
+import {SetOfTranslatableHtmlContentIdsEditorComponent} from 'extensions/objects/templates/set-of-translatable-html-content-ids-editor.component';
+import {SetOfUnicodeStringEditorComponent} from 'extensions/objects/templates/set-of-unicode-string-editor.component';
+import {SkillSelectorEditorComponent} from 'extensions/objects/templates/skill-selector-editor.component';
+import {SubtitledHtmlEditorComponent} from 'extensions/objects/templates/subtitled-html-editor.component';
+import {SubtitledUnicodeEditorComponent} from 'extensions/objects/templates/subtitled-unicode-editor.component';
+import {SvgEditorComponent} from 'extensions/objects/templates/svg-editor.component';
+import {TranslatableHtmlContentIdEditorComponent} from 'extensions/objects/templates/translatable-html-content-id.component';
+import {TranslatableSetOfNormalizedStringEditorComponent} from 'extensions/objects/templates/translatable-set-of-normalized-string-editor.component';
+import {TranslatableSetOfUnicodeStringEditorComponent} from 'extensions/objects/templates/translatable-set-of-unicode-string-editor.component';
+import {UnicodeStringEditorComponent} from 'extensions/objects/templates/unicode-string-editor.component';
+import {IntEditorComponent} from 'extensions/objects/templates/int-editor.component';
+
+import {LoggerService} from 'services/contextual/logger.service';
 import {SchemaDefaultValue} from 'services/schema-default-value.service';
 const EDITORS = {
   'algebraic-expression': AlgebraicExpressionEditorComponent,
@@ -174,14 +179,14 @@ export class ObjectEditorComponent
     ControlValueAccessor,
     Validator
 {
-  private _value: SchemaDefaultValue;
-  @Input() alwaysEditable: string;
-  @Input() initArgs: SchemaDefaultValue;
-  @Input() isEditable: string;
-  @Input() modalId: symbol;
-  @Input() objType: string;
-  @Input() schema;
-  @Input() form;
+  private _value!: SchemaDefaultValue;
+  @Input() alwaysEditable!: string;
+  @Input() initArgs!: SchemaDefaultValue;
+  @Input() isEditable!: string;
+  @Input() modalId!: symbol;
+  @Input() objType!: string;
+  @Input() schema!: SchemaDefaultValue;
+  @Input() form!: AbstractControl;
   @Output() validityChange: EventEmitter<void> = new EventEmitter();
   get value(): SchemaDefaultValue {
     return this._value;
@@ -194,8 +199,8 @@ export class ObjectEditorComponent
     // check to see if component has been created.
     if (this.componentRef) {
       this.componentRef.instance.value = this._value;
-      this.onChange(this._value);
-      this.valueChange.emit(this._value);
+      this.onChange(val);
+      this.valueChange.emit(this._value ?? undefined);
       if (this.componentRef.instance.ngOnChanges) {
         const componentInputPropsChangeObject: SimpleChanges = {
           value: new SimpleChange(previousValue, val, false),
@@ -205,11 +210,11 @@ export class ObjectEditorComponent
     }
   }
 
-  @Output() valueChange = new EventEmitter();
-  componentRef: ComponentRef<ObjectEditor>;
+  @Output() valueChange = new EventEmitter<SchemaDefaultValue>();
+  componentRef!: ComponentRef<ObjectEditor>;
   componentSubscriptions = new Subscription();
   onChange: (_: SchemaDefaultValue) => void = () => {};
-  onTouch: () => void;
+  onTouch!: () => void;
   onValidatorChange: () => void = () => {};
 
   // A hashmap is used instead of an array for faster lookup.
@@ -263,7 +268,7 @@ export class ObjectEditorComponent
       }
       const componentFactory =
         this.componentFactoryResolver.resolveComponentFactory(
-          EDITORS[editorName]
+          EDITORS[editorName as keyof typeof EDITORS] as Type<unknown>
         );
       this.viewContainerRef.clear();
       // Unknown is type is used because it is default property of
@@ -285,46 +290,54 @@ export class ObjectEditorComponent
       if (this.schema && !componentRef.instance.schema) {
         componentRef.instance.schema = this.schema;
       }
-      componentRef.instance.value = this.value;
+      componentRef.instance.value = this.value ?? this._value;
 
       // Listening to @Output events (valueChanged and validityChange).
       if (componentRef.instance.valueChanged) {
         this.componentSubscriptions.add(
-          componentRef.instance.valueChanged.subscribe(newValue => {
-            // Changes to array are not caught if the array reference doesn't
-            // change. This is a hack for change detection.
-            if (Array.isArray(newValue)) {
-              this.value = [...newValue];
-              return;
+          componentRef.instance.valueChanged.subscribe(
+            (newValue: SchemaDefaultValue) => {
+              // Changes to array are not caught if the array reference doesn't
+              // change. This is a hack for change detection.
+              if (Array.isArray(newValue)) {
+                this.value = [...newValue];
+                return;
+              }
+              this.value = newValue ?? this.value;
             }
-            this.value = newValue;
-          })
+          )
         );
       }
       if (componentRef.instance.validityChange) {
         this.componentSubscriptions.add(
-          componentRef.instance.validityChange.subscribe(errorsMap => {
-            for (const errorKey of Object.keys(errorsMap)) {
-              // Errors map contains true for a key if valid state and false
-              // for an error state. We remove the key from componentErrors
-              // when it is valid and add it when it is reported as error.
-              const errorState = errorsMap[errorKey];
-              if (errorState !== true) {
-                if (this.componentErrors[errorKey] === undefined) {
-                  this.componentErrors[errorKey] = errorState;
+          componentRef.instance.validityChange.subscribe(
+            (errorsMap: Record<string, boolean>) => {
+              for (const errorKey of Object.keys(errorsMap)) {
+                // Errors map contains true for a key if valid state and false
+                // for an error state. We remove the key from componentErrors
+                // when it is valid and add it when it is reported as error.
+                const errorState = errorsMap[errorKey];
+                if (errorState !== true) {
+                  if (this.componentErrors[errorKey] === undefined) {
+                    this.componentErrors[errorKey] = errorState;
+                  }
+                } else {
+                  if (this.componentErrors[errorKey] !== undefined) {
+                    delete this.componentErrors[errorKey];
+                  }
                 }
-              } else {
-                if (this.componentErrors[errorKey] !== undefined) {
-                  delete this.componentErrors[errorKey];
+                if (this.form) {
+                  (
+                    this.form as unknown as {
+                      $setValidity: (key: string, value: boolean) => void;
+                    }
+                  ).$setValidity(errorKey, errorsMap[errorKey]);
+                  this.validityChange.emit();
                 }
               }
-              if (this.form) {
-                this.form.$setValidity(errorKey, errorsMap[errorKey]);
-                this.validityChange.emit();
-              }
+              this.onValidatorChange();
             }
-            this.onValidatorChange();
-          })
+          )
         );
       }
       this.componentRef = componentRef;
@@ -347,6 +360,8 @@ export class ObjectEditorComponent
   ngOnDestroy(): void {
     this.componentSubscriptions.unsubscribe();
     this.viewContainerRef.clear();
-    this.componentRef.changeDetectorRef.detach();
+    if (this.componentRef) {
+      this.componentRef.changeDetectorRef.detach();
+    }
   }
 }

--- a/core/templates/components/forms/validators/schema-validators.spec.ts
+++ b/core/templates/components/forms/validators/schema-validators.spec.ts
@@ -57,15 +57,16 @@ describe('Schema validators', () => {
       ];
       const filter = SchemaValidators.hasLengthAtLeast(args);
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
         const errorsReturned = filter(control);
         if (testCase.expectedResult === true) {
-          expect(errorsReturned).toBe(null, testCase.toString());
+          expect(errorsReturned).toBe(null);
           return;
         }
-        expect(errorsReturned.hasLengthAtLeast)
-          .withContext(testCase.toString())
-          .toBeDefined();
+        if (!errorsReturned) {
+          fail('Expected validation error');
+        }
+        expect(errorsReturned.hasLengthAtLeast).toBeDefined();
       });
     });
     it('should throw an error when the value is not a string', () => {
@@ -102,15 +103,16 @@ describe('Schema validators', () => {
       ];
       const filter = SchemaValidators.hasLengthAtMost(args);
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
         const errorsReturned = filter(control);
         if (testCase.expectedResult === true) {
-          expect(errorsReturned).toBe(null, testCase.toString());
+          expect(errorsReturned).toBe(null);
           return;
         }
-        expect(errorsReturned.hasLengthAtMost)
-          .withContext(testCase.toString())
-          .toBeDefined();
+        if (!errorsReturned) {
+          fail('Expected validation error');
+        }
+        expect(errorsReturned.hasLengthAtMost).toBeDefined();
       });
     });
 
@@ -148,15 +150,16 @@ describe('Schema validators', () => {
       ];
       const filter = SchemaValidators.isAtLeast(args);
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
         const errorsReturned = filter(control);
         if (testCase.expectedResult === true) {
-          expect(errorsReturned).toBe(null, testCase.toString());
+          expect(errorsReturned).toBe(null);
           return;
         }
-        expect(errorsReturned.isAtLeast)
-          .withContext(testCase.toString())
-          .toBeDefined();
+        if (!errorsReturned) {
+          fail('Expected validation error');
+        }
+        expect(errorsReturned.isAtLeast).toBeDefined();
       });
     });
   });
@@ -180,15 +183,16 @@ describe('Schema validators', () => {
       ];
       const filter = SchemaValidators.isAtMost(args);
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
         const errorsReturned = filter(control);
         if (testCase.expectedResult === true) {
-          expect(errorsReturned).toBe(null, testCase.toString());
+          expect(errorsReturned).toBe(null);
           return;
         }
-        expect(errorsReturned.isAtMost)
-          .withContext(testCase.toString())
-          .toBeDefined();
+        if (!errorsReturned) {
+          fail('Expected validation error');
+        }
+        expect(errorsReturned.isAtMost).toBeDefined();
       });
     });
   });
@@ -230,18 +234,19 @@ describe('Schema validators', () => {
       ];
       const filter = SchemaValidators.isFloat();
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
         const errorsReturned = filter(control);
         if (testCase.expectedResult === true) {
-          expect(errorsReturned).toBe(null, testCase.toString());
+          expect(errorsReturned).toBe(null);
           return;
         }
         if (errorsReturned === null) {
           throw new Error(testCase.controlValue);
         }
-        expect(errorsReturned.isFloat)
-          .withContext(testCase.toString())
-          .toBeDefined();
+        if (!errorsReturned) {
+          fail('Expected validation error');
+        }
+        expect(errorsReturned.isFloat).toBeDefined();
       });
     });
   });
@@ -260,15 +265,16 @@ describe('Schema validators', () => {
 
       const filter = SchemaValidators.isInteger();
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
         const errorsReturned = filter(control);
         if (testCase.expectedResult === true) {
-          expect(errorsReturned).toBe(null, testCase.toString());
+          expect(errorsReturned).toBe(null);
           return;
         }
-        expect(errorsReturned.isInteger)
-          .withContext(testCase.toString())
-          .toBeDefined();
+        if (!errorsReturned) {
+          fail('Expected validation error');
+        }
+        expect(errorsReturned.isInteger).toBeDefined();
       });
     });
   });
@@ -285,15 +291,16 @@ describe('Schema validators', () => {
 
       const filter = SchemaValidators.isNonempty();
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
         const errorsReturned = filter(control);
         if (testCase.expectedResult === true) {
-          expect(errorsReturned).toBe(null, testCase.toString());
+          expect(errorsReturned).toBe(null);
           return;
         }
-        expect(errorsReturned.isNonempty)
-          .withContext(testCase.toString())
-          .toBeDefined();
+        if (!errorsReturned) {
+          fail('Expected validation error');
+        }
+        expect(errorsReturned.isNonempty).toBeDefined();
       });
     });
   });
@@ -311,7 +318,7 @@ describe('Schema validators', () => {
 
     const expectValidationToPass = (controlValue: string) => {
       control.setValue(controlValue);
-      expect(filter(control)).withContext(controlValue).toBe(null);
+      expect(filter(control)).toBe(null);
     };
 
     const expectValidationToFail = (controlValue: string) => {
@@ -423,10 +430,8 @@ describe('Schema validators', () => {
         {controlValue: 'special\\chars', expectedResult: false},
       ];
       testCases.forEach(testCase => {
-        control.setValue(testCase.controlValue);
-        expect(filter(control))
-          .withContext(testCase.toString())
-          .toEqual(errorMsg);
+        control.setValue(testCase.controlValue as SchemaDefaultValue);
+        expect(filter(control)).toEqual(errorMsg);
       });
     });
 

--- a/core/templates/components/interaction-display/interaction-display.component.spec.ts
+++ b/core/templates/components/interaction-display/interaction-display.component.spec.ts
@@ -67,7 +67,7 @@ describe('Interaction display', () => {
 
     componentInstance.viewContainerRef = {
       createComponent: null,
-    } as ViewContainerRef;
+    } as unknown as ViewContainerRef;
     spyOn(componentFactoryResolver, 'resolveComponentFactory');
     spyOn(componentInstance.viewContainerRef, 'createComponent')
       // Unknown type is used here because the type of the component
@@ -108,7 +108,7 @@ describe('Interaction display', () => {
 
     componentInstance.viewContainerRef = {
       createComponent: null,
-    } as ViewContainerRef;
+    } as unknown as ViewContainerRef;
     componentInstance.parentScope = {
       lastAnswer,
     };

--- a/core/templates/components/interaction-display/interaction-display.component.ts
+++ b/core/templates/components/interaction-display/interaction-display.component.ts
@@ -66,10 +66,16 @@ export class InteractionDisplayComponent {
 
       if (
         dom.body.firstElementChild &&
-        TAG_TO_INTERACTION_MAPPING[dom.body.firstElementChild.tagName]
+        TAG_TO_INTERACTION_MAPPING[
+          dom.body.firstElementChild
+            .tagName as keyof typeof TAG_TO_INTERACTION_MAPPING
+        ]
       ) {
         let interaction =
-          TAG_TO_INTERACTION_MAPPING[dom.body.firstElementChild.tagName];
+          TAG_TO_INTERACTION_MAPPING[
+            dom.body.firstElementChild
+              .tagName as keyof typeof TAG_TO_INTERACTION_MAPPING
+          ];
 
         const componentFactory =
           this.componentFactoryResolver.resolveComponentFactory(interaction);
@@ -92,9 +98,13 @@ export class InteractionDisplayComponent {
           // is irrelevant for this usecase).
           if (/[\])}[{(]/g.test(attribute.name)) {
             if (this.parentScope) {
-              attributeValue = this.parentScope[attributeNameInCamelCase];
+              const valueFromScope = (
+                this.parentScope as Record<string, unknown>
+              )[attributeNameInCamelCase];
+
+              attributeValue = (valueFromScope as string) ?? '';
             } else {
-              attributeValue = null;
+              attributeValue = '';
             }
           } else {
             componentRef.location.nativeElement.setAttribute(
@@ -103,7 +113,9 @@ export class InteractionDisplayComponent {
             );
           }
 
-          componentRef.instance[attributeNameInCamelCase] = attributeValue;
+          (componentRef.instance as Record<string, unknown>)[
+            attributeNameInCamelCase
+          ] = attributeValue;
         });
 
         componentRef.changeDetectorRef.detectChanges();

--- a/core/templates/components/oppia-angular-root.component.spec.ts
+++ b/core/templates/components/oppia-angular-root.component.spec.ts
@@ -49,7 +49,7 @@ class MockWindowRef {
       },
     },
     history: {
-      pushState(data, title: string, url?: string | null) {},
+      pushState(_: unknown, title: string, url?: string | null) {},
     },
   };
 }
@@ -85,7 +85,7 @@ describe('OppiaAngularRootComponent', function () {
         {
           provide: DocumentAttributeCustomizationService,
           useValue: {
-            addAttribute: (attr, code) => {},
+            addAttribute: (_: unknown, __: unknown) => {},
           },
         },
         {
@@ -110,7 +110,7 @@ describe('OppiaAngularRootComponent', function () {
   }));
 
   it('should only intialize rteElements once', () => {
-    expect(OppiaAngularRootComponent.rteElementsAreInitialized).toBeTrue();
+    expect(OppiaAngularRootComponent.rteElementsAreInitialized).toBe(true);
     const componentInstance = TestBed.createComponent(
       OppiaAngularRootComponent
     ).componentInstance;
@@ -139,7 +139,8 @@ describe('OppiaAngularRootComponent', function () {
   });
 
   it('should set OppiaAngularRootComponent.pageContextService if not set', () => {
-    OppiaAngularRootComponent.pageContextService = undefined;
+    OppiaAngularRootComponent.pageContextService =
+      undefined as unknown as (typeof component)['pageContextService'];
     expect(OppiaAngularRootComponent.pageContextService).toBeUndefined();
 
     component.ngAfterViewInit();

--- a/core/templates/components/oppia-angular-root.component.ts
+++ b/core/templates/components/oppia-angular-root.component.ts
@@ -83,22 +83,47 @@ import {ServicesConstants} from 'services/services.constants';
 // build to not complain.
 // TODO(#16309): Fix relative imports.
 import '../third-party-imports/ckeditor.import';
-
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveCollapsible} from 'rich_text_components/Collapsible/directives/oppia-noninteractive-collapsible.component';
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveImage} from 'rich_text_components/Image/directives/oppia-noninteractive-image.component';
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveLink} from 'rich_text_components/Link/directives/oppia-noninteractive-link.component';
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveMath} from 'rich_text_components/Math/directives/oppia-noninteractive-math.component';
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveSkillreview} from 'rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component';
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveTabs} from 'rich_text_components/Tabs/directives/oppia-noninteractive-tabs.component';
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveVideo} from 'rich_text_components/Video/directives/oppia-noninteractive-video.component';
-import {CkEditorInitializerService} from './ck-editor-helpers/ck-editor-4-widgets.initializer';
+import {
+  CkEditorInitializerService,
+  RteHelperService,
+} from './ck-editor-helpers/ck-editor-4-widgets.initializer';
 import {HtmlEscaperService} from 'services/html-escaper.service';
 import {MetaTagCustomizationService} from 'services/contextual/meta-tag-customization.service';
 import {AppConstants} from 'app.constants';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {UrlService} from 'services/contextual/url.service';
 import {I18nService} from 'i18n/i18n.service';
-import {RteHelperService} from 'services/rte-helper.service';
+// This throws "Cannot find module during Angular compilation".
+// We need to suppress this error because these components are loaded dynamically.
+// @ts-ignore
 import {NoninteractiveWorkedexample} from 'rich_text_components/Workedexample/directives/oppia-noninteractive-workedexample.component';
 
 const componentMap = {
@@ -131,7 +156,7 @@ const componentMap = {
 export const registerCustomElements = (injector: Injector): void => {
   for (const rteKey of Object.keys(ServicesConstants.RTE_COMPONENT_SPECS)) {
     const rteElement = createCustomElement(
-      componentMap[rteKey].component_class,
+      componentMap[rteKey as keyof typeof componentMap].component_class,
       {injector}
     );
     // Check if the custom elements have been previously defined. We can't
@@ -142,14 +167,18 @@ export const registerCustomElements = (injector: Injector): void => {
     if (
       customElements.get(
         'oppia-noninteractive-ckeditor-' +
-          ServicesConstants.RTE_COMPONENT_SPECS[rteKey].frontend_id
+          ServicesConstants.RTE_COMPONENT_SPECS[
+            rteKey as keyof typeof ServicesConstants.RTE_COMPONENT_SPECS
+          ].frontend_id
       ) !== undefined
     ) {
       continue;
     }
     customElements.define(
       'oppia-noninteractive-ckeditor-' +
-        ServicesConstants.RTE_COMPONENT_SPECS[rteKey].frontend_id,
+        ServicesConstants.RTE_COMPONENT_SPECS[
+          rteKey as keyof typeof ServicesConstants.RTE_COMPONENT_SPECS
+        ].frontend_id,
       rteElement
     );
   }
@@ -170,11 +199,11 @@ export class OppiaAngularRootComponent implements AfterViewInit {
   static pageTitleService: PageTitleService;
   static profilePageBackendApiService: ProfilePageBackendApiService;
   static rteElementsAreInitialized: boolean = false;
-  static rteHelperService;
+  static rteHelperService: RteHelperService;
   static ratingComputationService: RatingComputationService;
   static reviewTestBackendApiService: ReviewTestBackendApiService;
   static storyViewerBackendApiService: StoryViewerBackendApiService;
-  static ajsValueProvider: (string, unknown) => void;
+  static ajsValueProvider: (key: string, value: unknown) => void;
   static injector: Injector;
 
   constructor(

--- a/core/templates/components/question-directives/question-editor/question-editor.component.ts
+++ b/core/templates/components/question-directives/question-editor/question-editor.component.ts
@@ -97,9 +97,10 @@ export class QuestionEditorComponent implements OnInit, OnDestroy {
 
   saveInteractionData(displayedValue: InteractionData): void {
     this._updateQuestion(() => {
-      this.stateEditorService.setInteractionId(
-        cloneDeep(displayedValue.interactionId)
-      );
+      const interactionId = displayedValue.interactionId;
+      if (interactionId !== null) {
+        this.stateEditorService.setInteractionId(cloneDeep(interactionId));
+      }
       this.stateEditorService.setInteractionCustomizationArgs(
         cloneDeep(displayedValue.customizationArgs)
       );
@@ -188,7 +189,7 @@ export class QuestionEditorComponent implements OnInit, OnDestroy {
     const stateData = this.questionStateData;
     const outcome = stateData.interaction.defaultOutcome;
     if (outcome) {
-      outcome.setDestination(null);
+      outcome.setDestination('question');
     }
     if (stateData) {
       this.stateEditorService.onStateEditorInitialized.emit(stateData);
@@ -224,14 +225,16 @@ export class QuestionEditorComponent implements OnInit, OnDestroy {
     } else {
       this.editabilityService.markNotEditable();
     }
-    this.stateEditorService.setActiveStateName('question');
-    this.stateEditorService.setMisconceptionsBySkill(
-      this.misconceptionsBySkill
-    );
+    this.stateEditorService.setActiveStateName('question' as string);
+    if (this.misconceptionsBySkill) {
+      this.stateEditorService.setMisconceptionsBySkill(
+        this.misconceptionsBySkill
+      );
+    }
     this.oppiaBlackImgUrl =
       this.urlInterpolationService.getStaticCopyrightedImageUrl(
         '/avatar/oppia_avatar_100px.svg'
-      );
+      ) as string;
 
     this.interactionIsShown = false;
     this.stateEditorIsInitialized = false;

--- a/core/templates/components/question-directives/questions-list/questions-list.component.spec.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.spec.ts
@@ -52,11 +52,11 @@ import {QuestionsListComponent} from './questions-list.component';
 
 class MockNgbModalRef {
   componentInstance = {
-    skillSummaries: null,
-    skillsInSameTopicCount: null,
-    categorizedSkills: null,
-    allowSkillsFromOtherTopics: null,
-    untriagedSkillSummaries: null,
+    skillSummaries: [],
+    skillsInSameTopicCount: 0,
+    categorizedSkills: {},
+    allowSkillsFromOtherTopics: false,
+    untriagedSkillSummaries: [],
   };
 }
 
@@ -69,7 +69,7 @@ class MockNgbModal {
 }
 
 class MockUrlInterpolationService {
-  interpolateUrl(value) {
+  interpolateUrl(value: string): string {
     return value;
   }
 }
@@ -89,8 +89,8 @@ describe('Questions List Component', () => {
   let pageContextService: PageContextService;
   let questionValidationService: QuestionValidationService;
   let skill: Skill;
-  let question = null;
-  let questionStateData = null;
+  let question: Question | null = null;
+  let questionStateData: State | null = null;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -161,7 +161,7 @@ describe('Questions List Component', () => {
                 missing_prerequisite_skill_id: null,
               },
               rule_specs: [],
-              training_data: null,
+              training_data: [],
               tagged_skill_misconception_id: null,
             },
           ],
@@ -179,8 +179,8 @@ describe('Questions List Component', () => {
             },
           },
           default_outcome: {
-            dest: null,
-            dest_if_really_stuck: null,
+            dest: '',
+            dest_if_really_stuck: '',
             feedback: {
               html: 'Correct Answer',
               content_id: 'content_2',
@@ -213,11 +213,12 @@ describe('Questions List Component', () => {
         solicit_answer_details: false,
         card_is_checkpoint: false,
         linked_skill_id: null,
+        inapplicable_skill_misconception_ids: null,
       },
-      inapplicable_skill_misconception_ids: null,
       language_code: 'en',
       linked_skill_ids: [],
       next_content_id_index: 5,
+      inapplicable_skill_misconception_ids: [],
       question_state_data_schema_version: 44,
       version: 45,
     });
@@ -249,9 +250,9 @@ describe('Questions List Component', () => {
       language_code: 'en',
       version: 3,
       prerequisite_skill_ids: [],
-      all_questions_merged: null,
-      next_misconception_id: null,
-      superseding_skill_id: null,
+      all_questions_merged: false,
+      next_misconception_id: 0,
+      superseding_skill_id: '',
     });
 
     component.selectedSkillId = 'skillId1';
@@ -327,8 +328,7 @@ describe('Questions List Component', () => {
         })
       );
 
-      expect(component.misconceptionIdsForSelectedSkill).toEqual(undefined);
-
+      expect(component.misconceptionIdsForSelectedSkill).toBeUndefined();
       component.ngOnInit();
       tick();
 
@@ -362,9 +362,9 @@ describe('Questions List Component', () => {
         language_code: 'en',
         version: 3,
         prerequisite_skill_ids: [],
-        all_questions_merged: null,
-        next_misconception_id: null,
-        superseding_skill_id: null,
+        all_questions_merged: false,
+        next_misconception_id: 0,
+        superseding_skill_id: '',
       });
 
       spyOn(skillBackendApiService, 'fetchSkillAsync').and.returnValue(
@@ -375,7 +375,7 @@ describe('Questions List Component', () => {
         })
       );
 
-      expect(component.difficultyCount).toEqual(undefined);
+      expect(component.difficultyCount).toBeUndefined();
 
       component.ngOnInit();
       tick();
@@ -449,9 +449,9 @@ describe('Questions List Component', () => {
       language_code: 'en',
       version: 3,
       prerequisite_skill_ids: [],
-      all_questions_merged: null,
-      next_misconception_id: null,
-      superseding_skill_id: null,
+      all_questions_merged: false,
+      next_misconception_id: 0,
+      superseding_skill_id: '',
     });
     spyOn(skillBackendApiService, 'fetchMultiSkillsAsync').and.returnValue(
       Promise.resolve([skill])
@@ -567,6 +567,10 @@ describe('Questions List Component', () => {
     'should not save and publish question if there are' + ' validation errors',
     () => {
       component.question = question;
+      if (!component.question) {
+        throw new Error('Question should be initialized in test.');
+      }
+
       spyOn(alertsService, 'addWarning');
       spyOn(
         questionValidationService,
@@ -588,6 +592,10 @@ describe('Questions List Component', () => {
       ' errors from question backend api service',
     fakeAsync(() => {
       component.question = question;
+      if (!component.question) {
+        throw new Error('Question should be initialized in test.');
+      }
+
       component.questionIsBeingUpdated = false;
       spyOn(
         editableQuestionBackendApiService,
@@ -612,21 +620,25 @@ describe('Questions List Component', () => {
       ' being updated',
     fakeAsync(() => {
       component.question = question;
+      if (!component.question) {
+        throw new Error('Question should be initialized in test.');
+      }
+
       component.questionIsBeingUpdated = false;
       component.skillLinkageModificationsArray = [
         {
           id: '1',
-          task: null,
+          task: '',
           difficulty: 1,
         },
         {
           id: '2',
-          task: null,
+          task: '',
           difficulty: 2,
         },
         {
           id: '1',
-          task: null,
+          task: '',
           difficulty: 1,
         },
       ];
@@ -657,17 +669,17 @@ describe('Questions List Component', () => {
       ).toHaveBeenCalledWith('qId', [
         {
           id: '1',
-          task: null,
+          task: '',
           difficulty: 1,
         },
         {
           id: '2',
-          task: null,
+          task: '',
           difficulty: 2,
         },
         {
           id: '1',
-          task: null,
+          task: '',
           difficulty: 1,
         },
       ]);
@@ -676,6 +688,10 @@ describe('Questions List Component', () => {
 
   it('should save question when another question is being updated', fakeAsync(() => {
     component.question = question;
+    if (!component.question) {
+      throw new Error('Question should be initialized in test.');
+    }
+
     component.questionIsBeingUpdated = true;
 
     spyOn(
@@ -710,6 +726,10 @@ describe('Questions List Component', () => {
       ' is being updated',
     fakeAsync(() => {
       component.question = question;
+      if (!component.question) {
+        throw new Error('Question should be initialized in test.');
+      }
+
       component.questionIsBeingUpdated = true;
       spyOn(
         questionValidationService,
@@ -747,6 +767,10 @@ describe('Questions List Component', () => {
       ' a question',
     fakeAsync(() => {
       component.question = question;
+      if (!component.question) {
+        throw new Error('Question should be initialized in test.');
+      }
+
       component.questionIsBeingUpdated = true;
       spyOn(
         questionValidationService,
@@ -772,7 +796,7 @@ describe('Questions List Component', () => {
     "should show 'confirm question modal exit' modal when user " +
       'clicks cancel',
     fakeAsync(() => {
-      spyOn(ngbModal, 'open').and.callFake((dlg, opt) => {
+      spyOn(ngbModal, 'open').and.callFake((dlg: unknown, opt?: unknown) => {
         return {
           result: Promise.resolve(),
         } as NgbModalRef;
@@ -817,7 +841,7 @@ describe('Questions List Component', () => {
     "should close 'confirm question modal exit' modal when user clicks" +
       ' cancel',
     fakeAsync(() => {
-      spyOn(ngbModal, 'open').and.callFake((dlg, opt) => {
+      spyOn(ngbModal, 'open').and.callFake((dlg: unknown, opt?: unknown) => {
         return {
           result: Promise.reject(),
         } as NgbModalRef;
@@ -874,12 +898,14 @@ describe('Questions List Component', () => {
       question_content: '',
     });
     let skillDescription = 'Skill Description';
-    let difficulty: 0.9;
+    let difficulty = 0.9;
 
     it('should return null if editor is already opened', () => {
       component.editorIsOpen = true;
 
-      expect(component.editQuestion(null, null, null)).toBe(undefined);
+      expect(component.editQuestion(questionSummaryForOneSkill, '', 0)).toBe(
+        undefined
+      );
     });
 
     it(
@@ -888,7 +914,7 @@ describe('Questions List Component', () => {
         component.canEditQuestion = false;
         spyOn(alertsService, 'addWarning');
 
-        component.editQuestion(null, null, null);
+        component.editQuestion(questionSummaryForOneSkill, '', 0);
 
         expect(alertsService.addWarning).toHaveBeenCalledWith(
           'User does not have enough rights to edit the question'
@@ -1005,7 +1031,7 @@ describe('Questions List Component', () => {
         'editQuestionSkillLinksAsync'
       ).and.returnValue(Promise.resolve());
 
-      component.removeQuestionFromSkill(questionId);
+      component.removeQuestionFromSkill(questionId, 0);
       tick();
 
       expect(ngbModal.open).toHaveBeenCalled();
@@ -1037,7 +1063,7 @@ describe('Questions List Component', () => {
         'editQuestionSkillLinksAsync'
       ).and.returnValue(Promise.resolve());
 
-      component.removeQuestionFromSkill(questionId);
+      component.removeQuestionFromSkill(questionId, 0);
       tick();
 
       expect(ngbModal.open).toHaveBeenCalled();
@@ -1069,7 +1095,7 @@ describe('Questions List Component', () => {
       ).and.returnValue(Promise.resolve());
       spyOn(component, 'removeQuestionSkillLinkAsync');
 
-      component.removeQuestionFromSkill(questionId);
+      component.removeQuestionFromSkill(questionId, 0);
       tick();
       expect(ngbModal.open).toHaveBeenCalled();
       expect(component.removeQuestionSkillLinkAsync).not.toHaveBeenCalled();
@@ -1085,7 +1111,7 @@ describe('Questions List Component', () => {
     ];
     spyOn(alertsService, 'addInfoMessage');
 
-    component.removeSkill(null);
+    component.removeSkill('1');
 
     expect(alertsService.addInfoMessage).toHaveBeenCalledWith(
       'A question should be linked to at least one skill.'
@@ -1149,6 +1175,9 @@ describe('Questions List Component', () => {
 
   it('should show solution if interaction can have solution', () => {
     component.question = question;
+    if (!component.question) {
+      throw new Error('Question should be initialized in test.');
+    }
     spyOn(component.question, 'getStateData').and.returnValue({
       interaction: {
         id: 'TextInput',
@@ -1340,7 +1369,7 @@ describe('Questions List Component', () => {
       component.skillLinkageModificationsArray = [
         {
           id: '1',
-          task: null,
+          task: '',
           difficulty: 1,
         },
       ];
@@ -1383,12 +1412,12 @@ describe('Questions List Component', () => {
     component.skillLinkageModificationsArray = [
       {
         id: '1',
-        task: null,
+        task: '',
         difficulty: 1,
       },
       {
         id: '2',
-        task: null,
+        task: '',
         difficulty: 2,
       },
     ];

--- a/core/templates/components/question-directives/questions-list/questions-list.component.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.ts
@@ -56,6 +56,7 @@ import {QuestionEditorSaveModalComponent} from '../modal-templates/question-edit
 import {PageContextService} from 'services/page-context.service';
 import {FocusManagerService} from 'services/stateful/focus-manager.service';
 import {ImageLocalStorageService} from 'services/image-local-storage.service';
+import {ImageData} from 'domain/question/editable-question-backend-api.service';
 import {QuestionsListService} from 'services/questions-list.service';
 import {QuestionValidationService} from 'services/question-validation.service';
 import {SkillEditorRoutingService} from 'pages/skill-editor-page/services/skill-editor-routing.service';
@@ -77,39 +78,44 @@ interface GroupedSkillSummaries {
   templateUrl: './questions-list.component.html',
 })
 export class QuestionsListComponent implements OnInit, OnDestroy {
-  @Input() allSkillSummaries: ShortSkillSummary[];
-  @Input() canEditQuestion: boolean;
-  @Input() groupedSkillSummaries: GroupedSkillSummaries;
-  @Input() selectedSkillId: string;
-  @Input() selectSkillModalIsShown: boolean;
-  @Input() skillIdToRubricsObject: Record<string, Rubric>;
-  @Input() skillsCategorizedByTopics: CategorizedSkills;
-  @Input() untriagedSkillSummaries: SkillSummary[];
-  @Input() skillDescriptionsAreShown: boolean;
+  @Input() allSkillSummaries!: ShortSkillSummary[];
+  @Input() canEditQuestion!: boolean;
+  @Input() groupedSkillSummaries!: GroupedSkillSummaries;
+  @Input() selectedSkillId!: string;
+  @Input() selectSkillModalIsShown!: boolean;
+  @Input() skillIdToRubricsObject!: Record<string, Rubric>;
+  @Input() skillsCategorizedByTopics!: CategorizedSkills;
+  @Input() untriagedSkillSummaries!: SkillSummary[];
+  @Input() skillDescriptionsAreShown!: boolean;
 
-  associatedSkillSummaries: ShortSkillSummary[];
-  deletedQuestionIds: string[];
-  difficulty: number;
-  difficultyCardIsShown: boolean;
-  editorIsOpen: boolean;
-  isSkillDifficultyChanged: boolean;
-  linkedSkillsWithDifficulty: SkillDifficulty[];
-  misconceptionIdsForSelectedSkill: number[];
-  misconceptionsBySkill: MisconceptionSkillMap;
-  newQuestionIsBeingCreated: boolean;
-  newQuestionSkillDifficulties: number[];
-  newQuestionSkillIds: string[];
-  question: Question;
-  questionId: string;
-  questionIsBeingSaved: boolean;
-  questionIsBeingUpdated: boolean;
-  questionStateData: State;
+  associatedSkillSummaries!: ShortSkillSummary[];
+  deletedQuestionIds!: string[];
+  difficulty!: number;
+  difficultyCardIsShown!: boolean;
+  editorIsOpen!: boolean;
+  isSkillDifficultyChanged!: boolean;
+  linkedSkillsWithDifficulty!: SkillDifficulty[];
+  misconceptionIdsForSelectedSkill!: number[];
+  misconceptionsBySkill!: MisconceptionSkillMap;
+  newQuestionIsBeingCreated!: boolean;
+  newQuestionSkillDifficulties!: number[];
+  newQuestionSkillIds!: string[];
+  question: Question | null = null;
+  questionId: string | null = null;
+  questionIsBeingSaved!: boolean;
+  questionIsBeingUpdated!: boolean;
+  questionStateData!: State;
+
   questionSummariesForOneSkill: QuestionSummaryForOneSkill[] = [];
-  showDifficultyChoices: boolean;
-  skillLinkageModificationsArray: SkillLinkageModificationsArray[];
+
+  showDifficultyChoices!: boolean;
+  skillLinkageModificationsArray!: SkillLinkageModificationsArray[];
+
   directiveSubscriptions = new Subscription();
+
   MAX_SKILLS_PER_QUESTION: number = AppConstants.MAX_SKILLS_PER_QUESTION;
-  difficultyCount: number;
+
+  difficultyCount!: number;
 
   constructor(
     private alertsService: AlertsService,
@@ -159,10 +165,12 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
     this.imageLocalStorageService.flushStoredImagesData();
     this.pageContextService.setImageSaveDestinationToLocalStorage();
 
-    this.question = Question.createDefaultQuestion(this.newQuestionSkillIds);
+    const question = Question.createDefaultQuestion(this.newQuestionSkillIds);
+    this.question = question;
+
     this.questionUndoRedoService.clearChanges();
-    this.questionId = this.question.getId();
-    this.questionStateData = this.question.getStateData();
+    this.questionId = question.getId();
+    this.questionStateData = question.getStateData();
     this.questionIsBeingUpdated = false;
     this.newQuestionIsBeingCreated = true;
     this.topicEditorStateService.toggleQuestionEditor(
@@ -405,7 +413,18 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
     }
 
     const interactionId = this.question.getStateData().interaction.id;
-    return interactionId && INTERACTION_SPECS[interactionId].can_have_solution;
+
+    if (!interactionId) {
+      return false;
+    }
+
+    if (!(interactionId in INTERACTION_SPECS)) {
+      return false;
+    }
+
+    const typedInteractionId = interactionId as keyof typeof INTERACTION_SPECS;
+
+    return INTERACTION_SPECS[typedInteractionId].can_have_solution;
   }
 
   addSkill(): void {
@@ -502,12 +521,18 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
   }
 
   saveAndPublishQuestion(commitMessage: string | null): void {
+    if (!this.question) {
+      return;
+    }
+
+    const question = this.question;
+
     let validationErrors =
-      this.questionValidationService.getValidationErrorMessage(this.question);
-    let unaddressedMisconceptions =
-      this.question.getUnaddressedMisconceptionNames(
-        this.misconceptionsBySkill
-      );
+      this.questionValidationService.getValidationErrorMessage(question);
+
+    let unaddressedMisconceptions = question.getUnaddressedMisconceptionNames(
+      this.misconceptionsBySkill
+    );
     let unaddressedMisconceptionsErrorString = `Remaining misconceptions that need to be addressed: ${unaddressedMisconceptions.join(
       ', '
     )}`;
@@ -520,7 +545,14 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
     }
 
     if (!this.questionIsBeingUpdated) {
-      let imagesData = this.imageLocalStorageService.getStoredImagesData();
+      const rawImagesData = this.imageLocalStorageService.getStoredImagesData();
+
+      const imagesData: ImageData[] = rawImagesData
+        .filter(img => img.imageBlob !== null)
+        .map(img => ({
+          filename: img.filename,
+          imageBlob: img.imageBlob as Blob,
+        }));
       this.imageLocalStorageService.flushStoredImagesData();
       this.editableQuestionBackendApiService
         .createQuestionAsync(
@@ -564,10 +596,17 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
     } else {
       if (this.questionUndoRedoService.hasChanges()) {
         if (commitMessage) {
+          if (!this.questionId || !this.question) {
+            return;
+          }
+
+          const questionId = this.questionId;
+          const question = this.question;
+
           this.editableQuestionBackendApiService
             .updateQuestionAsync(
-              this.questionId,
-              String(this.question.getVersion()),
+              questionId,
+              String(question.getVersion()),
               commitMessage,
               this.questionUndoRedoService.getCommittableChangeList()
             )
@@ -620,7 +659,7 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
           this.pageContextService.resetImageSaveDestination();
           this.editorIsOpen = false;
           this.topicEditorStateService.toggleQuestionEditor(false);
-          this.windowRef.nativeWindow.location.hash = null;
+          this.windowRef.nativeWindow.location.hash = '';
           this.skillEditorRoutingService.questionIsBeingCreated = false;
         },
         () => {
@@ -632,9 +671,15 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
   }
 
   updateSkillLinkageAndQuestions(commitMsg: string): void {
+    if (!this.questionId) {
+      return;
+    }
+
+    const questionId = this.questionId;
+
     this.editableQuestionBackendApiService
       .editQuestionSkillLinksAsync(
-        this.questionId,
+        questionId,
         this.skillLinkageModificationsArray
       )
       .then(data => {
@@ -653,6 +698,10 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
   }
 
   updateSkillLinkage(): void {
+    if (!this.questionId) {
+      return;
+    }
+
     this.editableQuestionBackendApiService
       .editQuestionSkillLinksAsync(
         this.questionId,
@@ -666,7 +715,7 @@ export class QuestionsListComponent implements OnInit, OnDestroy {
   saveQuestion(): void {
     this.questionIsBeingSaved = true;
     this.pageContextService.resetImageSaveDestination();
-    this.windowRef.nativeWindow.location.hash = null;
+    this.windowRef.nativeWindow.location.hash = '';
     if (this.questionIsBeingUpdated) {
       this.ngbModal
         .open(QuestionEditorSaveModalComponent, {

--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.ts
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.ts
@@ -55,6 +55,9 @@ import {AnswerGroup} from 'domain/exploration/answer-group.model';
 import {Outcome} from 'domain/exploration/outcome.model';
 import {InteractionAnswer} from 'interactions/answer-defs';
 import {GenerateContentIdService} from 'services/generate-content-id.service';
+import {SafeHtml} from '@angular/platform-browser';
+
+const INTERACTION_SPECS_TYPED = INTERACTION_SPECS as typeof INTERACTION_SPECS;
 
 export interface InitializeAnswerGroups {
   interactionId: string;
@@ -84,15 +87,15 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
   @ViewChild('collapseAnswersAndResponsesButton')
   collapseAnswersAndResponsesButton!: ElementRef;
 
-  customizationModalReopened: boolean;
-  DEFAULT_TERMINAL_STATE_CONTENT: string;
+  customizationModalReopened!: boolean;
+  DEFAULT_TERMINAL_STATE_CONTENT!: string;
   directiveSubscriptions = new Subscription();
-  hasLoaded: boolean;
-  interactionEditorIsShown: boolean;
-  interactionId: string;
-  interactionIsDisabled: boolean;
-  interactionPreviewHtml: string;
-  windowIsNarrow: boolean;
+  hasLoaded!: boolean;
+  interactionEditorIsShown!: boolean;
+  interactionId!: string;
+  interactionIsDisabled!: boolean;
+  interactionPreviewHtml!: SafeHtml | null;
+  windowIsNarrow!: boolean;
 
   constructor(
     private alertsService: AlertsService,
@@ -114,7 +117,10 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
 
   getCurrentInteractionName(): string {
     return this.stateInteractionIdService.savedMemento
-      ? INTERACTION_SPECS[this.stateInteractionIdService.savedMemento].name
+      ? INTERACTION_SPECS_TYPED[
+          this.stateInteractionIdService
+            .savedMemento as keyof typeof INTERACTION_SPECS_TYPED
+        ].name
       : '';
   }
 
@@ -152,7 +158,7 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
       this.stateEditorService.getAnswerChoices(
         this.interactionId,
         this.stateCustomizationArgsService.savedMemento
-      )
+      ) ?? undefined
     );
   }
 
@@ -171,7 +177,9 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
     this.stateContentService.displayed.html =
       this.DEFAULT_TERMINAL_STATE_CONTENT;
     this.stateContentService.saveDisplayedValue();
-    this.onSaveStateContent.emit(this.stateContentService.displayed);
+    this.onSaveStateContent.emit(
+      this.stateContentService.displayed ?? undefined
+    );
   }
 
   focusOnCustomizeInteraction(event: KeyboardEvent): void {
@@ -201,7 +209,10 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
       this.stateInteractionIdService.savedMemento;
     if (hasInteractionIdChanged) {
       if (
-        INTERACTION_SPECS[this.stateInteractionIdService.displayed].is_terminal
+        INTERACTION_SPECS_TYPED[
+          this.stateInteractionIdService
+            .displayed as keyof typeof INTERACTION_SPECS_TYPED
+        ].is_terminal
       ) {
         this.updateDefaultTerminalStateContentIfEmpty();
       }
@@ -210,7 +221,7 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
     this.stateCustomizationArgsService.saveDisplayedValue();
 
     let interactionData: InteractionData = {
-      interactionId: this.stateInteractionIdService.displayed,
+      interactionId: this.stateInteractionIdService.displayed ?? '',
       customizationArgs: this.stateCustomizationArgsService.displayed,
     };
     this.onSaveInteractionData.emit(interactionData);
@@ -235,7 +246,7 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
       this.stateEditorService.getAnswerChoices(
         this.interactionId,
         this.stateCustomizationArgsService.savedMemento
-      )
+      ) ?? undefined
     );
   }
 
@@ -273,7 +284,7 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
       })
       .result.then(
         () => {
-          this.stateInteractionIdService.displayed = null;
+          this.stateInteractionIdService.displayed = '';
           this.stateCustomizationArgsService.displayed = {};
           this.stateSolutionService.displayed = null;
           this.interactionDetailsCacheService.removeDetails(
@@ -283,13 +294,15 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
           this.stateCustomizationArgsService.saveDisplayedValue();
 
           let interactionData: InteractionData = {
-            interactionId: this.stateInteractionIdService.displayed,
+            interactionId: this.stateInteractionIdService.displayed ?? '',
             customizationArgs: this.stateCustomizationArgsService.displayed,
           };
           this.onSaveInteractionData.emit(interactionData);
 
           this.stateSolutionService.saveDisplayedValue();
-          this.onSaveSolution.emit(this.stateSolutionService.displayed);
+          this.onSaveSolution.emit(
+            this.stateSolutionService.displayed ?? undefined
+          );
 
           this.stateInteractionIdService.onInteractionIdChanged.emit(
             this.stateInteractionIdService.savedMemento
@@ -336,9 +349,10 @@ export class StateInteractionEditorComponent implements OnInit, OnDestroy {
         this.hasLoaded = false;
         this.interactionDetailsCacheService.reset();
         this.responsesService.onInitializeAnswerGroups.emit({
-          interactionId: stateData.interaction.id,
+          interactionId: stateData.interaction.id ?? '',
           answerGroups: stateData.interaction.answerGroups,
-          defaultOutcome: stateData.interaction.defaultOutcome,
+          defaultOutcome:
+            stateData.interaction.defaultOutcome ?? ({} as Outcome),
           confirmedUnclassifiedAnswers:
             stateData.interaction.confirmedUnclassifiedAnswers,
         });


### PR DESCRIPTION
## Overview

1. This PR fixes part of #23496.
2. This PR resolves TypeScript strict mode errors in the Group 2 files.
   The changes update type annotations and remove type mismatches to ensure compatibility with strict TypeScript checks.
   These updates do not modify application logic and only affect typing.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (Not required since this PR only updates type annotations.)
- [x] The PR title starts with "Fix part of #23496: Enable strict checks for Group 2 files".
- [x] I will request reviewers or comment "@reviewer_username PTAL".

## Proof that changes are correct

No proof of UI changes is required because this PR only modifies TypeScript typings and does not introduce user-facing functionality.