### PR TITLE
Revert "Fix #23683: Align learning progress checkpoint numbers"

### DIFF
--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/checkpoint-bar.component.css
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/lesson-player-footer/checkpoint-bar.component.css
@@ -28,37 +28,36 @@
 }
 
 .completed-checkpoint-node {
-  align-items: center;
   background-color: #00645c;
   border-radius: 50%;
   cursor: pointer;
   display: flex;
-  height: 25px;
+  height: 12px;
   justify-content: center;
-  width: 25px;
+  width: 12px;
   z-index: 0;
 }
 
 .in-progress-checkpoint-node {
-  align-items: center;
+  align-items: flex-start;
   background-color: #fff;
   border: 2px solid #00645c;
   border-radius: 50%;
   display: flex;
-  height: 25px;
+  height: 20px;
   justify-content: center;
-  width: 25px;
+  width: 20px;
   z-index: 0;
 }
 
 .incomplete-checkpoint-node {
-  align-items: center;
+  align-items: flex-end;
   background-color: #fff;
   border: 1px solid #c0c0c0;
   border-radius: 50%;
   display: flex;
-  height: 25px;
+  height: 12px;
   justify-content: center;
-  width: 25px;
+  width: 12px;
   z-index: 111;
 }


### PR DESCRIPTION

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR Reverts oppia/oppia#24338.
2. We need to revert #24338 PR, as it breaks the checkpoint bar of the new lesson player. 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct


Image before breakage:

<img width="1918" height="929" alt="image" src="https://github.com/user-attachments/assets/32a1bc69-9677-429c-86c7-925b06f8ba25" />

Image after breakage:

<img width="1918" height="929" alt="image" src="https://github.com/user-attachments/assets/59102e15-5ac1-42b8-b537-47c3ae5f01fa" />


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
