### PR TITLE
Fix: #22459: Block exploration completion recording in story editor preview mode

### DIFF
--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -550,6 +550,9 @@ describe('Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(userService, 'getUserInfoAsync').and.returnValue(
       Promise.resolve(
         new UserInfo([], false, false, false, false, false, '', '', '', true)
@@ -711,6 +714,9 @@ describe('Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(userService, 'getUserInfoAsync').and.returnValue(
       Promise.resolve(
         new UserInfo([], false, false, false, false, false, '', '', '', true)
@@ -852,6 +858,9 @@ describe('Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(userService, 'getUserInfoAsync').and.returnValue(
       Promise.resolve(
         new UserInfo([], false, false, false, false, false, '', '', '', false)
@@ -987,6 +996,9 @@ describe('Conversation skin component', () => {
         username: true,
       };
       spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+        false
+      );
+      spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
         false
       );
       spyOn(userService, 'getUserInfoAsync').and.returnValue(
@@ -2135,6 +2147,9 @@ describe('Conversation skin component', () => {
     spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
       null
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
     spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
     spyOn(urlService, 'isIframed').and.returnValue(false);
@@ -2169,6 +2184,9 @@ describe('Conversation skin component', () => {
       spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
         null
       );
+      spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+        false
+      );
       spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
       spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
       spyOn(urlService, 'isIframed').and.returnValue(false);
@@ -2187,6 +2205,10 @@ describe('Conversation skin component', () => {
           capturedCallback = callback;
         }
       );
+    });
+
+    afterEach(() => {
+      window.sessionStorage.clear();
     });
 
     it('should validate unload conditions in the listener callback', fakeAsync(() => {
@@ -2251,4 +2273,84 @@ describe('Conversation skin component', () => {
       expect(capturedCallback()).toBeFalse();
     }));
   });
+
+  it('should not record exploration completed in story editor preview mode', fakeAsync(() => {
+    spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+      false
+    );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      true
+    );
+    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+    spyOn(statsReportingService, 'recordExplorationCompleted');
+    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+      null
+    );
+    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+    spyOn(urlService, 'isIframed').and.returnValue(false);
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(imagePreloaderService, 'onStateChange');
+    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+      false
+    );
+    spyOn(componentInstance, 'initializePage');
+
+    let mockOnPlayerStateChange = new EventEmitter();
+    let mockOnNewCardOpened = new EventEmitter();
+    let mockOnHintsExhausted = new EventEmitter();
+    let mockOnLearnerReallyStuck = new EventEmitter();
+    let mockOnLearnerGetsReallyStuck = new EventEmitter();
+    let mockOnHintConsumed = new EventEmitter();
+    let mockOnSolutionViewedEventEmitter = new EventEmitter();
+
+    spyOnProperty(
+      conversationFlowService,
+      'onPlayerStateChange'
+    ).and.returnValue(mockOnPlayerStateChange);
+    spyOnProperty(playerPositionService, 'onNewCardOpened').and.returnValue(
+      mockOnNewCardOpened
+    );
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onHintsExhausted'
+    ).and.returnValue(mockOnHintsExhausted);
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onLearnerReallyStuck'
+    ).and.returnValue(mockOnLearnerReallyStuck);
+    spyOnProperty(
+      conceptCardManagerService,
+      'onLearnerGetsReallyStuck'
+    ).and.returnValue(mockOnLearnerGetsReallyStuck);
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onHintConsumed'
+    ).and.returnValue(mockOnHintConsumed);
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onSolutionViewedEventEmitter'
+    ).and.returnValue(mockOnSolutionViewedEventEmitter);
+
+    const nextCard = new StateCard(
+      null,
+      null,
+      null,
+      new Interaction([], [], null, null, [], 'EndExploration', null),
+      [],
+      '',
+      null
+    );
+    conversationFlowService.setNextStateCard(nextCard);
+    conversationFlowService.setHasInteractedAtLeastOnce(true);
+    conversationFlowService.setDisplayedCard(displayedCard);
+
+    componentInstance.ngOnInit();
+    mockOnPlayerStateChange.emit('End');
+    tick(100);
+
+    expect(
+      statsReportingService.recordExplorationCompleted
+    ).not.toHaveBeenCalled();
+    flush();
+  }));
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -1134,6 +1134,9 @@ describe('Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       true
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
 
     spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
@@ -1513,6 +1516,9 @@ describe('Conversation skin component', () => {
       'has loaded',
     () => {
       spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+        false
+      );
+      spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
         false
       );
       spyOn(pageContextService, 'isInExplorationPlayerPage').and.returnValue(

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -2280,92 +2280,44 @@ describe('Conversation skin component', () => {
     }));
   });
 
-  it('should not record exploration completed in story editor preview mode', fakeAsync(() => {
+  const runExplorationCompletionTest = (
+    inPreviewMode: boolean,
+    expectCalled: boolean
+  ) => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
     spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
-      true
+      inPreviewMode
     );
     spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
-    spyOn(statsReportingService, 'recordExplorationCompleted');
     spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
       null
     );
     spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
-    spyOn(urlService, 'isIframed').and.returnValue(false);
     spyOn(loaderService, 'showLoadingScreen');
     spyOn(imagePreloaderService, 'onStateChange');
-    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
-      false
-    );
-    spyOn(componentInstance, 'initializePage');
-
-    let mockOnPlayerStateChange = new EventEmitter();
-    spyOnProperty(
-      conversationFlowService,
-      'onPlayerStateChange'
-    ).and.returnValue(mockOnPlayerStateChange);
-
-    const nextCard = new StateCard(
-      null,
-      null,
-      null,
-      new Interaction([], [], null, null, [], 'EndExploration', null),
-      [],
-      '',
-      null
-    );
-    conversationFlowService.setNextStateCard(nextCard);
-    conversationFlowService.setHasInteractedAtLeastOnce(true);
-    conversationFlowService.setDisplayedCard(displayedCard);
-
-    componentInstance.ngOnInit();
-    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
-    mockOnPlayerStateChange.emit('End');
-    flush();
-
-    expect(
-      statsReportingService.recordExplorationCompleted
-    ).not.toHaveBeenCalled();
-  }));
-
-  it('should record exploration completed when not in story editor preview mode', fakeAsync(() => {
-    spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
-      false
-    );
-    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
-      false
-    );
-    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
     spyOn(statsReportingService, 'recordExplorationCompleted');
-    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
-      null
-    );
-    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
-    spyOn(urlService, 'isIframed').and.returnValue(false);
-    spyOn(loaderService, 'showLoadingScreen');
-    spyOn(imagePreloaderService, 'onStateChange');
-    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
-      false
-    );
-    spyOn(componentInstance, 'initializePage');
-    spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
-    spyOn(playerTranscriptService, 'getNumCards').and.returnValue(1);
+    spyOn(statsReportingService, 'recordExplorationActuallyStarted');
 
-    let mockOnPlayerStateChange = new EventEmitter();
-    spyOnProperty(
-      conversationFlowService,
-      'onPlayerStateChange'
-    ).and.returnValue(mockOnPlayerStateChange);
+    spyOn(componentInstance, 'initializePage');
+
     spyOn(currentEngineService, 'getCurrentEngineService').and.returnValue(
       explorationEngineService
     );
     spyOn(explorationEngineService, 'getLanguageCode').and.returnValue('en');
+
+    spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
+    spyOn(playerTranscriptService, 'getNumCards').and.returnValue(1);
     spyOn(chapterProgressService, 'getCompletedChaptersCount').and.returnValue(
       0
     );
-    spyOn(statsReportingService, 'recordExplorationActuallyStarted');
+
+    let mockOnPlayerStateChange = new EventEmitter();
+    spyOnProperty(
+      conversationFlowService,
+      'onPlayerStateChange'
+    ).and.returnValue(mockOnPlayerStateChange);
 
     const nextCard = new StateCard(
       null,
@@ -2376,15 +2328,31 @@ describe('Conversation skin component', () => {
       '',
       null
     );
+
     conversationFlowService.setNextStateCard(nextCard);
     conversationFlowService.setHasInteractedAtLeastOnce(true);
     conversationFlowService.setDisplayedCard(displayedCard);
 
     componentInstance.ngOnInit();
-    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
     mockOnPlayerStateChange.emit('End');
     flush();
 
-    expect(statsReportingService.recordExplorationCompleted).toHaveBeenCalled();
+    if (expectCalled) {
+      expect(
+        statsReportingService.recordExplorationCompleted
+      ).toHaveBeenCalled();
+    } else {
+      expect(
+        statsReportingService.recordExplorationCompleted
+      ).not.toHaveBeenCalled();
+    }
+  };
+
+  it('should not record exploration completed in story editor preview mode', fakeAsync(() => {
+    runExplorationCompletionTest(true, false);
+  }));
+
+  it('should record exploration completed when not in story editor preview mode', fakeAsync(() => {
+    runExplorationCompletionTest(false, true);
   }));
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.spec.ts
@@ -2302,40 +2302,10 @@ describe('Conversation skin component', () => {
     spyOn(componentInstance, 'initializePage');
 
     let mockOnPlayerStateChange = new EventEmitter();
-    let mockOnNewCardOpened = new EventEmitter();
-    let mockOnHintsExhausted = new EventEmitter();
-    let mockOnLearnerReallyStuck = new EventEmitter();
-    let mockOnLearnerGetsReallyStuck = new EventEmitter();
-    let mockOnHintConsumed = new EventEmitter();
-    let mockOnSolutionViewedEventEmitter = new EventEmitter();
-
     spyOnProperty(
       conversationFlowService,
       'onPlayerStateChange'
     ).and.returnValue(mockOnPlayerStateChange);
-    spyOnProperty(playerPositionService, 'onNewCardOpened').and.returnValue(
-      mockOnNewCardOpened
-    );
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onHintsExhausted'
-    ).and.returnValue(mockOnHintsExhausted);
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onLearnerReallyStuck'
-    ).and.returnValue(mockOnLearnerReallyStuck);
-    spyOnProperty(
-      conceptCardManagerService,
-      'onLearnerGetsReallyStuck'
-    ).and.returnValue(mockOnLearnerGetsReallyStuck);
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onHintConsumed'
-    ).and.returnValue(mockOnHintConsumed);
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onSolutionViewedEventEmitter'
-    ).and.returnValue(mockOnSolutionViewedEventEmitter);
 
     const nextCard = new StateCard(
       null,
@@ -2351,12 +2321,70 @@ describe('Conversation skin component', () => {
     conversationFlowService.setDisplayedCard(displayedCard);
 
     componentInstance.ngOnInit();
+    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
     mockOnPlayerStateChange.emit('End');
-    tick(100);
+    flush();
 
     expect(
       statsReportingService.recordExplorationCompleted
     ).not.toHaveBeenCalled();
+  }));
+
+  it('should record exploration completed when not in story editor preview mode', fakeAsync(() => {
+    spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+      false
+    );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
+    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+    spyOn(statsReportingService, 'recordExplorationCompleted');
+    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+      null
+    );
+    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+    spyOn(urlService, 'isIframed').and.returnValue(false);
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(imagePreloaderService, 'onStateChange');
+    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+      false
+    );
+    spyOn(componentInstance, 'initializePage');
+    spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
+    spyOn(playerTranscriptService, 'getNumCards').and.returnValue(1);
+
+    let mockOnPlayerStateChange = new EventEmitter();
+    spyOnProperty(
+      conversationFlowService,
+      'onPlayerStateChange'
+    ).and.returnValue(mockOnPlayerStateChange);
+    spyOn(currentEngineService, 'getCurrentEngineService').and.returnValue(
+      explorationEngineService
+    );
+    spyOn(explorationEngineService, 'getLanguageCode').and.returnValue('en');
+    spyOn(chapterProgressService, 'getCompletedChaptersCount').and.returnValue(
+      0
+    );
+    spyOn(statsReportingService, 'recordExplorationActuallyStarted');
+
+    const nextCard = new StateCard(
+      null,
+      null,
+      null,
+      new Interaction([], [], null, null, [], 'EndExploration', null),
+      [],
+      '',
+      null
+    );
+    conversationFlowService.setNextStateCard(nextCard);
+    conversationFlowService.setHasInteractedAtLeastOnce(true);
+    conversationFlowService.setDisplayedCard(displayedCard);
+
+    componentInstance.ngOnInit();
+    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
+    mockOnPlayerStateChange.emit('End');
     flush();
+
+    expect(statsReportingService.recordExplorationCompleted).toHaveBeenCalled();
   }));
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
@@ -243,7 +243,6 @@ export class ConversationSkinComponent {
             !this.pageContextService.isInStoryEditorPreviewMode() &&
             nextCard.isTerminal()
           ) {
-            console.log('recordExplorationCompleted');
             const currentEngineService =
               this.currentEngineService.getCurrentEngineService();
             const completedChaptersCount =

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
@@ -72,6 +72,7 @@ export class ConversationSkinComponent {
   directiveSubscriptions = new Subscription();
 
   _editorPreviewMode;
+  _storyEditorPreviewMode!: boolean;
 
   isLoggedIn: boolean;
   voiceoversAreLoaded: boolean = false;
@@ -133,6 +134,8 @@ export class ConversationSkinComponent {
   ngOnInit(): void {
     this._editorPreviewMode =
       this.pageContextService.isInExplorationEditorPage();
+    this._storyEditorPreviewMode =
+      this.pageContextService.isInStoryEditorPreviewMode();
     this.correctnessFooterIsShown =
       !this.pageContextService.isInDiagnosticTestPlayerPage();
 
@@ -240,7 +243,7 @@ export class ConversationSkinComponent {
           // the end of the exploration.
           if (
             !this._editorPreviewMode &&
-            !this.pageContextService.isInStoryEditorPreviewMode() &&
+            !this._storyEditorPreviewMode &&
             nextCard.isTerminal()
           ) {
             const currentEngineService =

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.ts
@@ -238,7 +238,12 @@ export class ConversationSkinComponent {
           let nextCard = this.conversationFlowService.getNextStateCard();
           // Ensure the transition to a terminal state properly logs
           // the end of the exploration.
-          if (!this._editorPreviewMode && nextCard.isTerminal()) {
+          if (
+            !this._editorPreviewMode &&
+            !this.pageContextService.isInStoryEditorPreviewMode() &&
+            nextCard.isTerminal()
+          ) {
+            console.log('recordExplorationCompleted');
             const currentEngineService =
               this.currentEngineService.getCurrentEngineService();
             const completedChaptersCount =

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -1455,6 +1455,9 @@ describe('New Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       true
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
 
     spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
@@ -1834,6 +1837,9 @@ describe('New Conversation skin component', () => {
       'has loaded',
     () => {
       spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+        false
+      );
+      spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
         false
       );
       spyOn(pageContextService, 'isInExplorationPlayerPage').and.returnValue(

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -2634,92 +2634,45 @@ describe('New Conversation skin component', () => {
     }));
   });
 
-  it('should not record exploration completed in story editor preview mode', fakeAsync(() => {
+  const runExplorationCompletionTest = (
+    inPreviewMode: boolean,
+    expectCalled: boolean
+  ) => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
     spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
-      true
+      inPreviewMode
     );
     spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
-    spyOn(statsReportingService, 'recordExplorationCompleted');
     spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
       null
     );
     spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
-    spyOn(urlService, 'isIframed').and.returnValue(false);
     spyOn(loaderService, 'showLoadingScreen');
     spyOn(imagePreloaderService, 'onStateChange');
-    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
-      false
-    );
-    spyOn(componentInstance, 'initializePage');
 
-    let mockOnPlayerStateChange = new EventEmitter();
-    spyOnProperty(
-      conversationFlowService,
-      'onPlayerStateChange'
-    ).and.returnValue(mockOnPlayerStateChange);
-
-    const nextCard = new StateCard(
-      null,
-      null,
-      null,
-      new Interaction([], [], null, null, [], 'EndExploration', null),
-      [],
-      '',
-      null
-    );
-    conversationFlowService.setNextStateCard(nextCard);
-    conversationFlowService.setHasInteractedAtLeastOnce(true);
-    conversationFlowService.setDisplayedCard(displayedCard);
-
-    componentInstance.ngOnInit();
-    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
-    mockOnPlayerStateChange.emit('End');
-    flush();
-
-    expect(
-      statsReportingService.recordExplorationCompleted
-    ).not.toHaveBeenCalled();
-  }));
-
-  it('should record exploration completed when not in story editor preview mode', fakeAsync(() => {
-    spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
-      false
-    );
-    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
-      false
-    );
-    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
     spyOn(statsReportingService, 'recordExplorationCompleted');
-    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
-      null
-    );
-    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
-    spyOn(urlService, 'isIframed').and.returnValue(false);
-    spyOn(loaderService, 'showLoadingScreen');
-    spyOn(imagePreloaderService, 'onStateChange');
-    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
-      false
-    );
-    spyOn(componentInstance, 'initializePage');
-    spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
-    spyOn(playerTranscriptService, 'getNumCards').and.returnValue(1);
+    spyOn(statsReportingService, 'recordExplorationActuallyStarted');
 
-    let mockOnPlayerStateChange = new EventEmitter();
-    spyOnProperty(
-      conversationFlowService,
-      'onPlayerStateChange'
-    ).and.returnValue(mockOnPlayerStateChange);
+    spyOn(componentInstance, 'initializePage');
+
     spyOn(currentEngineService, 'getCurrentEngineService').and.returnValue(
       explorationEngineService
     );
     spyOn(explorationEngineService, 'getLanguageCode').and.returnValue('en');
+
+    spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
+    spyOn(playerTranscriptService, 'getNumCards').and.returnValue(1);
     spyOn(chapterProgressService, 'getCompletedChaptersCount').and.returnValue(
       0
     );
-    spyOn(statsReportingService, 'recordExplorationActuallyStarted');
+
+    let mockOnPlayerStateChange = new EventEmitter();
+    spyOnProperty(
+      conversationFlowService,
+      'onPlayerStateChange'
+    ).and.returnValue(mockOnPlayerStateChange);
 
     const nextCard = new StateCard(
       null,
@@ -2730,15 +2683,31 @@ describe('New Conversation skin component', () => {
       '',
       null
     );
+
     conversationFlowService.setNextStateCard(nextCard);
     conversationFlowService.setHasInteractedAtLeastOnce(true);
     conversationFlowService.setDisplayedCard(displayedCard);
 
     componentInstance.ngOnInit();
-    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
     mockOnPlayerStateChange.emit('End');
     flush();
 
-    expect(statsReportingService.recordExplorationCompleted).toHaveBeenCalled();
+    if (expectCalled) {
+      expect(
+        statsReportingService.recordExplorationCompleted
+      ).toHaveBeenCalled();
+    } else {
+      expect(
+        statsReportingService.recordExplorationCompleted
+      ).not.toHaveBeenCalled();
+    }
+  };
+
+  it('should not record exploration completed in story editor preview mode', fakeAsync(() => {
+    runExplorationCompletionTest(true, false);
+  }));
+
+  it('should record exploration completed when not in story editor preview mode', fakeAsync(() => {
+    runExplorationCompletionTest(false, true);
   }));
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -818,6 +818,9 @@ describe('New Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(userService, 'getUserInfoAsync').and.returnValue(
       Promise.resolve(
         new UserInfo([], false, false, false, false, false, '', '', '', true)
@@ -1032,6 +1035,9 @@ describe('New Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(userService, 'getUserInfoAsync').and.returnValue(
       Promise.resolve(
         new UserInfo([], false, false, false, false, false, '', '', '', true)
@@ -1173,6 +1179,9 @@ describe('New Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(userService, 'getUserInfoAsync').and.returnValue(
       Promise.resolve(
         new UserInfo([], false, false, false, false, false, '', '', '', false)
@@ -1308,6 +1317,9 @@ describe('New Conversation skin component', () => {
         username: true,
       };
       spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+        false
+      );
+      spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
         false
       );
       spyOn(userService, 'getUserInfoAsync').and.returnValue(
@@ -2472,6 +2484,9 @@ describe('New Conversation skin component', () => {
     spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
       false
     );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
     spyOn(pageContextService, 'isInDiagnosticTestPlayerPage').and.returnValue(
       false
     );
@@ -2512,6 +2527,9 @@ describe('New Conversation skin component', () => {
       spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
         false
       );
+      spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+        false
+      );
       spyOn(pageContextService, 'isInDiagnosticTestPlayerPage').and.returnValue(
         false
       );
@@ -2541,6 +2559,10 @@ describe('New Conversation skin component', () => {
           capturedCallback = callback;
         }
       );
+    });
+
+    afterEach(() => {
+      window.sessionStorage.clear();
     });
 
     it('should validate unload conditions in the listener callback', fakeAsync(() => {
@@ -2605,4 +2627,84 @@ describe('New Conversation skin component', () => {
       expect(capturedCallback()).toBeFalse();
     }));
   });
+
+  it('should not record exploration completed in story editor preview mode', fakeAsync(() => {
+    spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+      false
+    );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      true
+    );
+    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+    spyOn(statsReportingService, 'recordExplorationCompleted');
+    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+      null
+    );
+    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+    spyOn(urlService, 'isIframed').and.returnValue(false);
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(imagePreloaderService, 'onStateChange');
+    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+      false
+    );
+    spyOn(componentInstance, 'initializePage');
+
+    let mockOnPlayerStateChange = new EventEmitter();
+    let mockOnNewCardOpened = new EventEmitter();
+    let mockOnHintsExhausted = new EventEmitter();
+    let mockOnLearnerReallyStuck = new EventEmitter();
+    let mockOnLearnerGetsReallyStuck = new EventEmitter();
+    let mockOnHintConsumed = new EventEmitter();
+    let mockOnSolutionViewedEventEmitter = new EventEmitter();
+
+    spyOnProperty(
+      conversationFlowService,
+      'onPlayerStateChange'
+    ).and.returnValue(mockOnPlayerStateChange);
+    spyOnProperty(playerPositionService, 'onNewCardOpened').and.returnValue(
+      mockOnNewCardOpened
+    );
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onHintsExhausted'
+    ).and.returnValue(mockOnHintsExhausted);
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onLearnerReallyStuck'
+    ).and.returnValue(mockOnLearnerReallyStuck);
+    spyOnProperty(
+      conceptCardManagerService,
+      'onLearnerGetsReallyStuck'
+    ).and.returnValue(mockOnLearnerGetsReallyStuck);
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onHintConsumed'
+    ).and.returnValue(mockOnHintConsumed);
+    spyOnProperty(
+      hintsAndSolutionManagerService,
+      'onSolutionViewedEventEmitter'
+    ).and.returnValue(mockOnSolutionViewedEventEmitter);
+
+    const nextCard = new StateCard(
+      null,
+      null,
+      null,
+      new Interaction([], [], null, null, [], 'EndExploration', null),
+      [],
+      '',
+      null
+    );
+    conversationFlowService.setNextStateCard(nextCard);
+    conversationFlowService.setHasInteractedAtLeastOnce(true);
+    conversationFlowService.setDisplayedCard(displayedCard);
+
+    componentInstance.ngOnInit();
+    mockOnPlayerStateChange.emit('End');
+    tick(100);
+
+    expect(
+      statsReportingService.recordExplorationCompleted
+    ).not.toHaveBeenCalled();
+    flush();
+  }));
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.spec.ts
@@ -2656,40 +2656,10 @@ describe('New Conversation skin component', () => {
     spyOn(componentInstance, 'initializePage');
 
     let mockOnPlayerStateChange = new EventEmitter();
-    let mockOnNewCardOpened = new EventEmitter();
-    let mockOnHintsExhausted = new EventEmitter();
-    let mockOnLearnerReallyStuck = new EventEmitter();
-    let mockOnLearnerGetsReallyStuck = new EventEmitter();
-    let mockOnHintConsumed = new EventEmitter();
-    let mockOnSolutionViewedEventEmitter = new EventEmitter();
-
     spyOnProperty(
       conversationFlowService,
       'onPlayerStateChange'
     ).and.returnValue(mockOnPlayerStateChange);
-    spyOnProperty(playerPositionService, 'onNewCardOpened').and.returnValue(
-      mockOnNewCardOpened
-    );
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onHintsExhausted'
-    ).and.returnValue(mockOnHintsExhausted);
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onLearnerReallyStuck'
-    ).and.returnValue(mockOnLearnerReallyStuck);
-    spyOnProperty(
-      conceptCardManagerService,
-      'onLearnerGetsReallyStuck'
-    ).and.returnValue(mockOnLearnerGetsReallyStuck);
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onHintConsumed'
-    ).and.returnValue(mockOnHintConsumed);
-    spyOnProperty(
-      hintsAndSolutionManagerService,
-      'onSolutionViewedEventEmitter'
-    ).and.returnValue(mockOnSolutionViewedEventEmitter);
 
     const nextCard = new StateCard(
       null,
@@ -2705,12 +2675,70 @@ describe('New Conversation skin component', () => {
     conversationFlowService.setDisplayedCard(displayedCard);
 
     componentInstance.ngOnInit();
+    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
     mockOnPlayerStateChange.emit('End');
-    tick(100);
+    flush();
 
     expect(
       statsReportingService.recordExplorationCompleted
     ).not.toHaveBeenCalled();
+  }));
+
+  it('should record exploration completed when not in story editor preview mode', fakeAsync(() => {
+    spyOn(pageContextService, 'isInExplorationEditorPage').and.returnValue(
+      false
+    );
+    spyOn(pageContextService, 'isInStoryEditorPreviewMode').and.returnValue(
+      false
+    );
+    spyOn(pageContextService, 'getExplorationId').and.returnValue('exp_id');
+    spyOn(statsReportingService, 'recordExplorationCompleted');
+    spyOn(urlService, 'getCollectionIdFromExplorationUrl').and.returnValue(
+      null
+    );
+    spyOn(urlService, 'getPidFromUrl').and.returnValue(null);
+    spyOn(urlService, 'isIframed').and.returnValue(false);
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(imagePreloaderService, 'onStateChange');
+    spyOn(explorationModeService, 'isInQuestionPlayerMode').and.returnValue(
+      false
+    );
+    spyOn(componentInstance, 'initializePage');
+    spyOn(learnerParamsService, 'getAllParams').and.returnValue({});
+    spyOn(playerTranscriptService, 'getNumCards').and.returnValue(1);
+
+    let mockOnPlayerStateChange = new EventEmitter();
+    spyOnProperty(
+      conversationFlowService,
+      'onPlayerStateChange'
+    ).and.returnValue(mockOnPlayerStateChange);
+    spyOn(currentEngineService, 'getCurrentEngineService').and.returnValue(
+      explorationEngineService
+    );
+    spyOn(explorationEngineService, 'getLanguageCode').and.returnValue('en');
+    spyOn(chapterProgressService, 'getCompletedChaptersCount').and.returnValue(
+      0
+    );
+    spyOn(statsReportingService, 'recordExplorationActuallyStarted');
+
+    const nextCard = new StateCard(
+      null,
+      null,
+      null,
+      new Interaction([], [], null, null, [], 'EndExploration', null),
+      [],
+      '',
+      null
+    );
+    conversationFlowService.setNextStateCard(nextCard);
+    conversationFlowService.setHasInteractedAtLeastOnce(true);
+    conversationFlowService.setDisplayedCard(displayedCard);
+
+    componentInstance.ngOnInit();
+    // 'End' is the state name emitted; completion depends on interaction id 'EndExploration'.
+    mockOnPlayerStateChange.emit('End');
     flush();
+
+    expect(statsReportingService.recordExplorationCompleted).toHaveBeenCalled();
   }));
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
@@ -255,7 +255,11 @@ export class NewConversationSkinComponent {
           let nextCard = this.conversationFlowService.getNextStateCard();
           // Ensure the transition to a terminal state properly logs
           // the end of the exploration.
-          if (!this._editorPreviewMode && nextCard.isTerminal()) {
+          if (
+            !this._editorPreviewMode &&
+            !this.pageContextService.isInStoryEditorPreviewMode() &&
+            nextCard.isTerminal()
+          ) {
             const currentEngineService =
               this.currentEngineService.getCurrentEngineService();
             const completedChaptersCount =

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.ts
@@ -81,6 +81,7 @@ export class NewConversationSkinComponent {
   directiveSubscriptions = new Subscription();
 
   _editorPreviewMode!: boolean;
+  _storyEditorPreviewMode!: boolean;
 
   isLoggedIn!: boolean;
   voiceoversAreLoaded: boolean = false;
@@ -141,6 +142,8 @@ export class NewConversationSkinComponent {
   ngOnInit(): void {
     this._editorPreviewMode =
       this.pageContextService.isInExplorationEditorPage();
+    this._storyEditorPreviewMode =
+      this.pageContextService.isInStoryEditorPreviewMode();
     this.correctnessFooterIsShown =
       !this.pageContextService.isInDiagnosticTestPlayerPage();
 
@@ -257,7 +260,7 @@ export class NewConversationSkinComponent {
           // the end of the exploration.
           if (
             !this._editorPreviewMode &&
-            !this.pageContextService.isInStoryEditorPreviewMode() &&
+            !this._storyEditorPreviewMode &&
             nextCard.isTerminal()
           ) {
             const currentEngineService =

--- a/core/templates/pages/story-editor-page/story-preview-tab/story-preview-tab.component.spec.ts
+++ b/core/templates/pages/story-editor-page/story-preview-tab/story-preview-tab.component.spec.ts
@@ -166,11 +166,11 @@ describe('Story Preview tab', () => {
     component.ngOnInit();
     let node = story.getStoryContents().getNodes()[0];
     expect(component.getExplorationUrl(node)).toEqual(
-      '/explore/exp_1?story_id=storyId_0&node_id=node_1'
+      '/explore/exp_1?story_id=storyId_0&node_id=node_1&story_editor_page=true'
     );
     node = story.getStoryContents().getNodes()[1];
     expect(component.getExplorationUrl(node)).toEqual(
-      '/explore/exp_2?story_id=storyId_0&node_id=node_2'
+      '/explore/exp_2?story_id=storyId_0&node_id=node_2&story_editor_page=true'
     );
   });
 

--- a/core/templates/pages/story-editor-page/story-preview-tab/story-preview-tab.component.ts
+++ b/core/templates/pages/story-editor-page/story-preview-tab/story-preview-tab.component.ts
@@ -107,6 +107,7 @@ export class StoryPreviewTabComponent implements OnInit, OnDestroy {
     var result = '/explore/' + node.getExplorationId();
     result = this.urlService.addField(result, 'story_id', this.storyId);
     result = this.urlService.addField(result, 'node_id', node.getId());
+    result = this.urlService.addField(result, 'story_editor_page', 'true');
     return result;
   }
 

--- a/core/templates/services/page-context.service.spec.ts
+++ b/core/templates/services/page-context.service.spec.ts
@@ -625,4 +625,24 @@ describe('PageContext service', () => {
       expect(ecs.getExplorationId()).toBe('456');
     });
   });
+
+  describe('isInStoryEditorPreviewMode', () => {
+    beforeEach(() => {
+      ecs = TestBed.inject(PageContextService);
+      urlService = TestBed.inject(UrlService);
+      ecs.removeCustomEntityContext();
+    });
+
+    it('should return true when story_editor_page param is true', () => {
+      spyOn(urlService, 'getUrlParams').and.returnValue({
+        story_editor_page: 'true',
+      });
+      expect(ecs.isInStoryEditorPreviewMode()).toBe(true);
+    });
+
+    it('should return false when story_editor_page param is absent', () => {
+      spyOn(urlService, 'getUrlParams').and.returnValue({});
+      expect(ecs.isInStoryEditorPreviewMode()).toBe(false);
+    });
+  });
 });

--- a/core/templates/services/page-context.service.ts
+++ b/core/templates/services/page-context.service.ts
@@ -390,6 +390,10 @@ export class PageContextService {
     );
   }
 
+  isInStoryEditorPreviewMode(): boolean {
+    return this.urlService.getUrlParams()['story_editor_page'] === 'true';
+  }
+
   canAddOrEditComponents(): boolean {
     var currentPageContext = this.getPageContext();
     var allowedPageContext: string[] = [

--- a/core/templates/services/page-context.service.ts
+++ b/core/templates/services/page-context.service.ts
@@ -391,7 +391,7 @@ export class PageContextService {
   }
 
   isInStoryEditorPreviewMode(): boolean {
-    return this.urlService.getUrlParams()['story_editor_page'] === 'true';
+    return this.urlService.getUrlParams().story_editor_page === 'true';
   }
 
   canAddOrEditComponents(): boolean {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #22459.
2. This PR does the following: When a story editor preview is opened, the exploration loads at `/explore/<exp_id>?story_id=...&node_id=....` The existing guard on `recordExplorationCompleted()` only checks `isInExplorationEditorPage()`, which only covers `/create/<exp_id>` previews. This means story editor previews were incorrectly treated as real learner sessions and exploration completion was being recorded.

This PR fixes the issue by:

- Appending `story_editor_page=true` as a query param to the exploration URL when launched from the story editor preview tab
- Adding `isInStoryEditorPreviewMode()` in `PageContextService` that detects this param
- Extending the guard in both conversation skin components to block `recordExplorationCompleted()` when in story editor preview mode

3.The original bug occurred because the completion recording guard only checked `isInExplorationEditorPage()`, which matches `/create/<exp_id>` URLs. Story editor previews open explorations at `/explore/<exp_id>`, which doesn't match that check, so the player incorrectly recorded completion during preview sessions.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
### Before:

https://github.com/user-attachments/assets/637328a4-9ca6-4246-9449-e8d38d233eb0

### After:

https://github.com/user-attachments/assets/442304ab-b323-4b37-8bf3-0f38e6f68fea


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
