### PR TITLE
bug #20694: Search bar moves up and down when typing

### DIFF
--- a/core/templates/pages/library-page/library-page.component.html
+++ b/core/templates/pages/library-page/library-page.component.html
@@ -77,7 +77,7 @@
   </div>
 </div>
 <div class="oppia-library-container d-flex e2e-test-library-container e2e-test-community-library">
-  <div class="oppia-library-container-inner m-auto">
+  <div class="oppia-library-container-inner mx-auto">
     <div>
       <div class="oppia-exp-summary-tiles-container" *ngIf="pageMode === LIBRARY_PAGE_MODES.SEARCH">
         <oppia-search-results></oppia-search-results>


### PR DESCRIPTION
The search bar was vertically centered due to the m-auto class on a flex container child. Changed m-auto to mx-auto so that auto margins only apply horizontally, keeping the search bar at the top regardless of the number of search results.

## Overview

This PR fixes issue #20694.

The search bar on the community library page was moving up and down while typing. This happened because the element was vertically centered due to the use of the `m-auto` class inside a flex container, causing its position to shift depending on the number of search results.

## What this PR does

* Replaces `m-auto` with `mx-auto` in the search bar container.
* Ensures that auto margins are only applied horizontally.
* Keeps the search bar fixed at the top of the page during typing, regardless of content changes.

## Root Cause

The bug occurred because `m-auto` applies automatic margins on all sides, including vertical margins. In a flex container, this caused the search bar to be vertically centered dynamically, leading to the observed movement when the results list changed.

## Testing

To reproduce the bug:

1. Create at least 5 explorations.
2. Navigate to the community library page.
3. Start typing in the search bar.
4. Observe the search bar moving up and down.

After the fix:

* The search bar remains fixed at the top while typing.
* No vertical movement is observed regardless of the number of results.

## Conclusion

The issue has been resolved and the search bar now behaves as expected, providing a stable and consistent user experience.
