### PR TITLE
Fix #21124: Add safeguards and tests for missing guppy KaTeX fonts

### DIFF
--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -427,6 +427,41 @@ def install_elasticsearch_dev_server() -> None:
     print('ElasticSearch installed successfully.')
 
 
+def copy_missing_guppy_katex_fonts() -> None:
+    """Copies KaTeX fonts missing from guppy-dev/build/fonts.
+
+    guppy-default.min.css references KaTeX_Main-BoldItalic font files that are
+    not present in guppy-dev/build/fonts for the Oppia-pinned guppy revision.
+    Copy them from guppy-dev/lib/katex/fonts so webpack can emit them.
+    """
+    source_dir = os.path.join(
+        common.NODE_MODULES_PATH, 'guppy-dev', 'lib', 'katex', 'fonts'
+    )
+    target_dir = os.path.join(
+        common.NODE_MODULES_PATH, 'guppy-dev', 'build', 'fonts'
+    )
+    missing_font_filenames = [
+        'KaTeX_Main-BoldItalic.ttf',
+        'KaTeX_Main-BoldItalic.woff',
+        'KaTeX_Main-BoldItalic.woff2',
+    ]
+
+    if not os.path.exists(source_dir):
+        return
+
+    os.makedirs(target_dir, exist_ok=True)
+
+    for filename in missing_font_filenames:
+        source_file = os.path.join(source_dir, filename)
+        target_file = os.path.join(target_dir, filename)
+
+        if not os.path.exists(source_file):
+            continue
+
+        if not os.path.exists(target_file):
+            shutil.copy(source_file, target_file)
+
+
 def main() -> None:
     """Set up GAE and install third-party libraries for Oppia."""
     print('Running install_third_party_libs script...')
@@ -500,6 +535,7 @@ def main() -> None:
         'the start.py script.\n',
     )
     subprocess.check_call(['yarn', 'install', '--pure-lockfile'])
+    copy_missing_guppy_katex_fonts()
 
 
 # The 'no coverage' pragma is used as this line is un-testable. This is because

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -183,7 +183,7 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_external_script_call() -> None:
             pass
 
-        def mock_mkdir(unused_path: str) -> None:
+        def mock_mkdir(unused_path: str, unused_mode: int = 0o777) -> None:
             pass
 
         def mock_copytree(unused_src: str, unused_dst: str) -> None:
@@ -433,6 +433,129 @@ class InstallRedisAndElasticSearchTests(test_utils.GenericTestBase):
         with swap_call:
             install_third_party_libs.install_elasticsearch_dev_server()
         self.assertEqual(check_function_calls, expected_check_function_calls)
+
+
+class CopyMissingGuppyKatexFontsTests(test_utils.TestBase):
+    """Tests for copy_missing_guppy_katex_fonts."""
+
+    def test_copy_missing_guppy_katex_fonts_returns_if_source_dir_missing(
+        self,
+    ) -> None:
+        makedirs_called = False
+        copy_called = False
+
+        source_dir = os.path.join(
+            common.NODE_MODULES_PATH, 'guppy-dev', 'lib', 'katex', 'fonts'
+        )
+
+        def mock_exists(path: str) -> bool:
+            if path == source_dir:
+                return False
+            return True
+
+        def mock_makedirs(unused_path: str, exist_ok: bool = False) -> None:
+            del exist_ok
+            nonlocal makedirs_called
+            makedirs_called = True
+
+        def mock_copy(unused_src: str, unused_dst: str) -> None:
+            nonlocal copy_called
+            copy_called = True
+
+        swap_exists = self.swap(os.path, 'exists', mock_exists)
+        swap_makedirs = self.swap(os, 'makedirs', mock_makedirs)
+        swap_copy = self.swap(shutil, 'copy', mock_copy)
+
+        with swap_exists, swap_makedirs, swap_copy:
+            install_third_party_libs.copy_missing_guppy_katex_fonts()
+
+        self.assertFalse(makedirs_called)
+        self.assertFalse(copy_called)
+
+    def test_copy_missing_guppy_katex_fonts_creates_target_dir_with_exist_ok(
+        self,
+    ) -> None:
+        makedirs_args: List[Tuple[str, bool]] = []
+
+        target_dir = os.path.join(
+            common.NODE_MODULES_PATH, 'guppy-dev', 'build', 'fonts'
+        )
+
+        def mock_exists(unused_path: str) -> bool:
+            return True
+
+        def mock_makedirs(path: str, exist_ok: bool = False) -> None:
+            makedirs_args.append((path, exist_ok))
+
+        def mock_copy(unused_src: str, unused_dst: str) -> None:
+            pass
+
+        swap_exists = self.swap(os.path, 'exists', mock_exists)
+        swap_makedirs = self.swap(os, 'makedirs', mock_makedirs)
+        swap_copy = self.swap(shutil, 'copy', mock_copy)
+
+        with swap_exists, swap_makedirs, swap_copy:
+            install_third_party_libs.copy_missing_guppy_katex_fonts()
+
+        self.assertEqual(makedirs_args, [(target_dir, True)])
+
+    def test_copy_missing_guppy_katex_fonts_copies_only_missing_files(
+        self,
+    ) -> None:
+        copied_files: List[Tuple[str, str]] = []
+
+        source_dir = os.path.join(
+            common.NODE_MODULES_PATH, 'guppy-dev', 'lib', 'katex', 'fonts'
+        )
+        target_dir = os.path.join(
+            common.NODE_MODULES_PATH, 'guppy-dev', 'build', 'fonts'
+        )
+
+        existing_target_files = {
+            os.path.join(target_dir, 'KaTeX_Main-BoldItalic.ttf'),
+        }
+
+        source_files = {
+            os.path.join(source_dir, 'KaTeX_Main-BoldItalic.ttf'),
+            os.path.join(source_dir, 'KaTeX_Main-BoldItalic.woff'),
+            os.path.join(source_dir, 'KaTeX_Main-BoldItalic.woff2'),
+        }
+
+        def mock_exists(path: str) -> bool:
+            if path == source_dir:
+                return True
+            if path in source_files:
+                return True
+            if path in existing_target_files:
+                return True
+            return False
+
+        def mock_makedirs(unused_path: str, exist_ok: bool = False) -> None:
+            del exist_ok
+
+        def mock_copy(src: str, dst: str) -> None:
+            copied_files.append((src, dst))
+
+        swap_exists = self.swap(os.path, 'exists', mock_exists)
+        swap_makedirs = self.swap(os, 'makedirs', mock_makedirs)
+        swap_copy = self.swap(shutil, 'copy', mock_copy)
+
+        with swap_exists, swap_makedirs, swap_copy:
+            install_third_party_libs.copy_missing_guppy_katex_fonts()
+
+        self.assertEqual(
+            copied_files,
+            [
+                (
+                    os.path.join(source_dir, 'KaTeX_Main-BoldItalic.woff'),
+                    os.path.join(target_dir, 'KaTeX_Main-BoldItalic.woff'),
+                ),
+                (
+                    os.path.join(source_dir, 'KaTeX_Main-BoldItalic.woff2'),
+                    os.path.join(target_dir, 'KaTeX_Main-BoldItalic.woff2'),
+                ),
+            ],
+        )
 
 
 class SetupTests(test_utils.GenericTestBase):

--- a/webpack.common.config.ts
+++ b/webpack.common.config.ts
@@ -20,6 +20,7 @@ const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackRTLPlugin = require('webpack-rtl-plugin');
+const fs = require('fs');
 var path = require('path');
 var webpack = require('webpack');
 const macros = require('./webpack.common.macros.ts');
@@ -43,6 +44,38 @@ var defaultMeta = {
     'Oppia is a free, open-source learning platform. Join ' +
     'the community to create or try an exploration today!',
 };
+
+class CopyGuppyAssetsPlugin {
+  apply(compiler) {
+    compiler.hooks.done.tap('CopyGuppyAssetsPlugin', () => {
+      const outputPath = compiler.options.output.path;
+      const guppyBuildPath = path.resolve(
+        __dirname,
+        'node_modules',
+        'guppy-dev',
+        'build'
+      );
+      const assetDirectories = ['fonts', 'icons'];
+
+      assetDirectories.forEach(directoryName => {
+        const sourceDirectory = path.join(guppyBuildPath, directoryName);
+        const targetDirectory = path.join(outputPath, directoryName);
+
+        if (!fs.existsSync(sourceDirectory)) {
+          return;
+        }
+
+        fs.mkdirSync(targetDirectory, {recursive: true});
+        fs.readdirSync(sourceDirectory).forEach(filename => {
+          fs.copyFileSync(
+            path.join(sourceDirectory, filename),
+            path.join(targetDirectory, filename)
+          );
+        });
+      });
+    });
+  }
+}
 
 module.exports = {
   resolve: {
@@ -132,6 +165,7 @@ module.exports = {
         zindex: false,
       },
     }),
+    new CopyGuppyAssetsPlugin(),
   ],
   module: {
     rules: [
@@ -179,6 +213,21 @@ module.exports = {
           },
         ],
       },
+      // Rule for guppy-dev CSS - process url() for fonts and icons.
+      {
+        test: /\.css$/,
+        include: [path.resolve(__dirname, 'node_modules/guppy-dev')],
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              url: true,
+            },
+          },
+        ],
+      },
+      // Rule for all other CSS - keep url: false as original.
       {
         test: /\.css$/,
         include: [
@@ -186,12 +235,37 @@ module.exports = {
           path.resolve(__dirname, 'extensions'),
           path.resolve(__dirname, 'node_modules'),
         ],
+        exclude: [path.resolve(__dirname, 'node_modules/guppy-dev')],
         use: [
           MiniCssExtractPlugin.loader,
           {
             loader: 'css-loader',
             options: {
               url: false,
+            },
+          },
+        ],
+      },
+      {
+        test: /\.(woff|woff2|ttf|eot)$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: 'fonts/',
+            },
+          },
+        ],
+      },
+      {
+        test: /\.(png|jpg|gif)$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: 'icons/',
             },
           },
         ],


### PR DESCRIPTION
## Overview

1. This PR fixes #21124.
2. This PR fixes missing guppy font and icon assets that were causing 404 errors in interaction tests. Specifically, it copies the missing KaTeX font files into `guppy-dev/build/fonts`, preserves the required webpack handling for guppy assets, adds safeguards to avoid failures when expected asset files or directories are missing, and adds unit tests for the new logic.
3. The original bug occurred because the `guppy-dev` assets referenced by `guppy-default.min.css` were not fully present in the webpack output, which caused 404 errors for fonts and icons during tests.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Proof of changes has been provided via the before-and-after videos below.

This PR affects developer-facing asset handling and test/build behavior rather than a user-facing UI flow.

#### Proof of changes on desktop with slow/throttled network

Before:
https://youtu.be/HkjA2dNFNSw

After:
https://youtu.be/hQ9RSlyErcA

These videos show the missing guppy font/icon asset requests failing before the fix and succeeding after the fix.

#### Proof of changes on mobile phone

Not applicable, since this PR does not change a mobile UI flow.

#### Proof of changes in Arabic language

Not applicable, since this PR does not change user-facing UI text or layout.