### PR TITLE
Fix username overlapping in contributor dashboard (#22725)

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -251,7 +251,7 @@
     font-family: "Capriola", "Roboto", Arial, sans-serif;
     font-size: 24px;
     height: 30%;
-    padding-top: 10px;
+    padding-top: 20px;
     position: relative;
   }
   .oppia-short-contributor-username-container {


### PR DESCRIPTION
Increase padding-top from 10px to 20px to prevent username text from overlapping with other elements. This resolves the issue where long usernames would overlap with adjacent content.

Fixes #22725