### PR TITLE
fix: correct LinkedIn reference link casing in README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -28,7 +28,7 @@ Please refer to the [Installing Oppia page](https://github.com/oppia/oppia/wiki/
 
 The Oppia project is built by the community for the community. We welcome contributions from everyone, especially new contributors.
 
-You can help with Oppia's development in many ways, including art, coding, design and documentation.
+You can help with Oppia's development in many ways, including art, coding, design, and documentation.
 
 - **Developers**: please see [this wiki page](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#setting-things-up) for instructions on how to set things up and commit changes.
 - **All other contributors**: please see our [general contributor guidelines](https://github.com/oppia/oppia/wiki).
@@ -55,8 +55,7 @@ The Oppia code is released under the [Apache v2 license](https://github.com/oppi
 [<img height="30" src="https://img.shields.io/badge/twitter-1DA1F2.svg?&style=for-the-badge&logo=twitter&logoColor=white" />][twitter] [<img height="30" src="https://img.shields.io/badge/linkedin-0077B5.svg?&style=for-the-badge&logo=linkedin&logoColor=white" />][LinkedIn] [<img height="30" src = "https://img.shields.io/badge/facebook-1877F2.svg?&style=for-the-badge&logo=facebook&logoColor=white">][Facebook] [<img height="30" src = "https://img.shields.io/badge/medium-12100E.svg?&style=for-the-badge&logo=medium&logoColor=white">][medium] [<img height="30" src = "https://img.shields.io/badge/oppia.org%20youtube-FF0000.svg?&style=for-the-badge&logo=youtube&logoColor=white">][oppia-org-youtube] [<img height="30" src = "https://img.shields.io/badge/oppia%20dev%20youtube-FF0000.svg?&style=for-the-badge&logo=youtube&logoColor=white">][dev-youtube]
 
 [twitter]: https://twitter.com/oppiaorg
-[linkedIn]: https://www.linkedin.com/company/oppia-org/
-[medium]: https://medium.com/@oppia.org
+[LinkedIn]: https://www.linkedin.com/company/oppia-org/[medium]: https://medium.com/@oppia.org
 [facebook]: https://www.facebook.com/oppiaorg/
 [oppia-org-youtube]: https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw
 [dev-youtube]: https://www.youtube.com/channel/UCsrAX-oeqm0-NIQzQrdiUkQ


### PR DESCRIPTION
## Overview
This PR fixes a minor issue in the README file where the LinkedIn reference link had incorrect casing.

## Changes
- Corrected `[linkedIn]` to `[LinkedIn]` in the reference links.
- Ensured consistency with how the link is used in the document.

## Why is this needed?
The incorrect casing could lead to broken or inconsistent reference linking in Markdown.

## Proof of changes
Not required for this PR since it is a documentation-only change.