### PR TITLE
Fix #21308: Add missing backend tests for discard_draft in exp_services

### DIFF
--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -13023,3 +13023,13 @@ class ExplorationInOldSchemaFormatTests(test_utils.GenericTestBase):
         self.assertDictEqual(
             exploration_dict_with_voiceovers, expected_exploration_dict
         )
+
+    def test_get_updated_version_history_model_returns_none(self) -> None:
+        exploration = self.save_new_default_exploration('exp_id_2', 'owner_id')
+        with self.swap(
+            exp_models.ExplorationVersionHistoryModel, 'get', lambda *args, **kwargs: None
+        ):
+            result = exp_services.get_updated_version_history_model(
+                exploration, [], 'committer_id', {}, exploration.get_metadata()
+            )
+        self.assertIsNone(result)

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -10106,6 +10106,33 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
         self.assertIsNone(exp_user_data.draft_change_list_last_updated)
         self.assertIsNone(exp_user_data.draft_change_list_exp_version)
 
+    def test_discard_draft_clears_the_draft_successfully(self) -> None:
+        """Test that discard_draft properly clears the draft fields."""
+        exp_user_data_before = user_models.ExplorationUserDataModel.get_by_id(
+            '%s.%s' % (self.USER_ID, self.EXP_ID1)
+        )
+        self.assertIsNotNone(exp_user_data_before.draft_change_list)
+
+        exp_services.discard_draft(self.EXP_ID1, self.USER_ID)
+
+        exp_user_data_after = user_models.ExplorationUserDataModel.get_by_id(
+            '%s.%s' % (self.USER_ID, self.EXP_ID1)
+        )
+        self.assertIsNone(exp_user_data_after.draft_change_list)
+        self.assertIsNone(exp_user_data_after.draft_change_list_last_updated)
+        self.assertIsNone(exp_user_data_after.draft_change_list_exp_version)
+
+    def test_discard_draft_with_non_existent_model_does_not_fail(self) -> None:
+        """Test that discard_draft gracefully handles non-existent models."""
+        exp_services.discard_draft('invalid_exp_id', 'invalid_user_id')
+
+    def test_get_exp_user_data_model_with_draft_discarded_returns_none(self) -> None:
+        """Test that the function returns None when the user data model is missing."""
+        user_data_model = exp_services.get_exp_user_data_model_with_draft_discarded(
+            'invalid_exp_id', 'invalid_user_id'
+        )
+        self.assertIsNone(user_data_model)
+
     def test_create_or_update_draft_with_exploration_model_not_created(
         self,
     ) -> None:


### PR DESCRIPTION
## Overview

1. This PR fixes #21308
2. This PR does the following: Implements the missing backend unit tests for the `discard_draft` function inside `core/domain/exp_services.py`. All tests run successfully locally, ensuring full branch coverage for this specific flow.
3. (For bug-fixing PRs only) The original bug occurred because: N/A (Feature/Test coverage addition)

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@jayam04 PTAL" if I can't assign them directly).

## Proof that changes are correct

This is a backend-only change (adding unit tests for existing backend logic). There are no UI/frontend modifications.

#### Proof of successful local tests

Below is the terminal output proving that all backend tests in `exp_services_test.py` pass successfully:

<img width="1914" height="995" alt="opp1" src="https://github.com/user-attachments/assets/cc90af77-d50f-40f1-9e27-3619c4dbf2ef" />
<img width="1895" height="622" alt="opp2" src="https://github.com/user-attachments/assets/b2f05bcd-1c52-4faf-bc20-ebf4a21e4a1a" />
