### PR TITLE
Add Fante language removal audit jobs

### DIFF
--- a/core/jobs/batch_jobs/fante_language_removal_audit_jobs.py
+++ b/core/jobs/batch_jobs/fante_language_removal_audit_jobs.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit jobs for safely removing the Fante (fat) language from Oppia."""
+
+from __future__ import annotations
+
+from core.jobs import base_jobs
+from core.jobs.io import ndb_io
+from core.jobs.types import job_run_result
+from core.platform import models
+
+import apache_beam as beam
+
+MYPY = False
+if MYPY:  # pragma: no cover
+    from mypy_imports import translation_models
+    from mypy_imports import voiceover_models
+
+(translation_models, voiceover_models) = models.Registry.import_models(
+    [models.Names.TRANSLATION, models.Names.VOICEOVER]
+)
+
+FANTE_LANGUAGE_CODE = 'fat'
+
+
+class AuditFanteEntityTranslationsJob(base_jobs.JobBase):
+    """Audits EntityTranslationsModel for any Fante (fat) language entries."""
+
+    def run(self) -> beam.PCollection[job_run_result.JobRunResult]:
+        return (
+            self.pipeline
+            | 'Get all EntityTranslationsModels'
+            >> ndb_io.GetModels(
+                translation_models.EntityTranslationsModel.get_all(
+                    include_deleted=False
+                )
+            )
+            | 'Filter Fante translations'
+            >> beam.Filter(lambda m: m.language_code == FANTE_LANGUAGE_CODE)
+            | 'Report found Fante translations'
+            >> beam.Map(
+                lambda m: job_run_result.JobRunResult.as_stdout(
+                    'FOUND: EntityTranslationsModel id=%s '
+                    'has language_code=%s' % (m.id, m.language_code)
+                )
+            )
+        )
+
+
+class AuditFanteEntityVoiceoversJob(base_jobs.JobBase):
+    """Audits EntityVoiceoversModel for any Fante (fat-GH) accent entries."""
+
+    def run(self) -> beam.PCollection[job_run_result.JobRunResult]:
+        return (
+            self.pipeline
+            | 'Get all EntityVoiceoversModels'
+            >> ndb_io.GetModels(
+                voiceover_models.EntityVoiceoversModel.get_all(
+                    include_deleted=False
+                )
+            )
+            | 'Filter Fante voiceovers'
+            >> beam.Filter(
+                lambda m: FANTE_LANGUAGE_CODE in m.language_codes_mapping
+            )
+            | 'Report found Fante voiceovers'
+            >> beam.Map(
+                lambda m: job_run_result.JobRunResult.as_stdout(
+                    'FOUND: EntityVoiceoversModel id=%s '
+                    'has Fante language_codes_mapping' % m.id
+                )
+            )
+        )
+
+
+class AuditFanteMachineTranslationsJob(base_jobs.JobBase):
+    """Audits MachineTranslationModel for any Fante (fat) language entries."""
+
+    def run(self) -> beam.PCollection[job_run_result.JobRunResult]:
+        return (
+            self.pipeline
+            | 'Get all MachineTranslationModels'
+            >> ndb_io.GetModels(
+                translation_models.MachineTranslationModel.get_all(
+                    include_deleted=False
+                )
+            )
+            | 'Filter Fante machine translations'
+            >> beam.Filter(
+                lambda m: (
+                    m.source_language_code == FANTE_LANGUAGE_CODE
+                    or m.target_language_code == FANTE_LANGUAGE_CODE
+                )
+            )
+            | 'Report found Fante machine translations'
+            >> beam.Map(
+                lambda m: job_run_result.JobRunResult.as_stdout(
+                    'FOUND: MachineTranslationModel id=%s '
+                    'references language_code=%s' % (m.id, FANTE_LANGUAGE_CODE)
+                )
+            )
+        )

--- a/core/jobs/batch_jobs/fante_language_removal_audit_jobs_test.py
+++ b/core/jobs/batch_jobs/fante_language_removal_audit_jobs_test.py
@@ -1,0 +1,152 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Fante language removal audit jobs."""
+
+from __future__ import annotations
+
+from core.jobs.batch_jobs import fante_language_removal_audit_jobs
+from core.jobs.types import job_run_result
+from core.platform import models
+from core.tests import test_utils
+
+MYPY = False
+if MYPY:  # pragma: no cover
+    from mypy_imports import translation_models
+    from mypy_imports import voiceover_models
+
+(translation_models, voiceover_models) = models.Registry.import_models(
+    [models.Names.TRANSLATION, models.Names.VOICEOVER]
+)
+
+
+class AuditFanteEntityTranslationsJobTest(test_utils.JobTestBase):
+
+    JOB_CLASS = (
+        fante_language_removal_audit_jobs.AuditFanteEntityTranslationsJob
+    )
+
+    def test_no_fante_translations_reports_nothing(self) -> None:
+        translation_models.EntityTranslationsModel.create_new(
+            entity_type='exploration',
+            entity_id='exp1',
+            entity_version=1,
+            language_code='en',
+            translations={},
+        ).put()
+        self.assert_job_output_is_empty()
+
+    def test_fante_translation_is_reported(self) -> None:
+        model = translation_models.EntityTranslationsModel.create_new(
+            entity_type='exploration',
+            entity_id='exp2',
+            entity_version=1,
+            language_code='fat',
+            translations={},
+        )
+        model.put()
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult.as_stdout(
+                    'FOUND: EntityTranslationsModel id=%s '
+                    'has language_code=fat' % model.id
+                )
+            ]
+        )
+
+
+class AuditFanteEntityVoiceoversJobTest(test_utils.JobTestBase):
+
+    JOB_CLASS = fante_language_removal_audit_jobs.AuditFanteEntityVoiceoversJob
+
+    def test_no_fante_voiceovers_reports_nothing(self) -> None:
+        model = voiceover_models.EntityVoiceoversModel.create_new(
+            entity_type='exploration',
+            entity_id='exp1',
+            entity_version=1,
+            language_accent_code='en-US',
+        )
+        model.language_codes_mapping = {'en': {'en-US': False}}
+        model.put()
+        self.assert_job_output_is_empty()
+
+    def test_fante_voiceover_is_reported(self) -> None:
+        model = voiceover_models.EntityVoiceoversModel.create_new(
+            entity_type='exploration',
+            entity_id='exp2',
+            entity_version=1,
+            language_accent_code='fat-GH',
+        )
+        model.language_codes_mapping = {'fat': {'fat-GH': True}}
+        model.put()
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult.as_stdout(
+                    'FOUND: EntityVoiceoversModel id=%s '
+                    'has Fante language_codes_mapping' % model.id
+                )
+            ]
+        )
+
+
+class AuditFanteMachineTranslationsJobTest(test_utils.JobTestBase):
+
+    JOB_CLASS = (
+        fante_language_removal_audit_jobs.AuditFanteMachineTranslationsJob
+    )
+
+    def test_no_fante_machine_translations_reports_nothing(self) -> None:
+        translation_models.MachineTranslationModel.create_new(
+            source_language_code='en',
+            target_language_code='fr',
+            source_text='Hello',
+            translated_text='Bonjour',
+        ).put()
+        self.assert_job_output_is_empty()
+
+    def test_fante_as_target_language_is_reported(self) -> None:
+        model = translation_models.MachineTranslationModel.create_new(
+            source_language_code='en',
+            target_language_code='fat',
+            source_text='Hello',
+            translated_text='Hello in Fante',
+        )
+        model.put()
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult.as_stdout(
+                    'FOUND: MachineTranslationModel id=%s '
+                    'references language_code=fat' % model.id
+                )
+            ]
+        )
+
+    def test_fante_as_source_language_is_reported(self) -> None:
+        model = translation_models.MachineTranslationModel.create_new(
+            source_language_code='fat',
+            target_language_code='en',
+            source_text='Hello in Fante',
+            translated_text='Hello',
+        )
+        model.put()
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult.as_stdout(
+                    'FOUND: MachineTranslationModel id=%s '
+                    'references language_code=fat' % model.id
+                )
+            ]
+        )


### PR DESCRIPTION
## Overview

1. This PR fixes part of #18521.
2. This PR adds 3 Apache Beam audit jobs to safely audit the Fante (fat) language before removal, as part of the process defined in #18521:
   - `AuditFanteEntityTranslationsJob` — scans EntityTranslationsModel for language_code='fat'
   - `AuditFanteEntityVoiceoversJob` — scans EntityVoiceoversModel for 'fat' in language_codes_mapping
   - `AuditFanteMachineTranslationsJob` — scans MachineTranslationModel for source/target language_code='fat'
   Full unit tests are included for all 3 jobs.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

No proof of changes needed because these are backend-only Beam audit jobs with no user-facing interface changes.