### PR TITLE
Fix #25706: Remove the extra space after the April Financial campaign banner.

### DIFF
--- a/core/templates/components/campaign-banner/campaign-banner.component.css
+++ b/core/templates/components/campaign-banner/campaign-banner.component.css
@@ -124,6 +124,7 @@
 
 .oppia-campaign-end {
   color: #f4a33b;
+  font-family: 'Roboto', sans-serif;
   font-size: 12px;
   margin-top: 8px;
 }

--- a/core/templates/components/campaign-banner/campaign-banner.component.css
+++ b/core/templates/components/campaign-banner/campaign-banner.component.css
@@ -124,8 +124,9 @@
 
 .oppia-campaign-end {
   color: #f4a33b;
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Roboto-bold', sans-serif;
   font-size: 12px;
+  font-weight: 700;
   margin-top: 8px;
 }
 

--- a/core/templates/components/campaign-banner/campaign-banner.component.html
+++ b/core/templates/components/campaign-banner/campaign-banner.component.html
@@ -17,7 +17,7 @@
 
           <div class="oppia-campaign-description">
             <p class="font-roboto">
-              This {{ campaignEndMonth }} , Oppia is launching free, interactive financial literacy
+              This {{ campaignEndMonth }}, Oppia is launching free, interactive financial literacy
               lessons for learners who need them most. Your donation helps us
               reach more of them.
             </p>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #25706 
2. This PR does the following: Removed the extra space after "April" and updated the "Campaign ends April 30" text to use the Roboto font as specified in the mock(https://www.figma.com/design/wAUQVHxnPslVMaPelzAgCy/Untitled?node-id=0-1&p=f&t=WNAVkI6Jk7QhM9gH-0).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before : 

<img width="1043" height="498" alt="image" src="https://github.com/user-attachments/assets/8a5fc431-26cc-48f1-b7f5-58854bab81ea" />

After : 

<img width="1043" height="498" alt="image" src="https://github.com/user-attachments/assets/c3c621c5-1465-43f0-b59e-53c5f7203ec3" />


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
