### PR TITLE
Fix #24920: Fix mobile timeout flake in curriculum admin acceptance test

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -2429,10 +2429,6 @@ export class CurriculumAdmin extends TopicManager {
     await this.page.waitForSelector(addTopicFormFieldInput);
     await this.page.type(addTopicFormFieldInput, topicName);
 
-    if (this.isViewportAtMobileWidth()) {
-      await this.page.keyboard.press('Enter');
-    }
-
     await this.page.waitForSelector(topicSelector, {visible: true});
     const options = await this.page.$$(topicSelector);
     let foundOption = false;
@@ -2448,10 +2444,6 @@ export class CurriculumAdmin extends TopicManager {
 
     if (!foundOption) {
       throw new Error(`Could not find topic option matching: ${topicName}`);
-    }
-
-    if (this.isViewportAtMobileWidth()) {
-      await this.page.keyboard.press('Escape');
     }
 
     await this.page.waitForSelector(openTopicDropdownButton);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -2428,31 +2428,36 @@ export class CurriculumAdmin extends TopicManager {
     await this.clickOnElementWithSelector(topicDropDownFormField);
     await this.page.waitForSelector(addTopicFormFieldInput);
     await this.page.type(addTopicFormFieldInput, topicName);
-    await this.clickOnElementWithSelector(topicSelector);
-    const targetOptionHandle = (await this.page.waitForFunction(
-      (selector: string, expectedName: string) => {
-        const options = Array.from(document.querySelectorAll(selector));
-        return options.find(
-          option => option.textContent?.trim() === expectedName
-        );
-      },
-      {timeout: 10000},
-      topicSelector,
-      topicName
-    )) as ElementHandle;
 
-    await this.page.evaluate(
-      (el: HTMLElement) =>
-        el.scrollIntoView({behavior: 'instant', block: 'center'}),
-      targetOptionHandle
-    );
+    if (this.isViewportAtMobileWidth()) {
+      await this.page.keyboard.press('Enter');
+    }
 
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await this.page.waitForSelector(topicSelector, {visible: true});
+    const options = await this.page.$$(topicSelector);
+    let foundOption = false;
 
-    await targetOptionHandle.click();
+    for (const option of options) {
+      const text = await option.evaluate(el => el.textContent?.trim());
+      if (text === topicName) {
+        await this.clickOnElement(option);
+        foundOption = true;
+        break;
+      }
+    }
+
+    if (!foundOption) {
+      throw new Error(`Could not find topic option matching: ${topicName}`);
+    }
+
+    if (this.isViewportAtMobileWidth()) {
+      await this.page.keyboard.press('Escape');
+    }
+
     await this.page.waitForSelector(openTopicDropdownButton);
 
-    // Wait for the topic to appear in the classroom before adding prerequisites.
+    await this.waitForNetworkIdle(); // Wait for the topic to appear in the classroom before adding prerequisites.
+
     // Increased timeout to 60s because addTopicId makes an async API call that can take time.
     await this.page.waitForFunction(
       (

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -2428,7 +2428,11 @@ export class CurriculumAdmin extends TopicManager {
     await this.clickOnElementWithSelector(topicDropDownFormField);
     await this.page.waitForSelector(addTopicFormFieldInput);
     await this.page.type(addTopicFormFieldInput, topicName);
+    await this.page.waitForSelector(topicSelector, {visible: true});
+    await this.waitForElementToStabilize(topicSelector);
     await this.clickOnElementWithSelector(topicSelector);
+    await this.page.waitForSelector(topicSelector, {hidden: true});
+
     await this.page.waitForSelector(openTopicDropdownButton);
 
     // Wait for the topic to appear in the classroom before adding prerequisites.

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -2428,11 +2428,28 @@ export class CurriculumAdmin extends TopicManager {
     await this.clickOnElementWithSelector(topicDropDownFormField);
     await this.page.waitForSelector(addTopicFormFieldInput);
     await this.page.type(addTopicFormFieldInput, topicName);
-    await this.page.waitForSelector(topicSelector, {visible: true});
-    await this.waitForElementToStabilize(topicSelector);
-    await this.clickOnElementWithSelector(topicSelector);
-    await this.page.waitForSelector(topicSelector, {hidden: true});
+    const targetOptionHandle = (await this.page.waitForFunction(
+      (selector: string, expectedName: string) => {
+        const options = Array.from(document.querySelectorAll(selector));
+        return options.find(
+          option => option.textContent?.trim() === expectedName
+        );
+      },
+      {timeout: 10000},
+      topicSelector,
+      topicName
+    )) as ElementHandle;
 
+    await this.page.evaluate(
+      (el: HTMLElement) =>
+        el.scrollIntoView({behavior: 'instant', block: 'center'}),
+      targetOptionHandle
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    await targetOptionHandle.click();
+    await this.clickOnElementWithSelector(topicSelector);
     await this.page.waitForSelector(openTopicDropdownButton);
 
     // Wait for the topic to appear in the classroom before adding prerequisites.

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -2428,6 +2428,7 @@ export class CurriculumAdmin extends TopicManager {
     await this.clickOnElementWithSelector(topicDropDownFormField);
     await this.page.waitForSelector(addTopicFormFieldInput);
     await this.page.type(addTopicFormFieldInput, topicName);
+    await this.clickOnElementWithSelector(topicSelector);
     const targetOptionHandle = (await this.page.waitForFunction(
       (selector: string, expectedName: string) => {
         const options = Array.from(document.querySelectorAll(selector));
@@ -2449,7 +2450,6 @@ export class CurriculumAdmin extends TopicManager {
     await new Promise(resolve => setTimeout(resolve, 500));
 
     await targetOptionHandle.click();
-    await this.clickOnElementWithSelector(topicSelector);
     await this.page.waitForSelector(openTopicDropdownButton);
 
     // Wait for the topic to appear in the classroom before adding prerequisites.


### PR DESCRIPTION
## Overview

1. This PR fixes #24920
2. This PR does the following: Fixed the flaky mobile acceptance test by updating the addTopicToClassroom utility to wait for the mobile UI to stabilize before clicking the topic dropdown. Specifically, it adds waitForElementToStabilize() and visibility checks to ensure animations have finished, preventing the "click miss" that was causing timeouts.

3.Puppeteer was clicking the topic selector before it had fully rendered or stopped moving. This caused the click to fail silently, meaning the topic wasn't added, which eventually led to a 30s timeout in the subsequent waitForFunction block.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).
.

## Proof that changes are correct
Earlier the PR was failing significantly but now  it passed 100/100 after making the code changes.
![Screenshot_20260326_095906_Chrome](https://github.com/user-attachments/assets/368fceff-19e8-42e0-b07c-3aeac452b9af)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
