### PR TITLE
Fix part of #21448: Add LogType enum and log_to_terminal utility for colorized CI output

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import enum
+
 import contextlib
 import errno
 import getpass
@@ -45,6 +47,94 @@ _THIRD_PARTY_PATH = os.path.join(os.getcwd(), 'third_party', 'python_libs')
 sys.path.insert(0, _THIRD_PARTY_PATH)
 
 AFFIRMATIVE_CONFIRMATIONS = ['y', 'ye', 'yes']
+
+
+class LogType(enum.Enum):
+    """Enum for different types of log messages."""
+
+    INFO = 'info'
+    ERROR = 'error'
+    SUCCESS = 'success'
+    WARNING = 'warning'
+
+
+# ANSI escape codes for terminal text colors.
+_ANSI_COLORS: Final[Dict[LogType, str]] = {
+    LogType.ERROR: '\033[91m',
+    LogType.SUCCESS: '\033[92m',
+    LogType.WARNING: '\033[93m',
+    LogType.INFO: '\033[94m',
+}
+_ANSI_RESET: Final = '\033[0m'
+
+# Keywords that indicate error messages when auto-detecting log type.
+_ERROR_KEYWORDS: Final[List[str]] = [
+    'error',
+    'Error',
+    'ERROR',
+    'fail',
+    'Fail',
+    'FAIL',
+    'FAILED',
+    'Exception',
+    'exception',
+    'Traceback',
+]
+# Keywords that indicate warning messages when auto-detecting log type.
+_WARNING_KEYWORDS: Final[List[str]] = [
+    'warning',
+    'Warning',
+    'WARNING',
+    'warn',
+    'Warn',
+    'WARN',
+]
+
+
+def log_to_terminal(
+    message: str, message_type: Optional[LogType] = None
+) -> None:
+    """Prints a message to the terminal, optionally colored by its type.
+
+    If message_type is provided, the message is printed in the
+    corresponding color. If message_type is not provided, the function
+    auto-detects whether the message contains error or warning keywords
+    and colors it accordingly. Messages that do not match any auto-detect
+    pattern are printed without coloring.
+
+    Args:
+        message: str. The message to print.
+        message_type: Optional[LogType]. The type of the log message.
+            If None, the function will attempt to auto-detect the type.
+    """
+    if message_type is None:
+        message_type = _auto_detect_log_type(message)
+
+    if message_type is not None:
+        color_code = _ANSI_COLORS[message_type]
+        print('%s%s%s' % (color_code, message, _ANSI_RESET))
+    else:
+        print(message)
+
+
+def _auto_detect_log_type(message: str) -> Optional[LogType]:
+    """Attempts to detect the log type based on keywords in the message.
+
+    Args:
+        message: str. The message to analyze.
+
+    Returns:
+        Optional[LogType]. The detected log type, or None if no
+        keywords matched.
+    """
+    for keyword in _ERROR_KEYWORDS:
+        if keyword in message:
+            return LogType.ERROR
+    for keyword in _WARNING_KEYWORDS:
+        if keyword in message:
+            return LogType.WARNING
+    return None
+
 
 CURRENT_PYTHON_BIN = sys.executable
 

--- a/scripts/common_test.py
+++ b/scripts/common_test.py
@@ -1546,3 +1546,105 @@ class UrlRetrieveTests(CommonTests):
                 )
             with open(output_path, 'rb', encoding=None) as buffer:
                 self.assertEqual(buffer.read(), b'content')
+
+
+class LogToTerminalTests(test_utils.GenericTestBase):
+    """Tests for the LogType enum and log_to_terminal function."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.print_arr: list[str] = []
+
+        def mock_print(msg: str) -> None:
+            self.print_arr.append(msg)
+
+        self.print_swap = self.swap(builtins, 'print', mock_print)
+
+    def test_log_type_enum_values(self) -> None:
+        """Test that the LogType enum contains the expected values."""
+        self.assertEqual(common.LogType.INFO.value, 'info')
+        self.assertEqual(common.LogType.ERROR.value, 'error')
+        self.assertEqual(common.LogType.SUCCESS.value, 'success')
+        self.assertEqual(common.LogType.WARNING.value, 'warning')
+
+    def test_log_to_terminal_with_error_type(self) -> None:
+        """Test that ERROR type prints the message in red."""
+        with self.print_swap:
+            common.log_to_terminal('Something failed', common.LogType.ERROR)
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(self.print_arr[0], '\033[91mSomething failed\033[0m')
+
+    def test_log_to_terminal_with_success_type(self) -> None:
+        """Test that SUCCESS type prints the message in green."""
+        with self.print_swap:
+            common.log_to_terminal('All tests passed', common.LogType.SUCCESS)
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(self.print_arr[0], '\033[92mAll tests passed\033[0m')
+
+    def test_log_to_terminal_with_warning_type(self) -> None:
+        """Test that WARNING type prints the message in yellow."""
+        with self.print_swap:
+            common.log_to_terminal('Deprecation notice', common.LogType.WARNING)
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(self.print_arr[0], '\033[93mDeprecation notice\033[0m')
+
+    def test_log_to_terminal_with_info_type(self) -> None:
+        """Test that INFO type prints the message in blue."""
+        with self.print_swap:
+            common.log_to_terminal('Starting server', common.LogType.INFO)
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(self.print_arr[0], '\033[94mStarting server\033[0m')
+
+    def test_log_to_terminal_without_type_auto_detects_error(self) -> None:
+        """Test that auto-detection colors error messages in red."""
+        with self.print_swap:
+            common.log_to_terminal('An error occurred in the test')
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(
+            self.print_arr[0], '\033[91mAn error occurred in the test\033[0m'
+        )
+
+    def test_log_to_terminal_without_type_auto_detects_failure(self) -> None:
+        """Test that auto-detection colors failure messages in red."""
+        with self.print_swap:
+            common.log_to_terminal('Test FAILED unexpectedly')
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(
+            self.print_arr[0], '\033[91mTest FAILED unexpectedly\033[0m'
+        )
+
+    def test_log_to_terminal_without_type_auto_detects_warning(self) -> None:
+        """Test that auto-detection colors warning messages in yellow."""
+        with self.print_swap:
+            common.log_to_terminal('Warning: deprecated API usage')
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(
+            self.print_arr[0], '\033[93mWarning: deprecated API usage\033[0m'
+        )
+
+    def test_log_to_terminal_without_type_normal_message(self) -> None:
+        """Test that normal messages are printed without coloring."""
+        with self.print_swap:
+            common.log_to_terminal('Running test suite')
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(self.print_arr[0], 'Running test suite')
+
+    def test_log_to_terminal_auto_detects_traceback(self) -> None:
+        """Test that auto-detection colors traceback messages in red."""
+        with self.print_swap:
+            common.log_to_terminal('Traceback (most recent call last):')
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(
+            self.print_arr[0],
+            '\033[91mTraceback (most recent call last):\033[0m',
+        )
+
+    def test_log_to_terminal_auto_detects_exception(self) -> None:
+        """Test that auto-detection colors exception messages in red."""
+        with self.print_swap:
+            common.log_to_terminal('Exception raised during execution')
+        self.assertEqual(len(self.print_arr), 1)
+        self.assertEqual(
+            self.print_arr[0],
+            '\033[91mException raised during execution\033[0m',
+        )


### PR DESCRIPTION
### Overview
1. This PR fixes part of #21448.
2. This PR does the following: Adds a `LogType` enum and a `log_to_terminal(message, message_type)` function as a utility for colorizing terminal output in CI. The `LogType` enum defines `INFO`, `ERROR`, `SUCCESS`, and `WARNING` log types. The `log_to_terminal()` function prints messages in different colors based on their type (red for errors, green for success, yellow for warnings, blue for info). If no type is provided, it automatically detects error or warning keywords in the message and applies appropriate coloring. This improves readability of CI logs and makes debugging easier. This PR also adds unit tests covering all log types, auto-detection, and plain message output. Follow-up PRs can refactor existing scripts to use this utility instead of raw ANSI escape codes.

### Essential Checklist
- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

### Proof that changes are correct
No proof of changes needed because this PR only adds a Python utility function and its unit tests. There are no user-facing UI changes. The correctness is verified by the unit tests included in this PR.