### PR TITLE
fix: Corrected 'occurred' spelling across backend scripts and logs fo…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5465,7 +5465,7 @@ Bug fixes
 * Fix part of #6159: Fix revert exploration method (#6575)
 * Fix few translation tab related issues. (#6571)
 * Fix #6538: Adds a proper title for landing pages. (#6539)
-* Fix #6181:Removed the exception which occured during clearing search index (#6518)
+* Fix #6181:Removed the exception which occurred during clearing search index (#6518)
 * Fix issues with New Structures (#6506)
 * Fix #6383: Added regex to validate return_url in signup page (#6498)
 * Fix #6426: Added regex check for exploration id & nodes now can be saved with null exploration ids. (#6470)

--- a/core/controllers/contributor_dashboard.py
+++ b/core/controllers/contributor_dashboard.py
@@ -712,7 +712,7 @@ class MachineTranslationStateTextsHandler(
             dict('translated_texts': dict(str, str|None))
 
             A dictionary containing the translated texts stored as a mapping
-                from content ID to the translated text. If an error occured
+                from content ID to the translated text. If an error occurred
                 during retrieval of some content translations, but not others,
                 failed translations are mapped to None.
 

--- a/scripts/check_backend_test_coverage_test.py
+++ b/scripts/check_backend_test_coverage_test.py
@@ -88,7 +88,7 @@ class CheckOverallBackendTestCoverageTests(test_utils.GenericTestBase):
     def test_failure_to_execute_coverage_command_throws_error(self) -> None:
         class MockProcess:
             returncode = 1
-            stdout = 'Some error occured.'
+            stdout = 'Some error occurred.'
             stderr = 'Some error.'
 
         def mock_subprocess_run(  # pylint: disable=unused-argument
@@ -114,7 +114,7 @@ class CheckOverallBackendTestCoverageTests(test_utils.GenericTestBase):
         with swap_subprocess_run, self.assertRaisesRegex(
             RuntimeError,
             'Failed to calculate coverage because subprocess failed. '
-            '\nOUTPUT: Some error occured.\nERROR: Some error.',
+            '\nOUTPUT: Some error occurred.\nERROR: Some error.',
         ):
             check_backend_test_coverage.main()
 

--- a/scripts/run_backend_tests_test.py
+++ b/scripts/run_backend_tests_test.py
@@ -190,7 +190,7 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
             def communicate(  # pylint: disable=missing-docstring
                 self,
             ) -> Tuple[bytes, bytes]:
-                return (b'', b'Error XYZ occured.')
+                return (b'', b'Error XYZ occurred.')
 
         def mock_popen(  # pylint: disable=unused-argument
             cmd_tokens: List[str], **unsued_kwargs: str
@@ -205,7 +205,7 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
         )
         with swap_popen, self.swap_logs:
             with self.assertRaisesRegex(
-                Exception, 'Error 1\nError XYZ occured.'
+                Exception, 'Error 1\nError XYZ occurred.'
             ):
                 run_backend_tests.run_shell_cmd(self.coverage_exc_list)
 
@@ -703,7 +703,7 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
     def test_failure_in_test_execution_throws_error(self) -> None:
 
         def mock_execute_tasks(*_: str) -> None:
-            raise Exception('XYZ error occured.')
+            raise Exception('XYZ error occurred.')
 
         self.swap_execute_task = self.swap(
             concurrent_task_utils, 'execute_tasks', mock_execute_tasks


### PR DESCRIPTION
## Overview
This PR corrects the misspelling of 'occurred' (previously 'occured') across the codebase to maintain project standards and log consistency.

## Description
During a codebase walkthrough, I identified consistent typos in error strings and documentation. I have corrected these in the following files:
- CHANGELOG
- core/controllers/contributor_dashboard.py
- scripts/check_backend_test_coverage_test.py
- scripts/run_backend_tests_test.py

## Essential Checklist
- [x] I have followed the instructions for making a code change.
- [x] I have confirmed that the changes are what I want to make.
- [x] I have linked the issue that this PR fixes in the "Development" section (N/A).