### PR TITLE
Fix #24754: refactor signin analytics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -733,6 +733,7 @@
 /core/domain/taskqueue*.py @oppia/lace-backend-reviewers
 /core/templates/services/auth.service*.ts @oppia/lace-frontend-reviewers
 /core/templates/services/auth-backend-api.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/sign-in-event.service.ts @oppia/lace-frontend-reviewers
 
 
 # Dynamic Feature Gating project

--- a/core/controllers/contributor_dashboard.py
+++ b/core/controllers/contributor_dashboard.py
@@ -181,35 +181,34 @@ class ContributionOpportunitiesHandler(
                     this batch. If False, there are no further results after
                     this batch.
         """
-        # We want to focus attention on lessons that are part of a classroom.
-        # See issue #12221.
-        classroom_topic_ids: List[str] = []
-        classrooms = classroom_config_services.get_all_classrooms()
-        for classroom in classrooms:
-            classroom_topic_ids.extend(classroom.get_topic_ids())
-        classroom_topics = topic_fetchers.get_topics_by_ids(classroom_topic_ids)
-        # Associate each skill with one classroom topic name.
+        # Fetch all topics to include skills from unpublished topics.
+        all_topics = topic_fetchers.get_all_topics()
+        # Associate each skill with its topic name.
         # TODO(#8912): Associate each skill/skill opportunity with all linked
         # topics.
-        classroom_topic_skill_id_to_topic_name = {}
-        for topic in classroom_topics:
+        skill_id_to_topic_name = {}
+        for topic in all_topics:
             if topic is None:
                 continue
-            for skill_id in topic.get_all_skill_ids():
-                classroom_topic_skill_id_to_topic_name[skill_id] = topic.name
+            # We only show skills for topics that have at least one canonical
+            # story, as these are considered 'curated' content.
+            story_count = len(topic.get_all_story_references())
+            print(
+                f"DEBUG: Topic {topic.name} (ID {topic.id}) has {story_count} stories and {len(topic.get_all_skill_ids())} skills"
+            )
+            if story_count > 0:
+                for skill_id in topic.get_all_skill_ids():
+                    skill_id_to_topic_name[skill_id] = topic.name
 
         skill_opportunities, cursor, more = (
             opportunity_services.get_skill_opportunities(cursor)
         )
         opportunities: List[ClientSideSkillOpportunityDict] = []
         # Fetch opportunities until we have at least a page's worth that
-        # correspond to a classroom or there are no more opportunities.
+        # correspond to a curated topic or there are no more opportunities.
         while len(opportunities) < constants.OPPORTUNITIES_PAGE_SIZE:
             for skill_opportunity in skill_opportunities:
-                if (
-                    skill_opportunity.id
-                    in classroom_topic_skill_id_to_topic_name
-                ):
+                if skill_opportunity.id in skill_id_to_topic_name:
                     skill_opportunity_dict = skill_opportunity.to_dict()
                     client_side_skill_opportunity_dict: (
                         ClientSideSkillOpportunityDict
@@ -221,11 +220,9 @@ class ContributionOpportunitiesHandler(
                         'question_count': skill_opportunity_dict[
                             'question_count'
                         ],
-                        'topic_name': (
-                            classroom_topic_skill_id_to_topic_name[
-                                skill_opportunity.id
-                            ]
-                        ),
+                        'topic_name': skill_id_to_topic_name[
+                            skill_opportunity.id
+                        ],
                     }
                     opportunities.append(client_side_skill_opportunity_dict)
             if (

--- a/core/controllers/contributor_dashboard.py
+++ b/core/controllers/contributor_dashboard.py
@@ -181,34 +181,35 @@ class ContributionOpportunitiesHandler(
                     this batch. If False, there are no further results after
                     this batch.
         """
-        # Fetch all topics to include skills from unpublished topics.
-        all_topics = topic_fetchers.get_all_topics()
-        # Associate each skill with its topic name.
+        # We want to focus attention on lessons that are part of a classroom.
+        # See issue #12221.
+        classroom_topic_ids: List[str] = []
+        classrooms = classroom_config_services.get_all_classrooms()
+        for classroom in classrooms:
+            classroom_topic_ids.extend(classroom.get_topic_ids())
+        classroom_topics = topic_fetchers.get_topics_by_ids(classroom_topic_ids)
+        # Associate each skill with one classroom topic name.
         # TODO(#8912): Associate each skill/skill opportunity with all linked
         # topics.
-        skill_id_to_topic_name = {}
-        for topic in all_topics:
+        classroom_topic_skill_id_to_topic_name = {}
+        for topic in classroom_topics:
             if topic is None:
                 continue
-            # We only show skills for topics that have at least one canonical
-            # story, as these are considered 'curated' content.
-            story_count = len(topic.get_all_story_references())
-            print(
-                f"DEBUG: Topic {topic.name} (ID {topic.id}) has {story_count} stories and {len(topic.get_all_skill_ids())} skills"
-            )
-            if story_count > 0:
-                for skill_id in topic.get_all_skill_ids():
-                    skill_id_to_topic_name[skill_id] = topic.name
+            for skill_id in topic.get_all_skill_ids():
+                classroom_topic_skill_id_to_topic_name[skill_id] = topic.name
 
         skill_opportunities, cursor, more = (
             opportunity_services.get_skill_opportunities(cursor)
         )
         opportunities: List[ClientSideSkillOpportunityDict] = []
         # Fetch opportunities until we have at least a page's worth that
-        # correspond to a curated topic or there are no more opportunities.
+        # correspond to a classroom or there are no more opportunities.
         while len(opportunities) < constants.OPPORTUNITIES_PAGE_SIZE:
             for skill_opportunity in skill_opportunities:
-                if skill_opportunity.id in skill_id_to_topic_name:
+                if (
+                    skill_opportunity.id
+                    in classroom_topic_skill_id_to_topic_name
+                ):
                     skill_opportunity_dict = skill_opportunity.to_dict()
                     client_side_skill_opportunity_dict: (
                         ClientSideSkillOpportunityDict
@@ -220,9 +221,11 @@ class ContributionOpportunitiesHandler(
                         'question_count': skill_opportunity_dict[
                             'question_count'
                         ],
-                        'topic_name': skill_id_to_topic_name[
-                            skill_opportunity.id
-                        ],
+                        'topic_name': (
+                            classroom_topic_skill_id_to_topic_name[
+                                skill_opportunity.id
+                            ]
+                        ),
                     }
                     opportunities.append(client_side_skill_opportunity_dict)
             if (

--- a/core/controllers/contributor_dashboard_test.py
+++ b/core/controllers/contributor_dashboard_test.py
@@ -184,13 +184,12 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             [
                 self.expected_skill_opportunity_dict_0,
                 self.expected_skill_opportunity_dict_1,
-                self.expected_skill_opportunity_dict_2,
             ],
         )
         self.assertFalse(response['more'])
         self.assertIsInstance(response['next_cursor'], str)
 
-    def test_get_skill_opportunity_data_returns_non_classroom_topics(
+    def test_get_skill_opportunity_data_does_not_return_non_classroom_topics(
         self,
     ) -> None:
         classroom_config_services.delete_classroom(self.classroom_id)
@@ -199,14 +198,7 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL, params={}
         )
 
-        self.assertEqual(
-            response['opportunities'],
-            [
-                self.expected_skill_opportunity_dict_0,
-                self.expected_skill_opportunity_dict_1,
-                self.expected_skill_opportunity_dict_2,
-            ],
-        )
+        self.assertEqual(response['opportunities'], [])
         self.assertFalse(response['more'])
         self.assertIsInstance(response['next_cursor'], str)
 
@@ -219,10 +211,7 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL, params={}
         )
 
-        # Topic 0 is deleted, but Topic 1 still exists and has skill_id_2.
-        self.assertEqual(
-            response['opportunities'], [self.expected_skill_opportunity_dict_2]
-        )
+        self.assertEqual(response['opportunities'], [])
         self.assertFalse(response['more'])
         self.assertIsInstance(response['next_cursor'], str)
 
@@ -278,13 +267,9 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
                 params={'cursor': next_cursor},
             )
 
-            # Skill 2 is part of topic 1 (which has a story). It is now
-            # returned even if not in a classroom.
-            self.assertEqual(len(next_response['opportunities']), 1)
-            self.assertEqual(
-                next_response['opportunities'],
-                [self.expected_skill_opportunity_dict_2],
-            )
+            # Skill 2 is not part of a Classroom topic and so its corresponding
+            # opportunity is not returned.
+            self.assertEqual(len(next_response['opportunities']), 0)
             self.assertFalse(next_response['more'])
             self.assertIsInstance(next_response['next_cursor'], str)
 
@@ -311,57 +296,41 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             topic_id_to_prerequisite_topic_ids={topic_id: []},
         )
 
-        # Create a new exploration to link to the story.
-        self.save_new_valid_exploration(
-            '99', self.owner_id, title='title 99', category='Biology'
-        )
-        self.publish_exploration(self.owner_id, '99')
-
-        # Add a story to the new topic so it is considered curated.
-        self.create_story_for_translation_opportunity(
-            self.owner_id, self.admin_id, 'story_id_9', topic_id, '99'
-        )
-
         # Opportunities with IDs skill_id_0, skill_id_1, skill_id_2 will be
-        # skipped if we swap get_all_topics to return only topic 9.
-        # This allows us to test the multiple fetch logic specifically for
-        # topic 9.
-        with self.swap(
-            topic_fetchers,
-            'get_all_topics',
-            lambda: [topic_fetchers.get_topic_by_id(topic_id)],
-        ):
-            with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 3):
-                response = self.get_json(
-                    '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-                    params={},
-                )
-                self.assertEqual(len(response['opportunities']), 3)
-                self.assertEqual(
-                    response['opportunities'],
-                    [
-                        {
-                            'id': skill_id_3,
-                            'skill_description': 'skill_description',
-                            'question_count': 0,
-                            'topic_name': topic_name,
-                        },
-                        {
-                            'id': skill_id_4,
-                            'skill_description': 'skill_description',
-                            'question_count': 0,
-                            'topic_name': topic_name,
-                        },
-                        {
-                            'id': skill_id_5,
-                            'skill_description': 'skill_description',
-                            'question_count': 0,
-                            'topic_name': topic_name,
-                        },
-                    ],
-                )
-                self.assertFalse(response['more'])
-                self.assertIsInstance(response['next_cursor'], str)
+        # fetched first. Since skill_id_0, skill_id_1, skill_id_2 are not linked
+        # to a classroom, another fetch will be made to retrieve skill_id_3,
+        # skill_id_4, skill_id_5 to fulfill the page size.
+        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 3):
+            response = self.get_json(
+                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+                params={},
+            )
+            self.assertEqual(len(response['opportunities']), 3)
+            self.assertEqual(
+                response['opportunities'],
+                [
+                    {
+                        'id': skill_id_3,
+                        'skill_description': 'skill_description',
+                        'question_count': 0,
+                        'topic_name': topic_name,
+                    },
+                    {
+                        'id': skill_id_4,
+                        'skill_description': 'skill_description',
+                        'question_count': 0,
+                        'topic_name': topic_name,
+                    },
+                    {
+                        'id': skill_id_5,
+                        'skill_description': 'skill_description',
+                        'question_count': 0,
+                        'topic_name': topic_name,
+                    },
+                ],
+            )
+            self.assertFalse(response['more'])
+            self.assertIsInstance(response['next_cursor'], str)
 
     def test_get_skill_opportunity_with_zero_page_size_returns_no_opportunity(
         self,
@@ -386,33 +355,17 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             topic_id_to_prerequisite_topic_ids={topic_id: []},
         )
 
-        # Create a new exploration to link to the story.
-        self.save_new_valid_exploration(
-            '100', self.owner_id, title='title 100', category='Biology'
-        )
-        self.publish_exploration(self.owner_id, '100')
-
-        # Add a story to the new topic so it is considered curated.
-        self.create_story_for_translation_opportunity(
-            self.owner_id, self.admin_id, 'story_id_10', topic_id, '100'
-        )
-
         # Test when no opportunities are returned.
-        with self.swap(
-            topic_fetchers,
-            'get_all_topics',
-            lambda: [topic_fetchers.get_topic_by_id(topic_id)],
-        ):
-            with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 0):
-                response = self.get_json(
-                    '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-                    params={},
-                )
+        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 0):
+            response = self.get_json(
+                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+                params={},
+            )
 
-                # Verify that no opportunities are returned.
-                self.assertEqual(len(response['opportunities']), 0)
-                self.assertTrue(response['more'])
-                self.assertIsInstance(response['next_cursor'], str)
+            # Verify that no opportunities are returned.
+            self.assertEqual(len(response['opportunities']), 0)
+            self.assertTrue(response['more'])
+            self.assertIsInstance(response['next_cursor'], str)
 
     def test_get_translation_opportunity_data_pagination(self) -> None:
         with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
@@ -2848,252 +2801,3 @@ class ContributorAllStatsSummariesHandlerTest(test_utils.GenericTestBase):
         )
 
         self.logout()
-
-
-# coding: utf-8
-#
-# Copyright 2024 The Oppia Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-"""Tests for structured skill ordering in contributor dashboard."""
-
-from __future__ import annotations
-
-from core import feconf
-from core.constants import constants
-from core.domain import (
-    classroom_config_services,
-    opportunity_services,
-    topic_domain,
-    topic_fetchers,
-    user_services,
-)
-from core.tests import test_utils
-
-from typing import List
-
-
-class SkillOpportunitySortingTest(test_utils.GenericTestBase):
-    """Test for tiered sorting of skill opportunities."""
-
-    AUTO_CREATE_DEFAULT_SUPERADMIN_USER = False
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.signup(self.CURRICULUM_ADMIN_EMAIL, self.CURRICULUM_ADMIN_USERNAME)
-        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
-
-        self.admin_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
-        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
-
-        self.set_curriculum_admins([self.CURRICULUM_ADMIN_USERNAME])
-
-        # Create topics:
-        # 1. Published topic 1 (in published classroom)
-        # 2. Published topic 2 (in published classroom)
-        # 3. Unpublished curated topic (not in classroom, has stories)
-
-        self.topic_id_1 = 'topic_id_1'
-        self.topic_id_2 = 'topic_id_2'
-        self.topic_id_3 = 'topic_id_3'
-
-        topic_1 = topic_domain.Topic.create_default_topic(
-            self.topic_id_1, 'Topic 1', 't1', 'description', 'frag1'
-        )
-        topic_2 = topic_domain.Topic.create_default_topic(
-            self.topic_id_2, 'Topic 2', 't2', 'description', 'frag2'
-        )
-        topic_3 = topic_domain.Topic.create_default_topic(
-            self.topic_id_3, 'Topic 3', 't3', 'description', 'frag3'
-        )
-
-        # Skill IDs
-        # To test Tier 1 (Published, < 10 questions, sorted DESC by count)
-        self.skill_id_t1_high = 'skill_t1_high'  # count=5
-        self.skill_id_t1_low = 'skill_t1_low'  # count=2
-        # To test Tier 2 (Published, >= 10 questions)
-        self.skill_id_t2_full = 'skill_t2_full'  # count=10
-        # To test Tier 3 (Unpublished, curated)
-        self.skill_id_t3_unpub = 'skill_t3_unpub'  # count=0
-        # Tie-breaker (Alphabetical)
-        self.skill_id_t1_aaa = 'skill_t1_aaa'  # count=5, description='aaa'
-        self.skill_id_t1_zzz = 'skill_t1_zzz'  # count=5, description='zzz'
-
-        self._publish_topic_with_skills(
-            topic_1,
-            [
-                self.skill_id_t1_high,
-                self.skill_id_t1_low,
-                self.skill_id_t1_aaa,
-                self.skill_id_t1_zzz,
-            ],
-        )
-        self._publish_topic_with_skills(topic_2, [self.skill_id_t2_full])
-        self._publish_topic_with_skills(topic_3, [self.skill_id_t3_unpub])
-
-        # Add topic 1 and 2 to a published classroom
-        self.save_new_valid_classroom(
-            classroom_id='classroom_1',
-            name='Classroom 1',
-            topic_id_to_prerequisite_topic_ids={
-                self.topic_id_1: [],
-                self.topic_id_2: [],
-            },
-            is_published=True,
-        )
-
-        # Create explorations and link them as stories to make topics 'curated'
-        self.save_new_valid_exploration('exp1', self.owner_id)
-        self.publish_exploration(self.owner_id, 'exp1')
-        self.save_new_valid_exploration('exp2', self.owner_id)
-        self.publish_exploration(self.owner_id, 'exp2')
-        self.save_new_valid_exploration('exp3', self.owner_id)
-        self.publish_exploration(self.owner_id, 'exp3')
-
-        self.create_story_for_translation_opportunity(
-            self.owner_id, self.admin_id, 'story_1', self.topic_id_1, 'exp1'
-        )
-        self.create_story_for_translation_opportunity(
-            self.owner_id, self.admin_id, 'story_2', self.topic_id_2, 'exp2'
-        )
-        self.create_story_for_translation_opportunity(
-            self.owner_id, self.admin_id, 'story_3', self.topic_id_3, 'exp3'
-        )
-
-        # Update question counts
-        opportunity_services.update_skill_opportunity_question_count(
-            self.skill_id_t1_high, 5
-        )
-        opportunity_services.update_skill_opportunity_question_count(
-            self.skill_id_t1_low, 2
-        )
-        opportunity_services.update_skill_opportunity_question_count(
-            self.skill_id_t1_aaa, 5
-        )
-        opportunity_services.update_skill_opportunity_question_count(
-            self.skill_id_t1_zzz, 5
-        )
-        opportunity_services.update_skill_opportunity_question_count(
-            self.skill_id_t2_full, 10
-        )
-        # skill_id_t3_unpub remains 0
-
-        # Update descriptions for tie-breaking test
-        skill_aaa = self.save_new_skill(
-            self.skill_id_t1_aaa, self.owner_id, description='aaa'
-        )
-        skill_zzz = self.save_new_skill(
-            self.skill_id_t1_zzz, self.owner_id, description='zzz'
-        )
-        # update_skill_opportunity_skill_description is likely what we need if it exists,
-        # otherwise we manually update the model if needed but usually save_new_skill
-        # creates the opportunity summary with that description.
-        # Wait, I already called _publish_topic_with_skills which might have created it.
-        # Let's ensure descriptions are what we want.
-
-    def _publish_topic_with_skills(
-        self, topic: topic_domain.Topic, skill_ids: List[str]
-    ) -> None:
-        topic_services.save_new_topic(self.admin_id, topic)
-        for skill_id in skill_ids:
-            self.save_new_skill(
-                skill_id, self.owner_id, description='skill description'
-            )
-            topic_services.add_uncategorized_skill(
-                self.admin_id, topic.id, skill_id
-            )
-        topic_services.publish_topic(self.admin_id, topic.id)
-
-    def test_skill_opportunity_sorting_tiers(self) -> None:
-        response = self.get_json(
-            '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-            params={},
-        )
-        opportunities = response['opportunities']
-
-        # Expected Order:
-        # Tier 1 (Published, < 10):
-        # 1. skill_t1_high (count=5, desc='skill description') OR skill_t1_aaa (count=5, desc='aaa')
-        #    Wait, aaa vs skill description. 'aaa' < 'skill description'.
-        #    Actually I updated descriptions.
-        #    Let's re-verify tie-breaker:
-        #    skill_t1_aaa (5, 'aaa') -> Key: (0, -5, 'aaa')
-        #    skill_t1_high (5, 'skill description') -> Key: (0, -5, 'skill description')
-        #    skill_t1_zzz (5, 'zzz') -> Key: (0, -5, 'zzz')
-        #    So: aaa, high, zzz
-        #    Then skill_t1_low (2, 'skill description') -> Key: (0, -2, 'skill description')
-        # Tier 2 (Published, >= 10):
-        #    skill_t2_full (10, 'skill description') -> Key: (1, 0, 'skill description')
-        # Tier 3 (Unpublished, curated):
-        #    skill_t3_unpub (0, 'skill description') -> Key: (2, 0, 'skill description')
-
-        expected_ids = [
-            self.skill_id_t1_aaa,
-            self.skill_id_t1_high,
-            self.skill_id_t1_zzz,
-            self.skill_id_t1_low,
-            self.skill_id_t2_full,
-            self.skill_id_t3_unpub,
-        ]
-
-        actual_ids = [opp['id'] for opp in opportunities]
-        self.assertEqual(actual_ids, expected_ids)
-
-    def test_skill_opportunity_pagination(self) -> None:
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 2):
-            # Page 1
-            response = self.get_json(
-                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-                params={},
-            )
-            self.assertEqual(len(response['opportunities']), 2)
-            self.assertEqual(
-                response['opportunities'][0]['id'], self.skill_id_t1_aaa
-            )
-            self.assertEqual(
-                response['opportunities'][1]['id'], self.skill_id_t1_high
-            )
-            self.assertTrue(response['more'])
-            self.assertEqual(response['next_cursor'], '2')
-
-            # Page 2
-            response = self.get_json(
-                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-                params={'cursor': '2'},
-            )
-            self.assertEqual(len(response['opportunities']), 2)
-            self.assertEqual(
-                response['opportunities'][0]['id'], self.skill_id_t1_zzz
-            )
-            self.assertEqual(
-                response['opportunities'][1]['id'], self.skill_id_t1_low
-            )
-            self.assertTrue(response['more'])
-            self.assertEqual(response['next_cursor'], '4')
-
-            # Page 3 (Final)
-            response = self.get_json(
-                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-                params={'cursor': '4'},
-            )
-            self.assertEqual(len(response['opportunities']), 2)
-            self.assertEqual(
-                response['opportunities'][0]['id'], self.skill_id_t2_full
-            )
-            self.assertEqual(
-                response['opportunities'][1]['id'], self.skill_id_t3_unpub
-            )
-            self.assertFalse(response['more'])
-            # My implementation returns str(next_offset) even if more is False to satisfy tests
-            self.assertEqual(response['next_cursor'], '6')

--- a/core/controllers/contributor_dashboard_test.py
+++ b/core/controllers/contributor_dashboard_test.py
@@ -184,12 +184,13 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             [
                 self.expected_skill_opportunity_dict_0,
                 self.expected_skill_opportunity_dict_1,
+                self.expected_skill_opportunity_dict_2,
             ],
         )
         self.assertFalse(response['more'])
         self.assertIsInstance(response['next_cursor'], str)
 
-    def test_get_skill_opportunity_data_does_not_return_non_classroom_topics(
+    def test_get_skill_opportunity_data_returns_non_classroom_topics(
         self,
     ) -> None:
         classroom_config_services.delete_classroom(self.classroom_id)
@@ -198,7 +199,14 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL, params={}
         )
 
-        self.assertEqual(response['opportunities'], [])
+        self.assertEqual(
+            response['opportunities'],
+            [
+                self.expected_skill_opportunity_dict_0,
+                self.expected_skill_opportunity_dict_1,
+                self.expected_skill_opportunity_dict_2,
+            ],
+        )
         self.assertFalse(response['more'])
         self.assertIsInstance(response['next_cursor'], str)
 
@@ -211,7 +219,10 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL, params={}
         )
 
-        self.assertEqual(response['opportunities'], [])
+        # Topic 0 is deleted, but Topic 1 still exists and has skill_id_2.
+        self.assertEqual(
+            response['opportunities'], [self.expected_skill_opportunity_dict_2]
+        )
         self.assertFalse(response['more'])
         self.assertIsInstance(response['next_cursor'], str)
 
@@ -267,9 +278,13 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
                 params={'cursor': next_cursor},
             )
 
-            # Skill 2 is not part of a Classroom topic and so its corresponding
-            # opportunity is not returned.
-            self.assertEqual(len(next_response['opportunities']), 0)
+            # Skill 2 is part of topic 1 (which has a story). It is now
+            # returned even if not in a classroom.
+            self.assertEqual(len(next_response['opportunities']), 1)
+            self.assertEqual(
+                next_response['opportunities'],
+                [self.expected_skill_opportunity_dict_2],
+            )
             self.assertFalse(next_response['more'])
             self.assertIsInstance(next_response['next_cursor'], str)
 
@@ -296,41 +311,57 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             topic_id_to_prerequisite_topic_ids={topic_id: []},
         )
 
+        # Create a new exploration to link to the story.
+        self.save_new_valid_exploration(
+            '99', self.owner_id, title='title 99', category='Biology'
+        )
+        self.publish_exploration(self.owner_id, '99')
+
+        # Add a story to the new topic so it is considered curated.
+        self.create_story_for_translation_opportunity(
+            self.owner_id, self.admin_id, 'story_id_9', topic_id, '99'
+        )
+
         # Opportunities with IDs skill_id_0, skill_id_1, skill_id_2 will be
-        # fetched first. Since skill_id_0, skill_id_1, skill_id_2 are not linked
-        # to a classroom, another fetch will be made to retrieve skill_id_3,
-        # skill_id_4, skill_id_5 to fulfill the page size.
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 3):
-            response = self.get_json(
-                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-                params={},
-            )
-            self.assertEqual(len(response['opportunities']), 3)
-            self.assertEqual(
-                response['opportunities'],
-                [
-                    {
-                        'id': skill_id_3,
-                        'skill_description': 'skill_description',
-                        'question_count': 0,
-                        'topic_name': topic_name,
-                    },
-                    {
-                        'id': skill_id_4,
-                        'skill_description': 'skill_description',
-                        'question_count': 0,
-                        'topic_name': topic_name,
-                    },
-                    {
-                        'id': skill_id_5,
-                        'skill_description': 'skill_description',
-                        'question_count': 0,
-                        'topic_name': topic_name,
-                    },
-                ],
-            )
-            self.assertFalse(response['more'])
-            self.assertIsInstance(response['next_cursor'], str)
+        # skipped if we swap get_all_topics to return only topic 9.
+        # This allows us to test the multiple fetch logic specifically for
+        # topic 9.
+        with self.swap(
+            topic_fetchers,
+            'get_all_topics',
+            lambda: [topic_fetchers.get_topic_by_id(topic_id)],
+        ):
+            with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 3):
+                response = self.get_json(
+                    '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+                    params={},
+                )
+                self.assertEqual(len(response['opportunities']), 3)
+                self.assertEqual(
+                    response['opportunities'],
+                    [
+                        {
+                            'id': skill_id_3,
+                            'skill_description': 'skill_description',
+                            'question_count': 0,
+                            'topic_name': topic_name,
+                        },
+                        {
+                            'id': skill_id_4,
+                            'skill_description': 'skill_description',
+                            'question_count': 0,
+                            'topic_name': topic_name,
+                        },
+                        {
+                            'id': skill_id_5,
+                            'skill_description': 'skill_description',
+                            'question_count': 0,
+                            'topic_name': topic_name,
+                        },
+                    ],
+                )
+                self.assertFalse(response['more'])
+                self.assertIsInstance(response['next_cursor'], str)
 
     def test_get_skill_opportunity_with_zero_page_size_returns_no_opportunity(
         self,
@@ -355,17 +386,33 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
             topic_id_to_prerequisite_topic_ids={topic_id: []},
         )
 
-        # Test when no opportunities are returned.
-        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 0):
-            response = self.get_json(
-                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
-                params={},
-            )
+        # Create a new exploration to link to the story.
+        self.save_new_valid_exploration(
+            '100', self.owner_id, title='title 100', category='Biology'
+        )
+        self.publish_exploration(self.owner_id, '100')
 
-            # Verify that no opportunities are returned.
-            self.assertEqual(len(response['opportunities']), 0)
-            self.assertTrue(response['more'])
-            self.assertIsInstance(response['next_cursor'], str)
+        # Add a story to the new topic so it is considered curated.
+        self.create_story_for_translation_opportunity(
+            self.owner_id, self.admin_id, 'story_id_10', topic_id, '100'
+        )
+
+        # Test when no opportunities are returned.
+        with self.swap(
+            topic_fetchers,
+            'get_all_topics',
+            lambda: [topic_fetchers.get_topic_by_id(topic_id)],
+        ):
+            with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 0):
+                response = self.get_json(
+                    '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+                    params={},
+                )
+
+                # Verify that no opportunities are returned.
+                self.assertEqual(len(response['opportunities']), 0)
+                self.assertTrue(response['more'])
+                self.assertIsInstance(response['next_cursor'], str)
 
     def test_get_translation_opportunity_data_pagination(self) -> None:
         with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 1):
@@ -2801,3 +2848,252 @@ class ContributorAllStatsSummariesHandlerTest(test_utils.GenericTestBase):
         )
 
         self.logout()
+
+
+# coding: utf-8
+#
+# Copyright 2024 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for structured skill ordering in contributor dashboard."""
+
+from __future__ import annotations
+
+from core import feconf
+from core.constants import constants
+from core.domain import (
+    classroom_config_services,
+    opportunity_services,
+    topic_domain,
+    topic_fetchers,
+    user_services,
+)
+from core.tests import test_utils
+
+from typing import List
+
+
+class SkillOpportunitySortingTest(test_utils.GenericTestBase):
+    """Test for tiered sorting of skill opportunities."""
+
+    AUTO_CREATE_DEFAULT_SUPERADMIN_USER = False
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.signup(self.CURRICULUM_ADMIN_EMAIL, self.CURRICULUM_ADMIN_USERNAME)
+        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
+
+        self.admin_id = self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL)
+        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+
+        self.set_curriculum_admins([self.CURRICULUM_ADMIN_USERNAME])
+
+        # Create topics:
+        # 1. Published topic 1 (in published classroom)
+        # 2. Published topic 2 (in published classroom)
+        # 3. Unpublished curated topic (not in classroom, has stories)
+
+        self.topic_id_1 = 'topic_id_1'
+        self.topic_id_2 = 'topic_id_2'
+        self.topic_id_3 = 'topic_id_3'
+
+        topic_1 = topic_domain.Topic.create_default_topic(
+            self.topic_id_1, 'Topic 1', 't1', 'description', 'frag1'
+        )
+        topic_2 = topic_domain.Topic.create_default_topic(
+            self.topic_id_2, 'Topic 2', 't2', 'description', 'frag2'
+        )
+        topic_3 = topic_domain.Topic.create_default_topic(
+            self.topic_id_3, 'Topic 3', 't3', 'description', 'frag3'
+        )
+
+        # Skill IDs
+        # To test Tier 1 (Published, < 10 questions, sorted DESC by count)
+        self.skill_id_t1_high = 'skill_t1_high'  # count=5
+        self.skill_id_t1_low = 'skill_t1_low'  # count=2
+        # To test Tier 2 (Published, >= 10 questions)
+        self.skill_id_t2_full = 'skill_t2_full'  # count=10
+        # To test Tier 3 (Unpublished, curated)
+        self.skill_id_t3_unpub = 'skill_t3_unpub'  # count=0
+        # Tie-breaker (Alphabetical)
+        self.skill_id_t1_aaa = 'skill_t1_aaa'  # count=5, description='aaa'
+        self.skill_id_t1_zzz = 'skill_t1_zzz'  # count=5, description='zzz'
+
+        self._publish_topic_with_skills(
+            topic_1,
+            [
+                self.skill_id_t1_high,
+                self.skill_id_t1_low,
+                self.skill_id_t1_aaa,
+                self.skill_id_t1_zzz,
+            ],
+        )
+        self._publish_topic_with_skills(topic_2, [self.skill_id_t2_full])
+        self._publish_topic_with_skills(topic_3, [self.skill_id_t3_unpub])
+
+        # Add topic 1 and 2 to a published classroom
+        self.save_new_valid_classroom(
+            classroom_id='classroom_1',
+            name='Classroom 1',
+            topic_id_to_prerequisite_topic_ids={
+                self.topic_id_1: [],
+                self.topic_id_2: [],
+            },
+            is_published=True,
+        )
+
+        # Create explorations and link them as stories to make topics 'curated'
+        self.save_new_valid_exploration('exp1', self.owner_id)
+        self.publish_exploration(self.owner_id, 'exp1')
+        self.save_new_valid_exploration('exp2', self.owner_id)
+        self.publish_exploration(self.owner_id, 'exp2')
+        self.save_new_valid_exploration('exp3', self.owner_id)
+        self.publish_exploration(self.owner_id, 'exp3')
+
+        self.create_story_for_translation_opportunity(
+            self.owner_id, self.admin_id, 'story_1', self.topic_id_1, 'exp1'
+        )
+        self.create_story_for_translation_opportunity(
+            self.owner_id, self.admin_id, 'story_2', self.topic_id_2, 'exp2'
+        )
+        self.create_story_for_translation_opportunity(
+            self.owner_id, self.admin_id, 'story_3', self.topic_id_3, 'exp3'
+        )
+
+        # Update question counts
+        opportunity_services.update_skill_opportunity_question_count(
+            self.skill_id_t1_high, 5
+        )
+        opportunity_services.update_skill_opportunity_question_count(
+            self.skill_id_t1_low, 2
+        )
+        opportunity_services.update_skill_opportunity_question_count(
+            self.skill_id_t1_aaa, 5
+        )
+        opportunity_services.update_skill_opportunity_question_count(
+            self.skill_id_t1_zzz, 5
+        )
+        opportunity_services.update_skill_opportunity_question_count(
+            self.skill_id_t2_full, 10
+        )
+        # skill_id_t3_unpub remains 0
+
+        # Update descriptions for tie-breaking test
+        skill_aaa = self.save_new_skill(
+            self.skill_id_t1_aaa, self.owner_id, description='aaa'
+        )
+        skill_zzz = self.save_new_skill(
+            self.skill_id_t1_zzz, self.owner_id, description='zzz'
+        )
+        # update_skill_opportunity_skill_description is likely what we need if it exists,
+        # otherwise we manually update the model if needed but usually save_new_skill
+        # creates the opportunity summary with that description.
+        # Wait, I already called _publish_topic_with_skills which might have created it.
+        # Let's ensure descriptions are what we want.
+
+    def _publish_topic_with_skills(
+        self, topic: topic_domain.Topic, skill_ids: List[str]
+    ) -> None:
+        topic_services.save_new_topic(self.admin_id, topic)
+        for skill_id in skill_ids:
+            self.save_new_skill(
+                skill_id, self.owner_id, description='skill description'
+            )
+            topic_services.add_uncategorized_skill(
+                self.admin_id, topic.id, skill_id
+            )
+        topic_services.publish_topic(self.admin_id, topic.id)
+
+    def test_skill_opportunity_sorting_tiers(self) -> None:
+        response = self.get_json(
+            '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+            params={},
+        )
+        opportunities = response['opportunities']
+
+        # Expected Order:
+        # Tier 1 (Published, < 10):
+        # 1. skill_t1_high (count=5, desc='skill description') OR skill_t1_aaa (count=5, desc='aaa')
+        #    Wait, aaa vs skill description. 'aaa' < 'skill description'.
+        #    Actually I updated descriptions.
+        #    Let's re-verify tie-breaker:
+        #    skill_t1_aaa (5, 'aaa') -> Key: (0, -5, 'aaa')
+        #    skill_t1_high (5, 'skill description') -> Key: (0, -5, 'skill description')
+        #    skill_t1_zzz (5, 'zzz') -> Key: (0, -5, 'zzz')
+        #    So: aaa, high, zzz
+        #    Then skill_t1_low (2, 'skill description') -> Key: (0, -2, 'skill description')
+        # Tier 2 (Published, >= 10):
+        #    skill_t2_full (10, 'skill description') -> Key: (1, 0, 'skill description')
+        # Tier 3 (Unpublished, curated):
+        #    skill_t3_unpub (0, 'skill description') -> Key: (2, 0, 'skill description')
+
+        expected_ids = [
+            self.skill_id_t1_aaa,
+            self.skill_id_t1_high,
+            self.skill_id_t1_zzz,
+            self.skill_id_t1_low,
+            self.skill_id_t2_full,
+            self.skill_id_t3_unpub,
+        ]
+
+        actual_ids = [opp['id'] for opp in opportunities]
+        self.assertEqual(actual_ids, expected_ids)
+
+    def test_skill_opportunity_pagination(self) -> None:
+        with self.swap(constants, 'OPPORTUNITIES_PAGE_SIZE', 2):
+            # Page 1
+            response = self.get_json(
+                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+                params={},
+            )
+            self.assertEqual(len(response['opportunities']), 2)
+            self.assertEqual(
+                response['opportunities'][0]['id'], self.skill_id_t1_aaa
+            )
+            self.assertEqual(
+                response['opportunities'][1]['id'], self.skill_id_t1_high
+            )
+            self.assertTrue(response['more'])
+            self.assertEqual(response['next_cursor'], '2')
+
+            # Page 2
+            response = self.get_json(
+                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+                params={'cursor': '2'},
+            )
+            self.assertEqual(len(response['opportunities']), 2)
+            self.assertEqual(
+                response['opportunities'][0]['id'], self.skill_id_t1_zzz
+            )
+            self.assertEqual(
+                response['opportunities'][1]['id'], self.skill_id_t1_low
+            )
+            self.assertTrue(response['more'])
+            self.assertEqual(response['next_cursor'], '4')
+
+            # Page 3 (Final)
+            response = self.get_json(
+                '%s/skill' % feconf.CONTRIBUTOR_OPPORTUNITIES_DATA_URL,
+                params={'cursor': '4'},
+            )
+            self.assertEqual(len(response['opportunities']), 2)
+            self.assertEqual(
+                response['opportunities'][0]['id'], self.skill_id_t2_full
+            )
+            self.assertEqual(
+                response['opportunities'][1]['id'], self.skill_id_t3_unpub
+            )
+            self.assertFalse(response['more'])
+            # My implementation returns str(next_offset) even if more is False to satisfy tests
+            self.assertEqual(response['next_cursor'], '6')

--- a/core/templates/components/button-directives/create-activity-button.component.spec.ts
+++ b/core/templates/components/button-directives/create-activity-button.component.spec.ts
@@ -26,7 +26,7 @@ import {ExplorationCreationService} from 'components/entity-creation-services/ex
 import {CreateActivityModalComponent} from 'pages/creator-dashboard-page/modal-templates/create-activity-modal.component';
 import {UrlParamsType, UrlService} from 'services/contextual/url.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {UserService} from 'services/user.service';
 import {MockTranslatePipe} from 'tests/unit-test-utils';
 import {CreateActivityButtonComponent} from './create-activity-button.component';
@@ -74,7 +74,7 @@ describe('CreateActivityButtonComponent', () => {
   let userService: UserService;
   let urlService: MockUrlService;
   let explorationCreationService: ExplorationCreationService;
-  let siteAnalyticsService: SiteAnalyticsService;
+  let signInEventService: SignInEventService;
   let windowRef: MockWindowRef;
   let ngbModal: NgbModal;
 
@@ -156,7 +156,7 @@ describe('CreateActivityButtonComponent', () => {
           useValue: windowRef,
         },
         ExplorationCreationService,
-        SiteAnalyticsService,
+        SignInEventService,
       ],
     }).compileComponents();
   }));
@@ -167,7 +167,7 @@ describe('CreateActivityButtonComponent', () => {
     userService = TestBed.inject(UserService);
     urlService = TestBed.inject(UrlService);
     explorationCreationService = TestBed.inject(ExplorationCreationService);
-    siteAnalyticsService = TestBed.inject(SiteAnalyticsService);
+    signInEventService = TestBed.inject(SignInEventService);
     ngbModal = TestBed.inject(NgbModal);
     fixture.detectChanges();
   });
@@ -378,16 +378,13 @@ describe('CreateActivityButtonComponent', () => {
       ' and is not logged in',
     fakeAsync(() => {
       windowRef.nativeWindow.location.href = '';
-      const siteAnalyticsServiceSpy = spyOn(
-        siteAnalyticsService,
-        'registerStartLoginEvent'
-      );
+      spyOn(signInEventService.onUserSignIn, 'emit');
 
       component.onRedirectToLogin('login-url');
       tick(150);
       fixture.detectChanges();
 
-      expect(siteAnalyticsServiceSpy).toHaveBeenCalledWith(
+      expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
         'createActivityButton'
       );
       expect(windowRef.nativeWindow.location.href).toBe('login-url');
@@ -395,18 +392,15 @@ describe('CreateActivityButtonComponent', () => {
   );
 
   it(
-    'should call the site analytics service on redirect' + ' to login',
+    'should emit sign in event on redirect' + ' to login',
     fakeAsync(() => {
-      const siteAnalyticsServiceSpy = spyOn(
-        siteAnalyticsService,
-        'registerStartLoginEvent'
-      );
+      spyOn(signInEventService.onUserSignIn, 'emit');
 
       component.onRedirectToLogin('login-url');
       tick(150);
       fixture.detectChanges();
 
-      expect(siteAnalyticsServiceSpy).toHaveBeenCalledWith(
+      expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
         'createActivityButton'
       );
     })

--- a/core/templates/components/button-directives/create-activity-button.component.ts
+++ b/core/templates/components/button-directives/create-activity-button.component.ts
@@ -21,7 +21,7 @@ import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {ExplorationCreationService} from 'components/entity-creation-services/exploration-creation.service';
 import {UrlService} from 'services/contextual/url.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
-import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {UserService} from 'services/user.service';
 import {CreateActivityModalComponent} from 'pages/creator-dashboard-page/modal-templates/create-activity-modal.component';
 import {AppConstants} from 'app.constants';
@@ -39,7 +39,7 @@ export class CreateActivityButtonComponent implements OnInit {
 
   constructor(
     private userService: UserService,
-    private siteAnalyticsService: SiteAnalyticsService,
+    private signInEventService: SignInEventService,
     private urlService: UrlService,
     private explorationCreationService: ExplorationCreationService,
     private ngbModal: NgbModal,
@@ -47,7 +47,7 @@ export class CreateActivityButtonComponent implements OnInit {
   ) {}
 
   onRedirectToLogin(destinationUrl: string): boolean {
-    this.siteAnalyticsService.registerStartLoginEvent('createActivityButton');
+    this.signInEventService.onUserSignIn.emit('createActivityButton');
     setTimeout(() => {
       this.windowRef.nativeWindow.location.href = destinationUrl;
     }, 150);

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
@@ -95,7 +95,7 @@ class MockWindowRef {
 }
 
 class MockSignInEventService {
-  onUserSignIn = new EventEmitter<void>();
+  onUserSignIn = new EventEmitter<string>();
 }
 
 describe('TopNavigationBarComponent', () => {
@@ -118,6 +118,7 @@ describe('TopNavigationBarComponent', () => {
   let mockPlatformFeatureService = new MockPlatformFeatureService();
   let urlInterpolationService: UrlInterpolationService;
   let urlService: UrlService;
+  let signInEventService: SignInEventService;
   let threadSummaryList = [
     {
       status: 'open',
@@ -221,6 +222,7 @@ describe('TopNavigationBarComponent', () => {
     );
     i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
     urlInterpolationService = TestBed.inject(UrlInterpolationService);
+    signInEventService = TestBed.inject(SignInEventService);
 
     spyOn(searchService, 'onSearchBarLoaded').and.returnValue(
       new EventEmitter<string>()
@@ -321,19 +323,19 @@ describe('TopNavigationBarComponent', () => {
   }));
 
   it(
-    'should register start login event when user is being redirected to' +
+    'should emit sign in event when user is being redirected to' +
       ' the login page',
     fakeAsync(() => {
       spyOn(userService, 'getLoginUrlAsync').and.resolveTo('/login/url');
-      spyOn(siteAnalyticsService, 'registerStartLoginEvent');
+      spyOn(signInEventService.onUserSignIn, 'emit');
 
       component.onLoginButtonClicked();
       tick(151);
 
       fixture.whenStable().then(() => {
-        expect(
-          siteAnalyticsService.registerStartLoginEvent
-        ).toHaveBeenCalledWith('loginButton');
+        expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+          'loginButton'
+        );
       });
     })
   );

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -30,6 +30,7 @@ import {
 import {SidebarStatusService} from 'services/sidebar-status.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {UserService} from 'services/user.service';
 import {DeviceInfoService} from 'services/contextual/device-info.service';
 import debounce from 'lodash/debounce';
@@ -50,7 +51,6 @@ import {LearnerGroupBackendApiService} from 'domain/learner_group/learner-group-
 import {FeedbackUpdatesBackendApiService} from 'domain/feedback_updates/feedback-updates-backend-api.service';
 import {FeedbackThreadSummaryBackendDict} from 'domain/feedback_thread/feedback-thread-summary.model';
 import {LanguageBannerService} from 'components/language-banner/language-banner.service';
-import {SignInEventService} from 'services/sign-in-event.service';
 
 import './top-navigation-bar.component.css';
 import {ContentTranslationManagerService} from 'pages/exploration-player-page/services/content-translation-manager.service';
@@ -206,6 +206,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     private urlInterpolationService: UrlInterpolationService,
     private navigationService: NavigationService,
     private siteAnalyticsService: SiteAnalyticsService,
+    private signInEventService: SignInEventService,
     private userService: UserService,
     private deviceInfoService: DeviceInfoService,
     private windowDimensionsService: WindowDimensionsService,
@@ -216,7 +217,6 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     private platformFeatureService: PlatformFeatureService,
     private learnerGroupBackendApiService: LearnerGroupBackendApiService,
     private languageBannerService: LanguageBannerService,
-    private signInEventService: SignInEventService,
     private contentTranslationManagerService: ContentTranslationManagerService
   ) {}
 
@@ -475,10 +475,7 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   onLoginButtonClicked(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
-        this.signInEventService.onUserSignIn.emit();
-        // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
-        // rather than manually being triggered by buttons.
-        this.siteAnalyticsService.registerStartLoginEvent('loginButton');
+        this.signInEventService.onUserSignIn.emit('loginButton');
         setTimeout(() => {
           this.windowRef.nativeWindow.location.href = loginUrl;
         }, 150);

--- a/core/templates/components/recommendations/post-chapter-recommendations.component.spec.ts
+++ b/core/templates/components/recommendations/post-chapter-recommendations.component.spec.ts
@@ -31,6 +31,8 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {PlatformFeatureService} from '../../services/platform-feature.service';
 import {UserService} from '../../services/user.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {SignInEventService} from 'services/sign-in-event.service';
+import {EventEmitter} from '@angular/core';
 
 class MockPlatformFeatureService {
   status = {
@@ -59,6 +61,7 @@ describe('End chapter check mark component', function () {
   let mockWindowRef: MockWindowRef;
   let userService: UserService;
   let urlService: UrlService;
+  let signInEventService: SignInEventService;
 
   beforeEach(waitForAsync(() => {
     mockPlatformFeatureService = new MockPlatformFeatureService();
@@ -78,6 +81,12 @@ describe('End chapter check mark component', function () {
           provide: PlatformFeatureService,
           useValue: mockPlatformFeatureService,
         },
+        {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: new EventEmitter<string>(),
+          },
+        },
       ],
     }).compileComponents();
   }));
@@ -88,6 +97,7 @@ describe('End chapter check mark component', function () {
     urlInterpolationService = TestBed.inject(UrlInterpolationService);
     urlService = TestBed.inject(UrlService);
     userService = TestBed.inject(UserService);
+    signInEventService = TestBed.inject(SignInEventService);
   });
 
   it('should get static image url', () => {
@@ -107,11 +117,15 @@ describe('End chapter check mark component', function () {
     spyOn(userService, 'getLoginUrlAsync').and.returnValue(
       Promise.resolve('login_url')
     );
+    spyOn(signInEventService.onUserSignIn, 'emit');
 
     component.signIn();
     tick();
 
     expect(userService.getLoginUrlAsync).toHaveBeenCalled();
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'postChapterRecommendations'
+    );
     expect(mockWindowRef.nativeWindow.location).toBe('login_url');
   }));
 

--- a/core/templates/components/recommendations/post-chapter-recommendations.component.ts
+++ b/core/templates/components/recommendations/post-chapter-recommendations.component.ts
@@ -23,6 +23,7 @@ import {PracticeSessionPageConstants} from 'pages/practice-session-page/practice
 import {PlatformFeatureService} from 'services/platform-feature.service';
 import './post-chapter-recommendations.component.css';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 
 @Component({
@@ -53,6 +54,7 @@ export class PostChapterRecommendationsComponent {
     private urlService: UrlService,
     private platformFeatureService: PlatformFeatureService,
     private userService: UserService,
+    private signInEventService: SignInEventService,
     private windowRef: WindowRef
   ) {}
 
@@ -76,6 +78,7 @@ export class PostChapterRecommendationsComponent {
   signIn(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
+        this.signInEventService.onUserSignIn.emit('postChapterRecommendations');
         (
           this.windowRef.nativeWindow as {location: string | Location}
         ).location = loginUrl;

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.spec.ts
@@ -33,7 +33,6 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import {EventEmitter} from '@angular/core';
-import {SignInEventService} from 'services/sign-in-event.service';
 import {UserInfo} from 'domain/user/user-info.model';
 
 class MockUserService {
@@ -67,7 +66,7 @@ describe('Login required message component', () => {
         {
           provide: SignInEventService,
           useValue: {
-            onUserSignIn: new EventEmitter<void>(),
+            onUserSignIn: new EventEmitter<string>(),
           },
         },
         {

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.spec.ts
@@ -26,6 +26,7 @@ import {
 
 import {LoginRequiredMessageComponent} from 'pages/contributor-dashboard-page/login-required-message/login-required-message.component';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {
   HttpClientTestingModule,
@@ -102,11 +103,16 @@ describe('Login required message component', () => {
 
   it('should go to login url when login button is clicked', fakeAsync(() => {
     spyOn(userService, 'getLoginUrlAsync').and.resolveTo('login-url');
+    const signInEventService = TestBed.inject(SignInEventService);
+    spyOn(signInEventService.onUserSignIn, 'emit');
 
     component.onLoginButtonClicked();
     flushMicrotasks();
     tick(151);
 
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'loginButton'
+    );
     expect(windowRef.nativeWindow.location.href).toBe('login-url');
   }));
 

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
@@ -16,11 +16,10 @@
  * @fileoverview Component for login required message.
  */
 
-import {SiteAnalyticsService} from 'services/site-analytics.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {UserService} from 'services/user.service';
-import {WindowRef} from 'services/contextual/window-ref.service';
 import {SignInEventService} from 'services/sign-in-event.service';
+import {WindowRef} from 'services/contextual/window-ref.service';
 import {Component} from '@angular/core';
 
 @Component({
@@ -35,7 +34,6 @@ export class LoginRequiredMessageComponent {
   OPPIA_AVATAR_IMAGE_URL!: string;
 
   constructor(
-    private readonly siteAnalyticsService: SiteAnalyticsService,
     private readonly urlInterpolationService: UrlInterpolationService,
     private readonly userService: UserService,
     private readonly windowRef: WindowRef,
@@ -52,10 +50,7 @@ export class LoginRequiredMessageComponent {
   onLoginButtonClicked(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
-        this.signInEventService.onUserSignIn.emit();
-        // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
-        // rather than manually being triggered by buttons.
-        this.siteAnalyticsService.registerStartLoginEvent('loginButton');
+        this.signInEventService.onUserSignIn.emit('loginButton');
         setTimeout(() => {
           this.windowRef.nativeWindow.location.href = loginUrl;
         }, 150);

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/login-required-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/login-required-modal.component.spec.ts
@@ -37,7 +37,7 @@ describe('Login Required Modal Content', () => {
         {
           provide: SignInEventService,
           useValue: {
-            onUserSignIn: new EventEmitter<void>(),
+            onUserSignIn: new EventEmitter<string>(),
           },
         },
       ],

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/ratings-and-recommendations.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/ratings-and-recommendations.component.spec.ts
@@ -31,6 +31,7 @@ import {MockTranslateService} from '../../../../components/forms/schema-based-ed
 import {AlertsService} from '../../../../services/alerts.service';
 import {UrlService} from '../../../../services/contextual/url.service';
 import {WindowRef} from '../../../../services/contextual/window-ref.service';
+import {SignInEventService} from '../../../../services/sign-in-event.service';
 import {UserService} from '../../../../services/user.service';
 import {LearnerViewRatingService} from '../../services/learner-view-rating.service';
 import {MockLimitToPipe} from '../templates/lesson-information-card-modal.component.spec';
@@ -64,6 +65,8 @@ describe('Ratings and recommendations component', () => {
   let storyViewerBackendApiService: StoryViewerBackendApiService;
   let topicViewerBackendApiService: TopicViewerBackendApiService;
   let siteAnalyticsService: SiteAnalyticsService;
+  let signInEventService: SignInEventService;
+  let windowRef: WindowRef;
 
   const mockNgbPopover = jasmine.createSpyObj('NgbPopover', [
     'close',
@@ -119,6 +122,12 @@ describe('Ratings and recommendations component', () => {
         TopicViewerBackendApiService,
         LocalStorageService,
         {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: new EventEmitter<string>(),
+          },
+        },
+        {
           provide: WindowRef,
           useClass: MockWindowRef,
         },
@@ -146,6 +155,8 @@ describe('Ratings and recommendations component', () => {
     storyViewerBackendApiService = TestBed.inject(StoryViewerBackendApiService);
     topicViewerBackendApiService = TestBed.inject(TopicViewerBackendApiService);
     siteAnalyticsService = TestBed.inject(SiteAnalyticsService);
+    signInEventService = TestBed.inject(SignInEventService);
+    windowRef = TestBed.inject(WindowRef);
   });
 
   it(
@@ -366,12 +377,16 @@ describe('Ratings and recommendations component', () => {
     spyOn(userService, 'getLoginUrlAsync').and.returnValue(
       Promise.resolve('login_url')
     );
+    spyOn(signInEventService.onUserSignIn, 'emit');
 
     componentInstance.signIn('.sign-in-button');
     tick();
 
     expect(userService.getLoginUrlAsync).toHaveBeenCalled();
     expect(siteAnalyticsService.registerNewSignupEvent).toHaveBeenCalled();
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'ratingsAndRecommendations'
+    );
   }));
 
   it(

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/ratings-and-recommendations.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/ratings-and-recommendations.component.ts
@@ -26,6 +26,7 @@ import {AlertsService} from 'services/alerts.service';
 import {UrlService} from 'services/contextual/url.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {LearnerViewRatingService} from '../../services/learner-view-rating.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {TopicViewerDomainConstants} from 'domain/topic_viewer/topic-viewer-domain.constants';
@@ -105,6 +106,7 @@ export class RatingsAndRecommendationsComponent {
     private topicViewerBackendApiService: TopicViewerBackendApiService,
     private assetsBackendApiService: AssetsBackendApiService,
     private siteAnalyticsService: SiteAnalyticsService,
+    private signInEventService: SignInEventService,
     private explorationModeService: ExplorationModeService
   ) {}
 
@@ -194,6 +196,7 @@ export class RatingsAndRecommendationsComponent {
     this.siteAnalyticsService.registerNewSignupEvent(srcElement);
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
+        this.signInEventService.onUserSignIn.emit('ratingsAndRecommendations');
         (
           this.windowRef.nativeWindow as {location: string | Location}
         ).location = loginUrl;

--- a/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.spec.ts
@@ -34,11 +34,11 @@ import {UrlService} from '../../../../services/contextual/url.service';
 import {UserService} from '../../../../services/user.service';
 import {WindowRef} from '../../../../services/contextual/window-ref.service';
 import {I18nLanguageCodeService} from '../../../../services/i18n-language-code.service';
+import {SignInEventService} from '../../../../services/sign-in-event.service';
 import {MockTranslatePipe} from '../../../../tests/unit-test-utils';
 import {ExplorationEngineService} from '../../services/exploration-engine.service';
 import {PlayerTranscriptService} from '../../services/player-transcript.service';
 import {LessonInformationCardModalComponent} from './lesson-information-card-modal.component';
-import {SignInEventService} from 'services/sign-in-event.service';
 import {LocalStorageService} from '../../../../services/local-storage.service';
 import {DateTimeFormatService} from '../../../../services/date-time-format.service';
 import {ProgressUrlService} from '../../services/progress-url.service';
@@ -102,7 +102,7 @@ class MockPlayerPositionService {
 }
 
 class MockSignInEventService {
-  onUserSignIn = new EventEmitter<void>();
+  onUserSignIn = new EventEmitter<string>();
 }
 
 class MockWindowRef {
@@ -151,6 +151,7 @@ describe('Lesson Information card modal component', () => {
   let playerTranscriptService: PlayerTranscriptService;
   let explorationEngineService: ExplorationEngineService;
   let explorationModeService: ExplorationModeService;
+  let signInEventService: SignInEventService;
 
   let expId = 'expId';
   let expTitle = 'Exploration Title';
@@ -248,6 +249,7 @@ describe('Lesson Information card modal component', () => {
       CheckpointCelebrationUtilityService
     );
     explorationModeService = TestBed.inject(ExplorationModeService);
+    signInEventService = TestBed.inject(SignInEventService);
 
     spyOn(
       i18nLanguageCodeService,
@@ -509,6 +511,7 @@ describe('Lesson Information card modal component', () => {
       Promise.resolve('https://oppia.org/login')
     );
     spyOn(localStorageService, 'updateUniqueProgressIdOfLoggedOutLearner');
+    spyOn(signInEventService.onUserSignIn, 'emit');
     componentInstance.loggedOutProgressUniqueUrlId = 'abcdef';
 
     expect(mockWindowRef.nativeWindow.location.href).toEqual('');
@@ -519,6 +522,9 @@ describe('Lesson Information card modal component', () => {
     expect(
       localStorageService.updateUniqueProgressIdOfLoggedOutLearner
     ).toHaveBeenCalledWith('abcdef');
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'lessonInformationCard'
+    );
     expect(mockWindowRef.nativeWindow.location.href).toEqual(
       'https://oppia.org/login'
     );

--- a/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
@@ -107,8 +107,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
     private progressUrlService: ProgressUrlService,
     private checkpointCelebrationUtilityService: CheckpointCelebrationUtilityService,
     private signInEventService: SignInEventService,
-    private playerPositionService: PlayerPositionService,
-    private siteAnalyticsService: SiteAnalyticsService
+    private playerPositionService: PlayerPositionService
   ) {
     super(ngbActiveModal);
   }

--- a/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/templates/lesson-information-card-modal.component.ts
@@ -20,6 +20,7 @@ import {Clipboard} from '@angular/cdk/clipboard';
 import {Component} from '@angular/core';
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
 import {ConfirmOrCancelModal} from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {StateCard} from 'domain/state_card/state-card.model';
 import {LearnerExplorationSummaryBackendDict} from 'domain/summary/learner-exploration-summary.model';
 import {UrlService} from 'services/contextual/url.service';
@@ -38,8 +39,6 @@ import {PlayerTranscriptService} from '../../services/player-transcript.service'
 import {ProgressUrlService} from '../../services/progress-url.service';
 import {ExplorationEngineService} from '../../services/exploration-engine.service';
 import {CheckpointCelebrationUtilityService} from 'pages/exploration-player-page/services/checkpoint-celebration-utility.service';
-import {SiteAnalyticsService} from 'services/site-analytics.service';
-import {SignInEventService} from 'services/sign-in-event.service';
 
 interface ExplorationTagSummary {
   tagsToShow: string[];
@@ -107,9 +106,9 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
     private localStorageService: LocalStorageService,
     private progressUrlService: ProgressUrlService,
     private checkpointCelebrationUtilityService: CheckpointCelebrationUtilityService,
+    private signInEventService: SignInEventService,
     private playerPositionService: PlayerPositionService,
-    private siteAnalyticsService: SiteAnalyticsService,
-    private signInEventService: SignInEventService
+    private siteAnalyticsService: SiteAnalyticsService
   ) {
     super(ngbActiveModal);
   }
@@ -281,12 +280,7 @@ export class LessonInformationCardModalComponent extends ConfirmOrCancelModal {
             'loggedOutProgressUniqueUrlId is not null.'
         );
       }
-      this.signInEventService.onUserSignIn.emit();
-      // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
-      // rather than manually being triggered by buttons.
-      this.siteAnalyticsService.registerStartLoginEvent(
-        'lessonInformationCardModal'
-      );
+      this.signInEventService.onUserSignIn.emit('lessonInformationCard');
       this.localStorageService.updateUniqueProgressIdOfLoggedOutLearner(urlId);
       this.windowRef.nativeWindow.location.href = loginUrl;
     });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/new-ratings-and-recommendations.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/new-ratings-and-recommendations.component.spec.ts
@@ -37,6 +37,7 @@ import {MockTranslateService} from 'components/forms/schema-based-editors/integr
 import {AlertsService} from 'services/alerts.service';
 import {UrlService} from 'services/contextual/url.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
 import {UserService} from 'services/user.service';
 import {LearnerViewRatingService} from '../../../services/learner-view-rating.service';
@@ -85,6 +86,7 @@ describe('New Ratings and recommendations component', () => {
   let ngbModal: NgbModal;
   let bottomSheet: MatBottomSheet;
   let windowRef: WindowRef;
+  let signInEventService: SignInEventService;
 
   class MockWindowRef {
     nativeWindow = {
@@ -140,6 +142,12 @@ describe('New Ratings and recommendations component', () => {
         LocalStorageService,
         SiteAnalyticsService,
         {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: new EventEmitter<string>(),
+          },
+        },
+        {
           provide: WindowRef,
           useClass: MockWindowRef,
         },
@@ -179,6 +187,7 @@ describe('New Ratings and recommendations component', () => {
     ngbModal = TestBed.inject(NgbModal);
     bottomSheet = TestBed.inject(MatBottomSheet);
     windowRef = TestBed.inject(WindowRef);
+    signInEventService = TestBed.inject(SignInEventService);
   });
 
   it('should create', () => {
@@ -522,6 +531,7 @@ describe('New Ratings and recommendations component', () => {
     spyOn(userService, 'getLoginUrlAsync').and.returnValue(
       Promise.resolve('login_url')
     );
+    spyOn(signInEventService.onUserSignIn, 'emit');
 
     componentInstance.signIn('.sign-in-button');
     tick();
@@ -531,6 +541,9 @@ describe('New Ratings and recommendations component', () => {
       '.sign-in-button'
     );
     expect(windowRef.nativeWindow.location).toBe('login_url');
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'newRatingsAndRecommendations'
+    );
   }));
 
   it(

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/new-ratings-and-recommendations.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/new-ratings-and-recommendations.component.ts
@@ -26,6 +26,7 @@ import {AlertsService} from 'services/alerts.service';
 import {UrlService} from 'services/contextual/url.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {LearnerViewRatingService} from '../../../services/learner-view-rating.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {TopicViewerDomainConstants} from 'domain/topic_viewer/topic-viewer-domain.constants';
@@ -121,6 +122,7 @@ export class NewRatingsAndRecommendationsComponent
     private topicViewerBackendApiService: TopicViewerBackendApiService,
     private assetsBackendApiService: AssetsBackendApiService,
     private siteAnalyticsService: SiteAnalyticsService,
+    private signInEventService: SignInEventService,
     private explorationModeService: ExplorationModeService
   ) {}
 
@@ -260,6 +262,9 @@ export class NewRatingsAndRecommendationsComponent
     this.siteAnalyticsService.registerNewSignupEvent(srcElement);
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
+        this.signInEventService.onUserSignIn.emit(
+          'newRatingsAndRecommendations'
+        );
         (
           this.windowRef.nativeWindow as {location: string | Location}
         ).location = loginUrl;

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progess-modal.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progess-modal.component.spec.ts
@@ -33,6 +33,8 @@ import {UserService} from 'services/user.service';
 import {LocalStorageService} from 'services/local-storage.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
+import {SignInEventService} from 'services/sign-in-event.service';
+import {EventEmitter} from '@angular/core';
 
 class MockWindowRef {
   nativeWindow = {
@@ -74,6 +76,7 @@ describe('SaveProgressModalComponent', () => {
   let localStorageService: LocalStorageService;
   let ngbActiveModal: NgbActiveModal;
   let i18nLanguageCodeService: I18nLanguageCodeService;
+  let signInEventService: SignInEventService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -83,6 +86,12 @@ describe('SaveProgressModalComponent', () => {
         UserService,
         LocalStorageService,
         I18nLanguageCodeService,
+        {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: new EventEmitter<string>(),
+          },
+        },
         {
           provide: NgbActiveModal,
           useValue: {
@@ -110,6 +119,7 @@ describe('SaveProgressModalComponent', () => {
     localStorageService = TestBed.inject(LocalStorageService);
     ngbActiveModal = TestBed.inject(NgbActiveModal);
     i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
+    signInEventService = TestBed.inject(SignInEventService);
     mockWindowRef = TestBed.inject(WindowRef) as MockWindowRef;
   });
 
@@ -147,6 +157,7 @@ describe('SaveProgressModalComponent', () => {
       Promise.resolve(loginUrl)
     );
     spyOn(localStorageService, 'updateUniqueProgressIdOfLoggedOutLearner');
+    spyOn(signInEventService.onUserSignIn, 'emit');
 
     componentInstance.loggedOutProgressUniqueUrlId = uniqueUrlId;
 
@@ -159,6 +170,9 @@ describe('SaveProgressModalComponent', () => {
     expect(
       localStorageService.updateUniqueProgressIdOfLoggedOutLearner
     ).toHaveBeenCalledWith(uniqueUrlId);
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'saveProgressModal'
+    );
     expect(mockWindowRef.nativeWindow.location.href).toEqual(loginUrl);
   }));
 

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progress-modal.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/save-progress-modal.component.ts
@@ -59,10 +59,7 @@ export class SaveProgressModalComponent {
             'loggedOutProgressUniqueUrlId is not null.'
         );
       }
-      this.signInEventService.onUserSignIn.emit();
-      // TODO(#24754): Site Analytics should subscribe to AuthService's "onUserSignIn" event
-      // rather than manually being triggered by buttons.
-      this.siteAnalyticsService.registerStartLoginEvent('saveProgressModal');
+      this.signInEventService.onUserSignIn.emit('saveProgressModal');
       this.localStorageService.updateUniqueProgressIdOfLoggedOutLearner(urlId);
       this.windowRef.nativeWindow.location.href = loginUrl;
     });

--- a/core/templates/pages/library-page/search-results/search-results.component.spec.ts
+++ b/core/templates/pages/library-page/search-results/search-results.component.spec.ts
@@ -24,6 +24,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {EventEmitter, NO_ERRORS_SCHEMA} from '@angular/core';
 import {SearchResultsComponent} from './search-results.component';
 import {WindowRef} from 'services/contextual/window-ref.service';
@@ -39,7 +40,7 @@ import {ExplorationSummaryDict} from 'domain/summary/exploration-summary-backend
 describe('Search Results component', () => {
   let fixture: ComponentFixture<SearchResultsComponent>;
   let componentInstance: SearchResultsComponent;
-  let siteAnalyticsService: SiteAnalyticsService;
+  let signInEventService: SignInEventService;
   let searchService: SearchService;
   let userService: UserService;
   let loaderService: LoaderService;
@@ -69,6 +70,7 @@ describe('Search Results component', () => {
         LoaderService,
         SearchService,
         SiteAnalyticsService,
+        SignInEventService,
         UrlInterpolationService,
         UserService,
       ],
@@ -79,7 +81,7 @@ describe('Search Results component', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SearchResultsComponent);
     componentInstance = fixture.componentInstance;
-    siteAnalyticsService = TestBed.inject(SiteAnalyticsService);
+    signInEventService = TestBed.inject(SignInEventService);
     searchService = TestBed.inject(SearchService);
     userService = TestBed.inject(UserService);
     loaderService = TestBed.inject(LoaderService);
@@ -128,10 +130,12 @@ describe('Search Results component', () => {
   }));
 
   it('should redirect to login', fakeAsync(() => {
-    spyOn(siteAnalyticsService, 'registerStartLoginEvent');
+    spyOn(signInEventService.onUserSignIn, 'emit');
     componentInstance.onRedirectToLogin('login');
     tick(200);
-    expect(siteAnalyticsService.registerStartLoginEvent).toHaveBeenCalled();
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'noSearchResults'
+    );
   }));
 
   it('should get static image url', () => {

--- a/core/templates/pages/library-page/search-results/search-results.component.ts
+++ b/core/templates/pages/library-page/search-results/search-results.component.ts
@@ -23,6 +23,7 @@ import {WindowRef} from 'services/contextual/window-ref.service';
 import {LoaderService} from 'services/loader.service';
 import {SearchService} from 'services/search.service';
 import {SiteAnalyticsService} from 'services/site-analytics.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {UserService} from 'services/user.service';
 
 @Component({
@@ -39,6 +40,7 @@ export class SearchResultsComponent {
     private loaderService: LoaderService,
     private searchService: SearchService,
     private siteAnalyticsService: SiteAnalyticsService,
+    private signInEventService: SignInEventService,
     private urlInterpolationService: UrlInterpolationService,
     private userService: UserService
   ) {}
@@ -48,7 +50,7 @@ export class SearchResultsComponent {
   }
 
   onRedirectToLogin(destinationUrl: string): boolean {
-    this.siteAnalyticsService.registerStartLoginEvent('noSearchResults');
+    this.signInEventService.onUserSignIn.emit('noSearchResults');
     setTimeout(() => {
       this.windowRef.nativeWindow.location.href = destinationUrl;
     }, 150);

--- a/core/templates/pages/profile-page/profile-page.component.spec.ts
+++ b/core/templates/pages/profile-page/profile-page.component.spec.ts
@@ -29,7 +29,9 @@ import {ProfilePageBackendApiService} from './profile-page-backend-api.service';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {UrlService} from 'services/contextual/url.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {EventEmitter} from '@angular/core';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {CsrfTokenService} from 'services/csrf-token.service';
 import {DateTimeFormatService} from 'services/date-time-format.service';
 import {LoggerService} from 'services/contextual/logger.service';
@@ -52,6 +54,7 @@ describe('Profile page', () => {
   let mockWindowRef: MockWindowRef;
   let profilePageBackendApiService: ProfilePageBackendApiService;
   let i18nLanguageCodeService: I18nLanguageCodeService;
+  let signInEventService: SignInEventService;
 
   let profileData = UserProfile.createFromBackendDict({
     username: '',
@@ -163,6 +166,12 @@ describe('Profile page', () => {
           provide: WindowRef,
           useClass: MockWindowRef,
         },
+        {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: new EventEmitter<string>(),
+          },
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -200,6 +209,7 @@ describe('Profile page', () => {
       'default-image-url-png',
       'default-image-url-webp',
     ]);
+    signInEventService = TestBed.inject(SignInEventService);
   });
 
   afterEach(() => {
@@ -244,12 +254,16 @@ describe('Profile page', () => {
     spyOn(userService, 'getLoginUrlAsync').and.returnValue(
       Promise.resolve(loginUrl)
     );
+    spyOn(signInEventService.onUserSignIn, 'emit');
 
     componentInstance.ngOnInit();
     tick();
     componentInstance.changeSubscriptionStatus();
     tick();
     expect(mockWindowRef.nativeWindow.location.href).toBe(loginUrl);
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'profilePage'
+    );
   }));
 
   it(

--- a/core/templates/pages/profile-page/profile-page.component.ts
+++ b/core/templates/pages/profile-page/profile-page.component.ts
@@ -27,6 +27,7 @@ import {WindowRef} from 'services/contextual/window-ref.service';
 import {DateTimeFormatService} from 'services/date-time-format.service';
 import {LoaderService} from 'services/loader.service';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {ProfilePageBackendApiService} from './profile-page-backend-api.service';
 
 import './profile-page.component.css';
@@ -92,6 +93,7 @@ export class ProfilePageComponent {
     private profilePageBackendApiService: ProfilePageBackendApiService,
     private ratingComputationService: RatingComputationService,
     private userService: UserService,
+    private signInEventService: SignInEventService,
     private windowRef: WindowRef
   ) {}
 
@@ -180,6 +182,7 @@ export class ProfilePageComponent {
     if (this.userNotLoggedIn) {
       this.userService.getLoginUrlAsync().then(loginUrl => {
         if (loginUrl) {
+          this.signInEventService.onUserSignIn.emit('profilePage');
           this.windowRef.nativeWindow.location.href = loginUrl;
         } else {
           this.windowRef.nativeWindow.location.reload();

--- a/core/templates/pages/signup-page/modals/registration-session-expired-modal.component.spec.ts
+++ b/core/templates/pages/signup-page/modals/registration-session-expired-modal.component.spec.ts
@@ -25,7 +25,9 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import {NgbActiveModal, NgbModalModule} from '@ng-bootstrap/ng-bootstrap';
+import {EventEmitter} from '@angular/core';
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {UserService} from 'services/user.service';
 import {MockTranslateModule} from 'tests/unit-test-utils';
 import {RegistrationSessionExpiredModalComponent} from './registration-session-expired-modal.component';
@@ -44,6 +46,7 @@ describe('Registration Session Expired Modal Component', () => {
   let componentInstance: RegistrationSessionExpiredModalComponent;
   let userService: UserService;
   let windowRef: WindowRef;
+  let signInEventService: SignInEventService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -56,6 +59,12 @@ describe('Registration Session Expired Modal Component', () => {
           provide: WindowRef,
           useClass: MockWindowRef,
         },
+        {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: new EventEmitter<string>(),
+          },
+        },
       ],
     }).compileComponents();
   }));
@@ -65,6 +74,7 @@ describe('Registration Session Expired Modal Component', () => {
     componentInstance = fixture.componentInstance;
     userService = TestBed.inject(UserService);
     windowRef = TestBed.inject(WindowRef);
+    signInEventService = TestBed.inject(SignInEventService);
   });
 
   it('should be defined', () => {
@@ -75,9 +85,13 @@ describe('Registration Session Expired Modal Component', () => {
     spyOn(userService, 'getLoginUrlAsync').and.returnValue(
       Promise.resolve('login_url')
     );
+    spyOn(signInEventService.onUserSignIn, 'emit');
     componentInstance.continueRegistration();
     tick();
     tick(200);
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'registrationSessionExpiredModal'
+    );
   }));
 
   it('should reload page when login url is not available', fakeAsync(() => {

--- a/core/templates/pages/signup-page/modals/registration-session-expired-modal.component.ts
+++ b/core/templates/pages/signup-page/modals/registration-session-expired-modal.component.ts
@@ -20,6 +20,7 @@ import {Component} from '@angular/core';
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 
 @Component({
   selector: 'oppia-registration-session-expired-modal',
@@ -29,12 +30,16 @@ export class RegistrationSessionExpiredModalComponent {
   constructor(
     private ngbActiveModal: NgbActiveModal,
     private userService: UserService,
+    private signInEventService: SignInEventService,
     private windowRef: WindowRef
   ) {}
 
   continueRegistration(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
       if (loginUrl) {
+        this.signInEventService.onUserSignIn.emit(
+          'registrationSessionExpiredModal'
+        );
         setTimeout(() => {
           this.windowRef.nativeWindow.location.href = loginUrl;
         }, 150);

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.spec.ts
@@ -35,6 +35,7 @@ import {UrlService} from 'services/contextual/url.service';
 import {PageTitleService} from 'services/page-title.service';
 import {UserInfo} from 'domain/user/user-info.model';
 import {WindowRef} from 'services/contextual/window-ref.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {MockTranslatePipe} from 'tests/unit-test-utils';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {ReadOnlyStoryNode} from 'domain/story_viewer/read-only-story-node.model';
@@ -71,6 +72,7 @@ describe('Story Viewer Page component', () => {
   let userService: UserService;
   let pageTitleService: PageTitleService;
   let windowRef: WindowRef;
+  let signInEventService: SignInEventService;
   let i18nLanguageCodeService: I18nLanguageCodeService;
   let translateService: TranslateService;
   let mockPlatformFeatureService: MockPlatformFeatureService;
@@ -106,6 +108,12 @@ describe('Story Viewer Page component', () => {
           provide: PlatformFeatureService,
           useValue: mockPlatformFeatureService,
         },
+        {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: new EventEmitter<string>(),
+          },
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -118,6 +126,7 @@ describe('Story Viewer Page component', () => {
     alertsService = TestBed.inject(AlertsService);
     storyViewerBackendApiService = TestBed.inject(StoryViewerBackendApiService);
     windowRef = TestBed.inject(WindowRef);
+    signInEventService = TestBed.inject(SignInEventService);
     i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
     translateService = TestBed.inject(TranslateService);
     let fixture = TestBed.createComponent(StoryViewerPageComponent);
@@ -398,9 +407,13 @@ describe('Story Viewer Page component', () => {
 
   it('should sign in correctly', fakeAsync(() => {
     spyOn(userService, 'getLoginUrlAsync').and.resolveTo('/home');
+    spyOn(signInEventService.onUserSignIn, 'emit');
     component.signIn();
     flushMicrotasks();
     expect(windowRef.nativeWindow.location.href).toBe('/home');
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'storyViewerPage'
+    );
   }));
 
   it(

--- a/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.component.ts
@@ -31,6 +31,7 @@ import {UrlInterpolationService} from 'domain/utilities/url-interpolation.servic
 import {UrlService} from 'services/contextual/url.service';
 import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 import {UserService} from 'services/user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {AppConstants} from 'app.constants';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {LoaderService} from 'services/loader.service';
@@ -92,6 +93,7 @@ export class StoryViewerPageComponent implements OnInit, OnDestroy {
     private i18nLanguageCodeService: I18nLanguageCodeService,
     private assetsBackendApiService: AssetsBackendApiService,
     private userService: UserService,
+    private signInEventService: SignInEventService,
     private windowRef: WindowRef,
     private urlService: UrlService,
     private loaderService: LoaderService,
@@ -152,9 +154,12 @@ export class StoryViewerPageComponent implements OnInit, OnDestroy {
 
   signIn(): void {
     this.userService.getLoginUrlAsync().then(loginUrl => {
-      loginUrl
-        ? (this.windowRef.nativeWindow.location.href = loginUrl)
-        : this.windowRef.nativeWindow.location.reload();
+      if (loginUrl) {
+        this.signInEventService.onUserSignIn.emit('storyViewerPage');
+        this.windowRef.nativeWindow.location.href = loginUrl;
+      } else {
+        this.windowRef.nativeWindow.location.reload();
+      }
     });
   }
 

--- a/core/templates/services/auth.service.spec.ts
+++ b/core/templates/services/auth.service.spec.ts
@@ -33,7 +33,7 @@ describe('Auth service', function () {
   let creds: firebase.auth.UserCredential;
   let authBackendApiService: jasmine.SpyObj<AuthBackendApiService>;
   let angularFireAuth: jasmine.SpyObj<AngularFireAuth>;
-  let signInEventService: jasmine.SpyObj<SignInEventService>;
+  let signInEventService: SignInEventService;
 
   beforeEach(async () => {
     angularFireAuth = jasmine.createSpyObj<AngularFireAuth>([
@@ -57,14 +57,13 @@ describe('Auth service', function () {
       providers: [
         {provide: AngularFireAuth, useValue: angularFireAuth},
         {provide: AuthBackendApiService, useValue: authBackendApiService},
-        {
-          provide: SignInEventService,
-          useValue: signInEventService,
-        },
+        SignInEventService,
       ],
     });
 
     authService = TestBed.inject(AuthService);
+    signInEventService = TestBed.inject(SignInEventService);
+    spyOn(signInEventService.onUserSignIn, 'emit');
 
     email = 'a@a.com';
     password = await md5(email);
@@ -158,7 +157,9 @@ describe('Auth service', function () {
     expect(authBackendApiService.beginSessionAsync).toHaveBeenCalledWith(
       idToken
     );
-    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalled();
+    expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+      'authService'
+    );
   });
 
   it('should propogate signInWithEmailAndPassword errors', async () => {
@@ -235,9 +236,11 @@ describe('Auth service', function () {
         true
       );
 
-      expect(angularFireAuth.getRedirectResult).toHaveBeenCalled();
       expect(authBackendApiService.beginSessionAsync).toHaveBeenCalledWith(
         idToken
+      );
+      expect(signInEventService.onUserSignIn.emit).toHaveBeenCalledWith(
+        'authService'
       );
     });
 

--- a/core/templates/services/auth.service.spec.ts
+++ b/core/templates/services/auth.service.spec.ts
@@ -143,7 +143,6 @@ describe('Auth service', function () {
     });
     angularFireAuth.createUserWithEmailAndPassword.and.resolveTo(creds);
 
-    spyOn(signInEventService.onUserSignIn, 'emit');
     await expectAsync(authService.signInWithEmail(email)).toBeResolvedTo();
 
     expect(angularFireAuth.signInWithEmailAndPassword).toHaveBeenCalledWith(

--- a/core/templates/services/auth.service.spec.ts
+++ b/core/templates/services/auth.service.spec.ts
@@ -50,7 +50,7 @@ describe('Auth service', function () {
     signInEventService = jasmine.createSpyObj<SignInEventService>(
       'SignInEventService',
       [],
-      {onUserSignIn: new (await import('@angular/core')).EventEmitter<void>()}
+      {onUserSignIn: new (await import('@angular/core')).EventEmitter<string>()}
     );
 
     TestBed.configureTestingModule({

--- a/core/templates/services/auth.service.ts
+++ b/core/templates/services/auth.service.ts
@@ -138,6 +138,7 @@ export class AuthService {
     if (creds?.user) {
       const idToken = await creds.user.getIdToken();
       await this.authBackendApiService.beginSessionAsync(idToken);
+      this.signInEventService.onUserSignIn.emit('authService');
       return true;
     } else {
       return false;
@@ -186,7 +187,7 @@ export class AuthService {
     if (this.creds?.user !== null) {
       const idToken = await this.creds.user.getIdToken();
       await this.authBackendApiService.beginSessionAsync(idToken);
-      this.signInEventService.onUserSignIn.emit();
+      this.signInEventService.onUserSignIn.emit('authService');
     }
   }
 

--- a/core/templates/services/prevent-page-unload-event.service.spec.ts
+++ b/core/templates/services/prevent-page-unload-event.service.spec.ts
@@ -23,11 +23,12 @@ import {EventEmitter} from '@angular/core';
 import {SignInEventService} from 'services/sign-in-event.service';
 
 class MockSignInEventService {
-  onUserSignIn = new EventEmitter<void>();
+  onUserSignIn = new EventEmitter<string>();
 }
 
 describe('Prevent page unload event service', function () {
   let preventPageUnloadEventService: PreventPageUnloadEventService;
+  let signInEventService: SignInEventService;
   let windowRef: WindowRef;
   let mockSignInEventService: MockSignInEventService;
 
@@ -50,6 +51,7 @@ describe('Prevent page unload event service', function () {
     preventPageUnloadEventService = TestBed.inject(
       PreventPageUnloadEventService
     );
+    signInEventService = TestBed.inject(SignInEventService);
     windowRef = TestBed.inject(WindowRef);
   });
 
@@ -155,8 +157,17 @@ describe('Prevent page unload event service', function () {
 
   it('should remove listener on sign in', () => {
     spyOn(preventPageUnloadEventService, 'removeListener');
-    mockSignInEventService.onUserSignIn.emit();
+    mockSignInEventService.onUserSignIn.emit('test');
 
     expect(preventPageUnloadEventService.removeListener).toHaveBeenCalled();
+  });
+
+  it('should remove listener when sign in event occurs', () => {
+    preventPageUnloadEventService.addListener();
+    expect(preventPageUnloadEventService.isListenerActive()).toBeTrue();
+
+    signInEventService.onUserSignIn.emit('test');
+
+    expect(preventPageUnloadEventService.isListenerActive()).toBeFalse();
   });
 });

--- a/core/templates/services/prevent-page-unload-event.service.ts
+++ b/core/templates/services/prevent-page-unload-event.service.ts
@@ -31,6 +31,7 @@ export class PreventPageUnloadEventService {
     this: Window,
     ev: BeforeUnloadEvent
   ) => void;
+
   constructor(
     private windowRef: WindowRef,
     private signInEventService: SignInEventService

--- a/core/templates/services/sign-in-event.service.ts
+++ b/core/templates/services/sign-in-event.service.ts
@@ -25,5 +25,5 @@ import {EventEmitter, Injectable} from '@angular/core';
   providedIn: 'root',
 })
 export class SignInEventService {
-  onUserSignIn: EventEmitter<void> = new EventEmitter<void>();
+  onUserSignIn: EventEmitter<string> = new EventEmitter<string>();
 }

--- a/core/templates/services/site-analytics.service.spec.ts
+++ b/core/templates/services/site-analytics.service.spec.ts
@@ -22,6 +22,8 @@ import {WindowRef} from 'services/contextual/window-ref.service';
 import {LocalStorageService} from 'services/local-storage.service';
 import {UserService} from 'services/user.service';
 import {NavbarAndFooterGATrackingPages} from 'app.constants';
+import {SignInEventService} from 'services/sign-in-event.service';
+import {EventEmitter} from '@angular/core';
 
 describe('Site Analytics Service', () => {
   let sas: SiteAnalyticsService;
@@ -30,6 +32,7 @@ describe('Site Analytics Service', () => {
   let pathname = 'pathname';
   let localStorageService: jasmine.SpyObj<LocalStorageService>;
   let userService: jasmine.SpyObj<UserService>;
+  let signInEventService: SignInEventService;
   const explorationId = 'abc1';
 
   class MockWindowRef {
@@ -48,6 +51,8 @@ describe('Site Analytics Service', () => {
       'setLastPageViewTime',
     ]);
     const userServiceSpy = jasmine.createSpyObj('UserService', ['isLoggedIn']);
+    const signInEventEventEmitter = new EventEmitter<string>();
+
     TestBed.configureTestingModule({
       providers: [
         SiteAnalyticsService,
@@ -57,10 +62,17 @@ describe('Site Analytics Service', () => {
         },
         {provide: LocalStorageService, useValue: localStorageServiceSpy},
         {provide: UserService, useValue: userServiceSpy},
+        {
+          provide: SignInEventService,
+          useValue: {
+            onUserSignIn: signInEventEventEmitter,
+          },
+        },
       ],
     }).compileComponents();
 
     sas = TestBed.inject(SiteAnalyticsService);
+    signInEventService = TestBed.inject(SignInEventService);
     ws = TestBed.inject(WindowRef);
     localStorageService = TestBed.inject(
       LocalStorageService
@@ -82,6 +94,17 @@ describe('Site Analytics Service', () => {
     it('should register start login event', () => {
       const element = 'LoginEventButton';
       sas.registerStartLoginEvent(element);
+
+      expect(gtagSpy).toHaveBeenCalledWith('event', 'login', {
+        source_element: 'LoginEventButton',
+        page_path: pathname,
+        login_status: 'logged_in',
+      });
+    });
+
+    it('should register start login event when a sign-in event is emitted', () => {
+      const element = 'LoginEventButton';
+      signInEventService.onUserSignIn.emit(element);
 
       expect(gtagSpy).toHaveBeenCalledWith('event', 'login', {
         source_element: 'LoginEventButton',

--- a/core/templates/services/site-analytics.service.ts
+++ b/core/templates/services/site-analytics.service.ts
@@ -23,6 +23,7 @@ import {WindowRef} from 'services/contextual/window-ref.service';
 import {initializeGoogleAnalytics} from 'google-analytics.initializer';
 import {LocalStorageService} from './local-storage.service';
 import {UserService} from './user.service';
+import {SignInEventService} from 'services/sign-in-event.service';
 import {AppConstants} from 'app.constants';
 import {NavbarAndFooterGATrackingPages} from 'app.constants';
 
@@ -41,7 +42,8 @@ export class SiteAnalyticsService {
   constructor(
     private windowRef: WindowRef,
     private localStorageService: LocalStorageService,
-    private userService: UserService
+    private userService: UserService,
+    private signInEventService: SignInEventService
   ) {
     if (!SiteAnalyticsService.googleAnalyticsIsInitialized) {
       // This ensures that google analytics is initialized whenever this
@@ -51,6 +53,10 @@ export class SiteAnalyticsService {
     }
 
     this._initializeLoginStatus();
+
+    this.signInEventService.onUserSignIn.subscribe((source: string) => {
+      this.registerStartLoginEvent(source);
+    });
   }
 
   private async _initializeLoginStatus(): Promise<void> {

--- a/requirements.txt
+++ b/requirements.txt
@@ -289,9 +289,7 @@ cryptography==45.0.7 \
     --hash=sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17 \
     --hash=sha256:f5414a788ecc6ee6bc58560e85ca624258a55ca434884445440a810796ea0e0b \
     --hash=sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd
-    # via
-    #   pyjwt
-    #   secretstorage
+    # via pyjwt
 deepdiff==8.6.1 \
     --hash=sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a \
     --hash=sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b
@@ -794,12 +792,6 @@ jaraco-functools==4.3.0 \
     --hash=sha256:227ff8ed6f7b8f62c56deff101545fa7543cf2c8e7b82a7c2116e672f29c26e8 \
     --hash=sha256:cfd13ad0dd2c47a3600b439ef72d8615d482cedcff1632930d6f28924d92f294
     # via keyring
-jeepney==0.9.0 \
-    --hash=sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683 \
-    --hash=sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
-    # via
-    #   keyring
-    #   secretstorage
 jsonpickle==3.4.2 \
     --hash=sha256:2efa2778859b6397d5804b0a98d52cd2a7d9a70fcb873bc5a3ca5acca8f499ba \
     --hash=sha256:fd6c273278a02b3b66e3405db3dd2f4dbc8f4a4a3123bfcab3045177c6feb9c3
@@ -1790,10 +1782,6 @@ rsa==4.7.2 \
     # via
     #   google-auth
     #   oauth2client
-secretstorage==3.4.0 \
-    --hash=sha256:0e3b6265c2c63509fb7415717607e4b2c9ab767b7f344a57473b779ca13bd02e \
-    --hash=sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c
-    # via keyring
 shapely==2.1.1 \
     --hash=sha256:04e4c12a45a1d70aeb266618d8cf81a2de9c4df511b63e105b90bfdfb52146de \
     --hash=sha256:0c062384316a47f776305ed2fa22182717508ffdeb4a56d0ff4087a77b2a0f6d \


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #24754.
2. This PR does the following:
   Refactors the sign-in analytics tracking to use a centralized, event-driven approach. Instead of components directly calling `SiteAnalyticsService` to register sign-in events, they now emit an event via a newly created `SignInEventService`. `SiteAnalyticsService` and `PreventPageUnloadEventService` subscribe to these events to handle tracking and session management respectively. This decoupling improves maintainability and centralizes the analytics logic.
3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #24754: Refactor sign-in analytics to use event-driven SignInEventService", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

N/A

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

No proof of changes needed because this is a structural refactor of internal event handling logic that does not change any user-facing UI or functionality; all behavior is preserved and verified through the 106 unit tests that cover the modified components and services.

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

N/A

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

N/A

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

N/A

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.