### PR TITLE
Revert "Fix #22289: Ignore quoted PTAL comments and prevent self-assignment in workflow"

### DIFF
--- a/.github/workflows/assign_reviewer_on_ptal.yml
+++ b/.github/workflows/assign_reviewer_on_ptal.yml
@@ -47,12 +47,6 @@ jobs:
               core.setFailed(`Invalid repo (${repo}) or owner (${owner})`);
               return;
             }
-            const rawComment = (context.payload.comment?.body || '');
-            const comment = rawComment
-                       .split('\n')
-                       .filter(line => !line.trim().startsWith('>'))
-                       .join('\n')
-                       .trim();
             const comment = (context.payload.comment?.body || '').trim();
             const reviewerPattern = /((?:@[\w-]+[\s,]*)+)\s+(ptal|take\s+a\s+pass|please\s+review)\b/i;
             const match = comment.match(reviewerPattern);
@@ -79,9 +73,6 @@ jobs:
               core.setFailed('Issue is not a PR');
               return;
             }
-            reviewers = reviewers.filter(
-                r => r !== context.payload.comment.user.login
-            );
             await github.rest.issues.addAssignees({
               owner,
               repo,


### PR DESCRIPTION
## Overview

1. This PR fixes #[n/a]
2. This PR does the following: Reverts oppia/oppia#25161
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a clean revert.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.