### PR TITLE
Fix #25534: Update blog URL and open links in new tab in thanks modal

### DIFF
--- a/core/templates/base-components/thanks-for-subscribing-modal.component.html
+++ b/core/templates/base-components/thanks-for-subscribing-modal.component.html
@@ -27,13 +27,18 @@
         </div>
         <div class="row container btn-container mx-0 my-3">
           <div class="col-sm-6 watch-video-btn">
-            <a class="btn thanks-watch-video-btn e2e-test-thanks-for-subscribe-watch-video-btn" href="https://youtu.be/OConyxG7HaM">
+            <a class="btn thanks-watch-video-btn e2e-test-thanks-for-subscribe-watch-video-btn" 
+              href="https://youtu.be/OConyxG7HaM" 
+              target="_blank" 
+              rel="noopener">
               {{ 'I18N_DONATE_PAGE_WATCH_VIDEO_BUTTON_TEXT' | translate }}
             </a>
           </div>
           <div class="col-sm-6 read-blog-btn">
-            <!-- TODO(#16643): Update Blog URL after blog migration is complete -->
-            <a class="btn thanks-read-blog-btn e2e-test-thanks-for-subscribe-read-blog-btn" href="https://medium.com/oppia-org">
+            <a class="btn thanks-read-blog-btn e2e-test-thanks-for-subscribe-read-blog-btn" 
+              href="https://www.oppia.org/blog" 
+              target="_blank" 
+              rel="noopener">
               {{ 'I18N_DONATE_PAGE_READ_BLOG_BUTTON_TEXT' | translate }}
             </a>
           </div>


### PR DESCRIPTION
## Overview

1. This PR fixes #[25534] or fixes part of #[N/A].
2. This PR does the following:
 Updates the subscription modal links in the "Thanks for Subscribing" modal so that the Watch Video button opens the YouTube video in a new tab, and the Read Blog button points to the correct Oppia blog URL (https://www.oppia.org/blog) and opens in a new tab.
3. (For bug-fixing PRs only) The original bug occurred because: 
 The modal had old URLs and the links were not opening in new tabs.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **Update blog URL and open links in new tab in thanks modal** starts with "Fix #25534 : " or "Fix part of #N/A", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)


- [ ] A testing doc has been written: N/A — no production server changes.
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge. N/A

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

No proof of changes needed because this is a UI-only change updating URLs and adding target="_blank" to links. The changes are minimal and straightforward to verify by inspection.

#### Proof of changes on mobile phone

No proof of changes needed because this is a UI-only change updating URLs and adding target="_blank" to links. The changes are minimal and straightforward to verify by inspection.

#### Proof of changes in Arabic language

No proof of changes needed because only URLs and link attributes were changed; no layout or text content was modified.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
