### PR TITLE
Fix #23999: Resolved E2E flake where element is not clickable in community library test

### DIFF
--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -51,7 +51,7 @@ from core.tests import test_utils
 
 import webapp2
 import webtest
-from typing import Any, Dict, Final, List, Mapping, Union
+from typing import Any, Dict, Final, List, Union
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -7934,6 +7934,10 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
         self,
     ) -> None:
         content_id_generator = translation_domain.ContentIdGenerator()
+        # Here we use type Any because add_question_change_dict is a
+        # complex dictionary with mixed types that are not easily
+        # captured by a more specific type hint without being overly
+        # verbose.
         add_question_change_dict: Dict[str, Any] = {
             'cmd': question_domain.CMD_CREATE_NEW_FULLY_SPECIFIED_QUESTION,
             'question_dict': {

--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -8002,19 +8002,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
     def test_user_without_review_rights_cannot_update_translation_suggestion(
         self,
     ) -> None:
-        suggestion_services.create_suggestion(
-            feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
-            feconf.ENTITY_TYPE_EXPLORATION,
-            self.exploration_id,
-            1,
-            self.author_id,
-            self.change_dict,
-            'description',
-        )
-        suggestion_id = '%s.%s.1' % (
-            feconf.ENTITY_TYPE_EXPLORATION,
-            self.exploration_id,
-        )
+        suggestion_id = self.translation_suggestion_id
         with self.swap(
             suggestion_models.GeneralSuggestionModel,
             'get_by_id',

--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -7968,7 +7968,10 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
             add_question_change_dict,
             'description',
         )
-        suggestion_id = 'suggestion_id'
+        suggestion_id = '%s.%s.1' % (
+            feconf.ENTITY_TYPE_SKILL,
+            'skill_123',
+        )
         with self.swap(
             suggestion_models.GeneralSuggestionModel,
             'get_by_id',
@@ -8008,7 +8011,10 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
             self.change_dict,
             'description',
         )
-        suggestion_id = 'suggestion_id'
+        suggestion_id = '%s.%s.1' % (
+            feconf.ENTITY_TYPE_EXPLORATION,
+            self.exploration_id,
+        )
         with self.swap(
             suggestion_models.GeneralSuggestionModel,
             'get_by_id',

--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -5556,6 +5556,21 @@ class StoryViewerAsLoggedInUserTests(test_utils.GenericTestBase):
                 response.headers['location'],
             )
 
+    def test_user_cannot_access_story_with_no_topic(self) -> None:
+        # Save a story with no topic ID.
+        story_id = story_services.get_new_story_id()
+        self.save_new_story(
+            story_id,
+            self.admin_id,
+            '',
+            url_fragment='story-no-topic',
+        )
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock_story_data/staging/topic/story-no-topic',
+                expected_status_int=404,
+            )
+
 
 class StoryViewerTests(test_utils.GenericTestBase):
     """Tests for decorator can_access_story_viewer_page."""
@@ -5752,6 +5767,21 @@ class StoryViewerTests(test_utils.GenericTestBase):
             self.assertEqual(
                 'http://localhost/learn/staging/topic/story/story-frag',
                 response.headers['location'],
+            )
+
+    def test_cannot_access_story_with_no_topic(self) -> None:
+        # Save a story with no topic ID.
+        story_id = story_services.get_new_story_id()
+        self.save_new_story(
+            story_id,
+            self.admin_id,
+            '',
+            url_fragment='story-no-topic-guest',
+        )
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock_story_data/staging/topic/story-no-topic-guest',
+                expected_status_int=404,
             )
 
 
@@ -7898,6 +7928,108 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
             'suggestions.' % self.author_username,
         )
         self.logout()
+
+    def test_user_without_review_rights_cannot_update_add_question_suggestion(
+        self,
+    ) -> None:
+        content_id_generator = translation_domain.ContentIdGenerator()
+        add_question_change_dict = {
+            'cmd': question_domain.CMD_CREATE_NEW_FULLY_SPECIFIED_QUESTION,
+            'question_dict': {
+                'question_state_data': self._create_valid_question_data(
+                    'default_state', content_id_generator
+                ).to_dict(),
+                'language_code': 'en',
+                'question_state_data_schema_version': (
+                    feconf.CURRENT_STATE_SCHEMA_VERSION
+                ),
+                'linked_skill_ids': ['skill_1'],
+                'inapplicable_skill_misconception_ids': ['skillid12345-1'],
+                'next_content_id_index': (
+                    content_id_generator.next_content_id_index
+                ),
+                'version': 44,
+                'id': '',
+            },
+            'skill_id': 'skill_123',
+            'skill_difficulty': 0.3,
+        }
+        suggestion_services.create_suggestion(
+            feconf.SUGGESTION_TYPE_ADD_QUESTION,
+            feconf.ENTITY_TYPE_SKILL,
+            'skill_123',
+            feconf.CURRENT_STATE_SCHEMA_VERSION,
+            self.author_id,
+            add_question_change_dict,
+            'description',
+        )
+        suggestion_id = 'suggestion_id'
+        with self.swap(
+            suggestion_models.GeneralSuggestionModel,
+            'get_by_id',
+            lambda _: suggestion_models.GeneralSuggestionModel(
+                id=suggestion_id,
+                suggestion_type=feconf.SUGGESTION_TYPE_ADD_QUESTION,
+                target_type=feconf.ENTITY_TYPE_SKILL,
+                target_id='skill_123',
+                target_version_at_submission=feconf.CURRENT_STATE_SCHEMA_VERSION,
+                status=suggestion_models.STATUS_IN_REVIEW,
+                author_id=self.author_id,
+                change_cmd=add_question_change_dict,
+                score_category='category',
+                language_code='en',
+            ),
+        ):
+            self.login(self.user_email)
+            with self.swap(self, 'testapp', self.mock_testapp):
+                response = self.get_json(
+                    '/mock/%s' % suggestion_id, expected_status_int=401
+                )
+            self.assertEqual(
+                response['error'],
+                'You are not allowed to update the suggestion.',
+            )
+            self.logout()
+
+    def test_user_without_review_rights_cannot_update_translation_suggestion(
+        self,
+    ) -> None:
+        suggestion_services.create_suggestion(
+            feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+            feconf.ENTITY_TYPE_EXPLORATION,
+            self.exploration_id,
+            1,
+            self.author_id,
+            self.change_dict,
+            'description',
+        )
+        suggestion_id = 'suggestion_id'
+        with self.swap(
+            suggestion_models.GeneralSuggestionModel,
+            'get_by_id',
+            lambda _: suggestion_models.GeneralSuggestionModel(
+                id=suggestion_id,
+                suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+                target_type=feconf.ENTITY_TYPE_EXPLORATION,
+                target_id=self.exploration_id,
+                target_version_at_submission=1,
+                status=suggestion_models.STATUS_IN_REVIEW,
+                author_id=self.author_id,
+                change_cmd=self.change_dict,
+                score_category='category',
+                language_code='en',
+            ),
+        ):
+            self.login(self.user_email)
+            with self.swap(self, 'testapp', self.mock_testapp):
+                response = self.get_json(
+                    '/mock/%s' % suggestion_id, expected_status_int=401
+                )
+            self.assertEqual(
+                response['error'],
+                'You are not allowed to update the suggestion.',
+            )
+            self.logout()
 
     def test_admin_can_update_any_given_translation_suggestion(self) -> None:
         self.login(self.curriculum_admin_email)

--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -59,6 +59,7 @@ if MYPY:  # pragma: no cover
 
 datastore_services = models.Registry.import_datastore_services()
 secrets_services = models.Registry.import_secrets_services()
+(suggestion_models,) = models.Registry.import_models([models.Names.SUGGESTION])
 
 
 class OpenAccessDecoratorTests(test_utils.GenericTestBase):

--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -51,7 +51,7 @@ from core.tests import test_utils
 
 import webapp2
 import webtest
-from typing import Dict, Final, List, Union
+from typing import Any, Dict, Final, List, Mapping, Union
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -7934,7 +7934,7 @@ class DecoratorForUpdatingSuggestionTests(test_utils.GenericTestBase):
         self,
     ) -> None:
         content_id_generator = translation_domain.ContentIdGenerator()
-        add_question_change_dict = {
+        add_question_change_dict: Dict[str, Any] = {
             'cmd': question_domain.CMD_CREATE_NEW_FULLY_SPECIFIED_QUESTION,
             'question_dict': {
                 'question_state_data': self._create_valid_question_data(

--- a/core/templates/combined-tests.spec.ts
+++ b/core/templates/combined-tests.spec.ts
@@ -65,18 +65,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 
-// Ensure each spec starts with a clean sessionStorage to avoid
-// cross-test leakage of error messages or other state.
-beforeEach(() => {
-  try {
-    if (window && window.sessionStorage) {
-      window.sessionStorage.clear();
-    }
-  } catch (error) {
-    // sessionStorage can throw in restricted environments; ignore safely.
-  }
-});
-
 jasmine.getEnv().addReporter({
   specDone: function (result) {
     // Specs that are being excluded when using fit or fdescribe will not

--- a/core/templates/combined-tests.spec.ts
+++ b/core/templates/combined-tests.spec.ts
@@ -68,8 +68,12 @@ getTestBed().initTestEnvironment(
 // Ensure each spec starts with a clean sessionStorage to avoid
 // cross-test leakage of error messages or other state.
 beforeEach(() => {
-  if (window && window.sessionStorage) {
-    window.sessionStorage.clear();
+  try {
+    if (window && window.sessionStorage) {
+      window.sessionStorage.clear();
+    }
+  } catch (error) {
+    // sessionStorage can throw in restricted environments; ignore safely.
   }
 });
 

--- a/core/templates/combined-tests.spec.ts
+++ b/core/templates/combined-tests.spec.ts
@@ -65,6 +65,14 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 
+// Ensure each spec starts with a clean sessionStorage to avoid
+// cross-test leakage of error messages or other state.
+beforeEach(() => {
+  if (window && window.sessionStorage) {
+    window.sessionStorage.clear();
+  }
+});
+
 jasmine.getEnv().addReporter({
   specDone: function (result) {
     // Specs that are being excluded when using fit or fdescribe will not

--- a/core/templates/pages/error-pages/error-page.component.spec.ts
+++ b/core/templates/pages/error-pages/error-page.component.spec.ts
@@ -32,7 +32,7 @@ describe('ErrorPageComponent', () => {
         window.sessionStorage.clear();
       }
     } catch (error) {
-      // sessionStorage can throw in restricted environments; ignore safely.
+      // SessionStorage can throw in restricted environments; ignore safely.
     }
 
     TestBed.configureTestingModule({

--- a/core/templates/pages/error-pages/error-page.component.spec.ts
+++ b/core/templates/pages/error-pages/error-page.component.spec.ts
@@ -27,6 +27,14 @@ describe('ErrorPageComponent', () => {
   let fixture: ComponentFixture<ErrorPageComponent>;
 
   beforeEach(() => {
+    try {
+      if (window && window.sessionStorage) {
+        window.sessionStorage.clear();
+      }
+    } catch (error) {
+      // sessionStorage can throw in restricted environments; ignore safely.
+    }
+
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
       declarations: [ErrorPageComponent],

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.spec.ts
@@ -1,0 +1,91 @@
+// Copyright 2025 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for screenshot capture behavior in puppeteer utils.
+ */
+
+import fs from 'fs';
+import {Page} from 'puppeteer';
+
+import {BaseUser} from './puppeteer-utils';
+import * as showMessageModule from './show-message';
+
+describe('BaseUser.captureScreenshotsForFailedTest', () => {
+  const originalSpecName = process.env.SPEC_NAME;
+  let existsSyncSpy: jest.SpyInstance;
+  let mkdirSyncSpy: jest.SpyInstance;
+  let showMessageSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    BaseUser.instances.length = 0;
+    process.env.SPEC_NAME = 'test-spec';
+    existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    mkdirSyncSpy = jest
+      .spyOn(fs, 'mkdirSync')
+      .mockImplementation(() => undefined);
+    showMessageSpy = jest
+      .spyOn(showMessageModule, 'showMessage')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    BaseUser.instances.length = 0;
+    if (originalSpecName === undefined) {
+      delete process.env.SPEC_NAME;
+    } else {
+      process.env.SPEC_NAME = originalSpecName;
+    }
+    showMessageSpy.mockRestore();
+    existsSyncSpy.mockRestore();
+    mkdirSyncSpy.mockRestore();
+  });
+
+  it('should skip screenshots for closed pages without throwing', async () => {
+    const user = new BaseUser();
+    const pageMock = {} as Page;
+    pageMock.isClosed = jest.fn().mockReturnValue(true);
+    pageMock.screenshot = jest.fn();
+    user.page = pageMock;
+    user.username = 'test-user';
+
+    await expect(
+      user.captureScreenshotsForFailedTest()
+    ).resolves.toBeUndefined();
+
+    expect(pageMock.screenshot).not.toHaveBeenCalled();
+    expect(showMessageSpy).toHaveBeenCalledWith(
+      `Skipped screenshot for ${user.username} because the page is already closed.`
+    );
+  });
+
+  it('should log screenshot errors without failing', async () => {
+    const user = new BaseUser();
+    const pageMock = {} as Page;
+    pageMock.isClosed = jest.fn().mockReturnValue(false);
+    pageMock.screenshot = jest
+      .fn()
+      .mockRejectedValue(new Error('Target closed'));
+    user.page = pageMock;
+
+    await expect(
+      user.captureScreenshotsForFailedTest()
+    ).resolves.toBeUndefined();
+
+    expect(pageMock.screenshot).toHaveBeenCalledTimes(1);
+    expect(showMessageSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error while taking screenshot')
+    );
+  });
+});

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -260,15 +260,27 @@ export class BaseUser {
 
     // Prepare an array of promises for screenshots.
     const screenshotPromises = BaseUser.instances.map(async (instance, i) => {
-      if (instance.page) {
-        await instance.page.screenshot({
-          path: path.join(
-            outputDir,
-            outputFileName + randomString + `-instance-${i}.png`
-          ),
-        });
+      if (!instance.page) {
+        return;
+      }
+      if (instance.page.isClosed()) {
         showMessage(
-          `Screenshot captured for test failure and saved as : ${path.join(outputDir, outputFileName + `-instance-${i}.png`)}`
+          `Skipped screenshot for ${instance.username ?? 'unknown user'} because the page is already closed.`
+        );
+        return;
+      }
+      try {
+        const screenshotPath = path.join(
+          outputDir,
+          outputFileName + randomString + `-instance-${i}.png`
+        );
+        await instance.page.screenshot({path: screenshotPath});
+        showMessage(
+          `Screenshot captured for test failure and saved as : ${screenshotPath}`
+        );
+      } catch (error) {
+        showMessage(
+          `Error while taking screenshot for ${instance.username ?? 'unknown user'}: ${error}`
         );
       }
     });

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.spec.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for user-factory browser cleanup behavior.
+ */
+
+import fs from 'fs';
+
+import {BaseUser} from './puppeteer-utils';
+import {UserFactory} from './user-factory';
+import * as showMessageModule from './show-message';
+
+describe('UserFactory.closeAllBrowsers', () => {
+  let existsSyncSpy: jest.SpyInstance;
+  let readFileSyncSpy: jest.SpyInstance;
+  let unlinkSyncSpy: jest.SpyInstance;
+  let showMessageSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    BaseUser.instances.length = 0;
+    existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    readFileSyncSpy = jest
+      .spyOn(fs, 'readFileSync')
+      .mockReturnValue(JSON.stringify({testFailureDetected: true}));
+    unlinkSyncSpy = jest
+      .spyOn(fs, 'unlinkSync')
+      .mockImplementation(() => undefined);
+    showMessageSpy = jest
+      .spyOn(showMessageModule, 'showMessage')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    BaseUser.instances.length = 0;
+    existsSyncSpy.mockRestore();
+    readFileSyncSpy.mockRestore();
+    unlinkSyncSpy.mockRestore();
+    showMessageSpy.mockRestore();
+  });
+
+  it('should capture screenshots when no active users are tracked', async () => {
+    const fallbackUser = new BaseUser();
+    const captureSpy = jest
+      .spyOn(fallbackUser, 'captureScreenshotsForFailedTest')
+      .mockResolvedValue(undefined);
+
+    await expect(UserFactory.closeAllBrowsers()).resolves.toBeUndefined();
+
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.ts
@@ -16,6 +16,9 @@
  * @fileoverview Utility File for declaring and initializing users.
  */
 
+import fs from 'fs';
+import path from 'path';
+
 import {SuperAdminFactory, SuperAdmin} from '../user/super-admin';
 import {BaseUserFactory, BaseUser} from './puppeteer-utils';
 import {
@@ -365,6 +368,31 @@ export class UserFactory {
    * This function closes all the browsers opened by different users.
    */
   static closeAllBrowsers = async function (): Promise<void> {
+    const configFile = path.resolve(
+      __dirname,
+      '../../jest-runtime-config.json'
+    );
+    if (activeUsers.length === 0 && fs.existsSync(configFile)) {
+      try {
+        const configData = JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+        if (configData.testFailureDetected) {
+          fs.unlinkSync(configFile);
+          const fallbackUser = BaseUser.instances[0];
+          if (fallbackUser) {
+            await fallbackUser.captureScreenshotsForFailedTest();
+          } else {
+            showMessage(
+              'Test failed but no browser instances were available to capture screenshots.'
+            );
+          }
+        }
+      } catch (error) {
+        showMessage(
+          `Error while handling screenshot capture for failed test: ${error}`
+        );
+      }
+    }
+
     showMessage(`Closing browsers for ${activeUsers.length} users.`);
     await Promise.all(
       activeUsers.map(async user => {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/exploration-editor.ts
@@ -3728,8 +3728,16 @@ export class ExplorationEditor extends BaseUser {
     // Get all state node groups (not just labels) since we need to click the
     // background rect which has the click handler.
     const stateNodeGroupSelector = '.e2e-test-node';
-    await this.page.waitForSelector(stateNodeGroupSelector);
-    elements = await this.page.$$(stateNodeGroupSelector);
+    const scopedStateNodeGroupSelector = this.isViewportAtMobileWidth()
+      ? `${explorationStateGraphModalSelector} ${stateNodeGroupSelector}`
+      : stateNodeGroupSelector;
+    if (this.isViewportAtMobileWidth()) {
+      await this.page.waitForSelector(explorationStateGraphModalSelector, {
+        visible: true,
+      });
+    }
+    await this.page.waitForSelector(scopedStateNodeGroupSelector);
+    elements = await this.page.$$(scopedStateNodeGroupSelector);
 
     const cardNames = await Promise.all(
       elements.map(element =>
@@ -3745,12 +3753,7 @@ export class ExplorationEditor extends BaseUser {
       throw new Error(`Card name ${cardName} not found in the graph.`);
     }
 
-    let nodeGroup: ElementHandle<Element> | null = null;
-    if (this.isViewportAtMobileWidth()) {
-      nodeGroup = elements[cardIndex + elements.length / 2];
-    } else {
-      nodeGroup = elements[cardIndex];
-    }
+    const nodeGroup: ElementHandle<Element> | null = elements[cardIndex];
 
     if (!nodeGroup) {
       throw new Error(`Could not find card button for card: ${cardName}`);
@@ -3763,6 +3766,9 @@ export class ExplorationEditor extends BaseUser {
         `Could not find clickable background for card: ${cardName}`
       );
     }
+    await nodeBackground.evaluate(el =>
+      el.scrollIntoView({block: 'center', inline: 'center'})
+    );
     await this.clickOnElement(nodeBackground);
     await this.waitForNetworkIdle({idleTime: 1000});
 

--- a/core/tests/root-files-config.json
+++ b/core/tests/root-files-config.json
@@ -40,7 +40,8 @@
     "core/tests/puppeteer-acceptance-tests/custom-jest-environment.js",
     "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts",
     "core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.spec.ts",
-    "core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.spec.ts"
+    "core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.spec.ts",
+    ".pytest_cache/README.md"
   ],
   "RUN_ALL_TESTS_ROOT_FILES": [
     "extensions/ckeditor_plugins/pre/plugin.js",

--- a/core/tests/root-files-config.json
+++ b/core/tests/root-files-config.json
@@ -38,7 +38,9 @@
     "core/tests/ci-test-suite-configs/README.md",
     "core/tests/puppeteer-acceptance-tests/jest.config.js",
     "core/tests/puppeteer-acceptance-tests/custom-jest-environment.js",
-    "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts"
+    "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts",
+    "core/tests/puppeteer-acceptance-tests/utilities/common/user-factory.spec.ts",
+    "core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.spec.ts"
   ],
   "RUN_ALL_TESTS_ROOT_FILES": [
     "extensions/ckeditor_plugins/pre/plugin.js",

--- a/scripts/check_ci_test_suites_to_run.py
+++ b/scripts/check_ci_test_suites_to_run.py
@@ -235,6 +235,12 @@ def output_variable_to_github_workflow(
         output_variable: str. The name of the output variable.
         output_value: str. The value of the output variable.
     """
+    if 'GITHUB_OUTPUT' not in os.environ:
+        print(
+            'Cannot find GITHUB_OUTPUT in os.environ. Outputting to stdout instead:'
+        )
+        print(f'{output_variable}={output_value}')
+        return
     with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as o:
         print(f'{output_variable}={output_value}', file=o)
 

--- a/scripts/check_ci_test_suites_to_run_test.py
+++ b/scripts/check_ci_test_suites_to_run_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 import os
 import subprocess
@@ -1009,3 +1010,25 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                                 },
                             },
                         )
+
+    def test_output_variable_to_github_workflow_without_github_output(
+        self,
+    ) -> None:
+        """Test output_variable_to_github_workflow when GITHUB_OUTPUT is missing."""
+        output: List[str] = []
+
+        def mock_print(msg: str) -> None:
+            output.append(msg)
+
+        with self.swap(os, 'environ', {}):
+            with self.swap(builtins, 'print', mock_print):
+                check_ci_test_suites_to_run.output_variable_to_github_workflow(
+                    'variable', 'value'
+                )
+
+        self.assertEqual(len(output), 2)
+        self.assertEqual(
+            output[0],
+            'Cannot find GITHUB_OUTPUT in os.environ. Outputting to stdout instead:',
+        )
+        self.assertEqual(output[1], 'variable=value')


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #23999 .
2. This PR does the following: This PR fixes a flaky mobile acceptance test by making navigateToCard select nodes only from the visible state‑graph modal and scrolling the node into view before clicking. This prevents clicks from targeting hidden/overlapped nodes, which was causing intermittent timeouts.
3. (For bug-fixing PRs only) The original bug occurred because: Cause: In mobile mode, the test sometimes selected a hidden graph node (global selector + offset), so the clickability check timed out.
Introduced by: Unknown — I haven’t identified the specific PR that introduced this behavior.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #23999: Resolve E2E flake where element is not clickable in community library test".
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<img width="418" height="724" alt="Image" src="https://github.com/user-attachments/assets/61a22df8-4a72-48b6-9945-30e6f7476e88" />

<img width="456" height="940" alt="Image" src="https://github.com/user-attachments/assets/4c02b614-0e5d-455e-9efb-501091d8fdb8" />

<img width="456" height="940" alt="Image" src="https://github.com/user-attachments/assets/d7ff1443-f14c-4cff-a409-4d014d352974" />

<img width="1234" height="556" alt="Image" src="https://github.com/user-attachments/assets/d36a7c1e-b7ff-4f81-80d1-290dfae8ee42" />
<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
