### PR TITLE
Fix #25851, #25832, #25830: Wait for specific tab to render before switching in contributor dashboard

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -455,7 +455,15 @@ export class Contributor extends ExplorationEditor {
   async switchToTabInContributionDashboard(
     tabName: 'Translate Text' | 'My Contributions' | 'Submit Question'
   ): Promise<void> {
-    await this.page.waitForSelector(contributionTabSelector);
+    await this.page.waitForFunction(
+      (selector: string, name: string) => {
+        const tabs = Array.from(document.querySelectorAll(selector));
+        return tabs.some(tab => tab.textContent?.trim() === name);
+      },
+      {},
+      contributionTabSelector,
+      tabName
+    );
 
     // Get required tab element.
     const tabElements = await this.page.$$(contributionTabSelector);


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/25851 and fixes https://github.com/oppia/oppia/issues/25832 and fixes https://github.com/oppia/oppia/issues/25830
2. This PR replaces waitForSelector(contributionTabSelector) with waitForFunction in switchToTabInContributionDashboard to wait for the specific tab text to be present in the DOM before proceeding.
3. The original bug occurred because waitForSelector resolved as soon as any tab appeared in the DOM (e.g. "My Contributions"), without waiting for rights-gated tabs like "Submit Question" to render. The "Submit Question" tab is only enabled after /usercontributionrightsdatahandler responds and sets submitQuestionTab.enabled = true in ContributorDashboardPageComponent.ngOnInit. Since this is asynchronous, switchToTabInContributionDashboard would find no "Submit Question" tab and throw Tab Submit Question not found.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

practice-question-reviewer/review-submitted-questions -
Before - https://github.com/Mohak51234/oppia/actions/runs/24599109476
After - https://github.com/Mohak51234/oppia/actions/runs/24574058045 and https://github.com/Mohak51234/oppia/actions/runs/24599825332

practice-question-reviewer/view-contribution-stats-and-badges-earned
Before - https://github.com/Mohak51234/oppia/actions/runs/24445664114
After - https://github.com/Mohak51234/oppia/actions/runs/24580552472 and https://github.com/Mohak51234/oppia/actions/runs/24599832046

practice-question-submitter/check-contribution-stats-download-certificate-and-check-badges-earned
Before - https://github.com/Mohak51234/oppia/actions/runs/24603108274
After - https://github.com/Mohak51234/oppia/actions/runs/24603103818
## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
