### PR TITLE
Fixes #22122: Fix translation review badges not showing due to incorrect reviewableLanguages population

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.spec.ts
@@ -255,10 +255,10 @@ describe('Contributor badge component', () => {
           expect(component.userCanReviewTranslationSuggestion).toBeTrue();
           expect(component.reviewableLanguages).toContain('Spanish');
           expect(
-            component.translationBadges['Spanish'].review.length
+            component.translationBadges.Spanish.review.length
           ).toBeGreaterThan(0);
           expect(
-            component.translationBadges['Spanish'].correction.length
+            component.translationBadges.Spanish.correction.length
           ).toBeGreaterThan(0);
         })
       );

--- a/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.spec.ts
@@ -247,13 +247,19 @@ describe('Contributor badge component', () => {
       }));
 
       it(
-        'should mark languages as reviewable when they have both submission ' +
-          'and review stats',
+        'should show review and correction badges when a language has both ' +
+          'submission and review stats',
         fakeAsync(() => {
-          expect(component.selectedLanguage).toBe('Akan');
+          component.selectLanguageOption('Spanish');
+
           expect(component.userCanReviewTranslationSuggestion).toBeTrue();
-          expect(component.reviewableLanguages).toContain('Akan');
           expect(component.reviewableLanguages).toContain('Spanish');
+          expect(
+            component.translationBadges['Spanish'].review.length
+          ).toBeGreaterThan(0);
+          expect(
+            component.translationBadges['Spanish'].correction.length
+          ).toBeGreaterThan(0);
         })
       );
 

--- a/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.spec.ts
@@ -246,6 +246,17 @@ describe('Contributor badge component', () => {
         expect(component.questionReviewBadges.length).toBeGreaterThan(0);
       }));
 
+      it(
+        'should mark languages as reviewable when they have both submission ' +
+          'and review stats',
+        fakeAsync(() => {
+          expect(component.selectedLanguage).toBe('Akan');
+          expect(component.userCanReviewTranslationSuggestion).toBeTrue();
+          expect(component.reviewableLanguages).toContain('Akan');
+          expect(component.reviewableLanguages).toContain('Spanish');
+        })
+      );
+
       it('should toggle language dropdown when user clicks on it', fakeAsync(() => {
         component.dropdownShown = false;
 

--- a/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.ts
@@ -153,12 +153,14 @@ export class ContributorBadgesComponent {
             reviews: stat.reviewed_translations_count,
             corrections: stat.accepted_translations_with_reviewer_edits_count,
           };
-          this.reviewableLanguages.push(languageDescription);
         } else {
           this.totalTranslationStats[languageDescription].reviews +=
             stat.reviewed_translations_count;
           this.totalTranslationStats[languageDescription].corrections +=
             stat.accepted_translations_with_reviewer_edits_count;
+        }
+        if (!this.reviewableLanguages.includes(languageDescription)) {
+          this.reviewableLanguages.push(languageDescription);
         }
       });
     }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/22122
2. This PR does the following: reviewableLanguages is updated in both cases (whether translation submission stats exist or not), so that review and correction badges are displayed correctly.
3. (For bug-fixing PRs only) The original bug occurred because: 
The current implementation of translation review badges depends on how [reviewableLanguages](https://github.com/oppia/oppia/blob/212b4b9938bbe398a2d52b7823ba124c64f60749/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.ts#L80) is populated inside contributor-badges.component.ts. Right now,[ reviewableLanguages](https://github.com/oppia/oppia/blob/212b4b9938bbe398a2d52b7823ba124c64f60749/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.ts#L156) is only updated when a language is initialized inside the translation review stats block. However, if the same language is already initialized earlier due to translation submission stats, then the code goes into the else block and does not push that language into reviewableLanguages.

Because of this, even though review stats exist for that language, it is not marked as reviewable. Later in the UI, the visibility of review and correction badges depends on whether the selected language exists in [reviewableLanguages](https://github.com/oppia/oppia/blob/212b4b9938bbe398a2d52b7823ba124c64f60749/core/templates/pages/contributor-dashboard-page/contributor-badges/contributor-badges.component.ts#L228). Since the language is missing from this list, the UI assumes the user cannot review and hides the review and correction badges.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## Before FIX:

[Screencast from 2026-04-05 03-01-25.webm](https://github.com/user-attachments/assets/94d213db-6aee-45c2-a4ef-47acfc50d0b9)


## After FIX:

[Screencast from 2026-04-05 01-24-13.webm](https://github.com/user-attachments/assets/7911d1fa-b05b-448d-97f3-fe22309ff5bf)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
