### PR TITLE
Fix #23362: SVG editor cropping, auto-scaling, and text rendering

### DIFF
--- a/extensions/objects/templates/svg-editor.component.html
+++ b/extensions/objects/templates/svg-editor.component.html
@@ -13,7 +13,7 @@
       be reflected after "Use this Image" button is clicked.
     </div>
   </div>
-  <div class="svg-editor" *ngIf="!isDiagramSaved()" [style.min-height.px]="diagramHeight + 62">
+  <div class="svg-editor" *ngIf="!isDiagramSaved()" [style.min-height.px]="diagramHeight + SVG_EDITOR_TOOLBAR_HEIGHT_PX">
     <div class="fabric-canvas" [attr.id]="canvasContainerId">
       <canvas [attr.id]="canvasID" class="fabric-canvas-container"></canvas>
     </div>

--- a/extensions/objects/templates/svg-editor.component.html
+++ b/extensions/objects/templates/svg-editor.component.html
@@ -13,7 +13,7 @@
       be reflected after "Use this Image" button is clicked.
     </div>
   </div>
-  <div class="svg-editor" *ngIf="!isDiagramSaved()">
+  <div class="svg-editor" *ngIf="!isDiagramSaved()" [style.min-height.px]="diagramHeight + 62">
     <div class="fabric-canvas" [attr.id]="canvasContainerId">
       <canvas [attr.id]="canvasID" class="fabric-canvas-container"></canvas>
     </div>
@@ -369,7 +369,7 @@
     cursor: default;
     left: 68px;
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto;
     right: 0;
     top: 31px;
   }

--- a/extensions/objects/templates/svg-editor.component.spec.ts
+++ b/extensions/objects/templates/svg-editor.component.spec.ts
@@ -1044,4 +1044,49 @@ describe('SvgEditor with image save destination as local storage', () => {
       expect(component.diagramStatus).toBe('editing');
     }
   );
+
+  it('should set canvas dimensions correctly', () => {
+    spyOn(component.canvas, 'setHeight');
+    spyOn(component.canvas, 'setWidth');
+    spyOn(component.canvas, 'renderAll');
+
+    component.diagramHeight = 500;
+    component.diagramWidth = 600;
+    component.setCanvasDimensions();
+
+    expect(component.canvas.setHeight).toHaveBeenCalledWith(500);
+    expect(component.canvas.setWidth).toHaveBeenCalledWith(600);
+    expect(component.canvas.renderAll).toHaveBeenCalled();
+  });
+
+  it('should handle text object loading with horizontal boundary and missing styles', () => {
+    const mockElement = {
+      childNodes: [
+        {
+          nodeName: 'tspan',
+          childNodes: [{nodeValue: 'test'}],
+          style: {fill: '', stroke: '', strokeWidth: ''},
+        },
+      ],
+    } as unknown as Element;
+    const mockObj = {
+      toObject: () => ({
+        left: 500, // Greater than diagramWidth (450)
+        top: 50,
+        width: 100,
+      }),
+      get: (attr: string) => null,
+    } as unknown as fabric.Object;
+
+    component.diagramWidth = 450;
+    // @ts-ignore
+    component.loadTextObject(mockElement, mockObj);
+
+    // loadTextObject adds the text to the canvas.
+    const addedText = component.canvas.getObjects()[
+      component.canvas.getObjects().length - 1
+    ] as fabric.Textbox;
+    expect(addedText.left).toBe(450 - (addedText.width || 0));
+    expect(addedText.fill).toBe('#000');
+  });
 });

--- a/extensions/objects/templates/svg-editor.component.spec.ts
+++ b/extensions/objects/templates/svg-editor.component.spec.ts
@@ -1059,6 +1059,20 @@ describe('SvgEditor with image save destination as local storage', () => {
     expect(component.canvas.renderAll).toHaveBeenCalled();
   });
 
+  it('should return early from setCanvasDimensions if canvas is not initialized', () => {
+    const originalCanvas = component.canvas;
+    // This throws "Type 'null' is not assignable to type 'Canvas'". We need
+    // to suppress this error because we need to test the null canvas guard.
+    // @ts-ignore
+    component.canvas = null;
+
+    // Should not throw and should return early.
+    expect(() => component.setCanvasDimensions()).not.toThrowError();
+
+    // Restore canvas for cleanup.
+    component.canvas = originalCanvas;
+  });
+
   it('should handle text object loading with horizontal boundary and missing styles', () => {
     const mockElement = {
       childNodes: [
@@ -1079,10 +1093,12 @@ describe('SvgEditor with image save destination as local storage', () => {
     } as unknown as fabric.Object;
 
     component.diagramWidth = 450;
+    // This throws "Property 'loadTextObject' is private". We need to
+    // suppress this error because we need to test the private method directly.
     // @ts-ignore
     component.loadTextObject(mockElement, mockObj);
 
-    // loadTextObject adds the text to the canvas.
+    // LoadTextObject adds the text to the canvas.
     const addedText = component.canvas.getObjects()[
       component.canvas.getObjects().length - 1
     ] as fabric.Textbox;

--- a/extensions/objects/templates/svg-editor.component.ts
+++ b/extensions/objects/templates/svg-editor.component.ts
@@ -76,6 +76,9 @@ export class SvgEditorComponent implements OnInit {
   // modal dimensions.
   CANVAS_WIDTH = 494;
   CANVAS_HEIGHT = 368;
+  // Expose constant for use in template.
+  SVG_EDITOR_TOOLBAR_HEIGHT_PX =
+    SvgEditorConstants.SVG_EDITOR_TOOLBAR_HEIGHT_PX;
   drawMode = this.DRAW_MODE_NONE;
   polygonMode = this.CLOSED_POLYGON_MODE;
   isTouchDevice = this.deviceInfoService.hasTouchEvents();
@@ -655,6 +658,14 @@ export class SvgEditorComponent implements OnInit {
       this.canvas.getObjects(),
       {canvas: this.canvas}
     );
+    // Only scale wide images to fit the canvas width. Tall/narrow images
+    // should not be scaled to width as this causes them to exceed the
+    // canvas height and get clipped.
+    const selectionWidth = temporarySelection.width ?? 0;
+    const selectionHeight = temporarySelection.height ?? 0;
+    if (selectionWidth > selectionHeight) {
+      temporarySelection.scaleToWidth(this.canvas.getWidth());
+    }
     temporarySelection.center();
     this.canvas.setActiveObject(temporarySelection);
     this.canvas.discardActiveObject();
@@ -1692,6 +1703,12 @@ export class SvgEditorComponent implements OnInit {
     });
   }
 
+  // Sets the canvas dimensions based on diagramHeight and diagramWidth which
+  // are controlled by the user through the dimension inputs. Previously, this
+  // method used imagePreloaderService.getDimensionsOfImage() to get dimensions
+  // from the saved image, but that approach didn't work for new/edited images
+  // where the user has changed the dimensions. Using diagramHeight/diagramWidth
+  // ensures the canvas always matches what the user has specified.
   setCanvasDimensions(): void {
     if (!this.canvas) {
       return;

--- a/extensions/objects/templates/svg-editor.component.ts
+++ b/extensions/objects/templates/svg-editor.component.ts
@@ -255,6 +255,7 @@ export class SvgEditorComponent implements OnInit {
       this.diagramWidth = SvgEditorConstants.MIN_SVG_DIAGRAM_WIDTH;
     }
     this.currentDiagramWidth = this.diagramWidth;
+    this.setCanvasDimensions();
   }
 
   onHeightInputBlur(): void {
@@ -264,6 +265,7 @@ export class SvgEditorComponent implements OnInit {
       this.diagramHeight = SvgEditorConstants.MIN_SVG_DIAGRAM_HEIGHT;
     }
     this.currentDiagramHeight = this.diagramHeight;
+    this.setCanvasDimensions();
   }
 
   isDiagramCreated(): boolean {
@@ -550,24 +552,23 @@ export class SvgEditorComponent implements OnInit {
 
     value = obj['text-transform'] === 'uppercase' ? value.toUpperCase() : value;
 
-    obj.set({
-      text: value,
-    } as unknown);
-    var text = new fabric.Textbox(
-      (obj as unknown as {text: string}).text,
-      obj.toObject()
-    );
-    text.set({
+    // Use a new Textbox for editability, but copy properties from the loaded object.
+    const textOptions = (obj as fabric.Object).toObject();
+    const text = new fabric.Textbox(value, {
+      ...textOptions,
+      width: textOptions.width || this.diagramWidth,
       type: 'textbox',
       strokeUniform: true,
-    });
+      fill: (obj as fabric.Object).get('fill') || '#000',
+    }) as fabric.Textbox;
+
     // The text moves to the right every time the svg is
     // rendered so this is to ensure that the text doesn't
     // render outside the canvas.
     // https://github.com/fabricjs/fabric.js/issues/1280
-    if (text.left > this.CANVAS_WIDTH) {
+    if (text.left !== undefined && text.left > this.diagramWidth) {
       text.set({
-        left: this.CANVAS_WIDTH,
+        left: this.diagramWidth - (text.width || 0),
       });
     }
     coloredTextIndex.forEach(obj => {
@@ -654,7 +655,6 @@ export class SvgEditorComponent implements OnInit {
       this.canvas.getObjects(),
       {canvas: this.canvas}
     );
-    temporarySelection.scaleToWidth(this.canvas.getWidth());
     temporarySelection.center();
     this.canvas.setActiveObject(temporarySelection);
     this.canvas.discardActiveObject();
@@ -1693,10 +1693,11 @@ export class SvgEditorComponent implements OnInit {
   }
 
   setCanvasDimensions(): void {
-    let dimensions =
-      this.value && this.imagePreloaderService.getDimensionsOfImage(this.value);
-    this.canvas.setHeight(dimensions?.height || this.CANVAS_HEIGHT);
-    this.canvas.setWidth(dimensions?.width || this.CANVAS_WIDTH);
+    if (!this.canvas) {
+      return;
+    }
+    this.canvas.setHeight(this.diagramHeight);
+    this.canvas.setWidth(this.diagramWidth);
     this.canvas.renderAll();
   }
 

--- a/extensions/objects/templates/svg-editor.constants.ts
+++ b/extensions/objects/templates/svg-editor.constants.ts
@@ -25,4 +25,10 @@ export const SvgEditorConstants = {
   MAX_SVG_DIAGRAM_HEIGHT: 450,
   MIN_SVG_DIAGRAM_WIDTH: 30,
   MIN_SVG_DIAGRAM_HEIGHT: 30,
+  // The toolbar height accounts for the space taken by the dimension inputs,
+  // tool buttons, and padding above the canvas area. This value (62px) was
+  // measured from the rendered editor toolbar and is used to ensure the
+  // svg-editor container has enough minimum height to display both the
+  // toolbar and the full canvas without clipping.
+  SVG_EDITOR_TOOLBAR_HEIGHT_PX: 62,
 } as const;


### PR DESCRIPTION
## Overview

1. This PR fixes #23362.
2. This PR does the following: 
   - Implements dynamic container height for the SVG editor, allowing it to grow with the image (up to the modal's limits).
   - Enables vertical scrolling (`overflow-y: auto`) in the editor as a safeguard for tall images on small screens.
   - Disables the auto-scaling logic in `centerContent()` that forced narrow images to stretch to the full canvas width, which previously caused them to "explode" in height and be clipped.
   - Improves SVG text rendering in `loadTextObject()` by correctly capturing inherited styles (like color) and ensuring text boxes have sufficient width to prevent clipping.

3. (For bug-fixing PRs only) The original bug occurred because: 
   - The editor's parent container had a hardcoded `overflow-y: hidden` and didn't grow with the canvas, clipping any image taller than ~388px.
   - The `centerContent()` function forced a `scaleToWidth` call that distorted the aspect ratio of narrow images, pushing content vertically off-screen.
   - SVG text objects were being initialized with incorrect widths and lost inherited CSS styles during the import to Fabric.js.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #23362: " or "Fix part of #23362: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc

N/A

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Reproduction (Broken):**

https://github.com/user-attachments/assets/5ff8de86-4f3f-4f68-8b6f-a5005fd64bac

**After Fix (Working):**

https://github.com/user-attachments/assets/1b9a0d4e-b506-4303-87e0-f2cc7bfd54d2

#### Proof of changes on mobile phone
N/A (The SVG editor is primarily designed for desktop translators.)

#### Proof of changes in Arabic language
N/A (The fix affects the container layout and scaling logic, which is language-agnostic.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect