### PR TITLE
Fix #25786  Fixing Not a prefix operator error 

### DIFF
--- a/core/templates/services/guppy-configuration.service.ts
+++ b/core/templates/services/guppy-configuration.service.ts
@@ -62,7 +62,7 @@ const FRACTION_SYMBOL_DICT = {
   output: {
     latex: '\\frac{{$1}}{{$2}}',
     small_latex: '\\frac{{$1}}{{$2}}',
-    asciimath: '/',
+    asciimath: '({$1})/({$2})',
     text: '({$1})/({$2})',
   },
   input: 1,

--- a/typings/guppy-defs-2de64.d.ts
+++ b/typings/guppy-defs-2de64.d.ts
@@ -90,6 +90,8 @@ declare class GuppyOSK {
   constructor(config: Object);
 }
 
+declare module 'guppy-dev/build/guppy-default.min.css';
+
 declare namespace Guppy {
   export function init(config: GuppyInitConfig): void;
   export let instances: Object;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes : https://github.com/oppia/oppia/issues/25786
2. This PR does the following:  It fixes the Not a prefix operator error which was being shown when  two numbers where being divided . 
3. (For bug-fixing PRs only) The original bug occurred because: This bug originally seem to be a regression caused by the PR made in the guppy repo : https://github.com/oppia/guppy/pull/13 . 


https://github.com/user-attachments/assets/0773d157-dff7-41b2-9eed-9f6758520e71

If you take a look at the video you can see that I played a script in the console in order to get results . I did some resarch and got to know about **Monkey Patching**. With the help of monkey patching I was able to spy on what the third party liabrary guppy was sending to Oppia during run time . 

`const originalAsciimath = window.Guppy.prototype.asciimath;`

Here I grabbed the built in translation engine of guppy and stored it in a variable . 

`window.Guppy.prototype.asciimath = function() { ... };`

We violently overwrite Guppy's internal translation function with our own custom function. Now, whenever Oppia asks Guppy for the math string, it is secretly talking to our function.

`const result = originalAsciimath.apply(this, arguments)`
Inside our fake function, we call the real function behind the scenes. We pass it the exact same arguments Oppia gave us so Guppy can do its normal translation job and hand us the result.

`console.error("🔍 GUPPY IS SENDING...", result);`
We intercept the result! Before we hand it back to Oppia, we print it to the console. (We used console.error instead of console.log purely because the red text is easier to spot in a noisy console).

`return result;`
We hand the final string back to Oppia, acting like a perfect middleman. Oppia has no idea we wiretapped the connection.

In the video you will be able to see that I wrote 8/9 but guppy was returning 8 / / . This was the major clue which helped me determine that the error lied in  core/templates/services/guppy-configuration.service.ts.
  

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [✅ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [✅ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [✅ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [✅ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

https://github.com/user-attachments/assets/c2737d6d-7b8c-44c7-b8bd-02adf600c2ce 

`asciimath: '({$1})/({$2})` 
you will see in the console the correct thing is being returned and the UI error disappears , because of above fix . 

Beside this I also declared a new type in the typings file of guppy . This is because I was getting a error in the guppy.import.ts file which is shown in the below image : 
<img width="833" height="127" alt="Screenshot 2026-04-13 004110" src="https://github.com/user-attachments/assets/029f0ae7-07e0-4be7-845c-aa8bf31cc6d4" />

To fix this I declared a new type . 

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
