### PR TITLE
Fix #24885: Reduce mobile snapshot flake in manage-goals learner dashboard spec

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
@@ -265,24 +265,6 @@ describe('Logged-In Learner - Manage Goals', function () {
       '.e2e-test-learner-dashboard-sidebar'
     );
     await loggedInUser.waitForElementToStabilize('.e2e-test-goals-section');
-    await loggedInUser.page.evaluate(async () => {
-      const doc = document as Document & {fonts?: {ready: Promise<void>}};
-      const root = document.documentElement;
-      root.style.setProperty('text-size-adjust', '100%');
-      root.style.setProperty('-webkit-text-size-adjust', '100%');
-
-      if (doc.fonts !== undefined) {
-        await doc.fonts.ready;
-      }
-
-      await new Promise<void>(resolve => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            resolve();
-          });
-        });
-      });
-    });
 
     await loggedInUser.expectScreenshotToMatch(
       'goalsTabSidebarHighlighted',

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
@@ -265,6 +265,24 @@ describe('Logged-In Learner - Manage Goals', function () {
       '.e2e-test-learner-dashboard-sidebar'
     );
     await loggedInUser.waitForElementToStabilize('.e2e-test-goals-section');
+    await loggedInUser.page.evaluate(async () => {
+      const doc = document as Document & {fonts?: {ready: Promise<void>}};
+      const root = document.documentElement;
+      root.style.setProperty('text-size-adjust', '100%');
+      root.style.setProperty('-webkit-text-size-adjust', '100%');
+
+      if (doc.fonts !== undefined) {
+        await doc.fonts.ready;
+      }
+
+      await new Promise<void>(resolve => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+      });
+    });
 
     await loggedInUser.expectScreenshotToMatch(
       'goalsTabSidebarHighlighted',

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
@@ -261,6 +261,10 @@ describe('Logged-In Learner - Manage Goals', function () {
     await loggedInUser.expectGoalsTabButtonToBeVisible();
     await loggedInUser.navigateToGoalsSection();
     await loggedInUser.expectGoalsTabButtonToBeActive();
+    await loggedInUser.waitForElementToStabilize(
+      '.e2e-test-learner-dashboard-sidebar'
+    );
+    await loggedInUser.waitForElementToStabilize('.e2e-test-goals-section');
 
     await loggedInUser.expectScreenshotToMatch(
       'goalsTabSidebarHighlighted',

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -1089,7 +1089,7 @@ export class BaseUser {
     await currentPage.mouse.move(0, 0);
     // Wait for web fonts and paint frames so text layout is stable in screenshots.
     await currentPage.evaluate(async () => {
-      const doc = document as Document & {fonts?: FontFaceSet};
+      const doc = document as Document & {fonts?: {ready: Promise<void>}};
       if (doc.fonts !== undefined) {
         await doc.fonts.ready;
       }

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -1087,20 +1087,6 @@ export class BaseUser {
     const specName = process.env.SPEC_NAME;
     const currentPage = typeof newPage !== 'undefined' ? newPage : this.page;
     await currentPage.mouse.move(0, 0);
-    // Wait for web fonts and paint frames so text layout is stable in screenshots.
-    await currentPage.evaluate(async () => {
-      const doc = document as Document & {fonts?: {ready: Promise<void>}};
-      if (doc.fonts !== undefined) {
-        await doc.fonts.ready;
-      }
-      await new Promise<void>(resolve => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            resolve();
-          });
-        });
-      });
-    });
     // To wait for all images to load and the page to be stable.
     await currentPage.waitForTimeout(5000);
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -1087,6 +1087,20 @@ export class BaseUser {
     const specName = process.env.SPEC_NAME;
     const currentPage = typeof newPage !== 'undefined' ? newPage : this.page;
     await currentPage.mouse.move(0, 0);
+    // Wait for web fonts and paint frames so text layout is stable in screenshots.
+    await currentPage.evaluate(async () => {
+      const doc = document as Document & {fonts?: FontFaceSet};
+      if (doc.fonts !== undefined) {
+        await doc.fonts.ready;
+      }
+      await new Promise<void>(resolve => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+      });
+    });
     // To wait for all images to load and the page to be stable.
     await currentPage.waitForTimeout(5000);
 


### PR DESCRIPTION
## Overview

1. This PR fixes #24885.
2. This PR does the following: Fixed the flaky ~4% mobile snapshot mismatch by stabilizing the target UI before capture in the learner dashboard acceptance spec.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before: https://github.com/sbera01/oppia/actions/runs/23796434916

After: https://github.com/sbera01/oppia/actions/runs/23904240135

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
