### PR TITLE
Fix #10162: Non-currency input invalid error 

### DIFF
--- a/core/templates/domain/objects/number-with-units.model.spec.ts
+++ b/core/templates/domain/objects/number-with-units.model.spec.ts
@@ -308,6 +308,9 @@ describe('NumberWithUnits', () => {
         NumberWithUnits.fromRawInputString('blah');
       }).toThrowError(errors.INVALID_VALUE);
       expect(() => {
+        NumberWithUnits.fromRawInputString('blah 123');
+      }).toThrowError(errors.INVALID_VALUE);
+      expect(() => {
         NumberWithUnits.fromRawInputString('3 $');
       }).toThrowError(errors.INVALID_CURRENCY_FORMAT);
       expect(() => {
@@ -318,13 +321,13 @@ describe('NumberWithUnits', () => {
       }).toThrowError(errors.INVALID_CURRENCY);
       expect(() => {
         NumberWithUnits.fromRawInputString('kg 2 s^2');
-      }).toThrowError(errors.INVALID_CURRENCY);
+      }).toThrowError(errors.INVALID_VALUE);
       expect(() => {
         NumberWithUnits.fromRawInputString('2 m/s#');
       }).toThrowError(errors.INVALID_UNIT_CHARS);
       expect(() => {
         NumberWithUnits.fromRawInputString('@ 2');
-      }).toThrowError(errors.INVALID_CURRENCY);
+      }).toThrowError(errors.INVALID_VALUE);
       expect(() => {
         NumberWithUnits.fromRawInputString('2 / 3 kg&^-2');
       }).toThrowError(errors.INVALID_UNIT_CHARS);

--- a/core/templates/domain/objects/number-with-units.model.spec.ts
+++ b/core/templates/domain/objects/number-with-units.model.spec.ts
@@ -267,6 +267,14 @@ describe('NumberWithUnits', () => {
           Units.fromRawInputString('$')
         )
       );
+      expect(NumberWithUnits.fromRawInputString('Rs 5')).toEqual(
+        new NumberWithUnits(
+          'real',
+          5,
+          new Fraction(false, 0, 0, 1),
+          Units.fromRawInputString('Rs')
+        )
+      );
       expect(NumberWithUnits.fromRawInputString('Rs 2 / 3 per hour')).toEqual(
         new NumberWithUnits(
           'fraction',
@@ -315,7 +323,7 @@ describe('NumberWithUnits', () => {
       }).toThrowError(errors.INVALID_CURRENCY_FORMAT);
       expect(() => {
         NumberWithUnits.fromRawInputString('Rs5');
-      }).toThrowError(errors.INVALID_CURRENCY);
+      }).toThrowError(errors.INVALID_VALUE);
       expect(() => {
         NumberWithUnits.fromRawInputString('$');
       }).toThrowError(errors.INVALID_CURRENCY);

--- a/core/templates/domain/objects/number-with-units.model.spec.ts
+++ b/core/templates/domain/objects/number-with-units.model.spec.ts
@@ -305,6 +305,9 @@ describe('NumberWithUnits', () => {
         NumberWithUnits.fromRawInputString('3# m/s');
       }).toThrowError(errors.INVALID_VALUE);
       expect(() => {
+        NumberWithUnits.fromRawInputString('blah');
+      }).toThrowError(errors.INVALID_VALUE);
+      expect(() => {
         NumberWithUnits.fromRawInputString('3 $');
       }).toThrowError(errors.INVALID_CURRENCY_FORMAT);
       expect(() => {

--- a/core/templates/domain/objects/number-with-units.model.ts
+++ b/core/templates/domain/objects/number-with-units.model.ts
@@ -227,7 +227,6 @@ export class NumberWithUnits {
           }
         }
         if (startsWithCorrectCurrencyUnit === false) {
-          const containsDigit = rawInput.match(/[0-9]/);
           const startsWithCurrencySymbol = keys.some(key => {
             return ObjectsDomainConstants.CURRENCY_UNITS[key].front_units.some(
               frontUnit => {
@@ -242,7 +241,7 @@ export class NumberWithUnits {
               }
             );
           });
-          if (!containsDigit && !startsWithCurrencySymbol) {
+          if (!startsWithCurrencySymbol) {
             throw new Error(
               // eslint-disable-next-line max-len
               ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_VALUE

--- a/core/templates/domain/objects/number-with-units.model.ts
+++ b/core/templates/domain/objects/number-with-units.model.ts
@@ -212,22 +212,29 @@ export class NumberWithUnits {
           ObjectsDomainConstants.CURRENCY_UNITS
         ) as CurrencyUnitsKeys;
         const normalizedRawInput = rawInput.toLowerCase();
-        const startsWithCurrencyUnit = keys.some(key => {
-          return ObjectsDomainConstants.CURRENCY_UNITS[key].front_units.some(
-            frontUnit => {
-              const normalizedFrontUnit = frontUnit.toLowerCase();
-              return normalizedRawInput.startsWith(normalizedFrontUnit);
+        let matchingCurrencyFrontUnit: string | null = null;
+        for (let i = 0; i < keys.length; i++) {
+          const frontUnits =
+            ObjectsDomainConstants.CURRENCY_UNITS[keys[i]].front_units;
+          for (let j = 0; j < frontUnits.length; j++) {
+            const normalizedFrontUnit = frontUnits[j].toLowerCase();
+            if (normalizedRawInput.startsWith(normalizedFrontUnit)) {
+              matchingCurrencyFrontUnit = frontUnits[j];
+              break;
             }
-          );
-        });
+          }
+          if (matchingCurrencyFrontUnit !== null) {
+            break;
+          }
+        }
 
-        if (!startsWithCurrencyUnit) {
+        if (matchingCurrencyFrontUnit === null) {
           throw new Error(
             // eslint-disable-next-line max-len
             ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_VALUE
           );
         }
-        const ind = rawInput.indexOf(String(rawInput.match(/[0-9]/)));
+        const ind = rawInput.search(/[0-9]/);
         if (ind === -1) {
           throw new Error(
             // eslint-disable-next-line max-len
@@ -236,23 +243,7 @@ export class NumberWithUnits {
         }
         units = rawInput.substr(0, ind).trim();
 
-        let startsWithCorrectCurrencyUnit = false;
-        for (let i = 0; i < keys.length; i++) {
-          let unitLength =
-            ObjectsDomainConstants.CURRENCY_UNITS[keys[i]].front_units.length;
-          for (let j = 0; j < unitLength; j++) {
-            if (
-              units ===
-              ObjectsDomainConstants.CURRENCY_UNITS[keys[i]].front_units[
-                j
-              ].trim()
-            ) {
-              startsWithCorrectCurrencyUnit = true;
-              break;
-            }
-          }
-        }
-        if (startsWithCorrectCurrencyUnit === false) {
+        if (units !== matchingCurrencyFrontUnit.trim()) {
           throw new Error(
             // eslint-disable-next-line max-len
             ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_CURRENCY

--- a/core/templates/domain/objects/number-with-units.model.ts
+++ b/core/templates/domain/objects/number-with-units.model.ts
@@ -227,6 +227,27 @@ export class NumberWithUnits {
           }
         }
         if (startsWithCorrectCurrencyUnit === false) {
+          const containsDigit = rawInput.match(/[0-9]/);
+          const startsWithCurrencySymbol = keys.some(key => {
+            return ObjectsDomainConstants.CURRENCY_UNITS[key].front_units.some(
+              frontUnit => {
+                const trimmedFrontUnit = frontUnit.trim();
+                return (
+                  rawInput.startsWith(frontUnit) ||
+                  rawInput.startsWith(trimmedFrontUnit) ||
+                  rawInput
+                    .toLowerCase()
+                    .startsWith(trimmedFrontUnit.toLowerCase())
+                );
+              }
+            );
+          });
+          if (!containsDigit && !startsWithCurrencySymbol) {
+            throw new Error(
+              // eslint-disable-next-line max-len
+              ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_VALUE
+            );
+          }
           throw new Error(
             // eslint-disable-next-line max-len
             ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_CURRENCY

--- a/core/templates/domain/objects/number-with-units.model.ts
+++ b/core/templates/domain/objects/number-with-units.model.ts
@@ -211,7 +211,7 @@ export class NumberWithUnits {
         const keys = Object.keys(
           ObjectsDomainConstants.CURRENCY_UNITS
         ) as CurrencyUnitsKeys;
-        const normalizedRawInput = rawInput.toLowerCase();
+        const normalizedRawInput = rawInput.trim().toLowerCase();
         let matchingCurrencyFrontUnit: string | null = null;
         for (let i = 0; i < keys.length; i++) {
           const frontUnits =
@@ -234,7 +234,8 @@ export class NumberWithUnits {
             ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_VALUE
           );
         }
-        const ind = rawInput.search(/[0-9]/);
+        const digitMatch = rawInput.match(/[0-9]/);
+        const ind = digitMatch?.index ?? -1;
         if (ind === -1) {
           throw new Error(
             // eslint-disable-next-line max-len

--- a/core/templates/domain/objects/number-with-units.model.ts
+++ b/core/templates/domain/objects/number-with-units.model.ts
@@ -208,48 +208,23 @@ export class NumberWithUnits {
           }
         }
       } else {
-        let startsWithCorrectCurrencyUnit = false;
         const keys = Object.keys(
           ObjectsDomainConstants.CURRENCY_UNITS
         ) as CurrencyUnitsKeys;
-        for (let i = 0; i < keys.length; i++) {
-          let unitLength =
-            ObjectsDomainConstants.CURRENCY_UNITS[keys[i]].front_units.length;
-          for (let j = 0; j < unitLength; j++) {
-            if (
-              rawInput.startsWith(
-                ObjectsDomainConstants.CURRENCY_UNITS[keys[i]].front_units[j]
-              )
-            ) {
-              startsWithCorrectCurrencyUnit = true;
-              break;
+        const normalizedRawInput = rawInput.toLowerCase();
+        const startsWithCurrencyUnit = keys.some(key => {
+          return ObjectsDomainConstants.CURRENCY_UNITS[key].front_units.some(
+            frontUnit => {
+              const normalizedFrontUnit = frontUnit.toLowerCase();
+              return normalizedRawInput.startsWith(normalizedFrontUnit);
             }
-          }
-        }
-        if (startsWithCorrectCurrencyUnit === false) {
-          const startsWithCurrencySymbol = keys.some(key => {
-            return ObjectsDomainConstants.CURRENCY_UNITS[key].front_units.some(
-              frontUnit => {
-                const trimmedFrontUnit = frontUnit.trim();
-                return (
-                  rawInput.startsWith(frontUnit) ||
-                  rawInput.startsWith(trimmedFrontUnit) ||
-                  rawInput
-                    .toLowerCase()
-                    .startsWith(trimmedFrontUnit.toLowerCase())
-                );
-              }
-            );
-          });
-          if (!startsWithCurrencySymbol) {
-            throw new Error(
-              // eslint-disable-next-line max-len
-              ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_VALUE
-            );
-          }
+          );
+        });
+
+        if (!startsWithCurrencyUnit) {
           throw new Error(
             // eslint-disable-next-line max-len
-            ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_CURRENCY
+            ObjectsDomainConstants.NUMBER_WITH_UNITS_PARSING_ERROR_I18N_KEYS.INVALID_VALUE
           );
         }
         const ind = rawInput.indexOf(String(rawInput.match(/[0-9]/)));
@@ -261,7 +236,7 @@ export class NumberWithUnits {
         }
         units = rawInput.substr(0, ind).trim();
 
-        startsWithCorrectCurrencyUnit = false;
+        let startsWithCorrectCurrencyUnit = false;
         for (let i = 0; i < keys.length; i++) {
           let unitLength =
             ObjectsDomainConstants.CURRENCY_UNITS[keys[i]].front_units.length;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #10162 
2. This PR does the following: This PR updates NumberWithUnits input parsing so non-currency invalid text (for example, blah) no longer shows a currency-specific warning. Instead, it returns the generic invalid-value warning. It also adds a regression test to lock this behavior.
3. (For bug-fixing PRs only) The original bug occurred because: The original bug occurred because the parser treated any non-digit-starting input that did not match a front currency unit as INVALID_CURRENCY, even when the input was not attempting currency at all. This behavior comes from PR #5320.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
Before
<img width="1462" height="866" alt="Screenshot 2026-04-15 at 9 40 09 PM" src="https://github.com/user-attachments/assets/37380436-b0b2-459b-9fff-69f85287b938" />

After
<img width="1462" height="866" alt="Screenshot 2026-04-15 at 9 44 16 PM" src="https://github.com/user-attachments/assets/263f1035-7641-4abd-af8a-095afbf57965" />
<img width="1462" height="866" alt="Screenshot 2026-04-15 at 9 45 35 PM" src="https://github.com/user-attachments/assets/ebfa770c-c175-4c9d-97f1-05a9e740a48d" />
<img width="1462" height="866" alt="Screenshot 2026-04-15 at 9 45 32 PM" src="https://github.com/user-attachments/assets/477cce92-ef50-45f0-96ef-4d3d16fad9e8" />
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
N/A only changes error text 
<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
