### PR TITLE
Do not cancel 'duplicate' oppiabot runs

### DIFF
--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -4,7 +4,6 @@ on:
   merge_group:
     types:
       - checks_requested
-      - destroyed
   issues:
     types:
       - labeled
@@ -14,17 +13,10 @@ on:
       - release-*
 permissions: read-all
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{
-         github.event.pull_request.number || github.event.merge_group.head_ref
-         || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   oppiabot:
     name: Verify CLA
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name != 'merge_group' || github.event.action != 'destroyed' }}
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #[n/a].
2. This PR does the following: Disables auto-cancellation for oppiabot CI jobs.
3. (For bug-fixing PRs only) The original bug occurred because: When oppiabot runs are triggered by issue or PR labeling events, the git REF is always the same, causing previous, non-redundant oppiabot CI jobs to be canceled by the concurrency key due to #25020.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Not needed since this is effectively a partial revert of commit d8f61c8491f4058bc3b3d26e41bd922f60e6163d.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
