### PR TITLE
Fix #25534: Update blog URL and open links in new tab in thanks modal

### DIFF
--- a/core/templates/base-components/thanks-for-subscribing-modal.component.html
+++ b/core/templates/base-components/thanks-for-subscribing-modal.component.html
@@ -27,13 +27,18 @@
         </div>
         <div class="row container btn-container mx-0 my-3">
           <div class="col-sm-6 watch-video-btn">
-            <a class="btn thanks-watch-video-btn e2e-test-thanks-for-subscribe-watch-video-btn" href="https://youtu.be/OConyxG7HaM">
+            <a class="btn thanks-watch-video-btn e2e-test-thanks-for-subscribe-watch-video-btn" 
+              href="https://youtu.be/OConyxG7HaM" 
+              target="_blank" 
+              rel="noopener">
               {{ 'I18N_DONATE_PAGE_WATCH_VIDEO_BUTTON_TEXT' | translate }}
             </a>
           </div>
           <div class="col-sm-6 read-blog-btn">
-            <!-- TODO(#16643): Update Blog URL after blog migration is complete -->
-            <a class="btn thanks-read-blog-btn e2e-test-thanks-for-subscribe-read-blog-btn" href="https://medium.com/oppia-org">
+            <a class="btn thanks-read-blog-btn e2e-test-thanks-for-subscribe-read-blog-btn" 
+              href="https://www.oppia.org/blog" 
+              target="_blank" 
+              rel="noopener">
               {{ 'I18N_DONATE_PAGE_READ_BLOG_BUTTON_TEXT' | translate }}
             </a>
           </div>


### PR DESCRIPTION
## Overview

1. This PR fixes #25534.
2. This PR does the following: 
   - Updates the outdated Medium blog URL to the new migrated Oppia blog URL (https://www.oppia.org/blog ).
   - Ensures the "Watch Video" and "Read Blog" links in the modal open in a new tab (target="_blank"), so users don’t lose their place on the page.
3. (For bug-fixing PRs only) The original bug occurred because: The blog URL pointed to Medium, and the links lacked target="_blank".

## Essential Checklist

- [x] I have linked the issue that this PR fixes (#25534).
- [x] I have checked the "Files Changed" tab and confirmed the updates.
- [x] The PR title starts with: Fix #25534: Update blog URL and open links in new tab in thanks modal.
- [x] I have left a comment with "@Nik-09 PTAL" because I was unable to assign the reviewer directly.

## Proof that changes are correct

Verified that:
- The blog link now points to https://www.oppia.org/blog
- Both modal links open in a new browser tab.
- Tested locally on desktop and mobile; no regressions observed.

