### PR TITLE
Fix #20274: Disallow future date selection in contributor certificate modal

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.html
@@ -16,11 +16,11 @@
   <div *ngIf="!certificateDownloading">
     <div class="datepicker-container">
       <div class="date-label">From:</div>
-      <input class="datepicker" type="date" [(ngModel)]="fromDate" (change)="validateDate()">
+      <input class="datepicker" type="date" [max]="maxSelectableDate" [(ngModel)]="fromDate" (change)="validateDate()">
     </div>
     <div class="datepicker-container">
       <div class="date-label">To:</div>
-      <input class="datepicker" type="date"[(ngModel)]="toDate" (change)="validateDate()">
+      <input class="datepicker" type="date" [max]="maxSelectableDate" [(ngModel)]="toDate" (change)="validateDate()">
     </div>
     <div class="datepicker-container" *ngIf="errorsFound">
       <span class="date-range-error">{{errorMessage}}</span>

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.spec.ts
@@ -141,6 +141,16 @@ describe('Contributor Certificate Download Modal Component', () => {
     ).toHaveBeenCalled();
   });
 
+  it('should set max selectable date on both date pickers', () => {
+    const dateInputs =
+      fixture.nativeElement.querySelectorAll('input[type="date"]');
+
+    expect(dateInputs.length).toBe(2);
+    dateInputs.forEach((input: HTMLInputElement) => {
+      expect(input.max).toBe(component.maxSelectableDate);
+    });
+  });
+
   it('should set errorsFound and errorMessage for To date in the future', () => {
     const today = new Date();
     const tomorrow = new Date(today);

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.ts
@@ -39,6 +39,7 @@ export class CertificateDownloadModalComponent {
   @Input() suggestionType!: string;
   @Input() username!: string;
   @Input() languageCode!: string | null;
+  maxSelectableDate: string = this.getDateInInputFormat(new Date());
   fromDate!: string;
   toDate!: string;
   errorMessage!: string;
@@ -71,6 +72,12 @@ export class CertificateDownloadModalComponent {
 
   close(): void {
     this.activeModal.close();
+  }
+
+  private getDateInInputFormat(date: Date): string {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
   }
 
   validateDate(): void {


### PR DESCRIPTION

## Overview

1. This PR fixes  #20274.
2. This PR does the following: Prevents selecting future dates in the contributor certificate download modal (`/contributor-dashboard`) by adding a max-date constraint (today) to both `From` and `To` date inputs. It also adds a unit test to verify both date inputs receive the max constraint.
3. (For bug-fixing PRs only) The original bug occurred because: The certificate modal used plain `type="date"` inputs without a `max` attribute, so future dates were selectable in the browser date picker UI. Frontend/backend validation existed, but only after selection.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Files changed

- `core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.html`
  - Added `[max]="maxSelectableDate"` to both `From` and `To` date inputs.
- `core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.ts`
  - Added `maxSelectableDate` property in `YYYY-MM-DD` format for date input `max` binding.
  - Added helper method to format `Date` into input-compatible string.
- `core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.spec.ts`
  - Added unit test to verify both date inputs are bound to `maxSelectableDate`.

## Proof that changes are correct


**Before:** 

<img width="1920" height="1080" alt="Screenshot from 2026-03-09 09-58-49" src="https://github.com/user-attachments/assets/bbef7dac-0558-4686-8151-8a59df4d6bc0" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-09 09-58-42" src="https://github.com/user-attachments/assets/4e7fa4be-3295-43c4-afcf-4a938345790f" />



**After:**

<img width="1920" height="1080" alt="Screenshot from 2026-03-09 10-15-31" src="https://github.com/user-attachments/assets/35817fc1-9639-4ce8-a96e-ec461a8b46c1" />
<img width="1920" height="1080" alt="Screenshot from 2026-03-09 10-15-20" src="https://github.com/user-attachments/assets/3fdefa36-3a22-4c59-8110-3cbdd9f5db4c" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.



