### PR TITLE
Skip integration tests when in the merge queue

### DIFF
--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -94,7 +94,10 @@ jobs:
   e2e_test:
     needs: [check_test_suites_to_run, build]
     runs-on: ubuntu-22.04
-    if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).e2e.count > 0 }}
+    if: ${{ 
+        fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).e2e.count > 0 
+        && github.event_name != 'merge_group'
+      }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
@@ -189,7 +192,10 @@ jobs:
   acceptance_test:
     needs: [check_test_suites_to_run, build]
     runs-on: ubuntu-22.04
-    if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0 }}
+    if: ${{
+        fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0
+        && github.event_name != 'merge_group'
+      }}
     strategy:
       # Fast fail only if it's a merge queue.
       fail-fast: ${{ github.event_name == 'merge_group' }}
@@ -312,7 +318,10 @@ jobs:
 
   lighthouse_accessibility_test:
     needs: [check_test_suites_to_run]
-    if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_accessibility.count > 0 }}
+    if: ${{
+        fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_accessibility.count > 0
+        && github.event_name != 'merge_group'
+      }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
@@ -342,7 +351,10 @@ jobs:
   lighthouse_performance_test:
     needs: [check_test_suites_to_run, build]
     runs-on: ubuntu-22.04
-    if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_performance.count > 0 }}
+    if: ${{
+        fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).lighthouse_performance.count > 0
+        && github.event_name != 'merge_group'
+      }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
@@ -395,16 +407,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository so that local actions can be used
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@v4
       - name: Merge develop and set up dependencies
+        if: github.event_name != 'merge_group'
         uses: ./.github/actions/merge-develop-and-set-up-dependencies
       - name: Check workflow status
+        if: github.event_name != 'merge_group'
         uses: ./.github/actions/check-workflow-status
         id: check_workflow_status
         with:
           jobs: ${{ toJson(needs) }}
       - name: Fail if workflow status is failure
-        if: ${{ steps.check_workflow_status.outputs.WORKFLOW_STATUS == 'failure' }}
+        if: ${{ 
+            github.event_name != 'merge_group'
+            && steps.check_workflow_status.outputs.WORKFLOW_STATUS == 'failure' 
+          }}
         run: |
           echo ""
           echo "NOTE TO DEVELOPERS: This CI check is failing because another e2e/acceptance/lighthouse full-stack test workflow has failed. Please see that other workflow for the relevant logs to investigate. When all full-stack workflows pass, this CI check will automatically pass."
@@ -413,6 +431,9 @@ jobs:
           echo ""
           exit 1
         shell: bash
+      - name: Pass if we are in the merge group and therefore skipping previous jobs
+        if: github.event_name == 'merge_group'
+        run: echo "Pass even though tests were skipped because we are in the merge queue"
     permissions:
       pull-requests: write
   trigger_build_and_deploy:


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: Merging PRs has been taking unacceptably long recently because CI checks take so long to pass that the merge queue times out. To mitigate this problem, this PR causes integration tests (acceptance, E2E, lighthouse accessibility, and lighthouse performance) to not run and instead pass immediately. This is reasonably safe because: (a) integration tests are still required to pass on PRs before they can be added to the merge queue, and (b) bugs introduced by a combination of PRs merged in close succession will almost all cause unit test failures that the merge queue will still catch.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

I implemented this approach in a testing repository in golden-sunrise/actions-sandbox#7, and it worked as shown in https://github.com/golden-sunrise/actions-sandbox/actions/runs/23031400562/job/66890331649.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
