### PR TITLE
Fix #22178: Add validation before removing a nonexistent user role

### DIFF
--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -2609,6 +2609,26 @@ class AdminRoleHandlerTest(test_utils.GenericTestBase):
             expected_status_int=404,
         )
 
+    def test_removing_nonexistent_role_from_user_raises_error(self) -> None:
+        user_email = 'user1@example.com'
+        username = 'user1'
+
+        self.signup(user_email, username)
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+
+        response = self.delete_json(
+            feconf.ADMIN_ROLE_HANDLER_URL,
+            params={
+                'role': feconf.ROLE_ID_MODERATOR,
+                'username': username,
+            },
+            expected_status_int=500,
+        )
+        self.assertIn(
+            'The user does not have the given role.',
+            response['error'],
+        )
+
     def test_cannot_view_role_with_invalid_view_filter_criterion(self) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
         response = self.get_json(

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1706,6 +1706,8 @@ def remove_user_role(user_id: str, role: str) -> None:
         raise Exception('The role of a Mobile Learner cannot be changed.')
     if role in feconf.ALLOWED_DEFAULT_USER_ROLES_ON_REGISTRATION:
         raise Exception('Removing a default role is not allowed.')
+    if role not in user_settings.roles:
+        raise Exception('The user does not have the given role.')
 
     user_settings.roles.remove(role)
 

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -1231,6 +1231,18 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
 
         self.assertEqual(user_settings_model.roles, user_settings.roles)
 
+    def test_remove_user_role_for_nonexistent_role_raises_error(self) -> None:
+        user_id = user_services.create_new_user(
+            'someUser', 'user@example.com'
+        ).user_id
+
+        with self.assertRaisesRegex(
+            Exception, 'The user does not have the given role.'
+        ):
+            user_services.remove_user_role(
+                user_id, feconf.ROLE_ID_BLOG_POST_EDITOR
+            )
+
     def test_remove_user_role_for_default_role_raises_error(self) -> None:
         user_id = user_services.create_new_user(
             'someUser', 'user@example.com'


### PR DESCRIPTION
1. This PR fixes #22178.
2. This PR adds a validation check in `remove_user_role()` to verify that the role actually exists in the user's roles list before attempting to remove it. Without this, calling `.remove()` on a role the user doesn't have crashes with `ValueError: list.remove(x): x not in list`.
3. The original bug occurred because `remove_user_role()` in `user_services.py` directly called `user_settings.roles.remove(role)` without first checking if the role existed. Interestingly, the sister function `add_user_role()` already had this kind of guard — this one was just missing it.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This is a backend-only fix with no UI changes. Proof is via passing tests:

**`core.domain.user_services_test` — 191 tests passed:**
<img width="839" height="345" alt="Screenshot 2026-03-22 at 10 44 46 PM" src="https://github.com/user-attachments/assets/efa26901-da36-4b0a-a0a7-9aa3b111592e" />


**`core.controllers.admin_test` — 152 tests passed:**
<img width="831" height="397" alt="Screenshot 2026-03-22 at 10 49 30 PM" src="https://github.com/user-attachments/assets/bb394a75-54f9-4360-bdce-0299f1b7173b" />


The new test `test_remove_user_role_for_nonexistent_role_raises_error` directly covers the bug scenario — without the fix, this test would fail with a `ValueError` instead of the clean exception.

#### Proof of changes on desktop with slow/throttled network
Not applicable — backend-only change, no UI affected.

#### Proof of changes on mobile phone
Not applicable — backend-only change.

#### Proof of changes in Arabic language
Not applicable — no UI changes.
