### PR TITLE
Fix part of #23830: Disable browser closing in afterAll  to reproduce leftover process issue

### DIFF
--- a/.github/workflows/assign_reviewer_on_ptal.yml
+++ b/.github/workflows/assign_reviewer_on_ptal.yml
@@ -47,9 +47,9 @@ jobs:
               core.setFailed(`Invalid repo (${repo}) or owner (${owner})`);
               return;
             }
-            const comment = (context.payload.comment?.body || '').trim();
+            const commentBody = (context.payload.comment?.body || '').trim();
             const reviewerPattern = /((?:@[\w-]+[\s,]*)+)\s+(ptal|take\s+a\s+pass|please\s+review)\b/i;
-            const match = comment.match(reviewerPattern);
+            const match = commentBody.match(reviewerPattern);
             if (!match) {
               console.log('No PTAL pattern found');
               return;

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ debug.log
 
 # Puppeteer acceptance tests.
 jest-runtime-config.json
+
+oppia-env/

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ debug.log
 jest-runtime-config.json
 
 oppia-env/
+
+skulpt-dist/

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -87,6 +87,6 @@ describe('Community Library Browser', function () {
   });
 
   afterAll(async function () {
-    //   await UserFactory.closeAllBrowsers();
+    // Await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -84,10 +84,11 @@ describe('Community Library Browser', function () {
     // Check subscribed creators in preferences page.
     await communityLibraryBrowser.navigateToPreferencesPageUsingProfileDropdown();
     await communityLibraryBrowser.expectSubscribedCreatorsToContain('currAdm');
+    throw new Error('Intentional failure to test CI rerun behavior');
   });
 
   afterAll(async function () {
-    // Close browsers intentionally disabled to reproduce leftover process issue.
-    // Await UserFactory.closeAllBrowsers();
+    // Intentionally not closing browsers to simulate leftover processes and test CI rerun behavior.
+    // await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -86,7 +86,7 @@ describe('Community Library Browser', function () {
     await communityLibraryBrowser.expectSubscribedCreatorsToContain('currAdm');
   });
 
-  afterAll(async function () {
-    //await UserFactory.closeAllBrowsers();
-  });
+  //afterAll(async function () {
+  //await UserFactory.closeAllBrowsers();
+  //});
 });

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -87,6 +87,6 @@ describe('Community Library Browser', function () {
   });
 
   afterAll(async function () {
-    await UserFactory.closeAllBrowsers();
+    //await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -86,7 +86,7 @@ describe('Community Library Browser', function () {
     await communityLibraryBrowser.expectSubscribedCreatorsToContain('currAdm');
   });
 
-  //afterAll(async function () {
-  //await UserFactory.closeAllBrowsers();
-  //});
+  afterAll(async function () {
+    //await UserFactory.closeAllBrowsers();
+  });
 });

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -87,6 +87,7 @@ describe('Community Library Browser', function () {
   });
 
   afterAll(async function () {
+    // Close browsers intentionally disabled to reproduce leftover process issue.
     // Await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -84,11 +84,9 @@ describe('Community Library Browser', function () {
     // Check subscribed creators in preferences page.
     await communityLibraryBrowser.navigateToPreferencesPageUsingProfileDropdown();
     await communityLibraryBrowser.expectSubscribedCreatorsToContain('currAdm');
-    throw new Error('Intentional failure to test CI rerun behavior');
   });
 
   afterAll(async function () {
-    // Intentionally not closing browsers to simulate leftover processes and test CI rerun behavior.
-    // await UserFactory.closeAllBrowsers();
+    await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -87,6 +87,6 @@ describe('Community Library Browser', function () {
   });
 
   afterAll(async function () {
-    //await UserFactory.closeAllBrowsers();
+    //   await UserFactory.closeAllBrowsers();
   });
 });

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -753,12 +753,6 @@ def managed_portserver() -> Iterator[psutil.Process]:
             except Exception as e:
                 logging.error('Final kill attempt failed: %s' % e)
 
-            try:
-                if os.path.exists(common.PORTSERVER_SOCKET_FILEPATH):
-                    os.remove(common.PORTSERVER_SOCKET_FILEPATH)
-            except Exception as e:
-                logging.error('Failed to remove portserver socket file: %s' % e)
-
 
 @contextlib.contextmanager
 def managed_webdriverio_server(

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -741,6 +741,7 @@ def managed_portserver() -> Iterator[psutil.Process]:
                         'Portserver failed to shut down after 10 seconds.'
                     )
                     try:
+                        proc.terminate()
                         proc.kill()
                         proc.wait(timeout=5)
                     except Exception as e:

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -746,7 +746,7 @@ def managed_portserver() -> Iterator[psutil.Process]:
                     except Exception as e:
                         logging.error('Failed to force kill Portserver: %s' % e)
 
-            # Ensure process is not still running
+            # Ensure process is not still running.
             try:
                 if proc.is_running():
                     proc.kill()

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -740,6 +740,24 @@ def managed_portserver() -> Iterator[psutil.Process]:
                     logging.error(
                         'Portserver failed to shut down after 10 seconds.'
                     )
+                    try:
+                        proc.kill()
+                        proc.wait(timeout=5)
+                    except Exception as e:
+                        logging.error('Failed to force kill Portserver: %s' % e)
+
+            # Ensure process is not still running
+            try:
+                if proc.is_running():
+                    proc.kill()
+            except Exception as e:
+                logging.error('Final kill attempt failed: %s' % e)
+
+            try:
+                if os.path.exists(common.PORTSERVER_SOCKET_FILEPATH):
+                    os.remove(common.PORTSERVER_SOCKET_FILEPATH)
+            except Exception as e:
+                logging.error('Failed to remove portserver socket file: %s' % e)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #23830.
2. This PR fixes the portserver shutdown issue in scripts/servers.py by adding a forced termination fallback when graceful shutdown fails after 10 seconds.
3. (For bug-fixing PRs only): 
The portserver was not shutting down properly after SIGINT timeout, leaving processes alive and causing acceptance test re-run failures.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix part of #23830 ".
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@jayam04 PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

## Proof that changes are correct

- All 55 backend tests passing locally
- Acceptance tests running successfully multiple times
- portserver.socket not present after test runs

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
