### PR TITLE
Fix #20876: Add option to untag misconceptions from answer groups in Question Editor

### DIFF
--- a/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.html
+++ b/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.html
@@ -25,7 +25,7 @@
                                          [selectedMisconceptionSkillId]="selectedMisconceptionSkillId"
                                          [taggedSkillMisconceptionId]="taggedSkillMisconceptionId">
   </oppia-question-misconception-selector>
-  <button class="btn btn-success float-end" [disabled]="selectedMisconception === null" (click)="updateMisconception()">Save Misconception</button>
+  <button class="btn btn-success float-end" (click)="updateMisconception()">Save Misconception</button>
 </div>
 <button type="button"
         *ngIf="!misconceptionName && isEditable && rules && !outcome.labelledAsCorrect && containsMisconceptions()"

--- a/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.spec.ts
+++ b/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.spec.ts
@@ -292,6 +292,23 @@ describe('Question Misconception Editor Component', () => {
     expect(component.misconceptionName).toEqual('misc1');
   });
 
+  it('should untag misconception when selectedMisconception is null', () => {
+    const saveTaggedMisconceptionSpy = spyOn(
+      component.saveTaggedMisconception,
+      'emit'
+    );
+    component.selectedMisconception = null;
+    component.selectedMisconceptionSkillId = null;
+    component.misconceptionEditorIsOpen = true;
+
+    component.updateMisconception();
+
+    expect(saveTaggedMisconceptionSpy).toHaveBeenCalledWith(null);
+    expect(component.misconceptionName).toEqual('');
+    expect(component.selectedMisconceptionSkillId).toBeNull();
+    expect(component.misconceptionEditorIsOpen).toBeFalse();
+  });
+
   it('should update the values', () => {
     let updatedValues = {
       misconception: mockMisconceptionObject.abc[1],

--- a/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.ts
+++ b/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.ts
@@ -32,8 +32,8 @@ import {Rule} from 'domain/exploration/rule.model';
 import {Subscription} from 'rxjs';
 
 export interface MisconceptionUpdatedValues {
-  misconception: Misconception;
-  skillId: string;
+  misconception: Misconception | null;
+  skillId: string | null;
   feedbackIsUsed: boolean;
 }
 
@@ -49,7 +49,7 @@ export interface Outcome {
 export class QuestionMisconceptionEditorComponent implements OnInit {
   @Output() saveAnswerGroupFeedback: EventEmitter<Outcome> = new EventEmitter();
 
-  @Output() saveTaggedMisconception: EventEmitter<TaggedMisconception> =
+  @Output() saveTaggedMisconception: EventEmitter<TaggedMisconception | null> =
     new EventEmitter();
 
   // These properties are initialized using Angular lifecycle hooks
@@ -61,8 +61,8 @@ export class QuestionMisconceptionEditorComponent implements OnInit {
   @Input() taggedSkillMisconceptionId!: string | null;
   misconceptionName!: string;
   misconceptionsBySkill!: MisconceptionSkillMap;
-  selectedMisconception!: Misconception;
-  selectedMisconceptionSkillId!: string;
+  selectedMisconception!: Misconception | null;
+  selectedMisconceptionSkillId!: string | null;
   feedbackIsUsed: boolean = false;
   misconceptionEditorIsOpen: boolean = false;
   previousFeedbackIsUsed: boolean | null = null;
@@ -164,7 +164,7 @@ export class QuestionMisconceptionEditorComponent implements OnInit {
       this.feedbackIsUsed = newValues.feedbackIsUsed;
     }
     this.selectedMisconception = newValues.misconception;
-    this.selectedMisconceptionSkillId = newValues.skillId;
+    this.selectedMisconceptionSkillId = newValues.skillId ?? null;
   }
 
   tagAnswerGroupWithMisconception(): void {
@@ -194,8 +194,17 @@ export class QuestionMisconceptionEditorComponent implements OnInit {
   }
 
   updateMisconception(): void {
+    if (this.selectedMisconception === null) {
+      // The user chose to remove the misconception tag.
+      this.saveTaggedMisconception.emit(null);
+      this.misconceptionName = '';
+      this.selectedMisconceptionSkillId = null;
+      this.externalSaveService.onExternalSave.emit();
+      this.misconceptionEditorIsOpen = false;
+      return;
+    }
     let taggedMisconception = {
-      skillId: this.selectedMisconceptionSkillId,
+      skillId: this.selectedMisconceptionSkillId as string,
       misconceptionId: this.selectedMisconception.getId(),
     };
     this.saveTaggedMisconception.emit(taggedMisconception);

--- a/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.ts
+++ b/core/templates/components/question-directives/question-misconception-editor/question-misconception-editor.component.ts
@@ -204,7 +204,7 @@ export class QuestionMisconceptionEditorComponent implements OnInit {
       return;
     }
     let taggedMisconception = {
-      skillId: this.selectedMisconceptionSkillId as string,
+      skillId: this.selectedMisconceptionSkillId,
       misconceptionId: this.selectedMisconception.getId(),
     };
     this.saveTaggedMisconception.emit(taggedMisconception);

--- a/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.html
+++ b/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.html
@@ -23,7 +23,7 @@ Selected Misconception: {{ selectedMisconception && selectedMisconception.getNam
   <button class="btn btn-secondary misconception-button e2e-test-no-misconception-button"
           (click)="selectNoMisconception()"
           [ngClass]="{'misconception-button-selected': selectedMisconception === null}">
-    <strong class="d-inline">(No misconception)</strong>
+    <strong class="d-inline">No misconception</strong>
   </button>
 </div>
 <div *ngIf="selectedMisconception !== null" (click)="toggleMisconceptionFeedbackUsage()" (keydown.space)="toggleMisconceptionFeedbackUsage()" tabindex="0" class="misconception-feedback-usage-container">

--- a/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.html
+++ b/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.html
@@ -3,12 +3,12 @@ Selected Misconception: {{ selectedMisconception && selectedMisconception.getNam
 <div *ngFor="let member of misconceptionsBySkill | keyvalue" class="misconception-list-container">
   <div *ngFor="let misconception of member.value">
     <button class="btn btn-secondary misconception-button" (click)="selectMisconception(misconception, member.key)"
-            [ngClass]="{'misconception-button-selected': selectedMisconceptionSkillId === member.key && selectedMisconception.getId() === misconception.getId()}">
+            [ngClass]="{'misconception-button-selected': selectedMisconceptionSkillId === member.key && selectedMisconception?.getId() === misconception.getId()}">
       <strong class="d-inline e2e-test-misconception-title">{{ misconception.isMandatory() ? '' : ' (Optional) ' }}{{ misconception.getName() }}</strong>
       <oppia-rte-output-display class="misconception-notes-container" [rteString]="misconception.getNotes()">
       </oppia-rte-output-display>
     </button>
-    <div *ngIf="selectedMisconceptionSkillId === member.key && selectedMisconception.getId() === misconception.getId()"
+    <div *ngIf="selectedMisconceptionSkillId === member.key && selectedMisconception?.getId() === misconception.getId()"
          class="misconception-info-container">
       <label class="misconception-label"> Note to creators: </label>
       <oppia-rte-output-display [rteString]="misconception.getNotes() || 'None'">
@@ -19,7 +19,14 @@ Selected Misconception: {{ selectedMisconception && selectedMisconception.getNam
     </div>
   </div>
 </div>
-<div (click)="toggleMisconceptionFeedbackUsage()" (keydown.space)="toggleMisconceptionFeedbackUsage()" tabindex="0" class="misconception-feedback-usage-container">
+<div>
+  <button class="btn btn-secondary misconception-button e2e-test-no-misconception-button"
+          (click)="selectNoMisconception()"
+          [ngClass]="{'misconception-button-selected': selectedMisconception === null}">
+    <strong class="d-inline">(No misconception)</strong>
+  </button>
+</div>
+<div *ngIf="selectedMisconception !== null" (click)="toggleMisconceptionFeedbackUsage()" (keydown.space)="toggleMisconceptionFeedbackUsage()" tabindex="0" class="misconception-feedback-usage-container">
   <i *ngIf="!misconceptionFeedbackIsUsed" class="material-icons md-18 misconception-feedback-usage-checkbox">&#xE835;</i>
   <i *ngIf="misconceptionFeedbackIsUsed" class="material-icons md-18 misconception-feedback-usage-checkbox">&#xE834;</i>
   Use misconception feedback as answer group feedback.

--- a/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.spec.ts
+++ b/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.spec.ts
@@ -87,4 +87,18 @@ describe('Question Misconception Selector Component', () => {
     );
     expect(component.selectedMisconceptionSkillId).toEqual('def');
   });
+
+  it('should clear selected misconception when selectNoMisconception is called', () => {
+    const emitSpy = spyOn(component.updateMisconceptionValues, 'emit');
+
+    component.selectNoMisconception();
+
+    expect(component.selectedMisconception).toBeNull();
+    expect(component.selectedMisconceptionSkillId).toBeNull();
+    expect(emitSpy).toHaveBeenCalledWith({
+      misconception: null,
+      skillId: null,
+      feedbackIsUsed: component.misconceptionFeedbackIsUsed,
+    });
+  });
 });

--- a/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.ts
+++ b/core/templates/components/question-directives/question-misconception-selector/question-misconception-selector.component.ts
@@ -25,8 +25,8 @@ import {
 } from 'domain/skill/misconception.model';
 
 interface UpdatedValues {
-  misconception: Misconception;
-  skillId: string;
+  misconception: Misconception | null;
+  skillId: string | null;
   feedbackIsUsed: boolean;
 }
 
@@ -41,10 +41,10 @@ export class QuestionMisconceptionSelectorComponent implements OnInit {
   // These properties are initialized using Angular lifecycle hooks
   // and we need to do non-null assertion. For more information, see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
-  @Input() selectedMisconception!: Misconception;
-  @Input() selectedMisconceptionSkillId!: string;
+  @Input() selectedMisconception!: Misconception | null;
+  @Input() selectedMisconceptionSkillId!: string | null;
   @Input() misconceptionFeedbackIsUsed!: boolean;
-  @Input() taggedSkillMisconceptionId!: string;
+  @Input() taggedSkillMisconceptionId!: string | null;
   misconceptionsBySkill!: MisconceptionSkillMap;
 
   constructor(private stateEditorService: StateEditorService) {}
@@ -63,6 +63,17 @@ export class QuestionMisconceptionSelectorComponent implements OnInit {
     let updatedValues = {
       misconception: this.selectedMisconception,
       skillId: this.selectedMisconceptionSkillId,
+      feedbackIsUsed: this.misconceptionFeedbackIsUsed,
+    };
+    this.updateMisconceptionValues.emit(updatedValues);
+  }
+
+  selectNoMisconception(): void {
+    this.selectedMisconception = null;
+    this.selectedMisconceptionSkillId = null;
+    let updatedValues = {
+      misconception: null,
+      skillId: null,
       feedbackIsUsed: this.misconceptionFeedbackIsUsed,
     };
     this.updateMisconceptionValues.emit(updatedValues);

--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.ts
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.ts
@@ -44,7 +44,7 @@ import {BaseTranslatableObject} from 'interactions/rule-input-defs';
 import {PlatformFeatureService} from 'services/platform-feature.service';
 
 interface TaggedMisconception {
-  skillId: string;
+  skillId: string | null;
   misconceptionId: number;
 }
 

--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.ts
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.ts
@@ -66,7 +66,8 @@ export class AnswerGroupEditor implements OnInit, OnDestroy {
   @Output() onSaveAnswerGroupDest = new EventEmitter<Outcome>();
   @Output() onSaveAnswerGroupDestIfStuck = new EventEmitter<Outcome>();
   @Output() onSaveAnswerGroupFeedback = new EventEmitter<Outcome>();
-  @Output() onSaveTaggedMisconception = new EventEmitter<TaggedMisconception>();
+  @Output() onSaveTaggedMisconception =
+    new EventEmitter<TaggedMisconception | null>();
 
   rulesMemento: Rule[];
   directiveSubscriptions = new Subscription();
@@ -86,7 +87,7 @@ export class AnswerGroupEditor implements OnInit, OnDestroy {
     private platformFeatureService: PlatformFeatureService
   ) {}
 
-  sendOnSaveTaggedMisconception(event: TaggedMisconception): void {
+  sendOnSaveTaggedMisconception(event: TaggedMisconception | null): void {
     this.onSaveTaggedMisconception.emit(event);
   }
 

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.ts
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.ts
@@ -355,11 +355,18 @@ export class StateResponsesComponent implements OnInit, OnDestroy {
     }
   }
 
-  saveTaggedMisconception(taggedMisconception: TaggedMisconception): void {
-    const {skillId, misconceptionId} = taggedMisconception;
+  saveTaggedMisconception(
+    taggedMisconception: TaggedMisconception | null
+  ): void {
+    const taggedSkillMisconceptionId =
+      taggedMisconception !== null
+        ? taggedMisconception.skillId +
+          '-' +
+          taggedMisconception.misconceptionId
+        : null;
     this.responsesService.updateActiveAnswerGroup(
       {
-        taggedSkillMisconceptionId: skillId + '-' + misconceptionId,
+        taggedSkillMisconceptionId,
       } as AnswerGroup,
       newAnswerGroups => {
         this.onSaveInteractionAnswerGroups.emit(newAnswerGroups);

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.ts
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.ts
@@ -360,9 +360,7 @@ export class StateResponsesComponent implements OnInit, OnDestroy {
   ): void {
     const taggedSkillMisconceptionId =
       taggedMisconception !== null
-        ? taggedMisconception.skillId +
-          '-' +
-          taggedMisconception.misconceptionId
+        ? `${taggedMisconception.skillId}-${taggedMisconception.misconceptionId}`
         : null;
     this.responsesService.updateActiveAnswerGroup(
       {

--- a/core/templates/domain/skill/misconception.model.ts
+++ b/core/templates/domain/skill/misconception.model.ts
@@ -29,7 +29,7 @@ export interface MisconceptionSkillMap {
 }
 
 export interface TaggedMisconception {
-  skillId: string;
+  skillId: string | null;
   misconceptionId: number;
 }
 

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.ts
@@ -114,8 +114,13 @@ export class AddAnswerGroupModalComponent
     this.addState.emit(event);
   }
 
-  updateTaggedMisconception(taggedMisconception: TaggedMisconception): void {
-    this.tmpTaggedSkillMisconceptionId = `${taggedMisconception.skillId}-${taggedMisconception.misconceptionId}`;
+  updateTaggedMisconception(
+    taggedMisconception: TaggedMisconception | null
+  ): void {
+    this.tmpTaggedSkillMisconceptionId =
+      taggedMisconception !== null
+        ? `${taggedMisconception.skillId}-${taggedMisconception.misconceptionId}`
+        : null;
   }
 
   isSelfLoopWithNoFeedback(tmpOutcome: Outcome): boolean {

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.ts
@@ -51,7 +51,7 @@ import {InteractionSpecsKey} from 'pages/interaction-specs.constants';
 import {PlatformFeatureService} from 'services/platform-feature.service';
 
 interface TaggedMisconception {
-  skillId: string;
+  skillId: string | null;
   misconceptionId: number;
 }
 


### PR DESCRIPTION
## Overview

1. This PR fixes #20876.
2. This PR adds a **(No misconception)** option to the misconception selector, allowing creators to untag a misconception from an answer group. Previously, once a misconception was tagged, there was no way to remove it — the selector only showed existing misconceptions, and the Save button was disabled when nothing was selected.
3. The original bug occurred because `question-misconception-selector.component.html` never rendered a "no selection" option, and `question-misconception-editor.component.html` had `[disabled]="selectedMisconception === null"` on the Save button, making it impossible to save an untagged state.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Before:** Only existing misconceptions are shown in the selector. The Save button is disabled. There is no way to remove a tagged misconception.

**After:** A **(No misconception)** button appears at the bottom of the selector list. Clicking it highlights it and enables the Save button. Saving clears the tag and restores the "Tag with misconception" button.

<img width="1845" height="1095" alt="image" src="https://github.com/user-attachments/assets/695afc34-83c1-4e93-b008-752a53f99dc8" />

[Video proof](https://drive.google.com/file/d/1dgNE7B9HbxVUh-FDstjM7JkiRtW7UqNT/view?usp=sharing)

#### Proof of changes on mobile phone
NA

#### Proof of changes in Arabic language
NA

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
