### PR TITLE
Fixes #24339: Correct KaTeX syntax in Guppy placeholder

### DIFF
--- a/core/templates/services/guppy-configuration.service.spec.ts
+++ b/core/templates/services/guppy-configuration.service.spec.ts
@@ -80,8 +80,13 @@ describe('GuppyConfigurationService', () => {
     it('should configure guppy if service is not initialized', () => {
       GuppyConfigurationService.serviceIsInitialized = false;
       spyOn(Guppy, 'remove_global_symbol');
+      spyOn(Guppy, 'configure');
       guppyConfigurationService.init();
       expect(Guppy.remove_global_symbol).toHaveBeenCalled();
+      expect(Guppy.configure).toHaveBeenCalledWith(
+        'empty_content',
+        '\\color{grey}{\\small \\text{Type a formula here.}}'
+      );
     });
 
     it('should not configure guppy if service is initialized', () => {

--- a/core/templates/services/guppy-configuration.service.ts
+++ b/core/templates/services/guppy-configuration.service.ts
@@ -127,7 +127,7 @@ export class GuppyConfigurationService {
     Guppy.configure('buttons', ['controls']);
     Guppy.configure(
       'empty_content',
-      '\\color{grey}{\\text{\\small{Type a formula here.}}}'
+      '\\color{grey}{\\small \\text{Type a formula here.}}'
     );
     GuppyConfigurationService.serviceIsInitialized = true;
   }

--- a/core/templates/services/guppy-initialization.service.spec.ts
+++ b/core/templates/services/guppy-initialization.service.spec.ts
@@ -62,7 +62,13 @@ describe('GuppyInitializationService', () => {
     mockDocument.classList.add('guppy-div-creator', 'guppy_active');
     document.body.insertAdjacentHTML('beforeend', mockDocument.outerHTML);
 
+    const guppySpy = spyOn(MockGuppy.prototype, 'configure');
     guppyInitializationService.init('guppy-div-creator', 'placeholder', 'x=y');
+
+    expect(guppySpy).toHaveBeenCalledWith(
+      'empty_content',
+      '\\color{grey}{\\small \\text{placeholder}}'
+    );
 
     let guppyDivs = document.querySelectorAll('.guppy-div-creator');
     for (let i = 0; i < guppyDivs.length; i++) {

--- a/core/templates/services/guppy-initialization.service.ts
+++ b/core/templates/services/guppy-initialization.service.ts
@@ -59,7 +59,7 @@ export class GuppyInitializationService {
 
       guppyInstance.configure(
         'empty_content',
-        '\\color{grey}{\\text{\\small{' + placeholderText + '}}}'
+        '\\color{grey}{\\small \\text{' + placeholderText + '}}'
       );
 
       // Initialize it with a value for the creator's view.


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #24339.
2. This PR does the following: It corrects the invalid LaTeX syntax (\times) used in the Guppy math editor's placeholder text by changing it to \cdot. This ensures that multiplication is displayed correctly and doesn't trigger KaTeX errors.
3. (For bug-fixing PRs only) The original bug occurred because: The Guppy editor's placeholder was using \times, which is not supported in the specific context where Guppy renders its placeholders, leading to a KaTeX error in the console.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@brianrodri PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow [these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api) and link to the job request doc here. Otherwise, please delete this section.
-->

N/A

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including the browser devtools console) to demonstrate that the changes made in this PR work correctly.

Make sure the actions taken in the before and after videos are the same.

(For changes involving responsiveness or adjustment of UI elements, this should be a video that gradually resizes the viewport from wide to narrow and back again.)

If this PR is for a developer-facing feature, provide videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well. You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are no weird UI mistakes or other problems. Also, if there are any newly added fields, try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below). There should be no performance or UI issues while the network is slow.

References:
- Chrome: https://css-tricks.com/throttling-the-network/
- Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

https://github.com/user-attachments/assets/71e15eca-a0fb-43cf-9f79-8b4cbb178cd9


#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to support mobile phones, or for backend-only features). Feel free to use the Developer Tools emulator for this.

References:
- Chrome: https://developer.chrome.com/docs/devtools/device-mode/
- Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

N/A

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

N/A

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.