### PR TITLE
Fix #25534: Update blog URL and open modal links in new tab.

### DIFF
--- a/core/templates/base-components/thanks-for-subscribing-modal.component.html
+++ b/core/templates/base-components/thanks-for-subscribing-modal.component.html
@@ -32,7 +32,7 @@
             </a>
           </div>
           <div class="col-sm-6 read-blog-btn">
-            // Changed blog URL to an updated one
+            
             <a class="btn thanks-read-blog-btn e2e-test-thanks-for-subscribe-read-blog-btn"
             href="https://www.oppia.org/blog"
             target="_blank"

--- a/core/templates/base-components/thanks-for-subscribing-modal.component.html
+++ b/core/templates/base-components/thanks-for-subscribing-modal.component.html
@@ -27,13 +27,16 @@
         </div>
         <div class="row container btn-container mx-0 my-3">
           <div class="col-sm-6 watch-video-btn">
-            <a class="btn thanks-watch-video-btn e2e-test-thanks-for-subscribe-watch-video-btn" href="https://youtu.be/OConyxG7HaM">
+            <a class="btn thanks-watch-video-btn e2e-test-thanks-for-subscribe-watch-video-btn" href="https://youtu.be/OConyxG7HaM" target="_blank" rel="noopener noreferrer">
               {{ 'I18N_DONATE_PAGE_WATCH_VIDEO_BUTTON_TEXT' | translate }}
             </a>
           </div>
           <div class="col-sm-6 read-blog-btn">
-            <!-- TODO(#16643): Update Blog URL after blog migration is complete -->
-            <a class="btn thanks-read-blog-btn e2e-test-thanks-for-subscribe-read-blog-btn" href="https://medium.com/oppia-org">
+            // Changed blog URL to an updated one
+            <a class="btn thanks-read-blog-btn e2e-test-thanks-for-subscribe-read-blog-btn"
+            href="https://www.oppia.org/blog"
+            target="_blank"
+            rel="noopener noreferrer">
               {{ 'I18N_DONATE_PAGE_READ_BLOG_BUTTON_TEXT' | translate }}
             </a>
           </div>


### PR DESCRIPTION
Overview
This PR fixes #25534.
This PR does the following:
Updates the "Thanks for subscribing" modal to point to the new blog URL after migration.
Updates the modal video so that it opens in a new tab when clicked, improving user experience.
(For bug-fixing PRs only) The original bug occurred because the modal still pointed to the old blog URL and videos opened in the same tab, which could disrupt the user flow.

Essential Checklist
 I have linked the issue that this PR fixes in the "Development" section of the sidebar.
 I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
 I have written tests for my code. (Manual verification is sufficient for this UI change.)
 The PR title starts with:
Fix #25534: Update blog URL and enable video to open in new tab
 I have assigned the correct reviewers to this PR or will leave a comment with the phrase @oppia/core-maintainers PTAL if I can't assign them directly.
Testing doc (for PRs with Beam jobs that modify production server data)
Not applicable — this PR does not affect production server data.
Proof that changes are correct
Verified locally that:
The blog link in the "Thanks for subscribing" modal points to the new blog URL.
The video opens in a new tab when clicked.
The changes do not break other modal functionality or layout.
Tested in desktop and mobile views using browser developer tools.

Note: This is a minor UI change; screenshots/videos are not included because the changes are limited to the modal’s URL and video behavior.