### PR TITLE
Fix #25307: Stop email retries for permanent 4xx client errors

### DIFF
--- a/core/controllers/tasks.py
+++ b/core/controllers/tasks.py
@@ -79,7 +79,15 @@ class UnsentFeedbackEmailHandler(
                     'messages': [message_text],
                 }
 
-        email_manager.send_feedback_message_email(user_id, messages)
+        try:
+            email_manager.send_feedback_message_email(user_id, messages)
+        except email_services.PermanentEmailSendingError as e:
+            logging.error(
+                'Permanent error sending unsent feedback email: %s' % e
+            )
+            self.render_json({})
+            return
+
         feedback_services.pop_feedback_message_references_transactional(
             user_id, len(references)
         )
@@ -134,10 +142,16 @@ class ContributorDashboardAchievementEmailHandler(
             language_code,
             rank_name,
         )
-
-        email_manager.send_mail_to_notify_contributor_ranking_achievement(
-            email_info
-        )
+        try:
+            email_manager.send_mail_to_notify_contributor_ranking_achievement(
+                email_info
+            )
+        except email_services.PermanentEmailSendingError as e:
+            logging.error(
+                'Permanent error sending contributor achievement email: %s' % e
+            )
+            self.render_json({})
+            return
         self.render_json({})
 
 
@@ -162,15 +176,22 @@ class InstantFeedbackMessageEmailHandler(
         thread = feedback_services.get_thread(reference_dict['thread_id'])
 
         subject = 'New Oppia message in "%s"' % thread.subject
-        email_manager.send_instant_feedback_message_email(
-            user_id,
-            message.author_id,
-            message.text,
-            subject,
-            exploration.title,
-            reference_dict['entity_id'],
-            thread.subject,
-        )
+        try:
+            email_manager.send_instant_feedback_message_email(
+                user_id,
+                message.author_id,
+                message.text,
+                subject,
+                exploration.title,
+                reference_dict['entity_id'],
+                thread.subject,
+            )
+        except email_services.PermanentEmailSendingError as e:
+            logging.error(
+                'Permanent error sending instant feedback email: %s' % e
+            )
+            self.render_json({})
+            return
         self.render_json({})
 
 
@@ -200,15 +221,22 @@ class FeedbackThreadStatusChangeEmailHandler(
 
         text = 'changed status from %s to %s' % (old_status, new_status)
         subject = 'Oppia thread status change: "%s"' % thread.subject
-        email_manager.send_instant_feedback_message_email(
-            user_id,
-            message.author_id,
-            text,
-            subject,
-            exploration.title,
-            reference_dict['entity_id'],
-            thread.subject,
-        )
+        try:
+            email_manager.send_instant_feedback_message_email(
+                user_id,
+                message.author_id,
+                text,
+                subject,
+                exploration.title,
+                reference_dict['entity_id'],
+                thread.subject,
+            )
+        except email_services.PermanentEmailSendingError as e:
+            logging.error(
+                'Permanent error sending thread status change email: %s' % e
+            )
+            self.render_json({})
+            return
         self.render_json({})
 
 
@@ -229,9 +257,16 @@ class FlagExplorationEmailHandler(
 
         exploration = exp_fetchers.get_exploration_by_id(exploration_id)
 
-        email_manager.send_flag_exploration_email(
-            exploration.title, exploration_id, reporter_id, report_text
-        )
+        try:
+            email_manager.send_flag_exploration_email(
+                exploration.title, exploration_id, reporter_id, report_text
+            )
+        except email_services.PermanentEmailSendingError as e:
+            logging.error(
+                'Permanent error sending flagged exploration email: %s' % e
+            )
+            self.render_json({})
+            return
         self.render_json({})
 
 
@@ -307,6 +342,14 @@ class RetryEmailHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
             email_services.send_mail(
                 sender_email, recipient_id, subject, text_body, html_body
             )
+        except email_services.PermanentEmailSendingError as e:
+            logging.error(
+                'Retry dropped due to permanent 4xx error for recipient %s: %s',
+                recipient_id,
+                e,
+            )
+            self.render_json({})
+            return
         except Exception as e:
             logging.error(
                 'Email retry failed for recipient %s: %s', recipient_id, e

--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -17,9 +17,11 @@
 from __future__ import annotations
 
 import uuid
+from unittest import mock
 
 from core import feconf
 from core.domain import (
+    email_manager,
     email_services,
     exp_fetchers,
     exp_services,
@@ -257,7 +259,56 @@ class TasksTests(test_utils.EmailTestBase):
             'The Oppia Contributor Dashboard Team'
         )
         self.assertEqual(messages[0].html, expected_email_html_body)
-        self.assertEqual(messages[0].subject, expected_email_subject)
+
+    self.assertEqual(messages[0].subject, expected_email_subject)
+
+    @test_utils.set_platform_parameters(
+        [
+            (platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS, True),
+            (platform_parameter_list.ParamName.EMAIL_FOOTER, EMAIL_FOOTER),
+            (platform_parameter_list.ParamName.EMAIL_SENDER_NAME, 'sender'),
+            (
+                platform_parameter_list.ParamName.ADMIN_EMAIL_ADDRESS,
+                'testadmin@example.com',
+            ),
+            (
+                platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
+                'system@example.com',
+            ),
+            (
+                platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS,
+                'noreply@example.com',
+            ),
+        ]
+    )
+    def test_unsent_feedback_email_drops_task_on_permanent_error(self) -> None:
+        """Test that permanent 4xx errors return 200 OK to drop the task."""
+        with self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                feconf.ENTITY_TYPE_EXPLORATION,
+                self.exploration.id,
+                self.user_id_a,
+                'a subject',
+                'some text',
+            )
+            threadlist = feedback_services.get_all_threads(
+                feconf.ENTITY_TYPE_EXPLORATION, self.exploration.id, False
+            )
+            thread_id = threadlist.id
+            feedback_services.create_message(
+                thread_id, self.user_id_b, None, None, 'user b message'
+            )
+
+            mock_send_email = mock.Mock(
+                side_effect=email_services.PermanentEmailSendingError(
+                    'Fake 400 error'
+                )
+            )
+
+            with self.swap(
+                email_manager, 'send_feedback_message_email', mock_send_email
+            ):
+                self.process_and_flush_pending_tasks()
 
     @test_utils.set_platform_parameters(
         [

--- a/core/domain/email_services.py
+++ b/core/domain/email_services.py
@@ -34,6 +34,12 @@ if MYPY:  # pragma: no cover
 email_services = models.Registry.import_email_services()
 
 
+class PermanentEmailSendingError(exception):
+    """Exception raised when an email cannot be sent due to a permanent 4xx error."""
+
+    pass
+
+
 def _is_email_valid(email_address: str) -> bool:
     """Determines whether an email address is valid.
 

--- a/core/platform/email/mailgun_email_services.py
+++ b/core/platform/email/mailgun_email_services.py
@@ -205,6 +205,16 @@ def send_email_to_recipients(
             file_obj.close()
 
         if response.status_code != 200:
+            if 400 <= response.status_code < 500:
+                logging.error(
+                    'Failed to send email (Permanent Error): %s - %s.'
+                    % (response.status_code, response.text)
+                )
+                raise email_services.PermanentEmailSendingError(
+                    'Mailgun returned a permanent error %s: %s'
+                    % (response.status_code, response.text)
+                )
+
             logging.error(
                 'Failed to send email: %s - %s.'
                 % (response.status_code, response.text)

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -23,6 +23,7 @@ import textwrap
 from unittest import mock
 
 from core.domain import platform_parameter_list
+from core.domain import email_services
 from core.platform import models
 from core.platform.email import mailgun_email_services
 from core.tests import test_utils
@@ -442,3 +443,77 @@ class EmailTests(test_utils.GenericTestBase):
             timeout=mailgun_email_services.TIMEOUT_SECS,
         )
         self.assertFalse(resp)
+
+    @test_utils.set_platform_parameters(
+        [(platform_parameter_list.ParamName.MAILGUN_DOMAIN_NAME, 'domain')]
+    )
+    @mock.patch('requests.post')
+    def test_send_email_to_mailgun_returns_false_for_429_rate_limit(
+        self, mock_post: mock.Mock
+    ) -> None:
+        """Test that a 429 Too Many Requests error returns False to trigger retry."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 429
+        mock_response.text = 'Too Many Requests'
+        mock_post.return_value = mock_response
+
+        with self.swap_api_key_secrets_return_secret:
+            resp = mailgun_email_services.send_email_to_recipients(
+                'a@example.com',
+                ['b@example.com'],
+                'Test Subject',
+                'plaintext',
+                'html body',
+            )
+
+        self.assertFalse(resp)
+
+    @test_utils.set_platform_parameters(
+        [(platform_parameter_list.ParamName.MAILGUN_DOMAIN_NAME, 'domain')]
+    )
+    @mock.patch('requests.post')
+    def test_send_email_to_mailgun_returns_false_for_408_timeout(
+        self, mock_post: mock.Mock
+    ) -> None:
+        """Test that a 408 Timeout error returns False to trigger retry."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 408
+        mock_response.text = 'Request Timeout'
+        mock_post.return_value = mock_response
+
+        with self.swap_api_key_secrets_return_secret:
+            resp = mailgun_email_services.send_email_to_recipients(
+                'a@example.com',
+                ['b@example.com'],
+                'Test Subject',
+                'plaintext',
+                'html body',
+            )
+
+        self.assertFalse(resp)
+
+    @test_utils.set_platform_parameters(
+        [(platform_parameter_list.ParamName.MAILGUN_DOMAIN_NAME, 'domain')]
+    )
+    @mock.patch('requests.post')
+    def test_send_email_to_mailgun_raises_exception_for_permanent_4xx_error(
+        self, mock_post: mock.Mock
+    ) -> None:
+        """Test that a standard 4xx error (like 400) raises a permanent error."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 400
+        mock_response.text = 'Bad Request: Invalid Email'
+        mock_post.return_value = mock_response
+
+        with self.swap_api_key_secrets_return_secret:
+            with self.assertRaisesRegex(
+                email_services.PermanentEmailSendingError,
+                'Mailgun returned a permanent error 400: Bad Request: Invalid Email',
+            ):
+                mailgun_email_services.send_email_to_recipients(
+                    'a@example.com',
+                    ['bad-email@@example.com'],
+                    'Test Subject',
+                    'plaintext',
+                    'html body',
+                )


### PR DESCRIPTION
## Overview

1. This PR fixes part of #25307 .
2. This PR does the following: This PR improves the email retry mechanism by differentiating between all errors and permanent (4xx) errors to prevent retires on them.
3. No segregation of bug based on error response

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Passing tests are proof
## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
