### PR TITLE
Fix part of #21970: Add CsrfSecret domain object

### DIFF
--- a/core/domain/csrf_secret_domain.py
+++ b/core/domain/csrf_secret_domain.py
@@ -1,0 +1,15 @@
+from core.domain import base_domain
+from core import utils
+
+
+class CsrfSecret(base_domain.BaseDomainObject):
+
+    def __init__(self, oppia_csrf_secret):
+        self.oppia_csrf_secret = oppia_csrf_secret
+
+    def validate(self):
+        if not isinstance(self.oppia_csrf_secret, str):
+            raise utils.ValidationError("Must be string")
+
+        if self.oppia_csrf_secret == "":
+            raise utils.ValidationError("Cannot be empty")

--- a/core/domain/csrf_secret_domain_test.py
+++ b/core/domain/csrf_secret_domain_test.py
@@ -1,0 +1,20 @@
+import unittest
+from core.domain import csrf_secret_domain
+from core import utils
+
+
+class CsrfSecretDomainTest(unittest.TestCase):
+
+    def test_valid(self):
+        obj = csrf_secret_domain.CsrfSecret("abc")
+        obj.validate()
+
+    def test_empty(self):
+        obj = csrf_secret_domain.CsrfSecret("")
+        with self.assertRaises(utils.ValidationError):
+            obj.validate()
+
+    def test_wrong_type(self):
+        obj = csrf_secret_domain.CsrfSecret(123)
+        with self.assertRaises(utils.ValidationError):
+            obj.validate()


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21970.
2. This PR adds the CsrfSecret domain object and implements the validate() method.

The validation ensures that:

* oppia_csrf_secret is a string
* oppia_csrf_secret is not empty

Tests have also been added to verify both valid and invalid cases.

## Essential Checklist

* [x] I have checked the "Files Changed" tab and confirmed that the changes are correct.
* [x] I have written tests for my code.
* [x] The PR title starts with "Fix part of #21970: Add CsrfSecret domain object".
* [ ] 
## Proof that changes are correct

This PR introduces a backend domain object and does not affect the UI.

The correctness of the changes has been verified through unit tests:

* Validation passes for valid CSRF secret strings.
* Validation fails for empty strings.
* Validation fails for non-string inputs.

All added tests ensure that the validate() method behaves as expected.
