### PR TITLE
Fix #25570: Snapshot mismatch on donor page

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -2675,7 +2675,21 @@ export class LoggedOutUser extends BaseUser {
    * because the donor box is an iframe and a third-party service.
    */
   async isDonorBoxVisbleOnDonatePage(): Promise<void> {
-    const donorBox = await this.page.waitForSelector(donorBoxIframe);
+    const donorBox = await this.page.waitForSelector(donorBoxIframe, {
+      visible: true,
+    });
+    await this.page.waitForFunction(
+      selector => {
+        const element = document.querySelector(selector);
+        if (!element) {
+          return false;
+        }
+        const rect = element.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      },
+      {},
+      donorBoxIframe
+    );
     if (!donorBox) {
       throw new Error('The donor box is not visible on the donate page.');
     } else {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -2678,7 +2678,7 @@ export class LoggedOutUser extends BaseUser {
     const donorBox = await this.page.waitForSelector(donorBoxIframe);
     if (!this.isViewportAtMobileWidth()) {
       await this.page.waitForFunction(
-        selector => {
+        (selector: string) => {
           const element = document.querySelector(selector);
           if (!element) {
             return false;

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -2675,26 +2675,51 @@ export class LoggedOutUser extends BaseUser {
    * because the donor box is an iframe and a third-party service.
    */
   async isDonorBoxVisbleOnDonatePage(): Promise<void> {
-    const donorBox = await this.page.waitForSelector(donorBoxIframe, {
-      visible: true,
-    });
-    await this.page.waitForFunction(
-      selector => {
-        const element = document.querySelector(selector);
-        if (!element) {
-          return false;
-        }
-        const rect = element.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      },
-      {},
-      donorBoxIframe
-    );
+    const donorBox = await this.page.waitForSelector(donorBoxIframe);
+    if (!this.isViewportAtMobileWidth()) {
+      await this.page.waitForFunction(
+        selector => {
+          const element = document.querySelector(selector);
+          if (!element) {
+            return false;
+          }
+          const rect = element.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        },
+        {},
+        donorBoxIframe
+      );
+      await this.waitForDonorBoxFrameToLoad();
+    }
     if (!donorBox) {
       throw new Error('The donor box is not visible on the donate page.');
     } else {
       showMessage('The donor box is visible on the donate page.');
     }
+  }
+
+  /**
+   * Waits for the DonorBox iframe to load its frame URL.
+   * This avoids taking screenshots before the external content renders.
+   */
+  private async waitForDonorBoxFrameToLoad(): Promise<void> {
+    const maxWaitMsecs = 20000;
+    const pollIntervalMsecs = 500;
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < maxWaitMsecs) {
+      const donorBoxFrame = this.page
+        .frames()
+        .find(frame => frame.url().includes('donorbox.org'));
+      if (donorBoxFrame) {
+        return;
+      }
+      await this.page.waitForTimeout(pollIntervalMsecs);
+    }
+
+    throw new Error(
+      'The DonorBox iframe did not finish loading within the expected time.'
+    );
   }
 
   /**


### PR DESCRIPTION
## Overview

1. This PR fixes #25570 
2. This PR does the following: It kept the mobile flow from waiting on a hidden iframe, and for desktop It now wait for the DonorBox iframe to load its external frame URL before taking screenshots. This prevents snapshots from being captured before the donor box renders, eliminating the mismatches.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before: https://github.com/sbera01/oppia/actions/runs/23789620704

After: https://github.com/sbera01/oppia/actions/runs/23887553149

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
