### PR TITLE
Fix #23830: Add cleanup to kill lingering servers on acceptance test reruns

### DIFF
--- a/.github/actions/run-a-specific-acceptance-test/action.yml
+++ b/.github/actions/run-a-specific-acceptance-test/action.yml
@@ -44,6 +44,7 @@ runs:
         ${{ inputs.viewport-type == 'mobile' && '--mobile' || '' }}
         --prod_env
         --server_log_level=info
+        --force_cleanup_on_start
         | tee acceptance_test_${{ inputs.modified-suite-name-for-uploads || '' }}.log
 
     - name: Upload test logs

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1038,6 +1038,48 @@ def modify_constants(
         )
 
 
+def kill_processes_based_on_ports(ports: List[int]) -> None:
+    """Kills any process listening on the given ports.
+
+    Args:
+        ports: list(int). A list of port numbers. Any process listening on
+            these ports will be killed.
+    """
+    import psutil  # pylint: disable=import-outside-toplevel
+    procs_to_kill = []
+    for proc in psutil.process_iter(['name', 'pid']):
+        try:
+            for conn in proc.connections(kind='inet'):
+                if conn.laddr.port in ports:
+                    procs_to_kill.append(proc)
+                    break
+        except (
+            psutil.NoSuchProcess,
+            psutil.AccessDenied,
+            psutil.ZombieProcess
+        ):
+            pass
+
+    for proc in procs_to_kill:
+        print(
+            'Killing process %s (PID: %s) listening on one of the target '
+            'ports.' % (proc.info['name'], proc.info['pid'])
+        )
+        try:
+            proc.terminate()
+        except psutil.NoSuchProcess:
+            pass
+
+    if procs_to_kill:
+        _, alive = psutil.wait_procs(procs_to_kill, timeout=5)
+        for p in alive:
+            try:
+                p.kill()
+            except psutil.NoSuchProcess:
+                pass
+
+
+
 def is_oppia_server_already_running() -> bool:
     """Check if the ports are taken by any other processes. If any one of
     them is taken, it may indicate there is already one Oppia instance running.

--- a/scripts/common_test.py
+++ b/scripts/common_test.py
@@ -1286,6 +1286,63 @@ class CommonTests(test_utils.GenericTestBase):
 
             self.assertTrue(common.is_oppia_server_already_running())
 
+    def test_kill_processes_based_on_ports(self) -> None:
+        import psutil  # pylint: disable=import-outside-toplevel
+
+        class MockConnection:
+            def __init__(self, port: int) -> None:
+                class Laddr:
+                    def __init__(self, p: int) -> None:
+                        self.port = p
+                self.laddr = Laddr(port)
+
+        class MockProcess:
+            def __init__(self, pid: int, name: str, ports: List[int]) -> None:
+                self.info = {'pid': pid, 'name': name}
+                self.ports = ports
+                self.terminate_called = False
+                self.kill_called = False
+
+            def connections(self, kind: str) -> List[MockConnection]:
+                return [MockConnection(p) for p in self.ports]
+
+            def terminate(self) -> None:
+                self.terminate_called = True
+
+            def kill(self) -> None:
+                self.kill_called = True
+
+        proc1 = MockProcess(101, 'node', [8181])
+        proc2 = MockProcess(102, 'python', [8000])
+        proc3 = MockProcess(103, 'other', [9999])
+
+        def mock_process_iter(attrs: List[str]) -> List[MockProcess]:
+            return [proc1, proc2, proc3]
+
+        def mock_wait_procs(
+            procs: List[MockProcess], timeout: int
+        ) -> Tuple[List[MockProcess], List[MockProcess]]:
+            # proc1 successfully terminated, proc2 is still alive
+            return ([proc1], [proc2])
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                self.swap(psutil, 'process_iter', mock_process_iter)
+            )
+            stack.enter_context(
+                self.swap(psutil, 'wait_procs', mock_wait_procs)
+            )
+            common.kill_processes_based_on_ports([8181, 8000])
+
+        self.assertTrue(proc1.terminate_called)
+        self.assertFalse(proc1.kill_called)
+
+        self.assertTrue(proc2.terminate_called)
+        self.assertTrue(proc2.kill_called)
+
+        self.assertFalse(proc3.terminate_called)
+        self.assertFalse(proc3.kill_called)
+
     def test_start_subprocess_for_result(self) -> None:
         process = subprocess.Popen(
             ['echo', 'test'], stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/scripts/run_acceptance_tests.py
+++ b/scripts/run_acceptance_tests.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 
+from core import feconf
 from scripts import build, common, servers
 
 from typing import Final, List, Optional, Tuple
@@ -72,6 +73,12 @@ _PARSER.add_argument(
     '--mobile', help='Run the tests in mobile mode.', action='store_true'
 )
 
+_PARSER.add_argument(
+    '--force_cleanup_on_start',
+    help='If true, forcibly terminates any running test servers before starting.',
+    action='store_true',
+)
+
 
 def compile_test_ts_files() -> None:
     """Compiles the test typescript files into a build directory."""
@@ -109,6 +116,17 @@ def compile_test_ts_files() -> None:
 
 def run_tests(args: argparse.Namespace) -> Tuple[List[bytes], int]:
     """Run the scripts to start acceptance tests."""
+    if args.force_cleanup_on_start:
+        ports_to_kill = [
+            common.GAE_PORT_FOR_E2E_TESTING,
+            feconf.GAE_ADMIN_SERVER_PORT,
+            feconf.ES_LOCALHOST_PORT,
+            feconf.CLOUD_DATASTORE_EMULATOR_PORT,
+            feconf.FIREBASE_EMULATOR_PORT,
+            feconf.REDISPORT,
+        ]
+        common.kill_processes_based_on_ports(ports_to_kill)
+
     if common.is_oppia_server_already_running():
         sys.exit(
             """


### PR DESCRIPTION
## Overview

1. This PR fixes #23830.
2. This PR does the following: Ensures that acceptance test reruns start from a clean state by cleaning up any lingering server processes. It introduces a utility to terminate processes running on required ports and adds a `--force_cleanup_on_start` flag to the acceptance test runner so that cleanup happens before tests begin. The CI workflow is also updated to use this flag, preventing rerun failures caused by already running servers.
3. The original bug occurred because: When an acceptance test failed or timed out, the server processes were not properly shut down. As a result, during reruns, the system detected that the server was already running on required ports and aborted the tests, causing reruns to fail immediately.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this PR affects CI behavior and backend scripts only. The fix ensures that reruns start with a clean environment by terminating lingering server processes, which resolves the failure observed in CI logs.