### PR TITLE
Fix #21970: Add UserIdByFirebaseAuthId domain object

### DIFF
--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1850,3 +1850,18 @@ class TranslationCoordinatorStats:
             'coordinator_ids': self.coordinator_ids,
             'coordinators_count': self.coordinators_count,
         }
+
+
+class UserIdByFirebaseAuthId:
+    """Domain object for UserIdByFirebaseAuthIdModel."""
+
+    def __init__(self, user_id: str) -> None:
+        self.user_id = user_id
+
+    def validate(self) -> None:
+        if not isinstance(self.user_id, str):
+            raise utils.ValidationError(
+                'Expected user_id to be a string, received %s' % self.user_id
+            )
+        if not self.user_id:
+            raise utils.ValidationError('No user id specified.')

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1859,6 +1859,7 @@ class UserIdByFirebaseAuthId:
         self.user_id = user_id
 
     def validate(self) -> None:
+        """Validates the user_id."""
         if not isinstance(self.user_id, str):
             raise utils.ValidationError(
                 'Expected user_id to be a string, received %s' % self.user_id

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1961,7 +1961,8 @@ class UserContributionRightsUnitTest(test_utils.GenericTestBase):
 class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
     def test_valid_user_id(self) -> None:
         obj = user_domain.UserIdByFirebaseAuthId('abc123')
-        obj.validate()  #  should not raise error
+        # should not raise error
+        obj.validate()
 
     def test_invalid_user_id_type(self) -> None:
         # Here we use MyPy ignore because we are intentionally passing

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1956,3 +1956,23 @@ class UserContributionRightsUnitTest(test_utils.GenericTestBase):
         self.assertFalse(
             user_contribution_rights.can_submit_at_least_one_item()
         )
+
+
+class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
+    def test_valid_user_id(self) -> None:
+        obj = user_domain.UserIdByFirebaseAuthId('abc123')
+        obj.validate()  #  should not raise error
+
+    def test_invalid_user_id_type(self) -> None:
+        obj = user_domain.UserIdByFirebaseAuthId(123)  # type: ignore
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected user_id to be a string'
+        ):
+            obj.validate()
+
+    def test_empty_user_id(self) -> None:
+        obj = user_domain.UserIdByFirebaseAuthId('')
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'No user id specified.'
+        ):
+            obj.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1961,12 +1961,12 @@ class UserContributionRightsUnitTest(test_utils.GenericTestBase):
 class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
     def test_valid_user_id(self) -> None:
         obj = user_domain.UserIdByFirebaseAuthId('abc123')
-        # should not raise error
+        # Should not raise error
         obj.validate()
 
     def test_invalid_user_id_type(self) -> None:
         # Here we use MyPy ignore because we are intentionally passing
-        # an integer to test validation for incorrect type.
+        # An integer to test validation for incorrect type
         # type: ignore[arg-type]
         obj = user_domain.UserIdByFirebaseAuthId(123)
         with self.assertRaisesRegex(

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1975,6 +1975,6 @@ class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
     def test_empty_user_id(self) -> None:
         obj = user_domain.UserIdByFirebaseAuthId('')
         with self.assertRaisesRegex(
-            utils.ValidationError, 'No user id specified.'
+            utils.ValidationError, 'No user id specified'
         ):
             obj.validate()

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1964,6 +1964,8 @@ class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
         obj.validate()  #  should not raise error
 
     def test_invalid_user_id_type(self) -> None:
+        # Here we use MyPy ignore because we are intentionally passing
+        # an integer to test validation for incorrect type.
         # type: ignore[arg-type]
         obj = user_domain.UserIdByFirebaseAuthId(123)
         with self.assertRaisesRegex(

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1964,7 +1964,8 @@ class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
         obj.validate()  #  should not raise error
 
     def test_invalid_user_id_type(self) -> None:
-        obj = user_domain.UserIdByFirebaseAuthId(123)  # type: ignore
+        # type: ignore[arg-type]
+        obj = user_domain.UserIdByFirebaseAuthId(123)
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected user_id to be a string'
         ):

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1961,7 +1961,6 @@ class UserContributionRightsUnitTest(test_utils.GenericTestBase):
 class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
     def test_valid_user_id(self) -> None:
         obj = user_domain.UserIdByFirebaseAuthId('abc123')
-        # Should not raise error
         obj.validate()
 
     def test_invalid_user_id_type(self) -> None:

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1966,7 +1966,7 @@ class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
 
     def test_invalid_user_id_type(self) -> None:
         # Here we use MyPy ignore because we are intentionally passing
-        # An integer to test validation for incorrect type
+        # an integer to test validation for incorrect type
         # type: ignore[arg-type]
         obj = user_domain.UserIdByFirebaseAuthId(123)
         with self.assertRaisesRegex(

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1966,8 +1966,7 @@ class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
     def test_invalid_user_id_type(self) -> None:
         # Here we use MyPy ignore because we are intentionally passing
         # an integer to test validation for incorrect type
-        # type: ignore[arg-type]
-        obj = user_domain.UserIdByFirebaseAuthId(123)
+        obj = user_domain.UserIdByFirebaseAuthId(123)  # type: ignore[arg-type]
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected user_id to be a string'
         ):

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1965,7 +1965,7 @@ class UserIdByFirebaseAuthIdTests(test_utils.TestBase):
 
     def test_invalid_user_id_type(self) -> None:
         # Here we use MyPy ignore because we are intentionally passing
-        # an integer to test validation for incorrect type
+        # an integer to test validation for incorrect type.
         obj = user_domain.UserIdByFirebaseAuthId(123)  # type: ignore[arg-type]
         with self.assertRaisesRegex(
             utils.ValidationError, 'Expected user_id to be a string'


### PR DESCRIPTION
## Overview

1. This PR fixes or fix parts of #21970 
2. This PR does the following: Adds the domain object for UserIdByFirebaseAuthIdModel with validation checks to ensure that user_id is a non-empty string.
3. (For bug-fixing PRs only) N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

![oppia2](https://github.com/user-attachments/assets/c7ecde22-05ab-444b-80a5-a6de0867a893)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
