### PR TITLE
Fix lesson player mobile overflow

### DIFF
--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.css
@@ -46,11 +46,13 @@ oppia-conversation-skin .supplemental-card-parent-container {
 
 .conversation-skin-cards-container {
   align-items: flex-start;
+  box-sizing: border-box;
   display: -webkit-flex;
   display: flex;
   justify-content: center;
   margin: 0 auto;
   max-width: 1400px;
+  overflow-x: clip;
   padding: 56px 14px 0;
   width: 100%;
 }

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/ratings-and-recommendations.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/ratings-and-recommendations.component.html
@@ -59,12 +59,15 @@
       </button>
     </div>
     <div class="conversation-skin-login-secondary-options">
-      <button class="conversation-skin-login-button">
+      <button class="conversation-skin-login-button"
+              (click)="signIn('.conversation-skin-login-button')">
         Already have an account?
-        <span class="conversation-skin-login-button-text" translate="" (click)="signIn('.conversation-skin-login-button-text')">Sign In</span>
+        <span class="conversation-skin-login-button-text">Sign In</span>
       </button>
-      <button class="conversation-skin-hide-sign-up-section-button e2e-test-dismiss-sign-up-section-button">
-        <span class="conversation-skin-hide-sign-up-section-text" translate="I18N_SIGNUP_SECTION_DONT_ASK_ME_AGAIN" (click)="hideSignUpSection()"></span>
+      <button class="conversation-skin-hide-sign-up-section-button e2e-test-dismiss-sign-up-section-button"
+              (click)="hideSignUpSection()">
+        <span class="conversation-skin-hide-sign-up-section-text"
+              translate="I18N_SIGNUP_SECTION_DONT_ASK_ME_AGAIN"></span>
       </button>
     </div>
   </div>

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/tutor-card.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/tutor-card.component.css
@@ -26,8 +26,11 @@ oppia-tutor-card .oppia-learner-view-card {
 
 oppia-tutor-card .oppia-learner-view-card-top-content {
   background-color: rgba(224,242,241,1);
+  box-sizing: border-box;
   border-top-left-radius: 0;
   margin-bottom: 12px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   padding: 12px;
   width: 100%;
 }

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/conversation-display.component.css
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/conversation-display-components/conversation-display.component.css
@@ -18,6 +18,7 @@ oppia-conversation-display .oppia-learner-view-card-top-section {
 }
 
 oppia-conversation-display .oppia-learner-view-card {
+  box-sizing: border-box;
   border-radius: 2px;
   margin-left: 40px ;
   max-width: 100vw;
@@ -28,7 +29,10 @@ oppia-conversation-display .oppia-learner-view-card {
 }
 
 oppia-conversation-display .oppia-learner-view-card-top-content {
+  box-sizing: border-box;
   border-top-left-radius: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   padding: 12px;
   width: 100%;
 }
@@ -170,8 +174,10 @@ oppia-conversation-display .conversation-skin-responses-dropdown-icon-rotated {
 }
 
 oppia-conversation-display .conversation-skin-inline-interaction {
+  box-sizing: border-box;
   border-radius: 8px;
   margin-left: 40px;
+  max-width: calc(100vw - 40px);
   padding: 10px;
   position: relative;
 }
@@ -326,6 +332,7 @@ oppia-conversation-display .oppia-mcq-question-description-text {
 
   oppia-conversation-display .oppia-learner-view-card {
     margin-left: 40px;
+    max-width: calc(100vw - 40px);
     margin-top: 30px;
     padding-bottom: 30px;
   }
@@ -353,6 +360,7 @@ oppia-conversation-display .oppia-mcq-question-description-text {
 
   oppia-conversation-display .oppia-learner-view-card {
     margin-left: 55px;
+    max-width: calc(100vw - 55px);
     margin-top: 30px;
     padding-bottom: 30px;
   }

--- a/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.css
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/conversation-skin-components/new-conversation-skin.component.css
@@ -46,12 +46,14 @@ oppia-new-conversation-skin .new-supplemental-card-parent-container {
 
 .new-conversation-skin-cards-container {
   align-items: flex-start;
+  box-sizing: border-box;
   display: -webkit-flex;
   display: flex;
   justify-content: center;
   margin: 0 auto;
   margin-bottom: 50px;
   margin-top: 100px;
+  overflow-x: clip;
   padding: 56px 14px 0;
   padding-bottom: 50px;
   width: 100%;

--- a/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-page.component.css
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-page.component.css
@@ -27,6 +27,7 @@
   align-items: flex-end;
   display: flex;
   flex: 1;
+  overflow-x: clip;
   z-index: 0;
 }
 


### PR DESCRIPTION
## Overview

1. This PR fixes #23711.
2. This PR does the following: fixes mobile overflow issues in the lesson player by updating conversation card and wrapper styling so that lesson player content stays within the viewport on smaller screens. This prevents unwanted horizontal scrolling on mobile devices.
3. (For bug-fixing PRs only) The original bug occurred because some lesson player conversation card and wrapper elements were not fully constrained to the mobile viewport, which allowed content to overflow horizontally and caused sideways scrolling.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@HardikGoyal2003 PTAL" if I can't assign them directly).

## Proof that changes are correct

<img width="1920" height="949" alt="Screenshot 2026-03-31 101033" src="https://github.com/user-attachments/assets/2013bc44-dccb-436b-9840-cd1bb9c9a24b" />

#### Proof of changes on desktop with slow/throttled network

Will be added.

#### Proof of changes on mobile phone

<img width="1920" height="945" alt="Screenshot 2026-03-31 101952" src="https://github.com/user-attachments/assets/da78b079-5f81-46c8-9fe6-981a7c27b894" />

#### Proof of changes in Arabic language

Will be added.
