### PR TITLE
Fix#24107 :Remove duplicate keyword search button in blog page

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page.component.css
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.css
@@ -5,13 +5,8 @@
 */
 @media (max-width: 1024px) {
   oppia-blog-home-page .oppia-search-bar-form .oppia-search-bar-input {
-    border-radius: 4px 0 0 4px;
-    border-width: 1px 0 1px 1px;
-  }
-
-  oppia-blog-home-page .input-group .oppia-search-bar-icon {
-    border-radius: 0 4px 4px 0;
-    border-width: 1px 1px 1px 0;
+    border-radius: 4px;
+    border-width: 1px;
   }
 }
 
@@ -117,8 +112,8 @@ oppia-blog-home-page .search-heading {
 .oppia-search-bar-input {
   border-color: #333;
   border-left-width: 1px;
-  border-radius: 4px 0 0 4px;
-  border-right-width: 0;
+  border-radius: 4px;
+  border-right-width: 1px;
   color: #333;
   width: 100%;
 

--- a/core/templates/pages/blog-home-page/blog-home-page.component.html
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.html
@@ -109,22 +109,13 @@
             {{ 'I18N_BLOG_HOME_PAGE_QUERY_SEARCH_HEADING' | translate }}
           </h4>
           <form class="navbar-form oppia-search-bar-form ps-0 e2e-test-search-field" role="search">
-            <div class="mb-3 d-flex">
+            <div class="mb-3">
               <input type="text"
                      class="form-control oppia-search-bar-input oppia-search-bar-text-input e2e-test-search-input"
                      [(ngModel)]="searchQuery"
                      [ngModelOptions]="{ updateOn: 'change', standalone: 'true' }"
                      aria-label="Search bar"
                      (keydown.enter)="onSearchQueryChangeExec()">
-              <div class="input-group oppia-input-group">
-                <div class="input-group-text oppia-search-bar-icon" [ngClass]="{'d-block': isSmallScreenViewActive()}">
-                  <i class="fas fa-search material-icons oppia-translate-icon-down md-18" *ngIf="!isSearchInProgress()">
-                  </i>
-                  <span *ngIf="isSearchInProgress()">
-                    <i class="fas fa-sync material-icons md-18 oppia-animate-spin"></i>
-                  </span>
-                </div>
-              </div>
             </div>
           </form>
           <h4 class="d-flex flex-grow-1 search-heading">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #24107 
2. This PR does the following: Removes the duplicate keyword-search submit control on the blog page by deleting the magnifier button next to the keyword input and keeping the existing Search button as the single submit action. It also makes a small CSS adjustment so the input border/radius looks correct after removing the side control.
3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because: PR #21130 introduced a dedicated Search button while the existing keyword-field icon submit control was left in place, so both controls ended up triggering the same search action.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->


## Proof that changes are correct
before
<img width="1470" height="808" alt="Screenshot 2026-04-06 at 9 09 25 PM" src="https://github.com/user-attachments/assets/813020b2-c083-43a3-a316-d64beedeb244" />

after 
<img width="1470" height="808" alt="Screenshot 2026-04-06 at 9 13 27 PM" src="https://github.com/user-attachments/assets/021607c8-bc4c-4d6a-af43-001e6330a176" />

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
<img width="1470" height="808" alt="Screenshot 2026-04-06 at 9 13 27 PM" src="https://github.com/user-attachments/assets/908c76cf-7a8f-40e4-aeb7-72382d2e7911" />

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
<img width="1470" height="808" alt="Screenshot 2026-04-06 at 9 13 47 PM" src="https://github.com/user-attachments/assets/6a8f0162-32a7-4f4f-8b10-ba006b833a5c" />

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language
N/A
<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
