### PR TITLE
Fix#22113 Fix mypy unreachable code warnings

### DIFF
--- a/core/controllers/access_validators.py
+++ b/core/controllers/access_validators.py
@@ -29,7 +29,7 @@ from core.domain import (
     user_services,
 )
 
-from typing import Dict, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict, cast
 
 # TODO(#13605): Refactor access validation handlers to follow a single handler
 # pattern.
@@ -329,15 +329,33 @@ class PracticeSessionAccessValidationPage(
         """Handles GET requests."""
 
         assert self.normalized_request is not None
-        subtopics = self.normalized_request.get('selected_subtopic_ids')
+        raw_subtopics = self.normalized_request.get('selected_subtopic_ids')
 
-        if not isinstance(subtopics, list) or not all(
-            isinstance(s, int) for s in subtopics
+        # Here we use object because raw_subtopics comes from request payload
+        # and may be any runtime shape before validation.
+        # Here we use cast because the runtime validator must inspect a generic
+        # request value prior to narrowing it.
+        if not isinstance(cast(object, raw_subtopics), list) or not all(
+            # Here we use object because items are validated dynamically before
+            # they are narrowed to integers.
+            # Here we use cast because the all() loop must treat items as generic
+            # values while performing runtime type checks.
+            isinstance(s, int)
+            for s in cast(List[object], raw_subtopics)
         ):
             raise self.InvalidInputException('Invalid subtopic IDs')
+        # Here we use cast because subtopics is guaranteed to be List[int] after
+        # the validation check above.
+        subtopics = cast(List[int], raw_subtopics)
 
-        topic_url_fragment = self.request.route_kwargs.get('topic_url_fragment')
+        # Here we use cast because the route argument is required for this
+        # handler, but framework typing keeps route_kwargs values optional.
+        topic_url_fragment = cast(
+            str, self.request.route_kwargs.get('topic_url_fragment')
+        )
         topic = topic_fetchers.get_topic_by_url_fragment(topic_url_fragment)
+        if topic is None:
+            raise self.NotFoundException
 
         subtopics_ids = {subtopic.id for subtopic in topic.subtopics}
 

--- a/core/controllers/access_validators.py
+++ b/core/controllers/access_validators.py
@@ -29,10 +29,19 @@ from core.domain import (
     user_services,
 )
 
-from typing import Dict, List, Optional, TypedDict, cast
+from typing import Any, Dict, List, Optional, TypedDict, TypeGuard, cast
 
 # TODO(#13605): Refactor access validation handlers to follow a single handler
 # pattern.
+
+
+# Here we use type Any because this helper validates a runtime request value
+# before it is narrowed to a more specific list type.
+def _is_list_of_int(values: Any) -> TypeGuard[List[int]]:
+    """Returns whether the given value is a list of integers."""
+    return isinstance(values, list) and all(
+        isinstance(value, int) for value in values
+    )
 
 
 class ClassroomAccessValidationHandlerNormalizedRequestDict(TypedDict):
@@ -331,22 +340,10 @@ class PracticeSessionAccessValidationPage(
         assert self.normalized_request is not None
         raw_subtopics = self.normalized_request.get('selected_subtopic_ids')
 
-        # Here we use object because raw_subtopics comes from request payload
-        # and may be any runtime shape before validation.
-        # Here we use cast because the runtime validator must inspect a generic
-        # request value prior to narrowing it.
-        if not isinstance(cast(object, raw_subtopics), list) or not all(
-            # Here we use object because items are validated dynamically before
-            # they are narrowed to integers.
-            # Here we use cast because the all() loop must treat items as generic
-            # values while performing runtime type checks.
-            isinstance(s, int)
-            for s in cast(List[object], raw_subtopics)
-        ):
+        if not _is_list_of_int(raw_subtopics):
             raise self.InvalidInputException('Invalid subtopic IDs')
-        # Here we use cast because subtopics is guaranteed to be List[int] after
-        # the validation check above.
-        subtopics = cast(List[int], raw_subtopics)
+
+        subtopics = raw_subtopics
 
         # Here we use cast because the route argument is required for this
         # handler, but framework typing keeps route_kwargs values optional.

--- a/core/controllers/library.py
+++ b/core/controllers/library.py
@@ -28,7 +28,7 @@ from core.domain import (
     user_services,
 )
 
-from typing import Dict, List, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Dict, List, Optional, Sequence, Tuple, TypedDict, Union, cast
 
 UnionSummaryDictType = Union[
     summary_services.DisplayableExplorationSummaryDict,
@@ -407,7 +407,7 @@ class ExplorationSummariesHandler(
     def get(self) -> None:
         """Handles GET requests."""
         assert self.normalized_request is not None
-        exp_ids = self.normalized_request['stringified_exp_ids']
+        raw_exp_ids = self.normalized_request['stringified_exp_ids']
         include_private_exps = self.normalized_request.get(
             'include_private_explorations'
         )
@@ -416,10 +416,17 @@ class ExplorationSummariesHandler(
         if not editor_user_id:
             include_private_exps = False
 
-        if not isinstance(exp_ids, list) or not all(
-            isinstance(exp_id, str) for exp_id in exp_ids
+        # Here we use object because raw_exp_ids comes from a decoded request
+        # payload and needs runtime validation before narrowing.
+        # Here we use cast because the validator must inspect a generic request
+        # value before assigning a stricter type.
+        if not isinstance(cast(object, raw_exp_ids), list) or not all(
+            isinstance(exp_id, str) for exp_id in raw_exp_ids
         ):
             raise self.NotFoundException
+        # Here we use cast because raw_exp_ids is guaranteed to be List[str]
+        # after the type validation above.
+        exp_ids = cast(List[str], raw_exp_ids)
 
         if include_private_exps:
             summaries = (

--- a/core/controllers/library.py
+++ b/core/controllers/library.py
@@ -28,12 +28,31 @@ from core.domain import (
     user_services,
 )
 
-from typing import Dict, List, Optional, Sequence, Tuple, TypedDict, Union, cast
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypedDict,
+    TypeGuard,
+    Union,
+)
 
 UnionSummaryDictType = Union[
     summary_services.DisplayableExplorationSummaryDict,
     summary_services.DisplayableCollectionSummaryDict,
 ]
+
+
+# Here we use type Any because this helper validates a runtime request value
+# before it is narrowed to a more specific list type.
+def _is_list_of_str(value: Any) -> TypeGuard[List[str]]:
+    """Returns whether the given value is a list of strings."""
+    return isinstance(value, list) and all(
+        isinstance(item, str) for item in value
+    )
 
 
 def get_matching_activity_dicts(
@@ -376,7 +395,10 @@ class ExplorationSummariesHandlerNormalizedRequestDict(TypedDict):
     normalized_request dictionary.
     """
 
-    stringified_exp_ids: str
+    # Here we use type Any because JsonEncodedInString can normalize to any
+    # JSON type, and we narrow the value to List[str] in get() after runtime
+    # validation.
+    stringified_exp_ids: Any
     include_private_explorations: Optional[bool]
 
 
@@ -408,6 +430,11 @@ class ExplorationSummariesHandler(
         """Handles GET requests."""
         assert self.normalized_request is not None
         raw_exp_ids = self.normalized_request['stringified_exp_ids']
+
+        if not _is_list_of_str(raw_exp_ids):
+            raise self.NotFoundException
+
+        exp_ids = raw_exp_ids
         include_private_exps = self.normalized_request.get(
             'include_private_explorations'
         )
@@ -415,18 +442,6 @@ class ExplorationSummariesHandler(
         editor_user_id = self.user_id if include_private_exps else None
         if not editor_user_id:
             include_private_exps = False
-
-        # Here we use object because raw_exp_ids comes from a decoded request
-        # payload and needs runtime validation before narrowing.
-        # Here we use cast because the validator must inspect a generic request
-        # value before assigning a stricter type.
-        if not isinstance(cast(object, raw_exp_ids), list) or not all(
-            isinstance(exp_id, str) for exp_id in raw_exp_ids
-        ):
-            raise self.NotFoundException
-        # Here we use cast because raw_exp_ids is guaranteed to be List[str]
-        # after the type validation above.
-        exp_ids = cast(List[str], raw_exp_ids)
 
         if include_private_exps:
             summaries = (

--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -46,7 +46,6 @@ from core.domain import (
     skill_services,
     stats_domain,
     stats_services,
-    story_domain,
     story_fetchers,
     summary_services,
     translation_fetchers,
@@ -54,7 +53,7 @@ from core.domain import (
     user_services,
 )
 
-from typing import Dict, List, Optional, TypedDict, Union, cast
+from typing import Dict, List, Optional, TypedDict, Union
 
 MAX_SYSTEM_RECOMMENDATIONS = 4
 
@@ -1527,11 +1526,9 @@ class ExplorationMaybeLeaveHandler(
             )
 
         if user_id and story_id:
-            # Here we use object because get_story_by_id() is typed as
-            # non-optional, but we still guard against malformed mocked data
-            # in tests without making MyPy treat the fallback branch as
-            # unreachable.
-            story_or_none: object = story_fetchers.get_story_by_id(story_id)
+            story_or_none = story_fetchers.get_story_by_id(
+                story_id, strict=False
+            )
             if story_or_none is None:
                 logging.error(
                     'Could not find a story corresponding to %s '
@@ -1540,10 +1537,7 @@ class ExplorationMaybeLeaveHandler(
                 self.render_json({})
                 return
 
-            # Here we use cast because the None branch above narrows
-            # story_or_none at runtime, and we need the explicit Story type
-            # for attribute access in strict type checking.
-            story = cast(story_domain.Story, story_or_none)
+            story = story_or_none
             learner_progress_services.record_story_started(user_id, story.id)
             if story.corresponding_topic_id is not None:
                 learner_progress_services.record_topic_started(

--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -46,6 +46,7 @@ from core.domain import (
     skill_services,
     stats_domain,
     stats_services,
+    story_domain,
     story_fetchers,
     summary_services,
     translation_fetchers,
@@ -53,7 +54,7 @@ from core.domain import (
     user_services,
 )
 
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Optional, TypedDict, Union, cast
 
 MAX_SYSTEM_RECOMMENDATIONS = 4
 
@@ -1526,22 +1527,28 @@ class ExplorationMaybeLeaveHandler(
             )
 
         if user_id and story_id:
-            story = story_fetchers.get_story_by_id(story_id, strict=False)
-            if story is not None:
-                learner_progress_services.record_story_started(
-                    user_id, story.id
-                )
-                if story.corresponding_topic_id is not None:
-                    learner_progress_services.record_topic_started(
-                        user_id, story.corresponding_topic_id
-                    )
-            else:
+            # Here we use object because get_story_by_id() is typed as
+            # non-optional, but we still guard against malformed mocked data
+            # in tests without making MyPy treat the fallback branch as
+            # unreachable.
+            story_or_none: object = story_fetchers.get_story_by_id(story_id)
+            if story_or_none is None:
                 logging.error(
                     'Could not find a story corresponding to %s '
                     'id.' % story_id
                 )
                 self.render_json({})
                 return
+
+            # Here we use cast because the None branch above narrows
+            # story_or_none at runtime, and we need the explicit Story type
+            # for attribute access in strict type checking.
+            story = cast(story_domain.Story, story_or_none)
+            learner_progress_services.record_story_started(user_id, story.id)
+            if story.corresponding_topic_id is not None:
+                learner_progress_services.record_topic_started(
+                    user_id, story.corresponding_topic_id
+                )
 
         event_services.MaybeLeaveExplorationEventHandler.record(
             exploration_id,

--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -1526,7 +1526,7 @@ class ExplorationMaybeLeaveHandler(
             )
 
         if user_id and story_id:
-            story = story_fetchers.get_story_by_id(story_id)
+            story = story_fetchers.get_story_by_id(story_id, strict=False)
             if story is not None:
                 learner_progress_services.record_story_started(
                     user_id, story.id

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -48,7 +48,7 @@ from core.domain import (
 from core.platform import models
 from core.tests import test_utils
 
-from typing import Dict, Final, List, Optional, Union
+from typing import Dict, Final, List, Optional, Union, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -2746,9 +2746,7 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        state_hit_event_log_entry_model = all_models.get()
-        assert state_hit_event_log_entry_model is not None
-        model = state_hit_event_log_entry_model
+        model = cast(stats_models.StateHitEventLogEntryModel, all_models.get())
 
         self.assertEqual(model.exploration_id, exp_id)
         self.assertEqual(model.state_name, 'new_state')
@@ -2853,9 +2851,9 @@ class StateCompleteEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateCompleteEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        state_complete_event_log_entry_model = all_models.get()
-        assert state_complete_event_log_entry_model is not None
-        model = state_complete_event_log_entry_model
+        model = cast(
+            stats_models.StateCompleteEventLogEntryModel, all_models.get()
+        )
 
         self.assertEqual(model.exp_id, exp_id)
         self.assertEqual(model.state_name, 'state_name')
@@ -2930,9 +2928,10 @@ class LeaveForRefresherExpEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        exp_event_log_model = all_models.get()
-        assert exp_event_log_model is not None
-        model = exp_event_log_model
+        model = cast(
+            stats_models.LeaveForRefresherExplorationEventLogEntryModel,
+            all_models.get(),
+        )
 
         self.assertEqual(model.exp_id, exp_id)
         self.assertEqual(model.refresher_exp_id, 'refresher_exp_id')
@@ -3078,9 +3077,10 @@ class ExplorationStartEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StartExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        event_log_entry_model = all_models.get()
-        assert event_log_entry_model is not None
-        model = event_log_entry_model
+        model = cast(
+            stats_models.StartExplorationEventLogEntryModel,
+            all_models.get(),
+        )
 
         self.assertEqual(model.exploration_id, exp_id)
         self.assertEqual(model.state_name, 'state_name')
@@ -3154,9 +3154,10 @@ class ExplorationActualStartEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        event_log_entry_model = all_models.get()
-        assert event_log_entry_model is not None
-        model = event_log_entry_model
+        model = cast(
+            stats_models.ExplorationActualStartEventLogEntryModel,
+            all_models.get(),
+        )
 
         self.assertEqual(model.exp_id, exp_id)
         self.assertEqual(model.state_name, 'state_name')
@@ -3225,9 +3226,10 @@ class SolutionHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.SolutionHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        event_log_entry_model = all_models.get()
-        assert event_log_entry_model is not None
-        model = event_log_entry_model
+        model = cast(
+            stats_models.SolutionHitEventLogEntryModel,
+            all_models.get(),
+        )
 
         self.assertEqual(model.exp_id, exp_id)
         self.assertEqual(model.state_name, 'state_name')

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1828,6 +1828,8 @@ class LearnerProgressTest(test_utils.GenericTestBase):
 
         # If the exploration is played in context of an invalid story, raise
         # an error.
+        # Here we use object because this test double must accept arbitrary
+        # positional and keyword arguments from the mocked fetcher call.
         def _mock_none_function(*_: object, **__: object) -> None:
             """Mocks None."""
             return None

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1828,9 +1828,9 @@ class LearnerProgressTest(test_utils.GenericTestBase):
 
         # If the exploration is played in context of an invalid story, raise
         # an error.
-        def _mock_none_function(_: str) -> None:
+        def _mock_none_function(_: str, _strict: bool = True) -> None:
             """Mocks None."""
-            return None
+            pass
 
         story_fetchers_swap = self.swap(
             story_fetchers, 'get_story_by_id', _mock_none_function

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -2746,6 +2746,8 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms that exactly one log entry exists.
         model = cast(stats_models.StateHitEventLogEntryModel, all_models.get())
 
         self.assertEqual(model.exploration_id, exp_id)
@@ -2851,6 +2853,8 @@ class StateCompleteEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateCompleteEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.StateCompleteEventLogEntryModel, all_models.get()
         )
@@ -2928,6 +2932,8 @@ class LeaveForRefresherExpEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.LeaveForRefresherExplorationEventLogEntryModel,
             all_models.get(),
@@ -3077,6 +3083,8 @@ class ExplorationStartEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StartExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.StartExplorationEventLogEntryModel,
             all_models.get(),
@@ -3154,6 +3162,8 @@ class ExplorationActualStartEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.ExplorationActualStartEventLogEntryModel,
             all_models.get(),
@@ -3226,6 +3236,8 @@ class SolutionHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.SolutionHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.SolutionHitEventLogEntryModel,
             all_models.get(),

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1830,7 +1830,7 @@ class LearnerProgressTest(test_utils.GenericTestBase):
         # an error.
         def _mock_none_function(_: str, _strict: bool = True) -> None:
             """Mocks None."""
-            pass
+            return None
 
         story_fetchers_swap = self.swap(
             story_fetchers, 'get_story_by_id', _mock_none_function

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1828,7 +1828,7 @@ class LearnerProgressTest(test_utils.GenericTestBase):
 
         # If the exploration is played in context of an invalid story, raise
         # an error.
-        def _mock_none_function(_: str, _strict: bool = True) -> None:
+        def _mock_none_function(*_: object, **__: object) -> None:
             """Mocks None."""
             return None
 

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -2746,7 +2746,7 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms that exactly one log entry exists.
         model = cast(stats_models.StateHitEventLogEntryModel, all_models.get())
 
@@ -2853,7 +2853,7 @@ class StateCompleteEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateCompleteEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.StateCompleteEventLogEntryModel, all_models.get()
@@ -2932,7 +2932,7 @@ class LeaveForRefresherExpEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.LeaveForRefresherExplorationEventLogEntryModel,
@@ -3083,7 +3083,7 @@ class ExplorationStartEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StartExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.StartExplorationEventLogEntryModel,
@@ -3162,7 +3162,7 @@ class ExplorationActualStartEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.ExplorationActualStartEventLogEntryModel,
@@ -3236,7 +3236,7 @@ class SolutionHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.SolutionHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms that exactly one log entry exists.
         model = cast(
             stats_models.SolutionHitEventLogEntryModel,

--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -63,7 +63,13 @@ class StoryPageDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         Args:
             story_id: str. The story ID.
         """
-        story = story_fetchers.get_story_by_id(story_id)
+        story = story_fetchers.get_story_by_id(story_id, strict=False)
+        if story is None:
+            logging.error(
+                'Could not find a story corresponding to %s id.' % story_id
+            )
+            self.render_json({})
+            return
         topic_id = story.corresponding_topic_id
         topic_name = topic_fetchers.get_topic_by_id(topic_id).name
 
@@ -288,7 +294,7 @@ class StoryProgressHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
             node_id: str. The node ID.
         """
         assert self.user_id is not None
-        story = story_fetchers.get_story_by_id(story_id)
+        story = story_fetchers.get_story_by_id(story_id, strict=False)
         if story is None:
             logging.error(
                 'Could not find a story corresponding to ' '%s id.' % story_id

--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -63,13 +63,7 @@ class StoryPageDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         Args:
             story_id: str. The story ID.
         """
-        story = story_fetchers.get_story_by_id(story_id, strict=False)
-        if story is None:
-            logging.error(
-                'Could not find a story corresponding to %s id.' % story_id
-            )
-            self.render_json({})
-            return
+        story = story_fetchers.get_story_by_id(story_id)
         topic_id = story.corresponding_topic_id
         topic_name = topic_fetchers.get_topic_by_id(topic_id).name
 

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -933,7 +933,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
 
         def _mock_none_function(_: str, _strict: bool = True) -> None:
             """Mocks None."""
-            pass
+            return None
 
         story_fetchers_swap = self.swap(
             story_fetchers, 'get_story_by_id', _mock_none_function

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -931,6 +931,8 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             2,
         )
 
+        # Here we use object because this test double must accept arbitrary
+        # positional and keyword arguments from the mocked fetcher call.
         def _mock_none_function(*_: object, **__: object) -> None:
             """Mocks None."""
             return None

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -931,9 +931,9 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             2,
         )
 
-        def _mock_none_function(_: str) -> None:
+        def _mock_none_function(_: str, _strict: bool = True) -> None:
             """Mocks None."""
-            return None
+            pass
 
         story_fetchers_swap = self.swap(
             story_fetchers, 'get_story_by_id', _mock_none_function

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -931,7 +931,7 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             2,
         )
 
-        def _mock_none_function(_: str, _strict: bool = True) -> None:
+        def _mock_none_function(*_: object, **__: object) -> None:
             """Mocks None."""
             return None
 

--- a/core/domain/app_feedback_report_services.py
+++ b/core/domain/app_feedback_report_services.py
@@ -191,7 +191,7 @@ def _update_report_stats_model_in_transaction(
         )
     )
     stats_model = (
-        # Here use cast because get_by_id() can return None and this function
+        # Here we use cast because get_by_id() can return None and this function
         # handles both create and update flows.
         cast(
             Optional[app_feedback_report_models.AppFeedbackReportStatsModel],
@@ -226,7 +226,7 @@ def _update_report_stats_model_in_transaction(
             stats_id, platform, ticket_id, date, 0, stats_dict
         )
         stats_model = (
-            # Here use cast because get_by_id() can return None and this
+            # Here we use cast because get_by_id() can return None and this
             # branch re-fetches the Optional model after create.
             cast(
                 Optional[

--- a/core/domain/app_feedback_report_services.py
+++ b/core/domain/app_feedback_report_services.py
@@ -190,11 +190,15 @@ def _update_report_stats_model_in_transaction(
             platform, ticket_id, date
         )
     )
-    stats_model = cast(
-        Optional[app_feedback_report_models.AppFeedbackReportStatsModel],
-        app_feedback_report_models.AppFeedbackReportStatsModel.get_by_id(
-            stats_id
-        ),
+    stats_model = (
+        # Here use cast because get_by_id() can return None and this function
+        # handles both create and update flows.
+        cast(
+            Optional[app_feedback_report_models.AppFeedbackReportStatsModel],
+            app_feedback_report_models.AppFeedbackReportStatsModel.get_by_id(
+                stats_id
+            ),
+        )
     )
 
     stats_parameter_names = app_feedback_report_constants.StatsParameterNames
@@ -221,11 +225,17 @@ def _update_report_stats_model_in_transaction(
         app_feedback_report_models.AppFeedbackReportStatsModel.create(
             stats_id, platform, ticket_id, date, 0, stats_dict
         )
-        stats_model = cast(
-            Optional[app_feedback_report_models.AppFeedbackReportStatsModel],
-            app_feedback_report_models.AppFeedbackReportStatsModel.get_by_id(
-                stats_id
-            ),
+        stats_model = (
+            # Here use cast because get_by_id() can return None and this
+            # branch re-fetches the Optional model after create.
+            cast(
+                Optional[
+                    app_feedback_report_models.AppFeedbackReportStatsModel
+                ],
+                app_feedback_report_models.AppFeedbackReportStatsModel.get_by_id(
+                    stats_id
+                ),
+            )
         )
     else:
         # Update existing stats model.

--- a/core/domain/app_feedback_report_services.py
+++ b/core/domain/app_feedback_report_services.py
@@ -190,10 +190,11 @@ def _update_report_stats_model_in_transaction(
             platform, ticket_id, date
         )
     )
-    stats_model = (
+    stats_model = cast(
+        Optional[app_feedback_report_models.AppFeedbackReportStatsModel],
         app_feedback_report_models.AppFeedbackReportStatsModel.get_by_id(
             stats_id
-        )
+        ),
     )
 
     stats_parameter_names = app_feedback_report_constants.StatsParameterNames
@@ -220,10 +221,11 @@ def _update_report_stats_model_in_transaction(
         app_feedback_report_models.AppFeedbackReportStatsModel.create(
             stats_id, platform, ticket_id, date, 0, stats_dict
         )
-        stats_model = (
+        stats_model = cast(
+            Optional[app_feedback_report_models.AppFeedbackReportStatsModel],
             app_feedback_report_models.AppFeedbackReportStatsModel.get_by_id(
                 stats_id
-            )
+            ),
         )
     else:
         # Update existing stats model.

--- a/core/domain/app_feedback_report_services.py
+++ b/core/domain/app_feedback_report_services.py
@@ -291,6 +291,7 @@ def _update_report_stats_model_in_transaction(
             )
         )
 
+    assert stats_model is not None
     stats_model.daily_param_stats = stats_dict
     stats_model.total_reports_submitted += delta
 

--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -1481,9 +1481,9 @@ def save_collection_summary(
     }
 
     collection_summary_model = (
-        # Here use cast because get_by_id() returns a generic Model type
-        # that needs to be narrowed to Optional[CollectionSummaryModel] for
-        # type checker narrowing in the post-fetch None check branch.
+        # This cast narrows get_by_id() to Optional[CollectionSummaryModel] so
+        # the type checker can correctly narrow in the following None check.
+        # Here use cast because get_by_id() returns a generic Model type.
         cast(
             Optional[collection_models.CollectionSummaryModel],
             collection_models.CollectionSummaryModel.get_by_id(

--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -1483,7 +1483,7 @@ def save_collection_summary(
     collection_summary_model = (
         # This cast narrows get_by_id() to Optional[CollectionSummaryModel] so
         # the type checker can correctly narrow in the following None check.
-        # Here use cast because get_by_id() returns a generic Model type.
+        # Here we use cast because get_by_id() returns a generic Model type.
         cast(
             Optional[collection_models.CollectionSummaryModel],
             collection_models.CollectionSummaryModel.get_by_id(

--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -419,13 +419,24 @@ def get_collection_and_collection_rights_by_id(
     )
 
     collection = None
-    if collection_and_rights[0][0] is not None:
-        collection = get_collection_from_model(collection_and_rights[0][0])
+    # Here we use cast because the datastore fetch result is typed broadly,
+    # but this branch must stay reachable when the collection is missing.
+    collection_model = cast(
+        Optional[collection_models.CollectionModel], collection_and_rights[0][0]
+    )
+    if collection_model is not None:
+        collection = get_collection_from_model(collection_model)
 
     collection_rights = None
-    if collection_and_rights[1][0] is not None:
+    # Here we use cast because the datastore fetch result is typed broadly,
+    # but this branch must stay reachable when the rights row is missing.
+    collection_rights_model = cast(
+        Optional[collection_models.CollectionRightsModel],
+        collection_and_rights[1][0],
+    )
+    if collection_rights_model is not None:
         collection_rights = rights_manager.get_activity_rights_from_model(
-            collection_and_rights[1][0], constants.ACTIVITY_TYPE_COLLECTION
+            collection_rights_model, constants.ACTIVITY_TYPE_COLLECTION
         )
 
     return (collection, collection_rights)
@@ -1470,8 +1481,14 @@ def save_collection_summary(
     }
 
     collection_summary_model = (
-        collection_models.CollectionSummaryModel.get_by_id(
-            collection_summary.id
+        # Here use cast because get_by_id() returns a generic Model type
+        # that needs to be narrowed to Optional[CollectionSummaryModel] for
+        # type checker narrowing in the post-fetch None check branch.
+        cast(
+            Optional[collection_models.CollectionSummaryModel],
+            collection_models.CollectionSummaryModel.get_by_id(
+                collection_summary.id
+            ),
         )
     )
     if collection_summary_model is not None:

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -1076,6 +1076,9 @@ class DraftUpgradeUtil:
                 change.property_name
                 == exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS
             ):
+                # Here use cast because this branch only runs for
+                # answer_groups updates, where new_value is
+                # List[AnswerGroupDict].
                 new_value_list = cast(
                     List[state_domain.AnswerGroupDict], change.new_value
                 )

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -178,21 +178,20 @@ class DraftUpgradeUtil:
                 if 'choices' in new_value.keys():
                     # Here we use cast because we are narrowing down the type
                     # from various customization args value types to List[
-                    # SubtitledHtmlDict] type, and this is done because here
-                    # we are accessing 'choices' keys over customization_args
-                    # and every customization arg that has a 'choices' key will
-                    # contain values of type List[SubtitledHtmlDict].
+                    # Union[state_domain.SubtitledHtmlDict, str]] type, and this is
+                    # done because here we are accessing 'choices' keys over
+                    # customization_args and every customization arg that has a
+                    # 'choices' key will contain values of type
+                    # List[Union[state_domain.SubtitledHtmlDict, str]].
                     subtitled_html_new_value_dicts = cast(
-                        List[state_domain.SubtitledHtmlDict],
+                        List[Union[state_domain.SubtitledHtmlDict, str]],
                         new_value['choices']['value'],
                     )
                     for value_index, value in enumerate(
                         subtitled_html_new_value_dicts
                     ):
                         if isinstance(value, dict) and 'html' in value:
-                            subtitled_html_new_value_dicts[value_index][
-                                'html'
-                            ] = conversion_fn(value['html'])
+                            value['html'] = conversion_fn(value['html'])
                         elif isinstance(value, str):
                             subtitled_html_new_value_dicts[value_index] = (
                                 conversion_fn(value)
@@ -1071,15 +1070,21 @@ class DraftUpgradeUtil:
                 change.property_name == exp_domain.STATE_PROPERTY_INTERACTION_ID
                 and (change.new_value == 'MathExpressionInput')
             )
-            answer_groups_change_condition = (
+            answer_groups_change_condition = False
+
+            if (
                 change.property_name
                 == exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS
-                and isinstance(change.new_value, list)
-                and (
-                    change.new_value[0]['rule_specs'][0]['rule_type']
-                    == ('IsMathematicallyEquivalentTo')
+            ):
+                new_value_list = cast(
+                    List[state_domain.AnswerGroupDict], change.new_value
                 )
-            )
+
+                if new_value_list and (
+                    new_value_list[0]['rule_specs'][0]['rule_type']
+                    == 'IsMathematicallyEquivalentTo'
+                ):
+                    answer_groups_change_condition = True
             if interaction_id_change_condition or (
                 answer_groups_change_condition
             ):

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -1076,7 +1076,7 @@ class DraftUpgradeUtil:
                 change.property_name
                 == exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS
             ):
-                # Here use cast because this branch only runs for
+                # Here we use cast because this branch only runs for
                 # answer_groups updates, where new_value is
                 # List[AnswerGroupDict].
                 new_value_list = cast(

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -1813,6 +1813,46 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 }
             )
         ]
+        draft_change_list_3_v34 = [
+            exp_domain.ExplorationChange(
+                {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'Intro',
+                    'property_name': 'content',
+                    'new_value': 'new value',
+                }
+            ),
+            exp_domain.ExplorationChange(
+                {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'Intro',
+                    'property_name': 'answer_groups',
+                    'new_value': [
+                        {
+                            'rule_specs': [
+                                {
+                                    'rule_type': 'IsMathematicallyEquivalentTo',
+                                    'inputs': {'x': 'x+y/2'},
+                                }
+                            ],
+                            'outcome': {
+                                'dest': 'Introduction',
+                                'feedback': {
+                                    'content_id': 'feedback',
+                                    'html': '<p>Content</p>',
+                                },
+                                'param_changes': [],
+                                'labelled_as_correct': False,
+                                'refresher_exploration_id': None,
+                                'missing_prerequisite_skill_id': None,
+                            },
+                            'training_data': [],
+                            'tagged_skill_misconception_id': None,
+                        }
+                    ],
+                }
+            ),
+        ]
         # Migrate exploration to state schema version 35.
         self.create_and_migrate_new_exploration('34', '35')
         migrated_draft_change_list_1_v35 = (
@@ -1842,6 +1882,13 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
             migrated_draft_change_list_2_v35_dict_list,
         )
 
+        migrated_draft_change_list_3_v35 = (
+            draft_upgrade_services.try_upgrading_draft_to_exp_version(
+                draft_change_list_3_v34, 1, 2, self.EXP_ID
+            )
+        )
+        self.assertIsNone(migrated_draft_change_list_3_v35)
+
     def test_convert_states_v33_dict_to_v34_dict(self) -> None:
         html_content = (
             '<p>Value</p><oppia-noninteractive-math raw_latex-with-value="&a'
@@ -1865,7 +1912,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                         'choices': {
                             'value': [
                                 '<p>1</p>',
-                                '<p>2</p>',
+                                {'html': html_content},
                                 html_content,
                                 '<p>4</p>',
                             ]
@@ -2099,7 +2146,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                         'choices': {
                             'value': [
                                 '<p>1</p>',
-                                '<p>2</p>',
+                                {'html': expected_html_content},
                                 expected_html_content,
                                 '<p>4</p>',
                             ]
@@ -2330,50 +2377,6 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                             }
                         }
                     ],
-                }
-            ).to_dict(),
-        )
-
-    def test_convert_html_in_draft_change_list_with_widget_customization_args(
-        self,
-    ) -> None:
-        draft_change_list = [
-            exp_domain.ExplorationChange(
-                {
-                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                    'state_name': 'state2',
-                    'property_name': 'widget_customization_args',
-                    'new_value': {
-                        'choices': {
-                            'value': [
-                                '<p>1</p>',
-                                {'html': '<p>2</p>'},
-                            ]
-                        }
-                    },
-                }
-            )
-        ]
-
-        converted_draft_change_list = draft_upgrade_services.DraftUpgradeUtil._convert_html_in_draft_change_list(
-            draft_change_list, lambda html: 'converted-' + html
-        )
-
-        self.assertEqual(
-            converted_draft_change_list[0].to_dict(),
-            exp_domain.ExplorationChange(
-                {
-                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                    'state_name': 'state2',
-                    'property_name': 'widget_customization_args',
-                    'new_value': {
-                        'choices': {
-                            'value': [
-                                'converted-<p>1</p>',
-                                {'html': 'converted-<p>2</p>'},
-                            ]
-                        }
-                    },
                 }
             ).to_dict(),
         )

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -2334,7 +2334,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
             ).to_dict(),
         )
 
-    def test_convert_html_in_draft_change_list_with_interaction_customization_args(
+    def test_convert_html_in_draft_change_list_with_widget_customization_args(
         self,
     ) -> None:
         draft_change_list = [
@@ -2342,7 +2342,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 {
                     'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                     'state_name': 'state2',
-                    'property_name': 'interaction_customization_args',
+                    'property_name': 'widget_customization_args',
                     'new_value': {
                         'choices': {
                             'value': [
@@ -2354,8 +2354,8 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 }
             )
         ]
-        # We intentionally call this helper directly to test this branch.
-        converted_draft_change_list = draft_upgrade_services.DraftUpgradeUtil._convert_html_in_draft_change_list(  # pylint: disable=protected-access
+
+        converted_draft_change_list = draft_upgrade_services.DraftUpgradeUtil._convert_html_in_draft_change_list(
             draft_change_list, lambda html: 'converted-' + html
         )
 
@@ -2365,7 +2365,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 {
                     'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                     'state_name': 'state2',
-                    'property_name': 'interaction_customization_args',
+                    'property_name': 'widget_customization_args',
                     'new_value': {
                         'choices': {
                             'value': [

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -2354,8 +2354,8 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 }
             )
         ]
-
-        converted_draft_change_list = draft_upgrade_services.DraftUpgradeUtil._convert_html_in_draft_change_list(
+        # We intentionally call this helper directly to test this branch.
+        converted_draft_change_list = draft_upgrade_services.DraftUpgradeUtil._convert_html_in_draft_change_list(  # pylint: disable=protected-access
             draft_change_list, lambda html: 'converted-' + html
         )
 

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -2334,6 +2334,50 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
             ).to_dict(),
         )
 
+    def test_convert_html_in_draft_change_list_with_interaction_customization_args(
+        self,
+    ) -> None:
+        draft_change_list = [
+            exp_domain.ExplorationChange(
+                {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'state2',
+                    'property_name': 'interaction_customization_args',
+                    'new_value': {
+                        'choices': {
+                            'value': [
+                                '<p>1</p>',
+                                {'html': '<p>2</p>'},
+                            ]
+                        }
+                    },
+                }
+            )
+        ]
+
+        converted_draft_change_list = draft_upgrade_services.DraftUpgradeUtil._convert_html_in_draft_change_list(
+            draft_change_list, lambda html: 'converted-' + html
+        )
+
+        self.assertEqual(
+            converted_draft_change_list[0].to_dict(),
+            exp_domain.ExplorationChange(
+                {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'state2',
+                    'property_name': 'interaction_customization_args',
+                    'new_value': {
+                        'choices': {
+                            'value': [
+                                'converted-<p>1</p>',
+                                {'html': 'converted-<p>2</p>'},
+                            ]
+                        }
+                    },
+                }
+            ).to_dict(),
+        )
+
     def test_convert_states_v32_dict_to_v33_dict(self) -> None:
         draft_change_list_v32 = [
             exp_domain.ExplorationChange(

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -1912,7 +1912,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                         'choices': {
                             'value': [
                                 '<p>1</p>',
-                                {'html': html_content},
+                                '<p>2</p>',
                                 html_content,
                                 '<p>4</p>',
                             ]
@@ -2146,7 +2146,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                         'choices': {
                             'value': [
                                 '<p>1</p>',
-                                {'html': expected_html_content},
+                                '<p>2</p>',
                                 expected_html_content,
                                 '<p>4</p>',
                             ]

--- a/core/domain/email_services.py
+++ b/core/domain/email_services.py
@@ -43,7 +43,7 @@ def _is_email_valid(email_address: Optional[str]) -> bool:
     Returns:
         bool. Whether the specified email address is valid.
     """
-    if email_address is None:
+    if not isinstance(email_address, str):
         return False
 
     stripped_address = email_address.strip()

--- a/core/domain/email_services.py
+++ b/core/domain/email_services.py
@@ -34,15 +34,18 @@ if MYPY:  # pragma: no cover
 email_services = models.Registry.import_email_services()
 
 
-def _is_email_valid(email_address: str) -> bool:
+def _is_email_valid(email_address: Optional[str]) -> bool:
     """Determines whether an email address is valid.
 
     Args:
-        email_address: str. Email address to check.
+        email_address: str|None. Email address to check.
 
     Returns:
         bool. Whether the specified email address is valid.
     """
+    if email_address is None:
+        return False
+
     stripped_address = email_address.strip()
     if not stripped_address:
         return False

--- a/core/domain/email_services.py
+++ b/core/domain/email_services.py
@@ -43,9 +43,6 @@ def _is_email_valid(email_address: str) -> bool:
     Returns:
         bool. Whether the specified email address is valid.
     """
-    if not isinstance(email_address, str):
-        return False
-
     stripped_address = email_address.strip()
     if not stripped_address:
         return False

--- a/core/domain/event_services_test.py
+++ b/core/domain/event_services_test.py
@@ -36,6 +36,8 @@ from core.domain import (
 from core.platform import models
 from core.tests import test_utils
 
+from typing import cast
+
 MYPY = False
 if MYPY:  # pragma: no cover
     from mypy_imports import (
@@ -87,10 +89,10 @@ class ExplorationActualStartEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.ExplorationActualStartEventLogEntryModel,
+            all_models.get(),
+        )
         self.assertEqual(model.exp_id, 'exp_id')
         self.assertEqual(model.state_name, 'state_name')
         self.assertEqual(model.session_id, 'session_id')
@@ -110,10 +112,9 @@ class SolutionHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.SolutionHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.SolutionHitEventLogEntryModel, all_models.get()
+        )
         self.assertEqual(model.exp_id, 'exp_id')
         self.assertEqual(model.state_name, 'state_name')
         self.assertEqual(model.session_id, 'session_id')
@@ -135,10 +136,9 @@ class StartExplorationEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StartExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.StartExplorationEventLogEntryModel, all_models.get()
+        )
         self.assertEqual(model.event_type, feconf.EVENT_TYPE_START_EXPLORATION)
         self.assertEqual(model.exploration_id, 'exp_id')
         self.assertEqual(model.exploration_version, 1)
@@ -172,10 +172,10 @@ class MaybeLeaveExplorationEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.MaybeLeaveExplorationEventLogEntryModel,
+            all_models.get(),
+        )
         self.assertEqual(
             model.event_type, feconf.EVENT_TYPE_MAYBE_LEAVE_EXPLORATION
         )
@@ -212,10 +212,10 @@ class CompleteExplorationEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.CompleteExplorationEventLogEntryModel,
+            all_models.get(),
+        )
         self.assertEqual(
             model.event_type, feconf.EVENT_TYPE_COMPLETE_EXPLORATION
         )
@@ -242,10 +242,9 @@ class RateExplorationEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.RateExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.RateExplorationEventLogEntryModel, all_models.get()
+        )
         self.assertEqual(model.event_type, feconf.EVENT_TYPE_RATE_EXPLORATION)
         self.assertEqual(model.exploration_id, 'exp_id')
         self.assertEqual(model.rating, 3)
@@ -270,10 +269,7 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(stats_models.StateHitEventLogEntryModel, all_models.get())
         self.assertEqual(model.exploration_id, 'exp_id')
         self.assertEqual(model.state_name, 'state_name')
         self.assertEqual(model.session_id, 'session_id')
@@ -295,10 +291,9 @@ class StateCompleteEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateCompleteEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.StateCompleteEventLogEntryModel, all_models.get()
+        )
         self.assertEqual(model.exp_id, 'exp_id')
         self.assertEqual(model.state_name, 'state_name')
         self.assertEqual(model.session_id, 'session_id')
@@ -323,10 +318,10 @@ class LeaveForRefresherExpEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.LeaveForRefresherExplorationEventLogEntryModel,
+            all_models.get(),
+        )
         self.assertEqual(model.exp_id, 'exp_id')
         self.assertEqual(model.refresher_exp_id, 'refresher_exp_id')
         self.assertEqual(model.state_name, 'state_name')
@@ -455,9 +450,7 @@ class StatsEventsHandlerUnitTests(test_utils.GenericTestBase):
 
         all_models = stats_models.ExplorationStatsModel.get_all()
         self.assertEqual(all_models.count(), 1)
-        model = all_models.get()
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(stats_models.ExplorationStatsModel, all_models.get())
         self.assertEqual(model.exp_id, exp_id)
         self.assertEqual(model.exp_version, exploration.version)
 
@@ -537,10 +530,9 @@ class AnswerSubmissionEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.AnswerSubmittedEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert model is not None
+        model = cast(
+            stats_models.AnswerSubmittedEventLogEntryModel, all_models.get()
+        )
         self.assertEqual(model.exp_id, exp_id)
         self.assertEqual(model.exp_version, exploration.version)
 

--- a/core/domain/event_services_test.py
+++ b/core/domain/event_services_test.py
@@ -89,7 +89,7 @@ class ExplorationActualStartEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.ExplorationActualStartEventLogEntryModel,
@@ -114,7 +114,7 @@ class SolutionHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.SolutionHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.SolutionHitEventLogEntryModel, all_models.get()
@@ -140,7 +140,7 @@ class StartExplorationEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StartExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.StartExplorationEventLogEntryModel, all_models.get()
@@ -178,7 +178,7 @@ class MaybeLeaveExplorationEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.MaybeLeaveExplorationEventLogEntryModel,
@@ -220,7 +220,7 @@ class CompleteExplorationEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.CompleteExplorationEventLogEntryModel,
@@ -252,7 +252,7 @@ class RateExplorationEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.RateExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.RateExplorationEventLogEntryModel, all_models.get()
@@ -281,7 +281,7 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(stats_models.StateHitEventLogEntryModel, all_models.get())
         self.assertEqual(model.exploration_id, 'exp_id')
@@ -305,7 +305,7 @@ class StateCompleteEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateCompleteEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.StateCompleteEventLogEntryModel, all_models.get()
@@ -334,7 +334,7 @@ class LeaveForRefresherExpEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.LeaveForRefresherExplorationEventLogEntryModel,
@@ -468,7 +468,7 @@ class StatsEventsHandlerUnitTests(test_utils.GenericTestBase):
 
         all_models = stats_models.ExplorationStatsModel.get_all()
         self.assertEqual(all_models.count(), 1)
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one stats entry exists.
         model = cast(stats_models.ExplorationStatsModel, all_models.get())
         self.assertEqual(model.exp_id, exp_id)
@@ -550,7 +550,7 @@ class AnswerSubmissionEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.AnswerSubmittedEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
-        # Here use cast because get() returns Optional model in stubs while
+        # Here we use cast because get() returns Optional model in stubs while
         # count() above confirms exactly one answer event exists.
         model = cast(
             stats_models.AnswerSubmittedEventLogEntryModel, all_models.get()

--- a/core/domain/event_services_test.py
+++ b/core/domain/event_services_test.py
@@ -89,6 +89,8 @@ class ExplorationActualStartEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.ExplorationActualStartEventLogEntryModel,
             all_models.get(),
@@ -112,6 +114,8 @@ class SolutionHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.SolutionHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.SolutionHitEventLogEntryModel, all_models.get()
         )
@@ -136,6 +140,8 @@ class StartExplorationEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StartExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.StartExplorationEventLogEntryModel, all_models.get()
         )
@@ -172,6 +178,8 @@ class MaybeLeaveExplorationEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.MaybeLeaveExplorationEventLogEntryModel,
             all_models.get(),
@@ -212,6 +220,8 @@ class CompleteExplorationEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.CompleteExplorationEventLogEntryModel,
             all_models.get(),
@@ -242,6 +252,8 @@ class RateExplorationEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.RateExplorationEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.RateExplorationEventLogEntryModel, all_models.get()
         )
@@ -269,6 +281,8 @@ class StateHitEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateHitEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(stats_models.StateHitEventLogEntryModel, all_models.get())
         self.assertEqual(model.exploration_id, 'exp_id')
         self.assertEqual(model.state_name, 'state_name')
@@ -291,6 +305,8 @@ class StateCompleteEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.StateCompleteEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.StateCompleteEventLogEntryModel, all_models.get()
         )
@@ -318,6 +334,8 @@ class LeaveForRefresherExpEventHandlerTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one event log entry exists.
         model = cast(
             stats_models.LeaveForRefresherExplorationEventLogEntryModel,
             all_models.get(),
@@ -450,6 +468,8 @@ class StatsEventsHandlerUnitTests(test_utils.GenericTestBase):
 
         all_models = stats_models.ExplorationStatsModel.get_all()
         self.assertEqual(all_models.count(), 1)
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one stats entry exists.
         model = cast(stats_models.ExplorationStatsModel, all_models.get())
         self.assertEqual(model.exp_id, exp_id)
         self.assertEqual(model.exp_version, exploration.version)
@@ -530,6 +550,8 @@ class AnswerSubmissionEventHandlerTests(test_utils.GenericTestBase):
         all_models = stats_models.AnswerSubmittedEventLogEntryModel.get_all()
         self.assertEqual(all_models.count(), 1)
 
+        # Here use cast because get() returns Optional model in stubs while
+        # count() above confirms exactly one answer event exists.
         model = cast(
             stats_models.AnswerSubmittedEventLogEntryModel, all_models.get()
         )

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -492,7 +492,11 @@ def get_content_updates_from_cmd_edit_state_property_change(
     if change.cmd != exp_domain.CMD_EDIT_STATE_PROPERTY:
         return content_id_to_content_value
 
-    if change.new_value is None:
+    # Here we use object because change.new_value can be malformed at runtime,
+    # and we need a runtime guard without forcing MyPy to assume the branch is
+    # unreachable.
+    change_new_value: object = change.new_value
+    if change_new_value is None:
         return content_id_to_content_value
 
     def add_subtitled_html_from_dict(

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -882,16 +882,15 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_SOLICIT_ANSWER_DETAILS
                 ):
-                    # Here we use cast because change.new_value is typed as a
-                    # bool for this command, but we still want a runtime guard
-                    # that works on malformed data without making MyPy infer an
-                    # impossible str/bool intersection.
-                    # Here we use object because it preserves the isinstance guard
-                    # without allowing MyPy to infer an impossible str/bool union.
-                    if not isinstance(cast(object, change.new_value), bool):
+                    # Here we use object because change.new_value is typed as
+                    # a bool for this command, but we still need a runtime
+                    # guard for malformed data without making MyPy treat the
+                    # isinstance check as unreachable.
+                    solicit_answer_details_value: object = change.new_value
+                    if not isinstance(solicit_answer_details_value, bool):
                         raise Exception(
                             'Expected solicit_answer_details to be a '
-                            + 'bool, received %s' % change.new_value
+                            + 'bool, received %s' % solicit_answer_details_value
                         )
                     # Here we use cast because this 'elif'
                     # condition forces change to have type
@@ -907,16 +906,15 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_CARD_IS_CHECKPOINT
                 ):
-                    # Here we use cast because change.new_value is typed as a
-                    # bool for this command, but we still want a runtime guard
-                    # that works on malformed data without making MyPy infer an
-                    # impossible str/bool intersection.
-                    # Here we use object because it preserves the isinstance guard
-                    # without allowing MyPy to infer an impossible str/bool union.
-                    if not isinstance(cast(object, change.new_value), bool):
+                    # Here we use object because change.new_value is typed as
+                    # a bool for this command, but we still need a runtime
+                    # guard for malformed data without making MyPy treat the
+                    # isinstance check as unreachable.
+                    card_is_checkpoint_value: object = change.new_value
+                    if not isinstance(card_is_checkpoint_value, bool):
                         raise Exception(
                             'Expected card_is_checkpoint to be a '
-                            + 'bool, received %s' % change.new_value
+                            + 'bool, received %s' % card_is_checkpoint_value
                         )
                     # Here we use cast because this 'elif'
                     # condition forces change to have type

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -882,7 +882,13 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_SOLICIT_ANSWER_DETAILS
                 ):
-                    if not isinstance(change.new_value, bool):
+                    # Here we use cast because change.new_value is typed as a
+                    # bool for this command, but we still want a runtime guard
+                    # that works on malformed data without making MyPy infer an
+                    # impossible str/bool intersection.
+                    # Here we use object because it preserves the isinstance guard
+                    # without allowing MyPy to infer an impossible str/bool union.
+                    if not isinstance(cast(object, change.new_value), bool):
                         raise Exception(
                             'Expected solicit_answer_details to be a '
                             + 'bool, received %s' % change.new_value
@@ -901,7 +907,13 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_CARD_IS_CHECKPOINT
                 ):
-                    if not isinstance(change.new_value, bool):
+                    # Here we use cast because change.new_value is typed as a
+                    # bool for this command, but we still want a runtime guard
+                    # that works on malformed data without making MyPy infer an
+                    # impossible str/bool intersection.
+                    # Here we use object because it preserves the isinstance guard
+                    # without allowing MyPy to infer an impossible str/bool union.
+                    if not isinstance(cast(object, change.new_value), bool):
                         raise Exception(
                             'Expected card_is_checkpoint to be a '
                             + 'bool, received %s' % change.new_value

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -844,7 +844,13 @@ def apply_change_list(
                         exp_domain.EditExpStatePropertyInteractionHintsCmd,
                         change,
                     )
-                    hint_dicts = edit_state_interaction_hints_cmd.new_value
+                    # Here we use object because hint_dicts is typed as
+                    # a list for this command, but we still need a runtime
+                    # guard for malformed data without making MyPy treat the
+                    # isinstance check as unreachable.
+                    hint_dicts: object = (
+                        edit_state_interaction_hints_cmd.new_value
+                    )
                     if not isinstance(hint_dicts, list):
                         raise Exception(
                             'Expected hints_list to be a list,'

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -803,18 +803,16 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME
                 ):
-                    new_outcome = None
-                    if change.new_value:
-                        # Here we use cast because this 'elif'
-                        # condition forces change to have type
-                        # EditExpStatePropertyInteractionDefaultOutcomeCmd.
-                        edit_interaction_default_outcome_cmd = cast(
-                            exp_domain.EditExpStatePropertyInteractionDefaultOutcomeCmd,  # pylint: disable=line-too-long
-                            change,
-                        )
-                        new_outcome = state_domain.Outcome.from_dict(
-                            edit_interaction_default_outcome_cmd.new_value
-                        )
+                    # Here we use cast because this 'elif'
+                    # condition forces change to have type
+                    # EditExpStatePropertyInteractionDefaultOutcomeCmd.
+                    edit_interaction_default_outcome_cmd = cast(
+                        exp_domain.EditExpStatePropertyInteractionDefaultOutcomeCmd,  # pylint: disable=line-too-long
+                        change,
+                    )
+                    new_outcome = state_domain.Outcome.from_dict(
+                        edit_interaction_default_outcome_cmd.new_value
+                    )
                     state.update_interaction_default_outcome(new_outcome)
                 elif (
                     change.property_name
@@ -851,7 +849,6 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_INTERACTION_SOLUTION
                 ):
-                    new_solution = None
                     # Here we use cast because this 'elif'
                     # condition forces change to have type
                     # EditExpStatePropertyInteractionSolutionCmd.
@@ -859,16 +856,14 @@ def apply_change_list(
                         exp_domain.EditExpStatePropertyInteractionSolutionCmd,
                         change,
                     )
-                    if edit_interaction_solution_cmd.new_value is not None:
-                        if state.interaction.id is None:
-                            raise Exception(
-                                'solution cannot exist with None '
-                                'interaction id.'
-                            )
-                        new_solution = state_domain.Solution.from_dict(
-                            state.interaction.id,
-                            edit_interaction_solution_cmd.new_value,
+                    if state.interaction.id is None:
+                        raise Exception(
+                            'solution cannot exist with None ' 'interaction id.'
                         )
+                    new_solution = state_domain.Solution.from_dict(
+                        state.interaction.id,
+                        edit_interaction_solution_cmd.new_value,
+                    )
                     state.update_interaction_solution(new_solution)
                 elif (
                     change.property_name

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -492,13 +492,6 @@ def get_content_updates_from_cmd_edit_state_property_change(
     if change.cmd != exp_domain.CMD_EDIT_STATE_PROPERTY:
         return content_id_to_content_value
 
-    # Here we use object because change.new_value can be malformed at runtime,
-    # and we need a runtime guard without forcing MyPy to assume the branch is
-    # unreachable.
-    change_new_value: object = change.new_value
-    if change_new_value is None:
-        return content_id_to_content_value
-
     def add_subtitled_html_from_dict(
         subtitled_html: state_domain.SubtitledHtmlDict,
     ) -> None:
@@ -848,18 +841,7 @@ def apply_change_list(
                         exp_domain.EditExpStatePropertyInteractionHintsCmd,
                         change,
                     )
-                    # Here we use object because hint_dicts is typed as
-                    # a list for this command, but we still need a runtime
-                    # guard for malformed data without making MyPy treat the
-                    # isinstance check as unreachable.
-                    hint_dicts: object = (
-                        edit_state_interaction_hints_cmd.new_value
-                    )
-                    if not isinstance(hint_dicts, list):
-                        raise Exception(
-                            'Expected hints_list to be a list,'
-                            ' received %s' % hint_dicts
-                        )
+                    hint_dicts = edit_state_interaction_hints_cmd.new_value
                     new_hints_list = [
                         state_domain.Hint.from_dict(hint_dict)
                         for hint_dict in hint_dicts
@@ -892,16 +874,6 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_SOLICIT_ANSWER_DETAILS
                 ):
-                    # Here we use object because change.new_value is typed as
-                    # a bool for this command, but we still need a runtime
-                    # guard for malformed data without making MyPy treat the
-                    # isinstance check as unreachable.
-                    solicit_answer_details_value: object = change.new_value
-                    if not isinstance(solicit_answer_details_value, bool):
-                        raise Exception(
-                            'Expected solicit_answer_details to be a '
-                            + 'bool, received %s' % solicit_answer_details_value
-                        )
                     # Here we use cast because this 'elif'
                     # condition forces change to have type
                     # EditExpStatePropertySolicitAnswerDetailsCmd.
@@ -916,16 +888,6 @@ def apply_change_list(
                     change.property_name
                     == exp_domain.STATE_PROPERTY_CARD_IS_CHECKPOINT
                 ):
-                    # Here we use object because change.new_value is typed as
-                    # a bool for this command, but we still need a runtime
-                    # guard for malformed data without making MyPy treat the
-                    # isinstance check as unreachable.
-                    card_is_checkpoint_value: object = change.new_value
-                    if not isinstance(card_is_checkpoint_value, bool):
-                        raise Exception(
-                            'Expected card_is_checkpoint to be a '
-                            + 'bool, received %s' % card_is_checkpoint_value
-                        )
                     # Here we use cast because this 'elif'
                     # condition forces change to have type
                     # EditExpStatePropertyCardIsCheckpointCmd.

--- a/core/domain/html_validation_service.py
+++ b/core/domain/html_validation_service.py
@@ -29,7 +29,7 @@ from extensions.rich_text_components import components
 
 import bs4
 import defusedxml.ElementTree
-from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
+from typing import Callable, Dict, Iterator, List, Tuple, Union
 
 
 def wrap_with_siblings(tag: bs4.element.Tag, p: bs4.element.Tag) -> None:
@@ -983,9 +983,7 @@ def validate_math_tags_in_html_with_attribute_math_content(
     return error_list
 
 
-# Here we use type Any because callers may pass malformed runtime values, and
-# this helper needs to reject non-bytes inputs before parsing.
-def is_parsable_as_xml(xml_string: Any) -> bool:
+def is_parsable_as_xml(xml_string: bytes) -> bool:
     """Checks if input string is parsable as XML.
 
     Args:
@@ -994,8 +992,6 @@ def is_parsable_as_xml(xml_string: Any) -> bool:
     Returns:
         bool. Whether xml_string is parsable as XML or not.
     """
-    if not isinstance(xml_string, bytes):
-        return False
     try:
         defusedxml.ElementTree.fromstring(xml_string)
         return True

--- a/core/domain/html_validation_service.py
+++ b/core/domain/html_validation_service.py
@@ -29,7 +29,7 @@ from extensions.rich_text_components import components
 
 import bs4
 import defusedxml.ElementTree
-from typing import Callable, Dict, Iterator, List, Tuple, Union, cast
+from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
 
 def wrap_with_siblings(tag: bs4.element.Tag, p: bs4.element.Tag) -> None:
@@ -983,20 +983,18 @@ def validate_math_tags_in_html_with_attribute_math_content(
     return error_list
 
 
-def is_parsable_as_xml(xml_string: bytes) -> bool:
+# Here we use type Any because callers may pass malformed runtime values, and
+# this helper needs to reject non-bytes inputs before parsing.
+def is_parsable_as_xml(xml_string: Any) -> bool:
     """Checks if input string is parsable as XML.
 
     Args:
-        xml_string: bytes. The XML string in bytes.
+        xml_string: *. The XML string in bytes.
 
     Returns:
         bool. Whether xml_string is parsable as XML or not.
     """
-    # Here we use object because this validator can receive malformed runtime
-    # values even though the helper annotation is bytes.
-    # Here we use cast because the runtime guard should still handle malformed
-    # inputs even though the static type for this helper is already bytes.
-    if not isinstance(cast(object, xml_string), bytes):
+    if not isinstance(xml_string, bytes):
         return False
     try:
         defusedxml.ElementTree.fromstring(xml_string)

--- a/core/domain/html_validation_service.py
+++ b/core/domain/html_validation_service.py
@@ -29,7 +29,7 @@ from extensions.rich_text_components import components
 
 import bs4
 import defusedxml.ElementTree
-from typing import Callable, Dict, Iterator, List, Tuple, Union
+from typing import Callable, Dict, Iterator, List, Tuple, Union, cast
 
 
 def wrap_with_siblings(tag: bs4.element.Tag, p: bs4.element.Tag) -> None:
@@ -992,7 +992,11 @@ def is_parsable_as_xml(xml_string: bytes) -> bool:
     Returns:
         bool. Whether xml_string is parsable as XML or not.
     """
-    if not isinstance(xml_string, bytes):
+    # Here we use object because this validator can receive malformed runtime
+    # values even though the helper annotation is bytes.
+    # Here we use cast because the runtime guard should still handle malformed
+    # inputs even though the static type for this helper is already bytes.
+    if not isinstance(cast(object, xml_string), bytes):
         return False
     try:
         defusedxml.ElementTree.fromstring(xml_string)

--- a/core/domain/learner_playlist_services.py
+++ b/core/domain/learner_playlist_services.py
@@ -66,7 +66,7 @@ def save_learner_playlist(
         learner_playlist: LearnerPlaylist. The learner playlist domain object to
             be saved in the datastore.
     """
-    # Here use cast because get_by_id() can return None and this branch
+    # Here we use cast because get_by_id() can return None and this branch
     # explicitly handles both Optional outcomes.
     learner_playlist_model = cast(
         Optional[user_models.LearnerPlaylistModel],

--- a/core/domain/learner_playlist_services.py
+++ b/core/domain/learner_playlist_services.py
@@ -66,6 +66,8 @@ def save_learner_playlist(
         learner_playlist: LearnerPlaylist. The learner playlist domain object to
             be saved in the datastore.
     """
+    # Here use cast because get_by_id() can return None and this branch
+    # explicitly handles both Optional outcomes.
     learner_playlist_model = cast(
         Optional[user_models.LearnerPlaylistModel],
         user_models.LearnerPlaylistModel.get_by_id(learner_playlist.id),

--- a/core/domain/learner_playlist_services.py
+++ b/core/domain/learner_playlist_services.py
@@ -22,7 +22,7 @@ from core import feconf
 from core.domain import subscription_services, user_domain
 from core.platform import models
 
-from typing import Final, List, Optional, Tuple
+from typing import Final, List, Optional, Tuple, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -66,21 +66,24 @@ def save_learner_playlist(
         learner_playlist: LearnerPlaylist. The learner playlist domain object to
             be saved in the datastore.
     """
-    learner_playlist_dict = {
-        'exploration_ids': learner_playlist.exploration_ids,
-        'collection_ids': learner_playlist.collection_ids,
-    }
-
-    learner_playlist_model = user_models.LearnerPlaylistModel.get_by_id(
-        learner_playlist.id
+    learner_playlist_model = cast(
+        Optional[user_models.LearnerPlaylistModel],
+        user_models.LearnerPlaylistModel.get_by_id(learner_playlist.id),
     )
     if learner_playlist_model is not None:
+        learner_playlist_dict = {
+            'exploration_ids': learner_playlist.exploration_ids,
+            'collection_ids': learner_playlist.collection_ids,
+        }
         learner_playlist_model.populate(**learner_playlist_dict)
         learner_playlist_model.update_timestamps()
         learner_playlist_model.put()
     else:
-        learner_playlist_dict['id'] = learner_playlist.id
-        user_models.LearnerPlaylistModel(**learner_playlist_dict).put()
+        user_models.LearnerPlaylistModel(
+            id=learner_playlist.id,
+            exploration_ids=learner_playlist.exploration_ids,
+            collection_ids=learner_playlist.collection_ids,
+        ).put()
 
 
 def mark_exploration_to_be_played_later(

--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -45,19 +45,29 @@ from core.domain import (
 )
 from core.platform import models
 
-from typing import Dict, List, Optional, Tuple, TypedDict
+from typing import Dict, List, Optional, Tuple, TypedDict, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
     from mypy_imports import (
+        collection_models,
         datastore_services,
+        exp_models,
         story_models,
         topic_models,
         user_models,
     )
 
-(user_models, topic_models, story_models) = models.Registry.import_models(
-    [models.Names.USER, models.Names.TOPIC, models.Names.STORY]
+(user_models, topic_models, story_models, collection_models, exp_models) = (
+    models.Registry.import_models(
+        [
+            models.Names.USER,
+            models.Names.TOPIC,
+            models.Names.STORY,
+            models.Names.COLLECTION,
+            models.Names.EXPLORATION,
+        ]
+    )
 )
 datastore_services = models.Registry.import_datastore_services()
 
@@ -214,16 +224,22 @@ def _save_completed_activities(
         'learnt_topic_ids': activities_completed.learnt_topic_ids,
     }
 
-    completed_activities_model = user_models.CompletedActivitiesModel.get_by_id(
-        activities_completed.id
+    completed_activities_model = cast(
+        Optional[user_models.CompletedActivitiesModel],
+        user_models.CompletedActivitiesModel.get_by_id(activities_completed.id),
     )
     if completed_activities_model is not None:
         completed_activities_model.populate(**activities_completed_dict)
         completed_activities_model.update_timestamps()
         completed_activities_model.put()
     else:
-        activities_completed_dict['id'] = activities_completed.id
-        user_models.CompletedActivitiesModel(**activities_completed_dict).put()
+        user_models.CompletedActivitiesModel(
+            id=activities_completed.id,
+            exploration_ids=activities_completed.exploration_ids,
+            collection_ids=activities_completed.collection_ids,
+            story_ids=activities_completed.story_ids,
+            learnt_topic_ids=activities_completed.learnt_topic_ids,
+        ).put()
 
 
 def _save_incomplete_activities(
@@ -2084,14 +2100,13 @@ def get_learner_dashboard_activities(
     )
 
     # If completed model is present.
-    if learner_progress_models[0][0]:
-        # Here assert is used to narrow down the type from Model to
-        # CompletedActivitiesModel.
-        assert isinstance(
-            learner_progress_models[0][0], user_models.CompletedActivitiesModel
-        )
+    completed_activities_model = cast(
+        Optional[user_models.CompletedActivitiesModel],
+        learner_progress_models[0][0],
+    )
+    if completed_activities_model is not None:
         activities_completed = _get_completed_activities_from_model(
-            learner_progress_models[0][0]
+            completed_activities_model
         )
         completed_exploration_ids: List[str] = (
             activities_completed.exploration_ids
@@ -2108,14 +2123,13 @@ def get_learner_dashboard_activities(
         learnt_topic_ids = []
 
     # If incomplete model is present.
-    if learner_progress_models[1][0]:
-        # Here assert is used to narrow down the type from Model to
-        # IncompleteActivitiesModel.
-        assert isinstance(
-            learner_progress_models[1][0], user_models.IncompleteActivitiesModel
-        )
+    incomplete_activities_model = cast(
+        Optional[user_models.IncompleteActivitiesModel],
+        learner_progress_models[1][0],
+    )
+    if incomplete_activities_model is not None:
         incomplete_activities = _get_incomplete_activities_from_model(
-            learner_progress_models[1][0]
+            incomplete_activities_model
         )
         incomplete_exploration_ids: List[str] = (
             incomplete_activities.exploration_ids
@@ -2132,15 +2146,14 @@ def get_learner_dashboard_activities(
         partially_learnt_topic_ids = []
 
     # If learner playlist model is present.
-    if learner_progress_models[2][0]:
-        # Here assert is used to narrow down the type from Model to
-        # LearnerPlaylistModel.
-        assert isinstance(
-            learner_progress_models[2][0], user_models.LearnerPlaylistModel
-        )
+    learner_playlist_model = cast(
+        Optional[user_models.LearnerPlaylistModel],
+        learner_progress_models[2][0],
+    )
+    if learner_playlist_model is not None:
         learner_playlist = (
             learner_playlist_services.get_learner_playlist_from_model(
-                learner_progress_models[2][0]
+                learner_playlist_model
             )
         )
         exploration_playlist_ids: List[str] = learner_playlist.exploration_ids
@@ -2150,14 +2163,12 @@ def get_learner_dashboard_activities(
         collection_playlist_ids = []
 
     # If learner goals model is present.
-    if learner_progress_models[3][0]:
-        # Here assert is used to narrow down the type from Model to
-        # LearnerGoalsModel.
-        assert isinstance(
-            learner_progress_models[3][0], user_models.LearnerGoalsModel
-        )
+    learner_goals_model = cast(
+        Optional[user_models.LearnerGoalsModel], learner_progress_models[3][0]
+    )
+    if learner_goals_model is not None:
         learner_goals = learner_goals_services.get_learner_goals_from_model(
-            learner_progress_models[3][0]
+            learner_goals_model
         )
         topic_ids_to_learn: List[str] = learner_goals.topic_ids_to_learn
     else:
@@ -2233,35 +2244,39 @@ def get_topics_and_stories_progress(
             + untracked_topic_ids
         )
     )
-    activity_models = (
+    activity_models = cast(
+        Tuple[
+            List[Optional[topic_models.TopicSummaryModel]],
+            List[Optional[story_models.StorySummaryModel]],
+        ],
         datastore_services.fetch_multiple_entities_by_ids_and_models(
             [
                 ('TopicSummaryModel', unique_topic_ids),
                 ('StorySummaryModel', completed_story_ids),
             ]
-        )
+        ),
     )
 
     topic_id_to_model_dict: Dict[str, topic_domain.TopicSummary] = {}
-    for model in activity_models[0]:
-        if model is not None:
-            # Here assert is used to narrow down the type of modal from Model
-            # to TopicSummaryModel.
-            assert isinstance(model, topic_models.TopicSummaryModel)
-            topic_id_to_model_dict[model.id] = (
-                topic_fetchers.get_topic_summary_from_model(model)
+    for topic_summary_model in activity_models[0]:
+        if topic_summary_model is not None:
+            assert isinstance(
+                topic_summary_model, topic_models.TopicSummaryModel
+            )
+            topic_id_to_model_dict[topic_summary_model.id] = (
+                topic_fetchers.get_topic_summary_from_model(topic_summary_model)
             )
 
     completed_story_models = activity_models[1]
 
     completed_story_summaries: List[Optional[story_domain.StorySummary]] = []
-    for model in completed_story_models:
-        if model is not None:
-            # Here assert is used to narrow down the type of modal from Model
-            # to StorySummaryModel.
-            assert isinstance(model, story_models.StorySummaryModel)
+    for story_summary_model in completed_story_models:
+        if story_summary_model is not None:
+            story_model = cast(
+                story_models.StorySummaryModel, story_summary_model
+            )
             completed_story_summaries.append(
-                story_fetchers.get_story_summary_from_model(model)
+                story_fetchers.get_story_summary_from_model(story_model)
             )
         else:
             completed_story_summaries.append(None)
@@ -2441,19 +2456,22 @@ def get_collection_progress(
             + collection_playlist_ids
         )
     )
-    activity_models = (
+    activity_models = cast(
+        Tuple[List[Optional[collection_models.CollectionSummaryModel]],],
         datastore_services.fetch_multiple_entities_by_ids_and_models(
             [('CollectionSummaryModel', unique_collection_ids)]
-        )
+        ),
     )
 
     collection_id_to_model_dict: Dict[
         str, collection_domain.CollectionSummary
     ] = {}
-    for model in activity_models[0]:
-        if model is not None:
-            collection_id_to_model_dict[model.id] = (
-                collection_services.get_collection_summary_from_model(model)
+    for collection_summary_model in activity_models[0]:
+        if collection_summary_model is not None:
+            collection_id_to_model_dict[collection_summary_model.id] = (
+                collection_services.get_collection_summary_from_model(
+                    collection_summary_model
+                )
             )
 
     incomplete_collection_summaries = [
@@ -2584,17 +2602,20 @@ def get_exploration_progress(
             + exploration_playlist_ids
         )
     )
-    activity_models = (
+    activity_models = cast(
+        Tuple[List[Optional[exp_models.ExpSummaryModel]],],
         datastore_services.fetch_multiple_entities_by_ids_and_models(
             [('ExpSummaryModel', unique_exploration_ids)]
-        )
+        ),
     )
 
     exploration_id_to_model_dict: Dict[str, exp_domain.ExplorationSummary] = {}
-    for model in activity_models[0]:
-        if model is not None:
-            exploration_id_to_model_dict[model.id] = (
-                exp_fetchers.get_exploration_summary_from_model(model)
+    for exploration_summary_model in activity_models[0]:
+        if exploration_summary_model is not None:
+            exploration_id_to_model_dict[exploration_summary_model.id] = (
+                exp_fetchers.get_exploration_summary_from_model(
+                    exploration_summary_model
+                )
             )
 
     incomplete_exp_summaries = [

--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -224,7 +224,7 @@ def _save_completed_activities(
         'learnt_topic_ids': activities_completed.learnt_topic_ids,
     }
 
-    # Here use cast because get_by_id() can return None and this function
+    # Here we use cast because get_by_id() can return None and this function
     # handles both create and update flows explicitly.
     completed_activities_model = cast(
         Optional[user_models.CompletedActivitiesModel],
@@ -2102,7 +2102,7 @@ def get_learner_dashboard_activities(
     )
 
     # If completed model is present.
-    # Here use cast because datastore fetch returns generic Optional models and
+    # Here we use cast because datastore fetch returns generic Optional models and
     # we narrow to the expected CompletedActivitiesModel slot.
     completed_activities_model = cast(
         Optional[user_models.CompletedActivitiesModel],
@@ -2127,7 +2127,7 @@ def get_learner_dashboard_activities(
         learnt_topic_ids = []
 
     # If incomplete model is present.
-    # Here use cast because datastore fetch returns generic Optional models and
+    # Here we use cast because datastore fetch returns generic Optional models and
     # we narrow to the expected IncompleteActivitiesModel slot.
     incomplete_activities_model = cast(
         Optional[user_models.IncompleteActivitiesModel],
@@ -2152,7 +2152,7 @@ def get_learner_dashboard_activities(
         partially_learnt_topic_ids = []
 
     # If learner playlist model is present.
-    # Here use cast because datastore fetch returns generic Optional models and
+    # Here we use cast because datastore fetch returns generic Optional models and
     # we narrow to the expected LearnerPlaylistModel slot.
     learner_playlist_model = cast(
         Optional[user_models.LearnerPlaylistModel],
@@ -2171,7 +2171,7 @@ def get_learner_dashboard_activities(
         collection_playlist_ids = []
 
     # If learner goals model is present.
-    # Here use cast because datastore fetch returns generic Optional models and
+    # Here we use cast because datastore fetch returns generic Optional models and
     # we narrow to the expected LearnerGoalsModel slot.
     learner_goals_model = cast(
         Optional[user_models.LearnerGoalsModel], learner_progress_models[3][0]
@@ -2254,7 +2254,7 @@ def get_topics_and_stories_progress(
             + untracked_topic_ids
         )
     )
-    # Here use cast because this fetch returns grouped generic models and we
+    # Here we use cast because this fetch returns grouped generic models and we
     # narrow each group to the concrete summary model types by position.
     activity_models = cast(
         Tuple[
@@ -2284,7 +2284,7 @@ def get_topics_and_stories_progress(
     completed_story_summaries: List[Optional[story_domain.StorySummary]] = []
     for story_summary_model in completed_story_models:
         if story_summary_model is not None:
-            # Here use cast because story_summary_model is narrowed by the
+            # Here we use cast because story_summary_model is narrowed by the
             # None-check and must match StorySummaryModel for the fetcher API.
             story_model = cast(
                 story_models.StorySummaryModel, story_summary_model
@@ -2470,7 +2470,7 @@ def get_collection_progress(
             + collection_playlist_ids
         )
     )
-    # Here use cast because this fetch returns grouped generic models and we
+    # Here we use cast because this fetch returns grouped generic models and we
     # narrow the only group to CollectionSummaryModel entries.
     activity_models = cast(
         Tuple[List[Optional[collection_models.CollectionSummaryModel]],],
@@ -2618,7 +2618,7 @@ def get_exploration_progress(
             + exploration_playlist_ids
         )
     )
-    # Here use cast because this fetch returns grouped generic models and we
+    # Here we use cast because this fetch returns grouped generic models and we
     # narrow the only group to ExpSummaryModel entries.
     activity_models = cast(
         Tuple[List[Optional[exp_models.ExpSummaryModel]],],

--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -2284,13 +2284,8 @@ def get_topics_and_stories_progress(
     completed_story_summaries: List[Optional[story_domain.StorySummary]] = []
     for story_summary_model in completed_story_models:
         if story_summary_model is not None:
-            # Here we use cast because story_summary_model is narrowed by the
-            # None-check and must match StorySummaryModel for the fetcher API.
-            story_model = cast(
-                story_models.StorySummaryModel, story_summary_model
-            )
             completed_story_summaries.append(
-                story_fetchers.get_story_summary_from_model(story_model)
+                story_fetchers.get_story_summary_from_model(story_summary_model)
             )
         else:
             completed_story_summaries.append(None)

--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -224,6 +224,8 @@ def _save_completed_activities(
         'learnt_topic_ids': activities_completed.learnt_topic_ids,
     }
 
+    # Here use cast because get_by_id() can return None and this function
+    # handles both create and update flows explicitly.
     completed_activities_model = cast(
         Optional[user_models.CompletedActivitiesModel],
         user_models.CompletedActivitiesModel.get_by_id(activities_completed.id),
@@ -2100,6 +2102,8 @@ def get_learner_dashboard_activities(
     )
 
     # If completed model is present.
+    # Here use cast because datastore fetch returns generic Optional models and
+    # we narrow to the expected CompletedActivitiesModel slot.
     completed_activities_model = cast(
         Optional[user_models.CompletedActivitiesModel],
         learner_progress_models[0][0],
@@ -2123,6 +2127,8 @@ def get_learner_dashboard_activities(
         learnt_topic_ids = []
 
     # If incomplete model is present.
+    # Here use cast because datastore fetch returns generic Optional models and
+    # we narrow to the expected IncompleteActivitiesModel slot.
     incomplete_activities_model = cast(
         Optional[user_models.IncompleteActivitiesModel],
         learner_progress_models[1][0],
@@ -2146,6 +2152,8 @@ def get_learner_dashboard_activities(
         partially_learnt_topic_ids = []
 
     # If learner playlist model is present.
+    # Here use cast because datastore fetch returns generic Optional models and
+    # we narrow to the expected LearnerPlaylistModel slot.
     learner_playlist_model = cast(
         Optional[user_models.LearnerPlaylistModel],
         learner_progress_models[2][0],
@@ -2163,6 +2171,8 @@ def get_learner_dashboard_activities(
         collection_playlist_ids = []
 
     # If learner goals model is present.
+    # Here use cast because datastore fetch returns generic Optional models and
+    # we narrow to the expected LearnerGoalsModel slot.
     learner_goals_model = cast(
         Optional[user_models.LearnerGoalsModel], learner_progress_models[3][0]
     )
@@ -2244,6 +2254,8 @@ def get_topics_and_stories_progress(
             + untracked_topic_ids
         )
     )
+    # Here use cast because this fetch returns grouped generic models and we
+    # narrow each group to the concrete summary model types by position.
     activity_models = cast(
         Tuple[
             List[Optional[topic_models.TopicSummaryModel]],
@@ -2272,6 +2284,8 @@ def get_topics_and_stories_progress(
     completed_story_summaries: List[Optional[story_domain.StorySummary]] = []
     for story_summary_model in completed_story_models:
         if story_summary_model is not None:
+            # Here use cast because story_summary_model is narrowed by the
+            # None-check and must match StorySummaryModel for the fetcher API.
             story_model = cast(
                 story_models.StorySummaryModel, story_summary_model
             )
@@ -2456,6 +2470,8 @@ def get_collection_progress(
             + collection_playlist_ids
         )
     )
+    # Here use cast because this fetch returns grouped generic models and we
+    # narrow the only group to CollectionSummaryModel entries.
     activity_models = cast(
         Tuple[List[Optional[collection_models.CollectionSummaryModel]],],
         datastore_services.fetch_multiple_entities_by_ids_and_models(
@@ -2602,6 +2618,8 @@ def get_exploration_progress(
             + exploration_playlist_ids
         )
     )
+    # Here use cast because this fetch returns grouped generic models and we
+    # narrow the only group to ExpSummaryModel entries.
     activity_models = cast(
         Tuple[List[Optional[exp_models.ExpSummaryModel]],],
         datastore_services.fetch_multiple_entities_by_ids_and_models(

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -39,7 +39,7 @@ from core.domain import (
 )
 from core.platform import models
 
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -955,8 +955,11 @@ def create_skill_opportunity(skill_id: str, skill_description: str) -> None:
         Exception. If a SkillOpportunityModel corresponding to the supplied
             skill_id already exists.
     """
-    skill_opportunity_model = (
-        opportunity_models.SkillOpportunityModel.get_by_id(skill_id)
+    # Here we use cast because get_by_id() may return None and this branch checks
+    # for pre-existing opportunities before creation.
+    skill_opportunity_model = cast(
+        Optional[opportunity_models.SkillOpportunityModel],
+        opportunity_models.SkillOpportunityModel.get_by_id(skill_id),
     )
     if skill_opportunity_model is not None:
         raise Exception(
@@ -1032,8 +1035,11 @@ def _get_skill_opportunity(
         SkillOpportunity with the supplied skill_id, or None if it does not
         exist.
     """
-    skill_opportunity_model = (
-        opportunity_models.SkillOpportunityModel.get_by_id(skill_id)
+    # Here we use cast because get_by_id() may return None and callers depend on
+    # explicit Optional handling here.
+    skill_opportunity_model = cast(
+        Optional[opportunity_models.SkillOpportunityModel],
+        opportunity_models.SkillOpportunityModel.get_by_id(skill_id),
     )
     if skill_opportunity_model is not None:
         return get_skill_opportunity_from_model(skill_opportunity_model)

--- a/core/domain/question_fetchers_test.py
+++ b/core/domain/question_fetchers_test.py
@@ -30,6 +30,8 @@ from core.domain import (
 from core.platform import models
 from core.tests import test_utils
 
+from typing import cast
+
 MYPY = False
 if MYPY:  # pragma: no cover
     from mypy_imports import question_models
@@ -182,9 +184,11 @@ class QuestionFetchersUnitTests(test_utils.GenericTestBase):
 
         all_question_models = question_models.QuestionModel.get_all()
         self.assertEqual(all_question_models.count(), 1)
-        fetched_question_models = all_question_models.get()
-        # Ruling out the possibility of None for mypy type checking.
-        assert fetched_question_models is not None
+        # Here we use cast because the test already asserted one stored model,
+        # and get() returns that model for this query.
+        fetched_question_models = cast(
+            question_models.QuestionModel, all_question_models.get()
+        )
 
         with self.assertRaisesRegex(
             Exception,
@@ -233,9 +237,11 @@ class QuestionFetchersUnitTests(test_utils.GenericTestBase):
 
         all_question_models = question_models.QuestionModel.get_all()
         self.assertEqual(all_question_models.count(), 1)
-        fetched_question_models = all_question_models.get()
-        # Ruling out the possibility of None for mypy type checking.
-        assert fetched_question_models is not None
+        # Here we use cast because the test already asserted one stored model,
+        # and get() returns that model for this query.
+        fetched_question_models = cast(
+            question_models.QuestionModel, all_question_models.get()
+        )
         updated_question_model = question_fetchers.get_question_from_model(
             fetched_question_models
         )

--- a/core/domain/question_services.py
+++ b/core/domain/question_services.py
@@ -1072,7 +1072,7 @@ def populate_question_model_fields(
 
 
 def populate_question_summary_model_fields(
-    question_summary_model: question_models.QuestionSummaryModel,
+    question_summary_model: Optional[question_models.QuestionSummaryModel],
     question_summary: question_domain.QuestionSummary,
 ) -> question_models.QuestionSummaryModel:
     """Populate question summary model with the data from question summary

--- a/core/domain/question_services_test.py
+++ b/core/domain/question_services_test.py
@@ -1597,11 +1597,10 @@ class QuestionServicesUnitTest(test_utils.GenericTestBase):
             question
         )
         question_services.save_question_summary(question_summary)
-        # Here we use MyPy ignore because we need to test
-        # populate_question_summary_model_fields when the there is no
-        # input QuestionSummaryModel.
-        populated_model = question_services.populate_question_summary_model_fields(
-            None, question_summary  # type: ignore[arg-type]
+        populated_model = (
+            question_services.populate_question_summary_model_fields(
+                None, question_summary
+            )
         )
         self.assertEqual(
             populated_model.question_model_last_updated,

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1278,7 +1278,7 @@ def create_skill_summary(skill_id: str) -> None:
 
 
 def populate_skill_summary_model_fields(
-    skill_summary_model: skill_models.SkillSummaryModel,
+    skill_summary_model: Optional[skill_models.SkillSummaryModel],
     skill_summary: skill_domain.SkillSummary,
 ) -> skill_models.SkillSummaryModel:
     """Populate skill summary model with the data from skill summary object.

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -1953,11 +1953,9 @@ class Story:
         Returns:
             dict. The converted story_contents_dict.
         """
-        next_node_id = None
-        for node in reversed(story_contents_dict['nodes']):
-            if next_node_id:
-                node['destination_node_ids'] = [next_node_id]
-            next_node_id = node['id']
+        nodes = story_contents_dict['nodes']
+        for index in range(len(nodes) - 1):
+            nodes[index]['destination_node_ids'] = [nodes[index + 1]['id']]
 
         return story_contents_dict
 

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -1954,8 +1954,10 @@ class Story:
             dict. The converted story_contents_dict.
         """
         nodes = story_contents_dict['nodes']
-        for index in range(len(nodes) - 1):
-            nodes[index]['destination_node_ids'] = [nodes[index + 1]['id']]
+        # Link each node (except the last) to the next node by traversing
+        # the reversed list, which gives the previous node in original order.
+        for i in range(len(nodes) - 1):
+            nodes[i]['destination_node_ids'] = [nodes[i + 1]['id']]
 
         return story_contents_dict
 

--- a/core/domain/story_services.py
+++ b/core/domain/story_services.py
@@ -169,7 +169,7 @@ def apply_change_list(
                 update_story_node_outline_status = cast(
                     story_domain.UpdateStoryNodeOutlineStatusCmd, change
                 )
-                if update_story_node_outline_status.new_value:
+                if update_story_node_outline_status.new_value is True:
                     story.mark_node_outline_as_finalized(
                         update_story_node_outline_status.node_id
                     )

--- a/core/domain/story_services.py
+++ b/core/domain/story_services.py
@@ -41,7 +41,7 @@ from core.domain import (
 )
 from core.platform import models
 
-from typing import List, Sequence, Tuple, cast
+from typing import List, Optional, Sequence, Tuple, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -1039,7 +1039,7 @@ def create_story_summary(story_id: str) -> None:
 
 
 def populate_story_summary_model_fields(
-    story_summary_model: story_models.StorySummaryModel,
+    story_summary_model: Optional[story_models.StorySummaryModel],
     story_summary: story_domain.StorySummary,
 ) -> story_models.StorySummaryModel:
     """Populate story summary model with the data from story summary object.

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -866,12 +866,25 @@ class SuggestionTranslateContent(BaseSuggestion):
         Returns:
             list(str). The list of html content strings.
         """
-        assert isinstance(self.change_cmd.translation_html, str)
-        assert isinstance(self.change_cmd.content_html, str)
-        return [
-            self.change_cmd.translation_html,
-            self.change_cmd.content_html,
-        ]
+        # Here we use cast because translation/content HTML can be either
+        # string or list of strings, and we need to support both formats.
+        translation_html = cast(
+            Union[str, List[str]], self.change_cmd.translation_html
+        )
+        content_html = cast(Union[str, List[str]], self.change_cmd.content_html)
+
+        html_strings: List[str] = []
+        if isinstance(translation_html, list):
+            html_strings.extend(translation_html)
+        else:
+            html_strings.append(translation_html)
+
+        if isinstance(content_html, list):
+            html_strings.extend(content_html)
+        else:
+            html_strings.append(content_html)
+
+        return html_strings
 
     def get_target_entity_html_strings(self) -> List[str]:
         """Gets all html content strings from target entity used in the

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -866,11 +866,13 @@ class SuggestionTranslateContent(BaseSuggestion):
         Returns:
             list(str). The list of html content strings.
         """
-        # Here we use cast because translation/content HTML can be either
+        # Here we use cast because translation HTML can be either
         # string or list of strings, and we need to support both formats.
         translation_html = cast(
             Union[str, List[str]], self.change_cmd.translation_html
         )
+        # Here we use cast because content HTML can be either
+        # string or list of strings, and we need to support both formats.
         content_html = cast(Union[str, List[str]], self.change_cmd.content_html)
 
         html_strings: List[str] = []

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -866,16 +866,12 @@ class SuggestionTranslateContent(BaseSuggestion):
         Returns:
             list(str). The list of html content strings.
         """
-        content_strings = []
-        if isinstance(self.change_cmd.translation_html, list):
-            content_strings.extend(self.change_cmd.translation_html)
-        else:
-            content_strings.append(self.change_cmd.translation_html)
-        if isinstance(self.change_cmd.content_html, list):
-            content_strings.extend(self.change_cmd.content_html)
-        else:
-            content_strings.append(self.change_cmd.content_html)
-        return content_strings
+        assert isinstance(self.change_cmd.translation_html, str)
+        assert isinstance(self.change_cmd.content_html, str)
+        return [
+            self.change_cmd.translation_html,
+            self.change_cmd.content_html,
+        ]
 
     def get_target_entity_html_strings(self) -> List[str]:
         """Gets all html content strings from target entity used in the

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -3223,7 +3223,7 @@ def update_translation_contribution_stats_at_submission(
     assert exp_opportunity is not None
     topic_id = exp_opportunity.topic_id
 
-    # Here use cast because translation_html can be either str or List[str]
+    # Here we use cast because translation_html can be either str or List[str]
     # for legacy suggestions and we need both branches below.
     translation_html = cast(
         Union[str, List[str]], suggestion.change_cmd.translation_html
@@ -3403,7 +3403,7 @@ def update_translation_contribution_stats_at_review(
     assert exp_opportunity is not None
     topic_id = exp_opportunity.topic_id
 
-    # Here use cast because translation_html can be either str or List[str]
+    # Here we use cast because translation_html can be either str or List[str]
     # for legacy suggestions and we need both branches below.
     translation_html = cast(
         Union[str, List[str]], suggestion.change_cmd.translation_html
@@ -3570,7 +3570,7 @@ def update_translation_review_stats(
         suggestion.status == suggestion_models.STATUS_ACCEPTED
     )
 
-    # Here use cast because translation_html can be either str or List[str]
+    # Here we use cast because translation_html can be either str or List[str]
     # for legacy suggestions and we need both branches below.
     translation_html = cast(
         Union[str, List[str]], suggestion.change_cmd.translation_html
@@ -3743,7 +3743,7 @@ def update_question_contribution_stats_at_submission(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
-        # Here use cast because get_by_id() can return None and this branch
+        # Here we use cast because get_by_id() can return None and this branch
         # explicitly handles both Optional outcomes.
         question_submitter_total_stat_model = cast(
             Optional[
@@ -3864,7 +3864,7 @@ def update_question_contribution_stats_at_review(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
-        # Here use cast because get_by_id() can return None and this branch
+        # Here we use cast because get_by_id() can return None and this branch
         # explicitly handles both Optional outcomes.
         question_submitter_total_stat_model = cast(
             Optional[
@@ -3980,7 +3980,7 @@ def update_question_review_stats(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
-        # Here use cast because get_by_id() can return None and this branch
+        # Here we use cast because get_by_id() can return None and this branch
         # explicitly handles both Optional outcomes.
         question_reviewer_total_stat_model = cast(
             Optional[

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -3223,6 +3223,8 @@ def update_translation_contribution_stats_at_submission(
     assert exp_opportunity is not None
     topic_id = exp_opportunity.topic_id
 
+    # Here use cast because translation_html can be either str or List[str]
+    # for legacy suggestions and we need both branches below.
     translation_html = cast(
         Union[str, List[str]], suggestion.change_cmd.translation_html
     )
@@ -3401,6 +3403,8 @@ def update_translation_contribution_stats_at_review(
     assert exp_opportunity is not None
     topic_id = exp_opportunity.topic_id
 
+    # Here use cast because translation_html can be either str or List[str]
+    # for legacy suggestions and we need both branches below.
     translation_html = cast(
         Union[str, List[str]], suggestion.change_cmd.translation_html
     )
@@ -3566,6 +3570,8 @@ def update_translation_review_stats(
         suggestion.status == suggestion_models.STATUS_ACCEPTED
     )
 
+    # Here use cast because translation_html can be either str or List[str]
+    # for legacy suggestions and we need both branches below.
     translation_html = cast(
         Union[str, List[str]], suggestion.change_cmd.translation_html
     )
@@ -3737,6 +3743,8 @@ def update_question_contribution_stats_at_submission(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
+        # Here use cast because get_by_id() can return None and this branch
+        # explicitly handles both Optional outcomes.
         question_submitter_total_stat_model = cast(
             Optional[
                 suggestion_models.QuestionSubmitterTotalContributionStatsModel
@@ -3856,6 +3864,8 @@ def update_question_contribution_stats_at_review(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
+        # Here use cast because get_by_id() can return None and this branch
+        # explicitly handles both Optional outcomes.
         question_submitter_total_stat_model = cast(
             Optional[
                 suggestion_models.QuestionSubmitterTotalContributionStatsModel
@@ -3970,6 +3980,8 @@ def update_question_review_stats(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
+        # Here use cast because get_by_id() can return None and this branch
+        # explicitly handles both Optional outcomes.
         question_reviewer_total_stat_model = cast(
             Optional[
                 suggestion_models.QuestionReviewerTotalContributionStatsModel

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -3223,14 +3223,16 @@ def update_translation_contribution_stats_at_submission(
     assert exp_opportunity is not None
     topic_id = exp_opportunity.topic_id
 
-    if isinstance(suggestion.change_cmd.translation_html, list):
-        for content in suggestion.change_cmd.translation_html:
+    translation_html = cast(
+        Union[str, List[str]], suggestion.change_cmd.translation_html
+    )
+
+    if isinstance(translation_html, list):
+        for content in translation_html:
             content_plain_text = html_cleaner.strip_html_tags(content)
             content_word_count += len(content_plain_text.split())
     else:
-        content_plain_text = html_cleaner.strip_html_tags(
-            suggestion.change_cmd.translation_html
-        )
+        content_plain_text = html_cleaner.strip_html_tags(translation_html)
         content_word_count = len(content_plain_text.split())
 
     translation_contribution_stat_model = (
@@ -3399,14 +3401,16 @@ def update_translation_contribution_stats_at_review(
     assert exp_opportunity is not None
     topic_id = exp_opportunity.topic_id
 
-    if isinstance(suggestion.change_cmd.translation_html, list):
-        for content in suggestion.change_cmd.translation_html:
+    translation_html = cast(
+        Union[str, List[str]], suggestion.change_cmd.translation_html
+    )
+
+    if isinstance(translation_html, list):
+        for content in translation_html:
             content_plain_text = html_cleaner.strip_html_tags(content)
             content_word_count += len(content_plain_text.split())
     else:
-        content_plain_text = html_cleaner.strip_html_tags(
-            suggestion.change_cmd.translation_html
-        )
+        content_plain_text = html_cleaner.strip_html_tags(translation_html)
         content_word_count = len(content_plain_text.split())
 
     suggestion_is_accepted = (
@@ -3562,14 +3566,16 @@ def update_translation_review_stats(
         suggestion.status == suggestion_models.STATUS_ACCEPTED
     )
 
-    if isinstance(suggestion.change_cmd.translation_html, list):
-        for content in suggestion.change_cmd.translation_html:
+    translation_html = cast(
+        Union[str, List[str]], suggestion.change_cmd.translation_html
+    )
+
+    if isinstance(translation_html, list):
+        for content in translation_html:
             content_plain_text = html_cleaner.strip_html_tags(content)
             content_word_count += len(content_plain_text.split())
     else:
-        content_plain_text = html_cleaner.strip_html_tags(
-            suggestion.change_cmd.translation_html
-        )
+        content_plain_text = html_cleaner.strip_html_tags(translation_html)
         content_word_count = len(content_plain_text.split())
 
     translation_review_stat_model = (
@@ -3731,8 +3737,13 @@ def update_question_contribution_stats_at_submission(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
-        question_submitter_total_stat_model = suggestion_models.QuestionSubmitterTotalContributionStatsModel.get_by_id(
-            suggestion.author_id
+        question_submitter_total_stat_model = cast(
+            Optional[
+                suggestion_models.QuestionSubmitterTotalContributionStatsModel
+            ],
+            suggestion_models.QuestionSubmitterTotalContributionStatsModel.get_by_id(
+                suggestion.author_id
+            ),
         )
 
         if question_submitter_total_stat_model is None:
@@ -3845,8 +3856,13 @@ def update_question_contribution_stats_at_review(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
-        question_submitter_total_stat_model = suggestion_models.QuestionSubmitterTotalContributionStatsModel.get_by_id(
-            suggestion.author_id
+        question_submitter_total_stat_model = cast(
+            Optional[
+                suggestion_models.QuestionSubmitterTotalContributionStatsModel
+            ],
+            suggestion_models.QuestionSubmitterTotalContributionStatsModel.get_by_id(
+                suggestion.author_id
+            ),
         )
 
         if question_submitter_total_stat_model is None:
@@ -3954,8 +3970,13 @@ def update_question_review_stats(
     for topic in skill_services.get_all_topic_assignments_for_skill(
         suggestion.target_id
     ):
-        question_reviewer_total_stat_model = suggestion_models.QuestionReviewerTotalContributionStatsModel.get_by_id(
-            suggestion.final_reviewer_id
+        question_reviewer_total_stat_model = cast(
+            Optional[
+                suggestion_models.QuestionReviewerTotalContributionStatsModel
+            ],
+            suggestion_models.QuestionReviewerTotalContributionStatsModel.get_by_id(
+                suggestion.final_reviewer_id
+            ),
         )
 
         if question_reviewer_total_stat_model is None:

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -461,32 +461,31 @@ def _apply_study_guide_change(
     Raises:
         Exception. The subtopic doesn't exist.
     """
-    # Ruling out the possibility of any other type for mypy
-    # type checking.
-    assert isinstance(change.subtopic_id, int)
+    # Here we use cast because subtopic_id is int but BaseChange attrs are str.
+    subtopic_id = cast(int, change.subtopic_id)
     study_guide_id = study_guide_domain.StudyGuide.get_study_guide_id(
-        topic_id, change.subtopic_id
+        topic_id, subtopic_id
     )
     subtopic_page_id = subtopic_page_domain.SubtopicPage.get_subtopic_page_id(
-        topic_id, change.subtopic_id
+        topic_id, subtopic_id
     )
     if (modified_study_guides[study_guide_id] is None) or (
-        change.subtopic_id in deleted_subtopic_ids
+        subtopic_id in deleted_subtopic_ids
     ):
         raise Exception(
-            'The subtopic with id %s doesn\'t exist' % (change.subtopic_id)
+            'The subtopic with id %s doesn\'t exist' % (subtopic_id)
         )
 
     if change.property_name == study_guide_domain.STUDY_GUIDE_PROPERTY_SECTIONS:
-        # Here we use cast because this 'if'
-        # condition forces change to have type
-        # UpdateStudyGuidePropertyCmd.
+        # Here we use cast because mypy cannot infer the narrowed command type.
         update_study_guide_sections_cmd = cast(
             study_guide_domain.UpdateStudyGuidePropertyCmd, change
         )
-        new_sections_dict_list: List[
-            study_guide_domain.StudyGuideSectionDict
-        ] = update_study_guide_sections_cmd.new_value
+        # Here we use cast because new_value is generic on the base command type.
+        new_sections_dict_list = cast(
+            List[study_guide_domain.StudyGuideSectionDict],
+            update_study_guide_sections_cmd.new_value,
+        )
         new_sections: List[study_guide_domain.StudyGuideSection] = []
 
         # For updating the page_contents of the subtopic page corresponding
@@ -522,7 +521,7 @@ def _apply_study_guide_change(
         temporary_subtopic_page: Union[
             subtopic_page_domain.SubtopicPage, None
         ] = subtopic_page_services.get_subtopic_page_by_id(
-            topic_id, change.subtopic_id, False
+            topic_id, subtopic_id, strict=False
         )
         if temporary_subtopic_page is not None:
             modified_subtopic_pages[subtopic_page_id] = temporary_subtopic_page

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -1035,25 +1035,25 @@ def apply_change_list(
                 change.cmd
                 == subtopic_page_domain.CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY
             ):
-                # Ruling out the possibility of any other type for mypy
-                # type checking.
-                assert isinstance(change.subtopic_id, int)
+                # Here we use cast because BaseChange.__getattr__
+                # returns str, but subtopic_id is actually an int at
+                # runtime for subtopic page change commands.
+                subtopic_id = cast(int, change.subtopic_id)
                 subtopic_page_id = (
                     subtopic_page_domain.SubtopicPage.get_subtopic_page_id(
-                        topic_id, change.subtopic_id
+                        topic_id, subtopic_id
                     )
                 )
                 study_guide_id = (
                     study_guide_domain.StudyGuide.get_study_guide_id(
-                        topic_id, change.subtopic_id
+                        topic_id, subtopic_id
                     )
                 )
                 if (modified_subtopic_pages[subtopic_page_id] is None) or (
-                    change.subtopic_id in deleted_subtopic_ids
+                    subtopic_id in deleted_subtopic_ids
                 ):
                     raise Exception(
-                        'The subtopic with id %s doesn\'t exist'
-                        % (change.subtopic_id)
+                        'The subtopic with id %s doesn\'t exist' % (subtopic_id)
                     )
 
                 if (
@@ -1089,11 +1089,9 @@ def apply_change_list(
                                 study_guide_id
                             ].update_section_content
                         )(
-                            (
-                                update_study_guide_sections_content_cmd.new_value.get(
-                                    'html'
-                                )
-                            ),
+                            update_study_guide_sections_content_cmd.new_value[
+                                'html'
+                            ],
                             'section_content_1',
                         )
 
@@ -2488,13 +2486,14 @@ def populate_topic_model_fields(
 
 
 def populate_topic_summary_model_fields(
-    topic_summary_model: topic_models.TopicSummaryModel,
+    topic_summary_model: Optional[topic_models.TopicSummaryModel],
     topic_summary: topic_domain.TopicSummary,
 ) -> topic_models.TopicSummaryModel:
     """Populate topic summary model with the data from topic summary object.
 
     Args:
-        topic_summary_model: TopicSummaryModel. The model to populate.
+        topic_summary_model: TopicSummaryModel|None. The model to populate,
+            or None if a new model needs to be created.
         topic_summary: TopicSummary. The topic summary domain object which
             should be used to populate the model.
 
@@ -2683,10 +2682,18 @@ def get_all_published_story_exploration_ids(
     mappings = []
     ids_of_topic_summaries_without_mapping: List[str] = []
     for summary in fetched_topic_summaries:
-        if summary.published_story_exploration_mapping is None:
+        # Here we use cast because
+        # published_story_exploration_mapping is typed as
+        # Dict[str, List[str]], but at runtime older records may
+        # have None before the field is backfilled.
+        mapping_value = cast(
+            Optional[Dict[str, List[str]]],
+            summary.published_story_exploration_mapping,
+        )
+        if mapping_value is None:
             ids_of_topic_summaries_without_mapping.append(summary.id)
         else:
-            mappings.append(summary.published_story_exploration_mapping)
+            mappings.append(mapping_value)
     if len(ids_of_topic_summaries_without_mapping) > 0:
         topics_without_mapping = topic_fetchers.get_topics_by_ids(
             ids_of_topic_summaries_without_mapping

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -42,6 +42,7 @@ from core.platform import models
 import filetype
 import requests
 from typing import (
+    Any,
     Dict,
     Final,
     List,
@@ -49,6 +50,7 @@ from typing import (
     Optional,
     Sequence,
     TypedDict,
+    cast,
     overload,
 )
 
@@ -1050,12 +1052,20 @@ def convert_to_user_settings_model(
 
     # If user with the given user_id already exists, update that model
     # with the given user settings, otherwise, create a new one.
-    user_model = user_models.UserSettingsModel.get_by_id(user_settings.user_id)
+    # Here we use cast because get_by_id() may return None and the save path needs
+    # to preserve that possibility for the update-or-create branch.
+    user_model = cast(
+        Optional[user_models.UserSettingsModel],
+        user_models.UserSettingsModel.get_by_id(user_settings.user_id),
+    )
     if user_model is not None:
         user_model.populate(**user_settings_dict)
     else:
-        user_settings_dict['id'] = user_settings.user_id
-        user_model = user_models.UserSettingsModel(**user_settings_dict)
+        # Here we use type Any because model kwargs include a dynamic 'id'
+        # field that is not part of the UserSettingsDict TypedDict.
+        model_kwargs: Dict[str, Any] = dict(user_settings_dict)
+        model_kwargs['id'] = user_settings.user_id
+        user_model = user_models.UserSettingsModel(**model_kwargs)
 
     return user_model
 
@@ -1439,8 +1449,11 @@ def _save_user_auth_details(
 
     # If user auth details entry with the given user_id does not exist, create
     # a new one.
-    user_auth_details_model = auth_models.UserAuthDetailsModel.get_by_id(
-        user_auth_details.user_id
+    # Here we use cast because get_by_id() may return None and the save path
+    # needs to preserve that possibility for the update-or-create branch.
+    user_auth_details_model = cast(
+        Optional[auth_models.UserAuthDetailsModel],
+        auth_models.UserAuthDetailsModel.get_by_id(user_auth_details.user_id),
     )
     user_auth_details_dict = user_auth_details.to_dict()
     if user_auth_details_model is not None:
@@ -1448,8 +1461,11 @@ def _save_user_auth_details(
         user_auth_details_model.update_timestamps()
         user_auth_details_model.put()
     else:
-        user_auth_details_dict['id'] = user_auth_details.user_id
-        model = auth_models.UserAuthDetailsModel(**user_auth_details_dict)
+        # Here we use type Any because model kwargs include a dynamic 'id'
+        # field that is not part of the UserAuthDetailsDict TypedDict.
+        model_kwargs: Dict[str, Any] = dict(user_auth_details_dict)
+        model_kwargs['id'] = user_auth_details.user_id
+        model = auth_models.UserAuthDetailsModel(**model_kwargs)
         model.update_timestamps()
         model.put()
 

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -43,7 +43,7 @@ from core.platform import models
 from core.tests import test_utils
 
 import requests_mock
-from typing import Dict, Final, List
+from typing import Dict, Final, List, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -2506,9 +2506,12 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         )
         self.assertEqual(all_models_after_update.count(), 1)
 
-        user_audit_model = all_models_after_update.get()
-        # Ruling out the possibility of None for mypy type checking.
-        assert user_audit_model is not None
+        # Here we use cast because get() may be typed as optional/any, but this
+        # test has already asserted that exactly one model exists.
+        user_audit_model = cast(
+            audit_models.UsernameChangeAuditModel,
+            all_models_after_update.get(),
+        )
         self.assertEqual(user_audit_model.committer_id, committer_id)
         self.assertEqual(user_audit_model.old_username, 'oldUsername')
         self.assertEqual(user_audit_model.new_username, 'newUsername')

--- a/core/jobs/batch_jobs/number_with_units_audit_jobs.py
+++ b/core/jobs/batch_jobs/number_with_units_audit_jobs.py
@@ -22,7 +22,7 @@ from core.jobs.types import job_run_result
 from core.platform import models
 
 import apache_beam as beam
-from typing import Iterable
+from typing import Iterable, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -111,23 +111,32 @@ class FindNumberWithUnitsRuleUnitsJob(base_jobs.JobBase):
         if interaction_dict.get('id') != 'NumberWithUnits':
             return
 
-        answer_groups = interaction_dict.get('answer_groups', [])
+        answer_groups: object = interaction_dict.get('answer_groups', [])
         if not isinstance(answer_groups, list):
             return
 
         for answer_group in answer_groups:
+            answer_group = cast(object, answer_group)
             if not isinstance(answer_group, dict):
                 continue
-            for rule_spec in answer_group.get('rule_specs', []):
+            rule_specs: object = answer_group.get('rule_specs', [])
+            if not isinstance(rule_specs, list):
+                continue
+            for rule_spec in rule_specs:
+                rule_spec = cast(object, rule_spec)
                 if not isinstance(rule_spec, dict):
                     continue
-                inputs = rule_spec.get('inputs', {})
+                inputs: object = rule_spec.get('inputs', {})
                 if not isinstance(inputs, dict):
                     continue
-                number_with_units = inputs.get('f')
+                number_with_units: object = inputs.get('f')
                 if not isinstance(number_with_units, dict):
                     continue
-                for unit_dict in number_with_units.get('units', []):
+                units: object = number_with_units.get('units', [])
+                if not isinstance(units, list):
+                    continue
+                for unit_dict in units:
+                    unit_dict = cast(object, unit_dict)
                     if not isinstance(unit_dict, dict):
                         continue
                     unit_name = unit_dict.get('unit')

--- a/core/jobs/batch_jobs/number_with_units_audit_jobs.py
+++ b/core/jobs/batch_jobs/number_with_units_audit_jobs.py
@@ -111,31 +111,53 @@ class FindNumberWithUnitsRuleUnitsJob(base_jobs.JobBase):
         if interaction_dict.get('id') != 'NumberWithUnits':
             return
 
+        # Here we use object because this value comes from persisted JSON and
+        # must be runtime-validated before treating it as a specific type.
         answer_groups: object = interaction_dict.get('answer_groups', [])
         if not isinstance(answer_groups, list):
             return
 
         for answer_group in answer_groups:
+            # Here we use object because list entries from persisted JSON must
+            # be treated as unknown until runtime checks pass.
+            # Here use cast because each list item must be treated as an
+            # unknown value before runtime type checks are applied.
             answer_group = cast(object, answer_group)
             if not isinstance(answer_group, dict):
                 continue
+            # Here we use object because rule_specs can be malformed in
+            # persisted payloads and are validated with isinstance checks.
             rule_specs: object = answer_group.get('rule_specs', [])
             if not isinstance(rule_specs, list):
                 continue
             for rule_spec in rule_specs:
+                # Here we use object because list entries from persisted JSON
+                # must be treated as unknown until runtime checks pass.
+                # Here use cast because each rule spec is handled as unknown
+                # until runtime validation confirms its structure.
                 rule_spec = cast(object, rule_spec)
                 if not isinstance(rule_spec, dict):
                     continue
+                # Here we use object because inputs are loaded from storage
+                # and need runtime validation before dict access.
                 inputs: object = rule_spec.get('inputs', {})
                 if not isinstance(inputs, dict):
                     continue
+                # Here we use object because the "f" field can be malformed in
+                # legacy payloads and must be validated first.
                 number_with_units: object = inputs.get('f')
                 if not isinstance(number_with_units, dict):
                     continue
+                # Here we use object because units data comes from persisted
+                # state and is validated at runtime before iteration.
                 units: object = number_with_units.get('units', [])
                 if not isinstance(units, list):
                     continue
                 for unit_dict in units:
+                    # Here we use object because list entries from persisted
+                    # JSON must be treated as unknown until runtime checks pass.
+                    # Here use cast because each unit entry is treated as
+                    # unknown before validating that it is a dict.
                     unit_dict = cast(object, unit_dict)
                     if not isinstance(unit_dict, dict):
                         continue

--- a/core/jobs/batch_jobs/number_with_units_audit_jobs.py
+++ b/core/jobs/batch_jobs/number_with_units_audit_jobs.py
@@ -120,7 +120,7 @@ class FindNumberWithUnitsRuleUnitsJob(base_jobs.JobBase):
         for answer_group in answer_groups:
             # Here we use object because list entries from persisted JSON must
             # be treated as unknown until runtime checks pass.
-            # Here use cast because each list item must be treated as an
+            # Here we use cast because each list item must be treated as an
             # unknown value before runtime type checks are applied.
             answer_group = cast(object, answer_group)
             if not isinstance(answer_group, dict):
@@ -133,7 +133,7 @@ class FindNumberWithUnitsRuleUnitsJob(base_jobs.JobBase):
             for rule_spec in rule_specs:
                 # Here we use object because list entries from persisted JSON
                 # must be treated as unknown until runtime checks pass.
-                # Here use cast because each rule spec is handled as unknown
+                # Here we use cast because each rule spec is handled as unknown
                 # until runtime validation confirms its structure.
                 rule_spec = cast(object, rule_spec)
                 if not isinstance(rule_spec, dict):
@@ -156,7 +156,7 @@ class FindNumberWithUnitsRuleUnitsJob(base_jobs.JobBase):
                 for unit_dict in units:
                     # Here we use object because list entries from persisted
                     # JSON must be treated as unknown until runtime checks pass.
-                    # Here use cast because each unit entry is treated as
+                    # Here we use cast because each unit entry is treated as
                     # unknown before validating that it is a dict.
                     unit_dict = cast(object, unit_dict)
                     if not isinstance(unit_dict, dict):

--- a/core/jobs/batch_jobs/number_with_units_audit_jobs_test.py
+++ b/core/jobs/batch_jobs/number_with_units_audit_jobs_test.py
@@ -310,6 +310,23 @@ class FindNumberWithUnitsRuleUnitsJobTests(job_test_utils.JobTestBase):
         interaction_3['id'] = 'NumberWithUnits'
         interaction_3['answer_groups'] = ['not_a_dict']
 
+        # State with rule_specs that is not a list.
+        malformed_state_3b = self._create_base_malformed_state_dict(
+            'content_5', 'default_outcome_6'
+        )
+        interaction_3b = malformed_state_3b['interaction']
+        assert isinstance(interaction_3b, dict)
+        default_outcome_3b = interaction_3b['default_outcome']
+        interaction_3b['id'] = 'NumberWithUnits'
+        interaction_3b['answer_groups'] = [
+            {
+                'outcome': default_outcome_3b,
+                'rule_specs': 'not_a_list',
+                'training_data': [],
+                'tagged_skill_misconception_id': None,
+            }
+        ]
+
         # State with rule_spec that is not a dict.
         malformed_state_4 = self._create_base_malformed_state_dict(
             'content_6', 'default_outcome_7'
@@ -499,6 +516,7 @@ class FindNumberWithUnitsRuleUnitsJobTests(job_test_utils.JobTestBase):
                 'malformed_1': malformed_state_1,
                 'malformed_2': malformed_state_2,
                 'malformed_3': malformed_state_3,
+                'malformed_3b': malformed_state_3b,
                 'malformed_9': malformed_state_9,
                 'malformed_4': malformed_state_4,
                 'malformed_5': malformed_state_5,

--- a/core/jobs/batch_jobs/number_with_units_audit_jobs_test.py
+++ b/core/jobs/batch_jobs/number_with_units_audit_jobs_test.py
@@ -447,6 +447,40 @@ class FindNumberWithUnitsRuleUnitsJobTests(job_test_utils.JobTestBase):
             }
         ]
 
+        # State with units that is not a list.
+        malformed_state_9 = self._create_base_malformed_state_dict(
+            'content_16', 'default_outcome_17'
+        )
+        interaction_9 = malformed_state_9['interaction']
+        assert isinstance(interaction_9, dict)
+        default_outcome_9 = interaction_9['default_outcome']
+        interaction_9['id'] = 'NumberWithUnits'
+        interaction_9['answer_groups'] = [
+            {
+                'outcome': default_outcome_9,
+                'rule_specs': [
+                    {
+                        'rule_type': 'IsEquivalentTo',
+                        'inputs': {
+                            'f': {
+                                'type': 'real',
+                                'real': 2,
+                                'fraction': {
+                                    'isNegative': False,
+                                    'wholeNumber': 0,
+                                    'numerator': 0,
+                                    'denominator': 1,
+                                },
+                                'units': 'not_a_list',
+                            }
+                        },
+                    }
+                ],
+                'training_data': [],
+                'tagged_skill_misconception_id': None,
+            }
+        ]
+
         # Valid state with actual units to ensure job runs and produces output.
         valid_state = self._create_state_with_units(
             [{'unit': 'cm', 'exponent': 1}]
@@ -465,6 +499,7 @@ class FindNumberWithUnitsRuleUnitsJobTests(job_test_utils.JobTestBase):
                 'malformed_1': malformed_state_1,
                 'malformed_2': malformed_state_2,
                 'malformed_3': malformed_state_3,
+                'malformed_9': malformed_state_9,
                 'malformed_4': malformed_state_4,
                 'malformed_5': malformed_state_5,
                 'malformed_6': malformed_state_6,

--- a/core/jobs/transforms/validation/base_validation.py
+++ b/core/jobs/transforms/validation/base_validation.py
@@ -39,7 +39,17 @@ from core.jobs.types import base_validation_errors
 from core.platform import models
 
 import apache_beam as beam
-from typing import Any, Final, Generic, Iterator, Type, TypeVar, Union
+from typing import (
+    Any,
+    Final,
+    Generic,
+    Iterator,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -385,7 +395,7 @@ class BaseValidateCommitCmdsSchema(beam.DoFn, Generic[ModelInstanceType]):  # ty
 
     def _get_change_domain_class(
         self, unused_item: ModelInstanceType
-    ) -> Type[change_domain.BaseChange]:
+    ) -> Optional[Type[change_domain.BaseChange]]:
         """Returns a Change domain class for the changes made by commit
         commands of the model.
 
@@ -424,17 +434,26 @@ class BaseValidateCommitCmdsSchema(beam.DoFn, Generic[ModelInstanceType]):  # ty
             # For example, if a CollectionCommitLogEntryModel does
             # not have id starting with collection/rights, there is
             # no commit command domain object defined for this model.
-            yield base_validation_errors.CommitCmdsNoneError(entity)
+            # Here we use cast because this transform runs only on commit/snapshot
+            # models, but the generic type variable is too broad for MyPy.
+            yield base_validation_errors.CommitCmdsNoneError(
+                cast(
+                    Union[
+                        base_models.BaseCommitLogEntryModel,
+                        base_models.BaseSnapshotMetadataModel,
+                    ],
+                    entity,
+                )
+            )
             return
-        # Ruling out the possibility of any other model instance for mypy type
-        # checking.
-        assert isinstance(
+        if not isinstance(
             entity,
             (
                 base_models.BaseSnapshotMetadataModel,
                 base_models.BaseCommitLogEntryModel,
             ),
-        )
+        ):
+            return
         for commit_cmd_dict in entity.commit_cmds:
             if not commit_cmd_dict:
                 continue

--- a/core/jobs/transforms/validation/base_validation_test.py
+++ b/core/jobs/transforms/validation/base_validation_test.py
@@ -28,7 +28,7 @@ from core.jobs.types import base_validation_errors
 from core.platform import models
 
 import apache_beam as beam
-from typing import Type
+from typing import Optional, Type
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -614,15 +614,11 @@ class MockValidateCommitCmdsSchemaChangeDomain(
     base_validation.BaseValidateCommitCmdsSchema[base_models.BaseModel]
 ):
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's `_get_change_domain_class()` method, because
-    # in super class's method we are returning Type[BaseChange] and here for
-    # testing purposes we are returning 'None'. So, due to this conflict in
-    # return types, a conflict in signatures occurred which causes MyPy to
-    # throw an error. Thus, to avoid the error, we used ignore here.
-    def _get_change_domain_class(self, _: base_models.BaseModel) -> None:  # type: ignore[override]
+    def _get_change_domain_class(
+        self, _: base_models.BaseModel
+    ) -> Optional[Type[change_domain.BaseChange]]:
         """Method defined for testing purpose."""
-        pass
+        return None
 
 
 class MockValidateWrongSchema(

--- a/core/jobs/transforms/validation/collection_validation.py
+++ b/core/jobs/transforms/validation/collection_validation.py
@@ -120,9 +120,7 @@ class ValidateCollectionCommitLogEntryModel(
 ):
     """Overrides _get_change_domain_class for CollectionCommitLogEntryModel."""
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's _get_change_domain_class() method.
-    def _get_change_domain_class(  # type: ignore[override]
+    def _get_change_domain_class(
         self, input_model: collection_models.CollectionCommitLogEntryModel
     ) -> Optional[
         Type[

--- a/core/jobs/transforms/validation/exp_validation.py
+++ b/core/jobs/transforms/validation/exp_validation.py
@@ -138,9 +138,7 @@ class ValidateExplorationCommitLogEntryModel(
 ):
     """Overrides _get_change_domain_class for exploration models"""
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's _get_change_domain_class() method.
-    def _get_change_domain_class(  # type: ignore[override]
+    def _get_change_domain_class(
         self, input_model: exp_models.ExplorationCommitLogEntryModel
     ) -> Optional[
         Type[

--- a/core/jobs/transforms/validation/question_validation.py
+++ b/core/jobs/transforms/validation/question_validation.py
@@ -119,9 +119,7 @@ class ValidateQuestionCommitLogEntryModel(
 ):
     """Overrides _get_change_domain_class for QuestionCommitLogEntryModel."""
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's _get_change_domain_class() method.
-    def _get_change_domain_class(  # type: ignore[override]
+    def _get_change_domain_class(
         self,
         input_model: question_models.QuestionCommitLogEntryModel,  # pylint: disable=unused-argument
     ) -> Optional[Type[question_domain.QuestionChange]]:

--- a/core/jobs/transforms/validation/skill_validation.py
+++ b/core/jobs/transforms/validation/skill_validation.py
@@ -65,9 +65,7 @@ class ValidateSkillCommitLogEntryModel(
 ):
     """Overrides _get_change_domain_class for SkillCommitLogEntryModel."""
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's _get_change_domain_class() method.
-    def _get_change_domain_class(  # type: ignore[override]
+    def _get_change_domain_class(
         self, input_model: skill_models.SkillCommitLogEntryModel
     ) -> Optional[Type[skill_domain.SkillChange]]:
         """Returns a change domain class.

--- a/core/jobs/transforms/validation/story_validation.py
+++ b/core/jobs/transforms/validation/story_validation.py
@@ -65,9 +65,7 @@ class ValidateStoryCommitLogEntryModel(
 ):
     """Overrides _get_change_domain_class for StoryCommitLogEntryModel."""
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's _get_change_domain_class() method.
-    def _get_change_domain_class(  # type: ignore[override]
+    def _get_change_domain_class(
         self, input_model: story_models.StoryCommitLogEntryModel
     ) -> Optional[Type[story_domain.StoryChange]]:
         """Returns a change domain class.

--- a/core/jobs/transforms/validation/subtopic_validation.py
+++ b/core/jobs/transforms/validation/subtopic_validation.py
@@ -69,9 +69,7 @@ class ValidateSubtopicPageCommitLogEntryModel(
 ):
     """Overrides _get_change_domain_class for SubtopicPageCommitLogEntryModel."""
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's _get_change_domain_class() method.
-    def _get_change_domain_class(  # type: ignore[override]
+    def _get_change_domain_class(
         self, input_model: subtopic_models.SubtopicPageCommitLogEntryModel
     ) -> Optional[Type[subtopic_page_domain.SubtopicPageChange]]:
         """Returns a change domain class.

--- a/core/jobs/transforms/validation/topic_validation.py
+++ b/core/jobs/transforms/validation/topic_validation.py
@@ -120,9 +120,7 @@ class ValidateTopicCommitLogEntryModel(
 ):
     """Overrides _get_change_domain_class for TopicCommitLogEntryModel."""
 
-    # Here we use MyPy ignore because the signature of this method doesn't
-    # match with super class's _get_change_domain_class() method.
-    def _get_change_domain_class(  # type: ignore[override]
+    def _get_change_domain_class(
         self, input_model: topic_models.TopicCommitLogEntryModel
     ) -> Optional[
         Type[Union[topic_domain.TopicRightsChange, topic_domain.TopicChange]]

--- a/core/schema_utils.py
+++ b/core/schema_utils.py
@@ -200,10 +200,6 @@ def normalize_against_schema(
             raise Exception(
                 'Could not convert %s to int: %s' % (type(obj).__name__, obj)
             ) from e
-        assert isinstance(obj, numbers.Integral), (
-            'Expected int, received %s' % obj
-        )
-        assert isinstance(obj, int), 'Expected int, received %s' % obj
         normalized_obj = obj
     elif schema[SCHEMA_KEY_TYPE] == SCHEMA_TYPE_HTML:
         # TODO(#14028): Use just one type.

--- a/core/schema_utils.py
+++ b/core/schema_utils.py
@@ -585,9 +585,7 @@ class _Validators:
         Returns:
             bool. Whether the given object doesn't contain a valid email.
         """
-        if isinstance(obj, str):
-            return not bool(re.search(EMAIL_REGEX, obj))
-        return True
+        return not bool(re.search(EMAIL_REGEX, obj))
 
     @staticmethod
     def is_valid_user_id(obj: str) -> bool:

--- a/core/schema_utils.py
+++ b/core/schema_utils.py
@@ -576,15 +576,22 @@ class _Validators:
         return obj <= max_value
 
     @staticmethod
-    def does_not_contain_email(obj: str) -> bool:
+    def does_not_contain_email(
+        # Here we use object because this validator is applied to generic
+        # schema values that may not be strings, and non-string inputs should
+        # be treated as valid.
+        obj: object,
+    ) -> bool:
         """Ensures that obj doesn't contain a valid email.
 
         Args:
-            obj: str. The object to validate.
+            obj: object. The object to validate.
 
         Returns:
             bool. Whether the given object doesn't contain a valid email.
         """
+        if not isinstance(obj, str):
+            return True
         return not bool(re.search(EMAIL_REGEX, obj))
 
     @staticmethod

--- a/core/schema_utils_test.py
+++ b/core/schema_utils_test.py
@@ -880,6 +880,17 @@ class SchemaValidationUnitTests(test_utils.GenericTestBase):
         self.assertFalse(validate_url_fragment('Abc'))
         self.assertFalse(validate_url_fragment('!@#$%^&*()_+='))
 
+    def test_does_not_contain_email_validator_handles_non_string_input(
+        self,
+    ) -> None:
+        does_not_contain_email = schema_utils.get_validator(
+            'does_not_contain_email'
+        )
+
+        self.assertTrue(does_not_contain_email(2))
+        self.assertTrue(does_not_contain_email({'value': 'not an email'}))
+        self.assertTrue(does_not_contain_email(['email@email.com']))
+
     def test_global_validators_raise_exception_when_error_in_dict(self) -> None:
         with self.assertRaisesRegex(
             AssertionError,

--- a/core/storage/base_model/gae_models_test.py
+++ b/core/storage/base_model/gae_models_test.py
@@ -138,10 +138,9 @@ class BaseModelUnitTests(test_utils.GenericTestBase):
         model.put()
         all_models = base_models.BaseModel.get_all()
         self.assertEqual(all_models.count(), 1)
-        base_model = all_models.get()
-
-        # Ruling out the possibility of None for mypy type checking.
-        assert base_model is not None
+        # Here we use cast because get() is known to return the single stored
+        # model after we have asserted that exactly one entity exists.
+        base_model = cast(base_models.BaseModel, all_models.get())
         self.assertEqual(base_model, model)
 
         model_id = base_model.id

--- a/core/storage/blog/gae_models.py
+++ b/core/storage/blog/gae_models.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from core import utils
 from core.platform import models
 
-from typing import Dict, List, Literal, Optional, Sequence, TypedDict
+from typing import Dict, List, Literal, Optional, Sequence, TypedDict, cast
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -596,8 +596,13 @@ class BlogAuthorDetailsModel(base_models.BaseModel):
             dict. Dictionary of the data from BlogAuthorDetailModel.
         """
 
-        author_model = cls.query(cls.author_id == user_id).get()
-        if author_model:
+        # Here we use cast because query().get() may return None when no author
+        # detail exists for the given user.
+        author_model = cast(
+            Optional[BlogAuthorDetailsModel],
+            cls.query(cls.author_id == user_id).get(),
+        )
+        if author_model is not None:
             return {
                 'displayed_author_name': author_model.displayed_author_name,
                 'author_bio': author_model.author_bio,

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -34,6 +34,7 @@ from typing import (
     Tuple,
     TypedDict,
     Union,
+    cast,
 )
 
 MYPY = False
@@ -1332,8 +1333,11 @@ class CommunityContributionStatsModel(base_models.BaseModel):
         Returns:
             CommunityContributionStatsModel. The single model instance.
         """
-        community_contribution_stats_model = cls.get_by_id(
-            COMMUNITY_CONTRIBUTION_STATS_MODEL_ID
+        # Here we use cast because get_by_id() may return None when the singleton
+        # has not been created yet.
+        community_contribution_stats_model = cast(
+            Optional[CommunityContributionStatsModel],
+            cls.get_by_id(COMMUNITY_CONTRIBUTION_STATS_MODEL_ID),
         )
 
         if community_contribution_stats_model is None:

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -3399,10 +3399,9 @@ class LearnerGroupsUserModel(base_models.BaseModel):
         )
 
         if learner_grp_user_model is None:
-            return {
-                'invited_to_learner_groups_ids': [],
-                'learner_groups_user_details': [],
-            }
+            # Here we use cast because the takeout contract for missing users
+            # intentionally returns an empty dict instead of the TypedDict.
+            return cast(LearnerGroupsUserDataDict, {})
 
         return {
             'invited_to_learner_groups_ids': (

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -36,6 +36,7 @@ from typing import (
     Tuple,
     TypedDict,
     Union,
+    cast,
     overload,
 )
 
@@ -2980,7 +2981,11 @@ class UserContributionRightsModel(base_models.BaseModel):
         Returns:
             dict. Dictionary of the data from UserContributionRightsModel.
         """
-        rights_model = cls.get_by_id(user_id)
+        # Here we use cast because get_by_id() may return None for absent users,
+        # and this takeout path must preserve that branch explicitly.
+        rights_model = cast(
+            Optional[UserContributionRightsModel], cls.get_by_id(user_id)
+        )
 
         if rights_model is None:
             return {}
@@ -3387,10 +3392,17 @@ class LearnerGroupsUserModel(base_models.BaseModel):
         Returns:
             dict. Dictionary of the data from LearnerGroupsUserModel.
         """
-        learner_grp_user_model = cls.get_by_id(user_id)
+        # Here we use cast because get_by_id() may return None for absent users,
+        # and this takeout path must preserve that branch explicitly.
+        learner_grp_user_model = cast(
+            Optional[LearnerGroupsUserModel], cls.get_by_id(user_id)
+        )
 
         if learner_grp_user_model is None:
-            return {}
+            return {
+                'invited_to_learner_groups_ids': [],
+                'learner_groups_user_details': [],
+            }
 
         return {
             'invited_to_learner_groups_ids': (

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -874,7 +874,7 @@ class CheckedProof(BaseObject):
                 assert isinstance(raw['error_category'], str)
                 assert isinstance(raw['error_code'], str)
                 assert isinstance(raw['error_message'], str)
-                assert isinstance(raw['error_line_number'], int)
+                assert isinstance(raw['error_line_number'], str)
             return copy.deepcopy(raw)
         except Exception as e:
             raise TypeError('Cannot convert to checked proof %s' % raw) from e

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -635,7 +635,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             'error_category': 'layout',
             'error_code': 'bad_layout',
             'error_message': 'layout is bad',
-            'error_line_number': 2,
+            'error_line_number': '2',
         }
         mappings = [
             (valid_example_1, valid_example_1),

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -36,7 +36,7 @@ from scripts import (
 )
 
 import rcssmin
-from typing import Deque, Dict, List, Optional, Sequence, TextIO, Tuple
+from typing import Deque, Dict, List, Optional, Sequence, TextIO, Tuple, TypedDict
 
 ASSETS_DEV_DIR = os.path.join('assets', '')
 ASSETS_OUT_DIR = os.path.join('build', 'assets', '')
@@ -146,6 +146,8 @@ FILEPATHS_PROVIDED_TO_FRONTEND = (
 
 HASH_BLOCK_SIZE = 2**20
 
+DEPENDENCIES_FILE_PATH = os.path.join('dependencies.json')
+
 APP_DEV_YAML_FILEPATH = 'app_dev.yaml'
 
 APP_YAML_FILEPATH = 'app.yaml'
@@ -200,6 +202,13 @@ _PARSER.add_argument(
         'since karma does not use the Angular dist output.'
     ),
 )
+
+class DependencyBundleDict(TypedDict):
+    """Dictionary that represents dependency bundle."""
+
+    js: List[str]
+    css: List[str]
+    fontsPath: Optional[str]
 
 
 def run_webpack_compilation(source_maps: bool = False) -> None:
@@ -524,8 +533,179 @@ def process_html(
     write_to_file_stream(
         target_file_stream, REMOVE_WS(' ', source_file_stream.read())
     )
+def get_dependency_directory(dependency: Dict[str, str]) -> str:
+    """Get dependency directory from dependency dictionary.
+
+    Args:
+        dependency: dict(str, str). Dictionary representing single dependency
+            from dependencies.json.
+
+    Returns:
+        str. Dependency directory.
+    """
+    if 'targetDir' in dependency:
+        dependency_dir = dependency['targetDir']
+    else:
+        dependency_dir = dependency['targetDirPrefix'] + dependency['version']
+    return os.path.join(THIRD_PARTY_STATIC_DIR, dependency_dir)
 
 
+def get_css_filepaths(
+    dependency_bundle: DependencyBundleDict, dependency_dir: str
+) -> List[str]:
+    """Gets dependency css filepaths.
+
+    Args:
+        dependency_bundle: dict(str, list(str) | str). The dict has three keys:
+            - 'js': List of paths to js files that need to be copied.
+            - 'css': List of paths to css files that need to be copied.
+            - 'fontsPath': Path to folder containing fonts that need to be
+                copied.
+        dependency_dir: str. Path to directory where the files that need to
+            be copied are located.
+
+    Returns:
+        list(str). List of paths to css files that need to be copied.
+    """
+    css_files = dependency_bundle.get('css', [])
+    return [os.path.join(dependency_dir, css_file) for css_file in css_files]
+
+
+def get_js_filepaths(
+    dependency_bundle: DependencyBundleDict, dependency_dir: str
+) -> List[str]:
+    """Gets dependency js filepaths.
+
+    Args:
+        dependency_bundle: dict(str, list(str) | str). The dict has three keys:
+            - 'js': List of paths to js files that need to be copied.
+            - 'css': List of paths to css files that need to be copied.
+            - 'fontsPath': Path to folder containing fonts that need to be
+                copied.
+        dependency_dir: str. Path to directory where the files that need to
+            be copied are located.
+
+    Returns:
+        list(str). List of paths to js files that need to be copied.
+    """
+    js_files = dependency_bundle.get('js', [])
+    return [os.path.join(dependency_dir, js_file) for js_file in js_files]
+
+
+def get_font_filepaths(
+    dependency_bundle: DependencyBundleDict, dependency_dir: str
+) -> List[str]:
+    """Gets dependency font filepaths.
+
+    Args:
+        dependency_bundle: dict(str, list(str) | str). The dict has three keys:
+            - 'js': List of paths to js files that need to be copied.
+            - 'css': List of paths to css files that need to be copied.
+            - 'fontsPath': Path to folder containing fonts that need to be
+                copied.
+        dependency_dir: str. Path to directory where the files that need to
+            be copied are located.
+
+    Returns:
+        list(str). List of paths to font files that need to be copied.
+    """
+    fonts_path = dependency_bundle.get('fontsPath')
+    if not fonts_path:
+        # Skip dependency bundles in dependencies.json that do not have
+        # fontsPath property.
+        return []
+    # Obtain directory path to /font inside dependency folder.
+    # E.g. third_party/static/bootstrap-3.3.4/fonts/.
+    font_dir = os.path.join(dependency_dir, fonts_path)
+    font_filepaths = []
+    # Walk the directory and add all font files to list.
+    for root, _, filenames in os.walk(font_dir):
+        for filename in filenames:
+            font_filepaths.append(os.path.join(root, filename))
+    return font_filepaths
+
+
+def get_dependencies_filepaths() -> Dict[str, List[str]]:
+    """Extracts dependencies filepaths from dependencies.json file into
+    a dictionary.
+
+    Returns:
+        dict(str, list(str)). A dict mapping file types to lists of filepaths.
+        The dict has three keys: 'js', 'css' and 'fonts'. Each of the
+        corresponding values is a full list of dependency file paths of the
+        given type.
+    """
+    filepaths: Dict[str, List[str]] = {'js': [], 'css': [], 'fonts': []}
+    with open(DEPENDENCIES_FILE_PATH, 'r', encoding='utf-8') as json_file:
+        dependencies_json = json.loads(
+            json_file.read(), object_pairs_hook=collections.OrderedDict
+        )
+    frontend_dependencies = dependencies_json['frontendDependencies']
+    for dependency in frontend_dependencies.values():
+        if 'bundle' in dependency:
+            dependency_dir = get_dependency_directory(dependency)
+            filepaths['css'].extend(
+                get_css_filepaths(dependency['bundle'], dependency_dir)
+            )
+            filepaths['js'].extend(
+                get_js_filepaths(dependency['bundle'], dependency_dir)
+            )
+            filepaths['fonts'].extend(
+                get_font_filepaths(dependency['bundle'], dependency_dir)
+            )
+
+    _ensure_files_exist(filepaths['js'])
+    _ensure_files_exist(filepaths['css'])
+    _ensure_files_exist(filepaths['fonts'])
+    return filepaths
+
+
+def minify_third_party_libs(third_party_directory_path: str) -> None:
+    """Minify third_party.js and third_party.css and remove un-minified
+    files.
+    """
+
+    third_party_css_filepath = os.path.join(
+        third_party_directory_path, THIRD_PARTY_CSS_RELATIVE_FILEPATH
+    )
+
+    minified_third_party_css_filepath = os.path.join(
+        third_party_directory_path, MINIFIED_THIRD_PARTY_CSS_RELATIVE_FILEPATH
+    )
+
+    _minify_css(third_party_css_filepath, minified_third_party_css_filepath)
+    # Clean up un-minified third_party.js and third_party.css.
+    safe_delete_file(third_party_css_filepath)
+
+
+def build_third_party_libs(third_party_directory_path: str) -> None:
+    """Joins all third party css files into single css file and js files into
+    single js file. Copies both files and all fonts into third party folder.
+    """
+
+    print('Building third party libs at %s' % third_party_directory_path)
+
+    third_party_css_filepath = os.path.join(
+        third_party_directory_path, THIRD_PARTY_CSS_RELATIVE_FILEPATH
+    )
+    webfonts_dir = os.path.join(
+        third_party_directory_path, WEBFONTS_RELATIVE_DIRECTORY_PATH
+    )
+
+    dependency_filepaths = get_dependencies_filepaths()
+
+    common.ensure_directory_exists(os.path.dirname(third_party_css_filepath))
+    with open(
+        third_party_css_filepath, 'w+', encoding='utf-8'
+    ) as third_party_css_file:
+        _join_files(dependency_filepaths['css'], third_party_css_file)
+
+    common.ensure_directory_exists(webfonts_dir)
+    _execute_tasks(
+        _generate_copy_tasks_for_fonts(
+            dependency_filepaths['fonts'], webfonts_dir
+        )
+    )
 def build_using_ng() -> None:
     """Execute angular build process. This runs the angular compiler and
     generates an ahead of time compiled bundle. This bundle can be found in the

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -93,10 +93,10 @@ def test_python_version() -> None:
     Raises:
         Exception. The Python version does not match the expected prefix.
     """
-    running_python_version = '{0[0]}.{0[1]}.{0[2]}'.format(sys.version_info)
-    if running_python_version != '3.10.16':
-        print('Please use Python 3.10.16. Exiting...')
-        raise Exception('No suitable python version found.')
+    # running_python_version = '{0[0]}.{0[1]}.{0[2]}'.format(sys.version_info)
+    # if running_python_version != '3.10.16':
+    #     print('Please use Python 3.10.16. Exiting...')
+    #     raise Exception('No suitable python version found.')
 
 
 def download_and_install_package(url_to_retrieve: str, filename: str) -> None:

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -93,10 +93,10 @@ def test_python_version() -> None:
     Raises:
         Exception. The Python version does not match the expected prefix.
     """
-    # running_python_version = '{0[0]}.{0[1]}.{0[2]}'.format(sys.version_info)
-    # if running_python_version != '3.10.16':
-    #     print('Please use Python 3.10.16. Exiting...')
-    #     raise Exception('No suitable python version found.')
+    running_python_version = '{0[0]}.{0[1]}.{0[2]}'.format(sys.version_info)
+    if running_python_version != '3.10.16':
+        print('Please use Python 3.10.16. Exiting...')
+        raise Exception('No suitable python version found.')
 
 
 def download_and_install_package(url_to_retrieve: str, filename: str) -> None:

--- a/scripts/run_frontend_tests_test.py
+++ b/scripts/run_frontend_tests_test.py
@@ -23,7 +23,7 @@ import sys
 
 from core.tests import test_utils
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from . import (
     build,
@@ -41,10 +41,10 @@ class RunFrontendTestsTests(test_utils.GenericTestBase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.print_arr: list[str] = []
+        self.print_arr: list[Union[str, bytes]] = []
 
         def mock_print(  # pylint: disable=unused-argument
-            msg: str, end: str = '\n'
+            msg: Union[str, bytes], end: str = '\n'
         ) -> None:
             self.print_arr.append(msg)
 

--- a/scripts/run_mypy_checks.py
+++ b/scripts/run_mypy_checks.py
@@ -69,6 +69,7 @@ def get_mypy_cmd(files: Optional[List[str]]) -> List[str]:
         excluded_files_regex = '|'.join(EXCLUDED_DIRECTORIES)
         cmd = [
             mypy_cmd,
+            '--warn-unreachable',
             '--exclude',
             excluded_files_regex,
             '--config-file',

--- a/scripts/run_mypy_checks_test.py
+++ b/scripts/run_mypy_checks_test.py
@@ -88,6 +88,7 @@ class MypyScriptChecks(test_utils.GenericTestBase):
     def test_get_mypy_cmd_without_files(self) -> None:
         expected_cmd = [
             'mypy',
+            '--warn-unreachable',
             '--exclude',
             'dir1/|dir2/',
             '--config-file',


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #22113  

2. This PR does the following:  
This PR resolves multiple **MyPy unreachable code warnings** across controllers and domain services.

Key changes include:
- Added explicit runtime type checks before narrowing values from request payloads and datastore fetches.
- Replaced unsafe assumptions with `cast(...)`-based narrowing where appropriate.
- Updated several handlers to correctly handle `Optional` return values (e.g., `get_by_id()` and fetchers).
- Ensured safer handling of malformed inputs while keeping MyPy satisfied without introducing unreachable branches.
- Added/updated tests to maintain coverage and validate the new behavior.

3. (For bug-fixing PRs only) The original bug occurred because:  
The issue occurred due to improper type narrowing and assumptions about non-null values, which led MyPy to flag certain branches as unreachable.  

---

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

Before:
```
......
core/domain/event_services_test.py:302: error: Statement is unreachable  [unreachable]
core/domain/event_services_test.py:330: error: Statement is unreachable  [unreachable]
core/domain/event_services_test.py:461: error: Statement is unreachable  [unreachable]
core/domain/event_services_test.py:544: error: Statement is unreachable  [unreachable]
core/controllers/reader_test.py:2717: error: Statement is unreachable  [unreachable]
core/controllers/reader_test.py:2824: error: Statement is unreachable  [unreachable]
core/controllers/reader_test.py:2901: error: Statement is unreachable  [unreachable]
core/controllers/reader_test.py:3049: error: Statement is unreachable  [unreachable]
core/controllers/reader_test.py:3125: error: Statement is unreachable  [unreachable]
core/controllers/reader_test.py:3196: error: Statement is unreachable  [unreachable]
scripts/run_frontend_tests_test.py:635: error: Subclass of "str" and "bytes" cannot exist: would have incompatible method signatures  [unreachable]
scripts/run_frontend_tests_test.py:636: error: Statement is unreachable  [unreachable]
Found 94 errors in 35 files (checked 963 source files)

```
After:
<img width="1487" height="179" alt="image" src="https://github.com/user-attachments/assets/984aa601-1c30-475d-83e5-ae28333d3f56" />

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
