### PR TITLE
Fix part of #21970: Add BlogPostExitedEventLogEntry domain object and tests

### DIFF
--- a/core/domain/blog_domain.py
+++ b/core/domain/blog_domain.py
@@ -848,3 +848,44 @@ class BlogAuthorDetails:
                 'Expected Author Bio to be a string,'
                 ' received %s' % self.author_bio
             )
+
+
+
+
+class BlogPostExitedEventLogEntry:
+    """Domain object for a blog post exited event."""
+
+    def __init__(
+        self, 
+        blog_post_id: str, 
+        time_user_stayed_on_blog_post: float
+    ) -> None:
+        """Constructs a BlogPostExitedEventLogEntry domain object.
+
+        Args:
+            blog_post_id: str. The ID of the blog post.
+            time_user_stayed_on_blog_post: float. Time user stayed on the blog post.
+        """
+        self.blog_post_id = blog_post_id
+        self.time_user_stayed_on_blog_post = time_user_stayed_on_blog_post
+
+    def validate(self) -> None:
+        """Validates the properties of the domain object.
+
+        Raises:
+            ValidationError. One or more attributes are invalid.
+        """
+        if not isinstance(self.blog_post_id, str):
+            raise utils.ValidationError(
+                'Expected blog_post_id to be a string, received %s' %
+                self.blog_post_id)
+        if not self.blog_post_id:
+            raise utils.ValidationError('blog_post_id cannot be empty.')
+
+        if not isinstance(self.time_user_stayed_on_blog_post, float):
+            raise utils.ValidationError(
+                'Expected time_user_stayed_on_blog_post to be a float, '
+                'received %s' % self.time_user_stayed_on_blog_post)
+        if self.time_user_stayed_on_blog_post < 0.0:
+            raise utils.ValidationError(
+                'time_user_stayed_on_blog_post cannot be negative.')

--- a/core/domain/blog_domain_test.py
+++ b/core/domain/blog_domain_test.py
@@ -872,3 +872,40 @@ class BlogAuthorDetailsTests(test_utils.GenericTestBase):
             ' received %s' % self.author_details.author_bio,
         ):
             self.author_details.validate()
+
+
+class BlogPostExitedEventLogEntryTests(test_utils.GenericTestBase):
+    """Tests for the BlogPostExitedEventLogEntry domain object."""
+
+    def test_initialization_and_validation_with_valid_data(self) -> None:
+        event = blog_domain.BlogPostExitedEventLogEntry('post_id_1', 15.5)
+        event.validate()
+
+    def test_validation_fails_with_non_string_blog_post_id(self) -> None:
+        event = blog_domain.BlogPostExitedEventLogEntry(123, 15.5) # type: ignore[arg-type]
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be a string, received 123'):
+            event.validate()
+
+    def test_validation_fails_with_empty_blog_post_id(self) -> None:
+        event = blog_domain.BlogPostExitedEventLogEntry('', 15.5)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'blog_post_id cannot be empty.'):
+            event.validate()
+
+    def test_validation_fails_with_non_float_time_stayed(self) -> None:
+        event = blog_domain.BlogPostExitedEventLogEntry('post_1', '15.5') # type: ignore[arg-type]
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected time_user_stayed_on_blog_post to be a float, '
+            'received 15.5'):
+            event.validate()
+
+    def test_validation_fails_with_negative_time_stayed(self) -> None:
+        event = blog_domain.BlogPostExitedEventLogEntry('post_1', -5.0)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'time_user_stayed_on_blog_post cannot be negative.'):
+            event.validate()


### PR DESCRIPTION
## Overview
This PR fixes part of #21970.

This PR adds the `BlogPostExitedEventLogEntry` domain object to `core/domain/blog_domain.py` and its corresponding unit tests to `core/domain/blog_domain_test.py`. 

Following the issue guidelines, this domain object validates the `blog_post_id` and `time_user_stayed_on_blog_post` without storing datastore-specific properties like `id`, `created_on`, or `last_updated`.

## Essential Checklist
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
No proof of changes needed because this is a strictly backend, non-user-facing change with full unit test coverage.
