### PR TITLE
Fix #25739: Dropdown opening upward issue on mobile

### DIFF
--- a/core/templates/pages/library-page/search-bar/search-bar.component.css
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.css
@@ -320,3 +320,9 @@ oppia-search-bar .oppia-input-group {
     padding-left: 0;
   }
 }
+.dropdown-menu{
+  transform: none !important;
+  top:100% !important;
+  left:0 !important;
+  margin-top: 0 !important;
+}

--- a/core/templates/pages/library-page/search-bar/search-bar.component.css
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.css
@@ -320,9 +320,10 @@ oppia-search-bar .oppia-input-group {
     padding-left: 0;
   }
 }
-oppia-search-bar .oppia-search-bar-category-selector .dropdown-menu {
-  transform: none !important;
-  top: 100% !important;
-  left: 0 !important;
-  margin-top: 0 !important;
+@media (max-width: 767px) {
+  .oppia-search-bar .oppia-search-bar-category-selector .dropdown-menu {
+    transform: none !important;
+    top: 100% !important;
+    left: 0 !important;
+  }
 }

--- a/core/templates/pages/library-page/search-bar/search-bar.component.css
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.css
@@ -322,8 +322,8 @@ oppia-search-bar .oppia-input-group {
 }
 @media (max-width: 767px) {
   .oppia-search-bar .oppia-search-bar-category-selector .dropdown-menu {
-    transform: none !important;
-    top: 100% !important;
     left: 0 !important;
+    top: 100% !important;
+    transform: none !important;
   }
 }

--- a/core/templates/pages/library-page/search-bar/search-bar.component.css
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.css
@@ -320,9 +320,9 @@ oppia-search-bar .oppia-input-group {
     padding-left: 0;
   }
 }
-.dropdown-menu{
+oppia-search-bar .oppia-search-bar-category-selector .dropdown-menu {
   transform: none !important;
-  top:100% !important;
-  left:0 !important;
+  top: 100% !important;
+  left: 0 !important;
   margin-top: 0 !important;
 }

--- a/core/templates/pages/library-page/search-bar/search-bar.component.css
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.css
@@ -327,3 +327,4 @@ oppia-search-bar .oppia-input-group {
     transform: none !important;
   }
 }
+/* fix lint order */


### PR DESCRIPTION
## Explanation
This PR Fixes #25739.

This PR fixes the dropdown opening upward issue on mobile devices and removes the gap between the trigger and dropdown menu.

The issue occurred because the dropdown positioning was not properly aligned for mobile view.

## Essential Checklist
- [x] I have linked the issue that this PR fixes in the "Development" section.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code (if applicable).
- [x] The PR title starts with "Fix #bugnum:" and follows the required format.

