### PR TITLE
Fix #24943: Correct background color display on Next Lesson button

### DIFF
--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.css
@@ -127,10 +127,12 @@ oppia-conversation-skin .supplemental-card-parent-container {
   margin-right: 10px;
 }
 
-oppia-conversation-skin .oppia-button-raised.mat-raised-raised {
+button.oppia-button-raised.e2e-test-next-lesson-button.mat-focus-indicator.mat-raised-button.mat-button-base {
   align-items: center;
   background-color: #0d48a1;
   display: flex;
+  border: none;
+  padding: 0;
   height: 32px;
   justify-content: center;
   width: 32px;
@@ -138,6 +140,7 @@ oppia-conversation-skin .oppia-button-raised.mat-raised-raised {
 
 oppia-conversation-skin .oppia-button-icon {
   color: #fff;
+  font-size: 42px;
 }
 
 .oppia-exploration-checkpoints-message .toast-container .checkpoints-toast-info {

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.css
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.css
@@ -130,11 +130,11 @@ oppia-conversation-skin .supplemental-card-parent-container {
 button.oppia-button-raised.e2e-test-next-lesson-button.mat-focus-indicator.mat-raised-button.mat-button-base {
   align-items: center;
   background-color: #0d48a1;
-  display: flex;
   border: none;
-  padding: 0;
+  display: flex;
   height: 32px;
   justify-content: center;
+  padding: 0;
   width: 32px;
 }
 

--- a/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.html
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/learner-experience/conversation-skin.component.html
@@ -50,7 +50,7 @@
         <div>
           <a [href]="getExplorationLink()" target="{{ openInNewWindow ? '_blank' : '_self' }}">
             <button mat-raised-button class="oppia-button-raised e2e-test-next-lesson-button">
-              <i class="material-icons oppia-vcenter oppia-button-icon" aria-hidden="true">&#xE5C8;</i>
+              <i class="material-icons oppia-vcenter oppia-button-icon" aria-hidden="true">&#xE941;</i>
             </button>
           </a>
         </div>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #24943.
2. This PR does the following: The background color was not showing, so I fixed it and replaced the old forward arrow with a new one.
3. (For bug-fixing PRs only) The original bug occurred because: The global CSS was overriding the component's CSS.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before Changes:

<img width="1420" height="1182" alt="image" src="https://github.com/user-attachments/assets/a38361c3-b540-4fa3-904b-c626d0847430" />

After changes view on the desktop:

<img width="1913" height="1130" alt="image" src="https://github.com/user-attachments/assets/04425ec8-52cd-4f88-ae4a-94d1e45367f7" />

After changes, view on the mobile:

<img width="1914" height="1137" alt="image" src="https://github.com/user-attachments/assets/cfd10ac2-6935-4d21-b40f-b1c8b766cc93" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
