### PR TITLE
Fix #20338: Resolve race condition in exploration metadata model save flow

### DIFF
--- a/core/templates/pages/exploration-editor-page/modal-templates/exploration-metadata-modal.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/modal-templates/exploration-metadata-modal.component.spec.ts
@@ -18,6 +18,7 @@
 
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {BehaviorSubject, Observable} from 'rxjs';
 import {
   ComponentFixture,
   fakeAsync,
@@ -31,6 +32,7 @@ import {NgbActiveModal, NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {StateObjectsBackendDict} from 'domain/exploration/states.model';
 import {AlertsService} from 'services/alerts.service';
 import {ExplorationCategoryService} from '../services/exploration-category.service';
+import {ChangeListService} from '../services/change-list.service';
 import {ExplorationDataService} from '../services/exploration-data.service';
 import {ExplorationLanguageCodeService} from '../services/exploration-language-code.service';
 import {ExplorationObjectiveService} from '../services/exploration-objective.service';
@@ -55,6 +57,33 @@ class MockNgbModal {
   }
 }
 
+class MockChangeListService {
+  private autosaveInProgressSubject = new BehaviorSubject<boolean>(false);
+  private changeList: object[] = [];
+
+  get autosaveIsInProgress$(): Observable<boolean> {
+    return this.autosaveInProgressSubject.asObservable();
+  }
+
+  editExplorationProperty(): void {
+    this.changeList.push({});
+    this.autosaveInProgressSubject.next(true);
+  }
+
+  emitAutosaveCompletion(): void {
+    this.autosaveInProgressSubject.next(false);
+  }
+
+  getChangeList(): object[] {
+    return this.changeList;
+  }
+
+  reset(): void {
+    this.changeList = [];
+    this.autosaveInProgressSubject.next(false);
+  }
+}
+
 describe('Exploration Metadata Modal Component', () => {
   let component: ExplorationMetadataModalComponent;
   let fixture: ComponentFixture<ExplorationMetadataModalComponent>;
@@ -65,6 +94,7 @@ describe('Exploration Metadata Modal Component', () => {
   let explorationStatesService: ExplorationStatesService;
   let explorationTagsService: ExplorationTagsService;
   let explorationTitleService: ExplorationTitleService;
+  let changeListService: MockChangeListService;
   let ngbActiveModal: NgbActiveModal;
 
   beforeEach(waitForAsync(() => {
@@ -88,6 +118,10 @@ describe('Exploration Metadata Modal Component', () => {
         {
           provide: NgbModal,
           useClass: MockNgbModal,
+        },
+        {
+          provide: ChangeListService,
+          useClass: MockChangeListService,
         },
         AlertsService,
         ExplorationCategoryService,
@@ -114,7 +148,11 @@ describe('Exploration Metadata Modal Component', () => {
       explorationStatesService = TestBed.inject(ExplorationStatesService);
       explorationTagsService = TestBed.inject(ExplorationTagsService);
       explorationTitleService = TestBed.inject(ExplorationTitleService);
+      changeListService = TestBed.inject(
+        ChangeListService
+      ) as unknown as MockChangeListService;
       ngbActiveModal = TestBed.inject(NgbActiveModal);
+      changeListService.reset();
 
       explorationObjectiveService.init('');
       explorationTitleService.init('');
@@ -339,9 +377,11 @@ describe('Exploration Metadata Modal Component', () => {
         explorationTagsService.displayed = ['h1'];
         explorationTitleService.displayed = 'New Title';
         expect(component.isSavingAllowed()).toBe(true);
-        component.save();
 
-        tick(500);
+        component.save();
+        expect(ngbActiveModal.close).not.toHaveBeenCalled();
+
+        changeListService.emitAutosaveCompletion();
         flush();
 
         expect(ngbActiveModal.close).toHaveBeenCalledWith([
@@ -353,6 +393,29 @@ describe('Exploration Metadata Modal Component', () => {
         ]);
       })
     );
+
+    it('should close the modal immediately when no autosave is triggered', fakeAsync(() => {
+      spyOn(ngbActiveModal, 'close').and.stub();
+
+      explorationCategoryService.displayed = 'New Category';
+      explorationLanguageCodeService.displayed = 'en';
+      explorationObjectiveService.displayed =
+        'A valid objective already exists';
+      explorationTagsService.displayed = [];
+      explorationTitleService.displayed = 'New Title';
+
+      explorationCategoryService.savedMemento = 'New Category';
+      explorationLanguageCodeService.savedMemento = 'en';
+      explorationObjectiveService.savedMemento =
+        'A valid objective already exists';
+      explorationTagsService.savedMemento = [];
+      explorationTitleService.savedMemento = 'New Title';
+
+      component.save();
+      flush();
+
+      expect(ngbActiveModal.close).toHaveBeenCalledWith([]);
+    }));
   });
 
   describe('when all metadata are not filled', () => {
@@ -369,7 +432,11 @@ describe('Exploration Metadata Modal Component', () => {
       explorationStatesService = TestBed.inject(ExplorationStatesService);
       explorationTagsService = TestBed.inject(ExplorationTagsService);
       explorationTitleService = TestBed.inject(ExplorationTitleService);
+      changeListService = TestBed.inject(
+        ChangeListService
+      ) as unknown as MockChangeListService;
       ngbActiveModal = TestBed.inject(NgbActiveModal);
+      changeListService.reset();
       explorationObjectiveService.init('');
       explorationTitleService.init('');
       explorationCategoryService.init('Generic category');

--- a/core/templates/pages/exploration-editor-page/modal-templates/exploration-metadata-modal.component.ts
+++ b/core/templates/pages/exploration-editor-page/modal-templates/exploration-metadata-modal.component.ts
@@ -30,6 +30,8 @@ import {ExplorationTitleService} from '../services/exploration-title.service';
 import {AlertsService} from 'services/alerts.service';
 import {ExplorationStatesService} from '../services/exploration-states.service';
 import {ParamChange} from 'domain/exploration/param-change.model';
+import {ChangeListService} from '../services/change-list.service';
+import {filter, take} from 'rxjs/operators';
 
 interface CategoryChoices {
   id: string;
@@ -71,6 +73,7 @@ export class ExplorationMetadataModalComponent
     private explorationStatesService: ExplorationStatesService,
     private explorationTagsService: ExplorationTagsService,
     private explorationTitleService: ExplorationTitleService,
+    private changeListService: ChangeListService,
     private ngbActiveModal: NgbActiveModal
   ) {
     super(ngbActiveModal);
@@ -147,6 +150,9 @@ export class ExplorationMetadataModalComponent
       return;
     }
 
+    const initialChangeListLength =
+      this.changeListService.getChangeList().length;
+
     // Record any fields that have changed.
     let metadataList: string[] = [];
     if (this.explorationTitleService.hasChanged()) {
@@ -172,15 +178,21 @@ export class ExplorationMetadataModalComponent
     this.explorationLanguageCodeService.saveDisplayedValue();
     this.explorationTagsService.saveDisplayedValue();
 
-    // TODO(#20338): Get rid of the $timeout here.
-    // It's currently used because there is a race condition: the
-    // saveDisplayedValue() calls above result in autosave calls.
-    // These race with the discardDraft() call that
-    // will be called when the draft changes entered here
-    // are properly saved to the backend.
-    setTimeout(() => {
+    if (
+      this.changeListService.getChangeList().length === initialChangeListLength
+    ) {
       this.ngbActiveModal.close(metadataList);
-    }, 500);
+      return;
+    }
+
+    this.changeListService.autosaveIsInProgress$
+      .pipe(
+        filter(inProgress => !inProgress),
+        take(1)
+      )
+      .subscribe(() => {
+        this.ngbActiveModal.close(metadataList);
+      });
   }
 
   areRequiredFieldsFilled(): boolean {


### PR DESCRIPTION
## Overview

1. This PR fixes #20338.
2. This PR does the following:
   This PR fixes a race condition in the exploration metadata modal where the modal could close before autosave operations completed, leading to overlapping backend save requests.
3. (For bug-fixing PRs only) The original bug occurred because:
   Calls to `saveDisplayedValue()` trigger autosave operations via `ChangeListService.addChange()`, which are batched with a delay (~200ms). The modal was previously closed using a fixed `$timeout`, which does not guarantee autosave completion. As a result, the explicit save request and autosave draft request could execute concurrently, causing a race condition.

---

## Essential Checklist

* [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [x] I have written tests for my code.
* [x] The **PR title** starts with "Fix #20338: ", followed by a short, clear summary of the changes.
* [x] I have assigned the correct reviewers to this PR (or will leave a comment with "@Rohan-Unbeg PTAL").

---

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Before Fix (Race Condition Present):**

https://github.com/user-attachments/assets/0c3a6637-4f58-4e62-8e14-46d795c4bbf1



**After Fix (Race Condition Resolved):**

https://github.com/user-attachments/assets/bb3c3e0c-69b1-46fa-9d20-b0b1478e8094



Verification:

* Modal does not close prematurely
* Autosave completes before modal closure
* No overlapping backend requests observed
* No UI inconsistencies under slow/throttled network

📸 **Frontend test results:** <img width="1379" height="128" alt="FrontendTest" src="https://github.com/user-attachments/assets/8e68247e-907c-449a-bef2-a293668f1858" />

📊 **Coverage check:** <img width="1893" height="50" alt="CoverageCheck" src="https://github.com/user-attachments/assets/b684bb7d-3c96-4a6d-8fc2-040036cb6dda" />

All frontend tests pass successfully (`10611 SUCCESS`), and coverage remains consistent.

---

## Additional Notes

* Removed reliance on `$timeout`, eliminating non-deterministic behavior
* Used `ChangeListService.autosaveIsInProgress$` for a deterministic solution
* Aligns with Oppia’s reactive architecture and avoids flaky async behavior

---

## Difference from PR #20866

* Does not introduce Promise-based async flow
* Uses existing observable (`autosaveIsInProgress$`)
* Avoids modifying core async behavior, preventing flaky tests
* Provides a deterministic and Angular-friendly solution

---

## PR Pointers

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
* Some e2e tests are flaky; if CI fails, refer to: https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR
* See code owner expectations: https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers
