### PR TITLE
Fix Elasticsearch multi_match query to include fields

### DIFF
--- a/core/platform/search/elastic_search_services.py
+++ b/core/platform/search/elastic_search_services.py
@@ -327,6 +327,7 @@ def search(
             {
                 'multi_match': {
                     'query': query_string,
+                    'fields': ['title^3', 'objective^2']
                 }
             }
         ]

--- a/core/platform/search/elastic_search_services.py
+++ b/core/platform/search/elastic_search_services.py
@@ -327,7 +327,7 @@ def search(
             {
                 'multi_match': {
                     'query': query_string,
-                    'fields': ['title^3', 'objective^2']
+                    'fields': ['title^3', 'objective^2'],
                 }
             }
         ]

--- a/core/platform/search/elastic_search_services_test.py
+++ b/core/platform/search/elastic_search_services_test.py
@@ -216,6 +216,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                     'query': {
                         'bool': {
                             'must': [{'multi_match': {'query': 'query'}}],
+                            'fields': ['title^3', 'objective^2'],
                             'filter': [
                                 {
                                     'match': {

--- a/core/platform/search/elastic_search_services_test.py
+++ b/core/platform/search/elastic_search_services_test.py
@@ -215,8 +215,14 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 {
                     'query': {
                         'bool': {
-                            'must': [{'multi_match': {'query': 'query'}}],
-                            'fields': ['title^3', 'objective^2'],
+                            'must': [
+                                {
+                                    'multi_match': {
+                                        'query': 'query',
+                                        'fields': ['title^3', 'objective^2'],
+                                    }
+                                }
+                            ],
                             'filter': [
                                 {
                                     'match': {


### PR DESCRIPTION


## Overview

1. This PR fixes #24839.
2. This PR does the following: 
  -Updates the Elasticsearch `multi_match` query to explicitly target relevant fields: 
  - `title` (boosted 3x) 
  - `objective` (boosted 2x)
- Improves relevance ranking so that matches in the title appear higher.
- Updates the corresponding test file to match the new query structure.
4. (For bug-fixing PRs only) The original bug occurred because:  Oppia's search backend uses a `multi_match` query without specifying fields. 
This causes matches across unintended fields, resulting in irrelevant explorations appearing in search results.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ x] I have written tests for my code.
- [ x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<img width="957" height="527" alt="image" src="https://github.com/user-attachments/assets/fd05d45d-4929-4279-9ae4-0cedb0b53460" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
