### PR TITLE
Fix #16989 : Add Acceptance tests for contributor stats and badges

### DIFF
--- a/core/tests/ci-test-suite-configs/acceptance.json
+++ b/core/tests/ci-test-suite-configs/acceptance.json
@@ -547,6 +547,14 @@
     {
       "name": "logged-out-user/select-and-play-topic-from-classroom-page",
       "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/select-and-play-topic-from-classroom-page.spec.ts"
+    },
+    {
+      "name": "translation-submitter/check-contribution-stats-download-certificate-and-badges",
+      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-submitter/check-contribution-stats-download-certificate-and-badges.spec.ts"
+    },
+    {
+      "name": "translation-reviewer/check-contribution-stats-download-certificate-and-badges",
+      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/check-contribution-stats-download-certificate-and-badges.spec.ts"
     }
   ]
 }

--- a/core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/view-contribution-stats-and-badges-earned.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/view-contribution-stats-and-badges-earned.spec.ts
@@ -97,6 +97,7 @@ describe('Practice Question Reviewer', function () {
 
     // Update skill rubric.
     await curriculumAdmin.openSkillEditor('Addition');
+    await curriculumAdmin.updateRubric('Hard', 'This is for hard questions');
     await curriculumAdmin.updateRubric('Easy', 'This is for easy questions');
     await curriculumAdmin.updateRubric(
       'Medium',
@@ -132,7 +133,7 @@ describe('Practice Question Reviewer', function () {
       'Arithmetic Operations',
       'What is 231 + 12?'
     );
-  }, 900000);
+  }, 600000);
 
   it('should be able to check contribution stats', async function () {
     await questionReviewer.navigateToContributorDashboardUsingProfileDropdown();

--- a/core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/view-contribution-stats-and-badges-earned.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/view-contribution-stats-and-badges-earned.spec.ts
@@ -97,7 +97,6 @@ describe('Practice Question Reviewer', function () {
 
     // Update skill rubric.
     await curriculumAdmin.openSkillEditor('Addition');
-    await curriculumAdmin.updateRubric('Hard', 'This is for hard questions');
     await curriculumAdmin.updateRubric('Easy', 'This is for easy questions');
     await curriculumAdmin.updateRubric(
       'Medium',
@@ -133,7 +132,7 @@ describe('Practice Question Reviewer', function () {
       'Arithmetic Operations',
       'What is 231 + 12?'
     );
-  }, 600000);
+  }, 900000);
 
   it('should be able to check contribution stats', async function () {
     await questionReviewer.navigateToContributorDashboardUsingProfileDropdown();

--- a/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/check-contribution-stats-download-certificate-and-badges.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/check-contribution-stats-download-certificate-and-badges.spec.ts
@@ -40,13 +40,11 @@ describe('Translation Reviewer', function () {
   let curriculumAdm: CurriculumAdmin & ExplorationEditor & TopicManager;
 
   beforeAll(async function () {
-    // Create all users.
     translationSubmitter = await UserFactory.createNewUser(
       'translationsubmitter',
       'translationsubmitter@example.com'
     );
 
-    // Translation reviewer is given Arabic review rights.
     translationReviewer = await UserFactory.createNewUser(
       'translationreviewer',
       'translationreviewer@example.com',
@@ -60,13 +58,11 @@ describe('Translation Reviewer', function () {
       [ROLES.CURRICULUM_ADMIN]
     );
 
-    // Create and publish an exploration with 2 cards.
     const explorationId =
       await curriculumAdm.createAndPublishExplorationWithCards(
         'First Exploration'
       );
 
-    // Set up topic, skill, story, chapter, and classroom.
     await curriculumAdm.navigateToTopicAndSkillsDashboardPage();
     await curriculumAdm.createAndPublishTopic(
       'Test Topic',
@@ -87,7 +83,6 @@ describe('Translation Reviewer', function () {
       'Test Topic'
     );
 
-    // Translation submitter submits translations in Arabic.
     await translationSubmitter.navigateToContributorDashboardUsingProfileDropdown();
     await translationSubmitter.switchToTabInContributionDashboard(
       'Translate Text'
@@ -106,7 +101,6 @@ describe('Translation Reviewer', function () {
     await translationSubmitter.typeTextForRTE('محتوى البطاقة 1');
     await translationSubmitter.clickOnElementWithText('Save and close');
 
-    // Translation reviewer reviews and accepts the submitted translations.
     await translationReviewer.navigateToContributorDashboardUsingProfileDropdown();
     await translationReviewer.clickOnTranslateButtonInTranslateTextTabInTranslationReview(
       'First Chapter',
@@ -116,7 +110,7 @@ describe('Translation Reviewer', function () {
       'محتوى البطاقة 0',
       'Test Topic / Test Story'
     );
-    // Accept both card translations.
+
     await translationReviewer.submitTranslationReview('accept');
     await translationReviewer.submitTranslationReview('accept');
 
@@ -126,7 +120,6 @@ describe('Translation Reviewer', function () {
   }, 900000);
 
   it('should be able to check contribution stats', async function () {
-    // Navigate to Contribution Stats and select Translation Reviews.
     await translationReviewer.navigateToTabInMyContributions(
       'Contribution Stats'
     );
@@ -134,16 +127,13 @@ describe('Translation Reviewer', function () {
       'Translation Reviews'
     );
 
-    // Verify the stats table row contains the expected data.
-    // Column order for translation reviews: Date | Topic | Reviewed Cards |
-    // Reviewed Word Count | Accepted Cards | Accepted Word Count.
     await translationReviewer.expectContributionTableToContainRow([
-      null, // Date — changes every run.
-      'Test Topic', // Topic.
-      '2', // Reviewed cards (both cards submitted were reviewed).
-      null, // Reviewed word count can vary by card content.
-      '2', // Accepted cards (both cards were accepted).
-      null, // Accepted word count can vary by card content.
+      null,
+      'Test Topic',
+      '2',
+      null,
+      '2',
+      null,
     ]);
   });
 
@@ -157,13 +147,8 @@ describe('Translation Reviewer', function () {
 
   it('should be able to check badges earned', async function () {
     await translationReviewer.navigateToTabInMyContributions('Badges');
-    // Select Translation type in mobile view (desktop shows all badges).
     await translationReviewer.selectBadgeTypeInMobileView('Translation');
-    // Should show a badge for 2 translation reviews (both cards accepted).
-    // The badge value '1' is the threshold level of the first badge.
     await translationReviewer.expectBadgesToContain('1', 'Review', 'العربية');
-    // Verify the tooltip on the first locked (next achievable) badge.
-    // With 2 reviews done and next threshold at 10: 10 - 2 = 8 more needed.
     await translationReviewer.expectLockedBadgeTooltipText(
       '8 more reviews to achieve this badge'
     );

--- a/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/check-contribution-stats-download-certificate-and-badges.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/check-contribution-stats-download-certificate-and-badges.spec.ts
@@ -1,0 +1,175 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Acceptance test for translation reviewer contribution stats,
+ * certificate, and badges.
+ *
+ * Feature: TR.CD - Check contribution stats, download certificate and badges.
+ * Related issue: https://github.com/oppia/oppia/issues/16989
+ * Testing plan:
+ * https://docs.google.com/spreadsheets/d/1BKcrqmFzfjpexiKb3geIGoxV3Gfm6IqzNvAlECT9hvA
+ */
+
+import testConstants from '../../utilities/common/test-constants';
+import {UserFactory} from '../../utilities/common/user-factory';
+import {Contributor} from '../../utilities/user/contributor';
+import {CurriculumAdmin} from '../../utilities/user/curriculum-admin';
+import {ExplorationEditor} from '../../utilities/user/exploration-editor';
+import {LoggedInUser} from '../../utilities/user/logged-in-user';
+import {TopicManager} from '../../utilities/user/topic-manager';
+import {TranslationReviewer} from '../../utilities/user/translation-reviewer';
+import {TranslationSubmitter} from '../../utilities/user/translation-submitter';
+
+const ROLES = testConstants.Roles;
+
+describe('Translation Reviewer', function () {
+  let translationReviewer: TranslationReviewer & Contributor & LoggedInUser;
+  let translationSubmitter: TranslationSubmitter & Contributor & LoggedInUser;
+  let curriculumAdm: CurriculumAdmin & ExplorationEditor & TopicManager;
+
+  beforeAll(async function () {
+    // Create all users.
+    translationSubmitter = await UserFactory.createNewUser(
+      'translationsubmitter',
+      'translationsubmitter@example.com'
+    );
+
+    // Translation reviewer is given Arabic review rights.
+    translationReviewer = await UserFactory.createNewUser(
+      'translationreviewer',
+      'translationreviewer@example.com',
+      [ROLES.TRANSLATION_REVIEWER],
+      'ar'
+    );
+
+    curriculumAdm = await UserFactory.createNewUser(
+      'curriculumAdm',
+      'curriculumAdm@example.com',
+      [ROLES.CURRICULUM_ADMIN]
+    );
+
+    // Create and publish an exploration with 2 cards.
+    const explorationId =
+      await curriculumAdm.createAndPublishExplorationWithCards(
+        'First Exploration'
+      );
+
+    // Set up topic, skill, story, chapter, and classroom.
+    await curriculumAdm.navigateToTopicAndSkillsDashboardPage();
+    await curriculumAdm.createAndPublishTopic(
+      'Test Topic',
+      'Test Sub-topic',
+      'Test Skill'
+    );
+    await curriculumAdm.createAndPublishStoryWithChapter(
+      'Test Story',
+      'test-story',
+      'First Chapter',
+      explorationId as string,
+      'Test Topic'
+    );
+
+    await curriculumAdm.createAndPublishClassroom(
+      'Math',
+      'math-classroom',
+      'Test Topic'
+    );
+
+    // Translation submitter submits translations in Arabic.
+    await translationSubmitter.navigateToContributorDashboardUsingProfileDropdown();
+    await translationSubmitter.switchToTabInContributionDashboard(
+      'Translate Text'
+    );
+    await translationSubmitter.selectLanguageFilter('العربية (Arabic)');
+
+    await translationSubmitter.clickOnTranslateButtonInTranslateTextTab(
+      'First Chapter',
+      'Test Story'
+    );
+    await translationSubmitter.typeTextForRTE('محتوى البطاقة 0');
+    await translationSubmitter.clickOnElementWithText(
+      'Save and translate another'
+    );
+    await translationSubmitter.clickOnSkipTranslationButton();
+    await translationSubmitter.typeTextForRTE('محتوى البطاقة 1');
+    await translationSubmitter.clickOnElementWithText('Save and close');
+
+    // Translation reviewer reviews and accepts the submitted translations.
+    await translationReviewer.navigateToContributorDashboardUsingProfileDropdown();
+    await translationReviewer.clickOnTranslateButtonInTranslateTextTabInTranslationReview(
+      'First Chapter',
+      'Test Story'
+    );
+    await translationReviewer.startTranslationReview(
+      'محتوى البطاقة 0',
+      'Test Topic / Test Story'
+    );
+    // Accept both card translations.
+    await translationReviewer.submitTranslationReview('accept');
+    await translationReviewer.submitTranslationReview('accept');
+
+    await translationReviewer.switchToTabInContributionDashboard(
+      'My Contributions'
+    );
+  }, 900000);
+
+  it('should be able to check contribution stats', async function () {
+    // Navigate to Contribution Stats and select Translation Reviews.
+    await translationReviewer.navigateToTabInMyContributions(
+      'Contribution Stats'
+    );
+    await translationReviewer.selectContributionTypeInContributionDashboard(
+      'Translation Reviews'
+    );
+
+    // Verify the stats table row contains the expected data.
+    // Column order for translation reviews: Date | Topic | Reviewed Cards |
+    // Reviewed Word Count | Accepted Cards | Accepted Word Count.
+    await translationReviewer.expectContributionTableToContainRow([
+      null, // Date — changes every run.
+      'Test Topic', // Topic.
+      '2', // Reviewed cards (both cards submitted were reviewed).
+      null, // Reviewed word count can vary by card content.
+      '2', // Accepted cards (both cards were accepted).
+      null, // Accepted word count can vary by card content.
+    ]);
+  });
+
+  it('should be able to download a contribution certificate', async function () {
+    // TODO(#22743): The "Download Certificate" button is only shown for
+    // the "Translation Contributions" stats view, not "Translation Reviews".
+    // A reviewer-only account has no contribution data to trigger the button.
+    // Once the certificate download issue is resolved and the UI is updated
+    // to support reviewer certificates, add assertions here.
+  });
+
+  it('should be able to check badges earned', async function () {
+    await translationReviewer.navigateToTabInMyContributions('Badges');
+    // Select Translation type in mobile view (desktop shows all badges).
+    await translationReviewer.selectBadgeTypeInMobileView('Translation');
+    // Should show a badge for 2 translation reviews (both cards accepted).
+    // The badge value '1' is the threshold level of the first badge.
+    await translationReviewer.expectBadgesToContain('1', 'Review', 'العربية');
+    // Verify the tooltip on the first locked (next achievable) badge.
+    // With 2 reviews done and next threshold at 10: 10 - 2 = 8 more needed.
+    await translationReviewer.expectLockedBadgeTooltipText(
+      '8 more reviews to achieve this badge'
+    );
+  });
+
+  afterAll(async function () {
+    await UserFactory.closeAllBrowsers();
+  });
+});

--- a/core/tests/puppeteer-acceptance-tests/specs/translation-submitter/check-contribution-stats-download-certificate-and-badges.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/translation-submitter/check-contribution-stats-download-certificate-and-badges.spec.ts
@@ -1,0 +1,147 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Acceptance test for translation submitter contribution stats,
+ * certificate, and badges.
+ *
+ * Feature: TS.CD - Check contribution stats, download certificate and badges.
+ * Related issue: https://github.com/oppia/oppia/issues/16989
+ * Testing plan:
+ * https://docs.google.com/spreadsheets/d/1BKcrqmFzfjpexiKb3geIGoxV3Gfm6IqzNvAlECT9hvA
+ */
+
+import testConstants from '../../utilities/common/test-constants';
+import {UserFactory} from '../../utilities/common/user-factory';
+import {Contributor} from '../../utilities/user/contributor';
+import {CurriculumAdmin} from '../../utilities/user/curriculum-admin';
+import {ExplorationEditor} from '../../utilities/user/exploration-editor';
+import {LoggedInUser} from '../../utilities/user/logged-in-user';
+import {TopicManager} from '../../utilities/user/topic-manager';
+import {TranslationReviewer} from '../../utilities/user/translation-reviewer';
+import {TranslationSubmitter} from '../../utilities/user/translation-submitter';
+
+const ROLES = testConstants.Roles;
+
+describe('Translation Submitter', function () {
+  let translationSubmitter: TranslationSubmitter & Contributor & LoggedInUser;
+  let curriculumAdm: CurriculumAdmin & ExplorationEditor & TopicManager;
+  let translationReviewer: TranslationReviewer & Contributor & LoggedInUser;
+
+  beforeAll(async function () {
+    translationSubmitter = await UserFactory.createNewUser(
+      'translationsubmitter',
+      'translationsubmitter@example.com'
+    );
+
+    curriculumAdm = await UserFactory.createNewUser(
+      'curriculumAdm',
+      'curriculumAdm@example.com',
+      [ROLES.CURRICULUM_ADMIN]
+    );
+
+    translationReviewer = await UserFactory.createNewUser(
+      'translationreviewer',
+      'translationreviewer@example.com',
+      [ROLES.TRANSLATION_REVIEWER],
+      'ar'
+    );
+
+    const explorationId =
+      await curriculumAdm.createAndPublishExplorationWithCards(
+        'First Exploration'
+      );
+
+    await curriculumAdm.navigateToTopicAndSkillsDashboardPage();
+    await curriculumAdm.createAndPublishTopic(
+      'Test Topic',
+      'Test Sub-topic',
+      'Test Skill'
+    );
+    await curriculumAdm.createAndPublishStoryWithChapter(
+      'Test Story',
+      'test-story',
+      'First Chapter',
+      explorationId as string,
+      'Test Topic'
+    );
+
+    await curriculumAdm.createAndPublishClassroom(
+      'Math',
+      'math-classroom',
+      'Test Topic'
+    );
+
+    await translationSubmitter.navigateToContributorDashboardUsingProfileDropdown();
+    await translationSubmitter.switchToTabInContributionDashboard(
+      'Translate Text'
+    );
+    await translationSubmitter.selectLanguageFilter('العربية (Arabic)');
+
+    await translationSubmitter.clickOnTranslateButtonInTranslateTextTab(
+      'First Chapter',
+      'Test Story'
+    );
+    await translationSubmitter.typeTextForRTE('محتوى البطاقة 0');
+    await translationSubmitter.clickOnElementWithText(
+      'Save and translate another'
+    );
+    await translationSubmitter.clickOnSkipTranslationButton();
+    await translationSubmitter.typeTextForRTE('محتوى البطاقة 1');
+    await translationSubmitter.clickOnElementWithText('Save and close');
+
+    await translationSubmitter.switchToTabInContributionDashboard(
+      'My Contributions'
+    );
+  }, 900000);
+
+  it('should be able to check contribution stats', async function () {
+    await translationSubmitter.navigateToTabInMyContributions(
+      'Contribution Stats'
+    );
+    await translationSubmitter.selectContributionTypeInContributionDashboard(
+      'Translation Contributions'
+    );
+    await translationSubmitter.expectContributionTableToContainRow([
+      null,
+      'Test Topic',
+      '0',
+      '0',
+    ]);
+  });
+
+  it('should be able to download a contribution certificate', async function () {
+    // TODO(#22743): Certificate download does not work when the "To" date is
+    // today and the only contribution was made today. Once that issue is
+    // resolved, add assertions to verify the downloaded file here.
+  });
+
+  it('should be able to check badges earned', async function () {
+    await translationSubmitter.navigateToTabInMyContributions('Badges');
+    await translationSubmitter.selectBadgeTypeInMobileView('Translation');
+    await translationSubmitter.selectBadgeLanguageInPanel('العربية (Arabic)');
+    await translationSubmitter.expectBadgesToContain(
+      '1',
+      'Submission',
+      'العربية'
+    );
+    await translationSubmitter.expectLockedBadgeTooltipText(
+      '8 more submissions to achieve this badge'
+    );
+  });
+
+  afterAll(async function () {
+    await UserFactory.closeAllBrowsers();
+  });
+});

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -352,12 +352,10 @@ export class Contributor extends ExplorationEditor {
       ? `${mobileBadgeContainerSelector} ${lockedBadgeContainerSelector}`
       : `${desktopBadgeContainerSelector} ${lockedBadgeContainerSelector}`;
     await this.expectElementToBeVisible(viewBasedBadgeContainerSelector);
-    // Hover over the first locked badge to trigger the ngbPopover.
     const lockedBadge = await this.page.$(viewBasedBadgeContainerSelector);
     if (!lockedBadge) {
       throw new Error('No locked badge found.');
     }
-    // Use page.mouse.move() for more reliable hover triggering in headless mode.
     const boundingBox = await lockedBadge.boundingBox();
     if (!boundingBox) {
       throw new Error('Could not get bounding box for locked badge.');
@@ -366,7 +364,7 @@ export class Contributor extends ExplorationEditor {
       boundingBox.x + boundingBox.width / 2,
       boundingBox.y + boundingBox.height / 2
     );
-    // Wait for the popover to appear (ngbPopover may take a moment to render).
+
     await this.page.waitForSelector(popoverBodySelector, {
       visible: true,
       timeout: 60000,
@@ -381,12 +379,10 @@ export class Contributor extends ExplorationEditor {
    * Selects a language from the language dropdown in the badges panel.
    * Only applies to the desktop view; on mobile, the selectBadgeTypeInMobileView
    * selects the language separately.
-   * @param {string} language - Display name of the language to select, e.g. 'العربية'.
+   * @param {string} language - Display name of the language to select.
    */
   async selectBadgeLanguageInPanel(language: string): Promise<void> {
     if (this.isViewportAtMobileWidth()) {
-      // In mobile view, use the mobile language selector (also uses
-      // topicOptionSelector / topicSelector).
       await this.clickOnElementWithSelector(topicSelector);
       await this.expectElementToBeVisible(topicOptionSelector);
       const optionXPath = `//*[contains(@class, 'e2e-test-topic-selector-option') and contains(text(), '${language}')]`;
@@ -398,9 +394,6 @@ export class Contributor extends ExplorationEditor {
       }
       await optionEl.click();
     } else {
-      // Desktop view: the language selector in the badge panel is inside
-      // `.e2e-test-desktop-badge-container`. We scope the selector to it
-      // to avoid accidentally clicking a hidden mobile element.
       const desktopBadgeSelector = `${desktopBadgeContainerSelector} .e2e-test-topic-selector-selected`;
       await this.waitForElementToStabilize(desktopBadgeSelector);
       const languageSelectorEl = await this.page.$(desktopBadgeSelector);

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -44,6 +44,8 @@ const badgeSelector = '.e2e-test-badge';
 const badgeValueSelector = '.e2e-test-badge-value';
 const badgeCaptionSelector = '.e2e-test-badge-caption';
 const badgeLanguageSelector = '.e2e-test-badge-language';
+const lockedBadgeContainerSelector = '.locked-badge-container';
+const popoverBodySelector = '.popover-body';
 
 const topicSelector = '.e2e-test-topic-selector';
 const selectedTopicSelector = '.e2e-test-topic-selector-selected';
@@ -337,6 +339,89 @@ export class Contributor extends ExplorationEditor {
     }
     if (!badge) {
       throw new Error('Badge not found.');
+    }
+  }
+
+  /**
+   * Hovers over the first locked badge in the badge panel and verifies the
+   * ngbPopover tooltip text matches the expected string.
+   * @param {string} expectedText - The expected popover text.
+   */
+  async expectLockedBadgeTooltipText(expectedText: string): Promise<void> {
+    const viewBasedBadgeContainerSelector = this.isViewportAtMobileWidth()
+      ? `${mobileBadgeContainerSelector} ${lockedBadgeContainerSelector}`
+      : `${desktopBadgeContainerSelector} ${lockedBadgeContainerSelector}`;
+    await this.expectElementToBeVisible(viewBasedBadgeContainerSelector);
+    // Hover over the first locked badge to trigger the ngbPopover.
+    const lockedBadge = await this.page.$(viewBasedBadgeContainerSelector);
+    if (!lockedBadge) {
+      throw new Error('No locked badge found.');
+    }
+    // Use page.mouse.move() for more reliable hover triggering in headless mode.
+    const boundingBox = await lockedBadge.boundingBox();
+    if (!boundingBox) {
+      throw new Error('Could not get bounding box for locked badge.');
+    }
+    await this.page.mouse.move(
+      boundingBox.x + boundingBox.width / 2,
+      boundingBox.y + boundingBox.height / 2
+    );
+    // Wait for the popover to appear (ngbPopover may take a moment to render).
+    await this.page.waitForSelector(popoverBodySelector, {
+      visible: true,
+      timeout: 60000,
+    });
+    const popoverText = await this.page.$eval(popoverBodySelector, el =>
+      el.textContent?.trim()
+    );
+    expect(popoverText).toBe(expectedText);
+  }
+
+  /**
+   * Selects a language from the language dropdown in the badges panel.
+   * Only applies to the desktop view; on mobile, the selectBadgeTypeInMobileView
+   * selects the language separately.
+   * @param {string} language - Display name of the language to select, e.g. 'العربية'.
+   */
+  async selectBadgeLanguageInPanel(language: string): Promise<void> {
+    if (this.isViewportAtMobileWidth()) {
+      // In mobile view, use the mobile language selector (also uses
+      // topicOptionSelector / topicSelector).
+      await this.clickOnElementWithSelector(topicSelector);
+      await this.expectElementToBeVisible(topicOptionSelector);
+      const optionXPath = `//*[contains(@class, 'e2e-test-topic-selector-option') and contains(text(), '${language}')]`;
+      const optionEl = await this.page.waitForXPath(optionXPath);
+      if (!optionEl) {
+        throw new Error(
+          `Language option '${language}' not found in mobile panel.`
+        );
+      }
+      await optionEl.click();
+    } else {
+      // Desktop view: the language selector in the badge panel is inside
+      // `.e2e-test-desktop-badge-container`. We scope the selector to it
+      // to avoid accidentally clicking a hidden mobile element.
+      const desktopBadgeSelector = `${desktopBadgeContainerSelector} .e2e-test-topic-selector-selected`;
+      await this.waitForElementToStabilize(desktopBadgeSelector);
+      const languageSelectorEl = await this.page.$(desktopBadgeSelector);
+      if (!languageSelectorEl) {
+        throw new Error('No selector found for language in badge panel.');
+      }
+      await languageSelectorEl.click();
+      await this.expectElementToBeVisible(topicOptionSelector);
+      const options = await this.page.$$(topicOptionSelector);
+      let found = false;
+      for (const option of options) {
+        const text = await option.evaluate(el => el.textContent?.trim());
+        if (text === language) {
+          await option.click();
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        throw new Error(`Language '${language}' not found in badge panel.`);
+      }
     }
   }
 


### PR DESCRIPTION
## Overview


1. This PR fixes part of #16989.
2. This PR does the following: Adds a complete Acceptance  test suite for the **Translation Submitter** 
                                                Adds a complete Acceptance  test suite for the **Translation Reviewer** 
                                                Updates the contributor . ts
3.  NA
## Essential Checklist


- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Passing CI tests


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
