### PR TITLE
Fix #20164: Improve visibility of hint numbering in hint modal

### DIFF
--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/display-new-hint-modal.component.html
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/display-new-hint-modal.component.html
@@ -1,7 +1,9 @@
 <p class="oppia-learner-hint-and-solution-modal-title">
-  {{ 'I18N_NEW_HINT_TITLE' | translate: { hintIndex: activeHintIndex + 1 } }}
+  <strong>
+    {{ 'I18N_NEW_HINT_TITLE' | translate: { hintIndex: activeHintIndex + 1 } }}
+  </strong>
 </p>
-
+<hr>
 <div class="modal-body">
   <oppia-rte-output-display class="oppia-learner-hint-and-solution-modal-body"
     [rteString]="hint.html">
@@ -13,7 +15,7 @@
     {{ 'I18N_HINT_PREVIOUS_BUTTON_TEXT' | translate }}
   </button>
 
-  <p *ngIf="numHintsReleased > 1">
+  <p *ngIf="numHintsReleased > 1" style="font-weight: 500;">
     {{ 'I18N_HINTS_COUNT' | translate: {
       hintIndex: activeHintIndex + 1,
       totalHints: numHintsReleased


### PR DESCRIPTION
## Overview

1. This PR fixes #20164.
2. This PR improves the visibility of hint numbering in the hint modal by making the hint title bold. This helps learners clearly identify the order of hints (Hint 1, Hint 2, etc.).
3. (For bug-fixing PRs only) N/A

## Essential Checklist

* [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [ ] I have written tests for my code. (Not required for this small UI-only change)
* [x] The PR title starts with "Fix #20164: Improve visibility of hint numbering in hint modal".
* [ ] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

### Before

(Add screenshot here)

### After

(Add screenshot here)

#### Proof of changes on desktop with slow/throttled network

No issues observed. The hint modal renders correctly under throttled network.

#### Proof of changes on mobile phone

Tested using responsive mode. Layout remains correct.

#### Proof of changes in Arabic language

(Not tested)
<img width="1920" height="1080" alt="Screenshot From 2026-03-23 10-42-28" src="https://github.com/user-attachments/assets/0dac3d71-1907-43e6-8ba7-416e6d7a3d0f" />
<img width="1920" height="1080" alt="Screenshot From 2026-03-23 10-42-28" src="https://github.com/user-attachments/assets/196d6eb9-4f46-4b8c-be2b-9b3da87d80ef" />
