### PR TITLE
Fix #25559: Batch fetch explorations in feedback email task

### DIFF
--- a/core/controllers/tasks.py
+++ b/core/controllers/tasks.py
@@ -57,15 +57,18 @@ class UnsentFeedbackEmailHandler(
 
         feedback_services.update_feedback_email_retries_transactional(user_id)
 
+        unique_exp_ids = list({ref.entity_id for ref in references})
+        explorations_by_id = exp_fetchers.get_multiple_explorations_by_id(
+            unique_exp_ids
+        )
+
         messages: Dict[str, email_manager.FeedbackMessagesDict] = {}
         for reference in references:
             message = feedback_services.get_message(
                 reference.thread_id, reference.message_id
             )
 
-            exploration = exp_fetchers.get_exploration_by_id(
-                reference.entity_id
-            )
+            exploration = explorations_by_id[reference.entity_id]
 
             message_text = message.text
             if len(message_text) > 200:

--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -209,6 +209,78 @@ class TasksTests(test_utils.EmailTestBase):
                 platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS,
                 'noreply@example.com',
             ),
+        ]
+    )
+    def test_feedback_email_groups_messages_from_multiple_explorations(
+        self,
+    ) -> None:
+        """Tests that UnsentFeedbackEmailHandler correctly groups messages
+        from multiple explorations into a single email, verifying the
+        batch-fetch path where references span more than one exploration.
+        """
+        exploration_b = self.save_new_default_exploration(
+            'B', self.editor_id, title='Title B'
+        )
+
+        with self.can_send_feedback_email_ctx:
+            # Create one feedback thread on each exploration from user A.
+            feedback_services.create_thread(
+                feconf.ENTITY_TYPE_EXPLORATION,
+                self.exploration.id,
+                self.user_id_a,
+                'subject for A',
+                'message in A',
+            )
+            feedback_services.create_thread(
+                feconf.ENTITY_TYPE_EXPLORATION,
+                exploration_b.id,
+                self.user_id_a,
+                'subject for B',
+                'message in B',
+            )
+
+            # No email sent yet before tasks run.
+            mock_email_messages = self._get_sent_email_messages(
+                self.EDITOR_EMAIL
+            )
+            self.assertEqual(len(mock_email_messages), 0)
+
+            # Flush the pending email tasks.
+            self.process_and_flush_pending_tasks()
+            mock_email_messages = self._get_sent_email_messages(
+                self.EDITOR_EMAIL
+            )
+
+            # Both messages should be grouped into one email to the editor.
+            self.assertEqual(len(mock_email_messages), 1)
+            expected_message = (
+                'Hi editor,\n\nYou\'ve received 2 new messages on your'
+                ' Oppia explorations:\n- Title:\n- message in A'
+                '\n- Title B:\n- message in B'
+                '\nYou can view and reply to your messages from your'
+                ' dashboard.\n\nThanks, and happy teaching!\n\nBest'
+                ' wishes,\nThe Oppia Team\n\nYou can change your email'
+                ' preferences via the Preferences page.'
+            )
+            self.assertEqual(mock_email_messages[0].body, expected_message)
+
+    @test_utils.set_platform_parameters(
+        [
+            (platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS, True),
+            (platform_parameter_list.ParamName.EMAIL_FOOTER, EMAIL_FOOTER),
+            (platform_parameter_list.ParamName.EMAIL_SENDER_NAME, 'sender'),
+            (
+                platform_parameter_list.ParamName.ADMIN_EMAIL_ADDRESS,
+                'testadmin@example.com',
+            ),
+            (
+                platform_parameter_list.ParamName.SYSTEM_EMAIL_ADDRESS,
+                'system@example.com',
+            ),
+            (
+                platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS,
+                'noreply@example.com',
+            ),
             (
                 platform_parameter_list.ParamName.OPPIA_SITE_URL_FOR_EMAILS,
                 'http://localhost:8181',


### PR DESCRIPTION
## Overview

1. This PR fixes https://github.com/oppia/oppia/issues/25559.

2. This PR does the following: Replaces N sequential `get_exploration_by_id` calls inside `UnsentFeedbackEmailHandler.post` with a single upfront `get_multiple_explorations_by_id` call, reducing datastore RPCs from O(N references) to one batched multi-get (with cache layer). A new test `test_feedback_email_groups_messages_from_multiple_explorations` is added to verify that references spanning multiple explorations are correctly batch-fetched and grouped into a single digest email.

3. N/A — this is a performance improvement, not a bug fix.

---

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- **PR title:** `Perf: Batch-fetch explorations in UnsentFeedbackEmailHandler to reduce datastore RPCs`
- [x] I have assigned the correct reviewers to this PR.

---

## Proof that changes are correct

No proof of changes needed because this is a backend-only performance improvement to a Cloud Tasks handler and no user-facing UI changes.

No screenshots or videos for desktop, mobile, or Arabic are applicable.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.