### PR TITLE
Fix navbar layout for long translations

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -619,3 +619,15 @@
     }
   }
 }
+/* Fix for long translation text overflow */
+.oppia-top-navigation-bar .nav-item-links {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.oppia-top-navigation-bar .nav-item-links a {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 150px;
+}


### PR DESCRIPTION
## Overview

This PR fixes the navbar layout issue where longer language translations cause text overlap and break the UI.

## Changes

* Added flex-wrap to navbar container to prevent overlapping
* Applied overflow handling using ellipsis for long text

## Proof

This fix ensures that navbar items no longer overlap when long translation text is used and remain properly aligned.

## Checklist

* [x] The PR fixes #25624
* [x] Changes are minimal and focused
* [x] Code follows existing structure
