### PR TITLE
[WIP] Fix voiceover submission error (#25488)

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.ts
@@ -136,8 +136,13 @@ export class VoiceoverCardComponent implements OnInit, AfterViewChecked {
 
   ngOnInit(): void {
     this.languageCode = this.translationLanguageService.getActiveLanguageCode();
-    this.languageAccentCode =
+    const storedAccent =
       this.localStorageService.getLastSelectedLanguageAccentCode() as string;
+
+    this.languageAccentCode =
+      storedAccent && storedAccent !== 'undefined'
+        ? storedAccent
+        : this.translationLanguageService.getActiveLanguageAccentCode() || 'en-US';
     this.languageAccentCodeIsSelected = this.languageAccentCode !== 'undefined';
     this.voiceoverAdminConfigIsLoading = true;
 


### PR DESCRIPTION
## Overview
This PR attempts to fix the voiceover submission error where users receive a "language_access_code" error while saving changes.

## What this PR does
- Ensures a valid languageAccentCode is always set
- Adds fallback logic when stored value is undefined or invalid

## Approach
- Retrieve languageAccentCode from local storage
- Validate against undefined values
- Fallback to active language accent or default ("en-US")

## Testing
- Local full testing is limited due to system constraints (RAM issue while running Oppia locally)
- TypeScript compiles successfully
- Change is minimal and targeted

## Notes for reviewers
Please let me know if additional validation or adjustments are needed. Happy to improve the implementation.

Fixes #25488