### PR TITLE
Fix #18312: Workflow to assign reviewers

### DIFF
--- a/.github/workflows/process_new_pull_request.yml
+++ b/.github/workflows/process_new_pull_request.yml
@@ -1,0 +1,243 @@
+name: Process New Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  manage-reviewers:
+    name: Manage Reviewers and Notify Contributors
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Handle reviewers and post guidance
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          retries: 3
+          script: |
+            // ======================
+            // INPUT SANITIZATION
+            // ======================
+            const validateGitHubUsername = (username) => {
+              if (typeof username !== 'string') return false;
+              return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(username);
+            };
+
+            const sanitizeUsername = (input) => {
+              return validateGitHubUsername(input) ? input : '';
+            };
+
+            const sanitizeRepo = (input) => {
+              const allowed = /^[A-Za-z0-9_.-]{1,100}$/;
+              if (typeof input !== 'string') return '';
+              return allowed.test(input) ? input : '';
+            };
+
+            const sanitizePrNumber = (num) => {
+              const n = Number(num);
+              return Number.isInteger(n) && n > 0 ? n : NaN;
+            };
+
+            if (!context.payload?.pull_request || !context.payload.repository) {
+              core.setFailed('Invalid event payload');
+              return;
+            }
+
+            const prNumber = sanitizePrNumber(context.payload.pull_request.number);
+            if (isNaN(prNumber)) {
+              core.setFailed('Invalid PR number');
+              return;
+            }
+
+            const repo = sanitizeRepo(context.payload.repository.name);
+            const owner = sanitizeUsername(context.payload.repository.owner.login);
+            if (!repo || !owner) {
+              core.setFailed('Invalid repo or owner');
+              return;
+            }
+
+            const prAuthor = sanitizeUsername(context.payload.pull_request.user?.login);
+            if (!prAuthor) {
+              core.setFailed('Unable to determine PR author');
+              return;
+            }
+
+            // ======================
+            // FETCH LATEST PR STATE
+            // ======================
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber
+            });
+
+            const existingAssignees = (pr.assignees || [])
+              .map(a => sanitizeUsername(a?.login))
+              .filter(Boolean);
+
+            if (existingAssignees.length > 0) {
+              console.log('PR already has assignees. Skipping assignment.');
+              return;
+            }
+
+            // ======================
+            // CONTRIBUTOR CHECK
+            // ======================
+            let isNewContributor = false;
+            try {
+              const searchResults = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${owner}/${repo} type:pr is:merged author:${prAuthor}`
+              });
+              isNewContributor = searchResults.data.total_count === 0;
+            } catch (error) {
+              core.setFailed(`Contributor check failed: ${error.message}`);
+              return;
+            }
+
+            console.log(
+              `User @${prAuthor} is ${isNewContributor ? 'a new contributor' : 'not a new contributor'}.`
+            );
+
+            // ======================
+            // REVIEWER ASSIGNMENT (runs for ALL PRs)
+            // ======================
+            const requestedIndividualReviewers =
+              (context.payload.pull_request.requested_reviewers || [])
+                .map(r => sanitizeUsername(r?.login))
+                .filter(Boolean);
+
+            if (requestedIndividualReviewers.length > 0) {
+              const randomIndex = Math.floor(Math.random() * requestedIndividualReviewers.length);
+              const assignedReviewer = requestedIndividualReviewers[randomIndex];
+
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: prNumber,
+                assignees: [assignedReviewer]
+              });
+
+              console.log(
+                `Assigned reviewer as assignee: ${assignedReviewer}`
+              );
+
+              // Post new contributor guidance if applicable, naming reviewers explicitly
+              if (isNewContributor) {
+                const reviewerMentions = requestedIndividualReviewers
+                  .map(r => `@${r}`)
+                  .join(', ');
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body:
+                    `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
+                    `Your PR has been assigned to ${reviewerMentions} for review. ` +
+                    `Please make sure the **"Assignees"** section in the sidebar on the right ` +
+                    `matches the **"Reviewers"** section.\n\n` +
+                    `If you need to request a different reviewer, you can leave a comment ` +
+                    `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
+                });
+              }
+
+            } else {
+              // No individual reviewers from CODEOWNERS — try random from dev-workflow-reviewers
+              let randomAssignmentSucceeded = false;
+              try {
+                const teamMembers = await github.rest.teams.listMembersInOrg({
+                  org: owner,
+                  team_slug: 'dev-workflow-reviewers'
+                });
+
+                if (teamMembers.data && teamMembers.data.length > 0) {
+                  const randomIndex = Math.floor(Math.random() * teamMembers.data.length);
+                  const randomReviewer = sanitizeUsername(teamMembers.data[randomIndex].login);
+
+                  if (randomReviewer) {
+                    await github.rest.pulls.requestReviewers({
+                      owner,
+                      repo,
+                      pull_number: prNumber,
+                      reviewers: [randomReviewer]
+                    });
+
+                    await github.rest.issues.addAssignees({
+                      owner,
+                      repo,
+                      issue_number: prNumber,
+                      assignees: [randomReviewer]
+                    });
+
+                    console.log(`Assigned random reviewer @${randomReviewer} from dev-workflow-reviewers.`);
+                    randomAssignmentSucceeded = true;
+
+                    // Post new contributor guidance if applicable, mentioning assigned reviewer
+                    if (isNewContributor) {
+                      await github.rest.issues.createComment({
+                        owner,
+                        repo,
+                        issue_number: prNumber,
+                        body:
+                          `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
+                          `Your PR has been assigned to @${randomReviewer} for review. ` +
+                          `Please make sure the **"Assignees"** section in the sidebar on the right ` +
+                          `matches the **"Reviewers"** section.\n\n` +
+                          `If you need to request a different reviewer, you can leave a comment ` +
+                          `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
+                      });
+                    }
+                  }
+                }
+              } catch (error) {
+                console.error(`Random reviewer assignment failed: ${error.message}`);
+              }
+
+              // Fall back to general notification if random assignment failed
+              if (!randomAssignmentSucceeded) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body:
+                    `No individual reviewers were found for this PR. ` +
+                    `@oppia/dev-workflow-reviewers, could you please assign an appropriate ` +
+                    `reviewer? Thank you!`
+                });
+
+                // Still post new contributor guidance even if assignment failed
+                if (isNewContributor) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    body:
+                      `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
+                      `We were unable to automatically assign a reviewer for your PR. ` +
+                      `Please make sure the **"Assignees"** section in the sidebar on the right ` +
+                      `matches the **"Reviewers"** section once a reviewer is assigned.\n\n` +
+                      `If you need to request a specific reviewer yourself, you can leave a comment ` +
+                      `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
+                  });
+                }
+              }
+            }
+
+  report-failure:
+    needs: manage-reviewers
+    runs-on: ubuntu-24.04
+    if: ${{ always() && needs.manage-reviewers.result == 'failure' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Send failure notification
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "The process-new-pull-request workflow failed."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/process_new_pull_request.yml
+++ b/.github/workflows/process_new_pull_request.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - develop
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   manage-reviewers:

--- a/.github/workflows/process_new_pull_request.yml
+++ b/.github/workflows/process_new_pull_request.yml
@@ -15,10 +15,17 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Generate a token for GitHub App
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.OPPIA_GITHUB_APP_ID }}
+          private-key: ${{ secrets.OPPIA_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Handle reviewers and post guidance
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.generate_token.outputs.token }}
           retries: 3
           script: |
             // ======================
@@ -26,7 +33,7 @@ jobs:
             // ======================
             const validateGitHubUsername = (username) => {
               if (typeof username !== 'string') return false;
-              return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(username);
+              return /^[a-z\d](?:[a-z\d]|-[a-z\d]){0,38}$/i.test(username);
             };
 
             const sanitizeUsername = (input) => {
@@ -105,10 +112,30 @@ jobs:
             );
 
             // ======================
+            // HELPER FUNCTION
+            // ======================
+            // Posts a welcome comment for new contributors, naming the assigned reviewer.
+            const postNewContributorGuidance = async (assignedReviewer) => {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body:
+                  `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
+                  `@${assignedReviewer} has been assigned to do the first-pass review of your PR. ` +
+                  `Other reviewers may be added after the first pass.\n\n` +
+                  `Please make sure the **"Assignees"** section in the sidebar on the right ` +
+                  `matches the **"Reviewers"** section.\n\n` +
+                  `If you need to request a different reviewer, you can leave a comment ` +
+                  `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
+              });
+            };
+
+            // ======================
             // REVIEWER ASSIGNMENT (runs for ALL PRs)
             // ======================
             const requestedIndividualReviewers =
-              (context.payload.pull_request.requested_reviewers || [])
+              (pr.requested_reviewers || [])
                 .map(r => sanitizeUsername(r?.login))
                 .filter(Boolean);
 
@@ -129,21 +156,7 @@ jobs:
 
               // Post new contributor guidance if applicable, naming reviewers explicitly
               if (isNewContributor) {
-                const reviewerMentions = requestedIndividualReviewers
-                  .map(r => `@${r}`)
-                  .join(', ');
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  body:
-                    `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
-                    `Your PR has been assigned to ${reviewerMentions} for review. ` +
-                    `Please make sure the **"Assignees"** section in the sidebar on the right ` +
-                    `matches the **"Reviewers"** section.\n\n` +
-                    `If you need to request a different reviewer, you can leave a comment ` +
-                    `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
-                });
+                await postNewContributorGuidance(assignedReviewer);
               }
 
             } else {
@@ -174,23 +187,22 @@ jobs:
                       assignees: [randomReviewer]
                     });
 
+                    await github.rest.issues.createComment({
+                      owner,
+                      repo,
+                      issue_number: prNumber,
+                      body:
+                        `No individual reviewers were found from CODEOWNERS. ` +
+                        `@${randomReviewer}, could you please review this PR and assign ` +
+                        `an appropriate reviewer if needed? Thank you!`
+                    });
+
                     console.log(`Assigned random reviewer @${randomReviewer} from dev-workflow-reviewers.`);
                     randomAssignmentSucceeded = true;
 
                     // Post new contributor guidance if applicable, mentioning assigned reviewer
                     if (isNewContributor) {
-                      await github.rest.issues.createComment({
-                        owner,
-                        repo,
-                        issue_number: prNumber,
-                        body:
-                          `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
-                          `Your PR has been assigned to @${randomReviewer} for review. ` +
-                          `Please make sure the **"Assignees"** section in the sidebar on the right ` +
-                          `matches the **"Reviewers"** section.\n\n` +
-                          `If you need to request a different reviewer, you can leave a comment ` +
-                          `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
-                      });
+                      await postNewContributorGuidance(randomReviewer);
                     }
                   }
                 }

--- a/.github/workflows/process_new_pull_request.yml
+++ b/.github/workflows/process_new_pull_request.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           app-id: ${{ secrets.OPPIA_GITHUB_APP_ID }}
           private-key: ${{ secrets.OPPIA_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
           permission-pull-requests: write
           permission-members: read
 

--- a/.github/workflows/process_new_pull_request.yml
+++ b/.github/workflows/process_new_pull_request.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           app-id: ${{ secrets.OPPIA_GITHUB_APP_ID }}
           private-key: ${{ secrets.OPPIA_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-pull-requests: write
+          permission-members: read
 
       - name: Handle reviewers and post guidance
         uses: actions/github-script@v7
@@ -124,9 +127,7 @@ jobs:
                   `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
                   `@${assignedReviewer} has been assigned to do the first-pass review of your PR. ` +
                   `Other reviewers may be added after the first pass.\n\n` +
-                  `Please make sure the **"Assignees"** section in the sidebar on the right ` +
-                  `matches the **"Reviewers"** section.\n\n` +
-                  `If you need to request a different reviewer, you can leave a comment ` +
+                  `If you'd like additional reviewers to look at your PR, please assign them by leaving a comment ` +
                   `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
               });
             };
@@ -231,9 +232,7 @@ jobs:
                     body:
                       `Hello @${prAuthor}! Thank you for making a PR. 👋\n\n` +
                       `We were unable to automatically assign a reviewer for your PR. ` +
-                      `Please make sure the **"Assignees"** section in the sidebar on the right ` +
-                      `matches the **"Reviewers"** section once a reviewer is assigned.\n\n` +
-                      `If you need to request a specific reviewer yourself, you can leave a comment ` +
+                      `If you'd like someone to look at your PR, please assign them by leaving a comment ` +
                       `with the syntax \`@reviewer_username PTAL\`.\n\nThanks!`
                   });
                 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/18312
2. This PR improves the first-PR experience for new contributors by updating the GitHub Actions workflow (process-new-pull-request.yml) to automatically post a comment when a new PR is opened, informing the contributor that a reviewer has been assigned and explaining how to request a different reviewer using the @reviewer_username PTAL syntax. If no reviewer can be automatically assigned, the contributor is also notified with guidance on next steps.
3. The original bug occurred because: The PR template mentioned reviewer assignment via @reviewer_username PTAL only in the "PR Pointers" section at the bottom, which new contributors consistently overlooked. There was no automated notification to inform contributors that a reviewer had been assigned or to surface the assignment instructions prominently. This caused PRs to sit unreviewed until they were auto-closed, creating a poor first-PR experience.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Case 1 - New contributor + Reviewer found

<img width="1614" height="833" alt="Screenshot 2026-04-01 194242" src="https://github.com/user-attachments/assets/04fe587e-161f-44d1-bc8f-82b03fb869f4" />
<img width="1171" height="861" alt="Screenshot 2026-04-01 194207" src="https://github.com/user-attachments/assets/e3a0746b-0016-4772-aafc-1e93179f7fd3" />

Case 2 - New contributor + No Reviewer found

<img width="1362" height="856" alt="Screenshot 2026-04-01 215606" src="https://github.com/user-attachments/assets/f9e45e12-1789-48d1-995a-159704f14979" />

Case 3 - Existing contributor + Reviewer found

<img width="1648" height="907" alt="Screenshot 2026-04-01 214423" src="https://github.com/user-attachments/assets/2aef15ef-1fa8-474a-b22a-70da2462dfec" />
<img width="1487" height="903" alt="Screenshot 2026-04-01 214414" src="https://github.com/user-attachments/assets/00769113-584c-4218-a49d-9b526c5256cc" />

Case 4 - Existing contributor + No Reviewer found

<img width="1358" height="900" alt="Screenshot 2026-04-01 215929" src="https://github.com/user-attachments/assets/19bbe198-c295-43d9-8086-ce028b889fe1" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
