### PR TITLE
Fixes prod ops issues filed during automated voiceover testing

### DIFF
--- a/core/controllers/voiceover.py
+++ b/core/controllers/voiceover.py
@@ -234,7 +234,7 @@ class AutomaticVoiceoverRegenerationRecordHandler(
         self.values.update(
             {
                 'automatic_voiceover_regeneration_records': [
-                    cloud_task_run.to_dict()
+                    cloud_task_run.to_dict_with_timezone_info()
                     for cloud_task_run in cloud_task_run_objects[
                         :maximum_allowed_records
                     ]

--- a/core/controllers/voiceover_test.py
+++ b/core/controllers/voiceover_test.py
@@ -496,7 +496,7 @@ class AutomaticVoiceoverRegenerationRecordHandlerTests(
         )
         self.assertEqual(
             json_response['automatic_voiceover_regeneration_records'],
-            [cloud_task_run.to_dict()],
+            [cloud_task_run.to_dict_with_timezone_info()],
         )
         self.logout()
 

--- a/core/domain/cloud_task_domain.py
+++ b/core/domain/cloud_task_domain.py
@@ -91,6 +91,34 @@ class CloudTaskRun:
             'created_on': self.created_on.isoformat(),
         }
 
+    def to_dict_with_timezone_info(self) -> CloudTaskRunDict:
+        """Returns a dictionary representation of this domain object with timezone
+        information included in the datetime fields.
+
+        Returns:
+            CloudTaskRunDict. A dictionary representation of the CloudTaskRun
+            object, with keys matching the attributes of the object and timezone
+            information included in the datetime fields.
+        """
+        return {
+            'task_run_id': self.task_run_id,
+            'cloud_task_name': self.cloud_task_name,
+            'task_id': self.task_id,
+            'queue_id': self.queue_id,
+            'latest_job_state': self.latest_job_state,
+            'function_id': self.function_id,
+            'exception_messages_for_failed_runs': (
+                self.exception_messages_for_failed_runs
+            ),
+            'current_retry_attempt': self.current_retry_attempt,
+            'last_updated': self.last_updated.replace(
+                tzinfo=datetime.timezone.utc
+            ).isoformat(),
+            'created_on': self.created_on.replace(
+                tzinfo=datetime.timezone.utc
+            ).isoformat(),
+        }
+
     @classmethod
     def from_dict(cls, cloud_task_run_dict: CloudTaskRunDict) -> CloudTaskRun:
         """Returns a domain object from a dictionary.

--- a/core/domain/cloud_task_domain_test.py
+++ b/core/domain/cloud_task_domain_test.py
@@ -107,6 +107,30 @@ class CloudTaskDomainTests(test_utils.GenericTestBase):
 
         self.assertEqual(cloud_task_run.to_dict(), cloud_task_run_dict)
 
+    def test_should_convert_datetime_fields_with_timezone_info(self) -> None:
+        cloud_task_run = cloud_task_domain.CloudTaskRun(
+            task_run_id='cloud_task_run_id',
+            cloud_task_name='projects/dev-project-id/locations/us-central/'
+            'queues/test_queue_name/tasks/task_id',
+            task_id='task_id',
+            queue_id='test_queue_name',
+            latest_job_state='running',
+            function_id='delete_exps_from_user_models',
+            exception_messages_for_failed_runs=[],
+            current_retry_attempt=0,
+            last_updated=datetime.datetime(2026, 1, 2, 3, 4, 5),
+            created_on=datetime.datetime(2026, 1, 2, 3, 4, 6),
+        )
+
+        cloud_task_run_dict = cloud_task_run.to_dict_with_timezone_info()
+
+        self.assertEqual(
+            cloud_task_run_dict['last_updated'], '2026-01-02T03:04:05+00:00'
+        )
+        self.assertEqual(
+            cloud_task_run_dict['created_on'], '2026-01-02T03:04:06+00:00'
+        )
+
 
 class VoiceoverRegenerationJobTests(test_utils.GenericTestBase):
     """Unit tests for VoiceoverRegenerationJob domain object."""

--- a/core/templates/components/forms/forms-templates/mark-translations-as-needing-update-modal.component.html
+++ b/core/templates/components/forms/forms-templates/mark-translations-as-needing-update-modal.component.html
@@ -20,16 +20,11 @@
       </p>
     </li>
     <li>
-      <p *ngIf="!modifyTranslationsFeatureFlagIsEnabled">
-        <strong>Mark translations as stale:</strong>
-        Mark the existing translations for the given content as stale. Select this if your changes will require the translations
-        to be updated, but the previous translations can still be used.
-      </p>
       <p *ngIf="modifyTranslationsFeatureFlagIsEnabled">
         <strong>Modify existing translations:</strong>
         Select this if your changes mean that existing translations will need to be modified slightly.
       </p>
-      <p>
+      <p *ngIf="!modifyTranslationsFeatureFlagIsEnabled">
         <strong>Mark as Stale:</strong>
         Keep the existing translations, but mark them and any English voiceovers
         for updates. Choose this if your changes are small and only need minor fixes.

--- a/core/templates/domain/cloud-task/cloud-task-run.model.ts
+++ b/core/templates/domain/cloud-task/cloud-task-run.model.ts
@@ -63,7 +63,7 @@ export class CloudTaskRun {
     this.exceptionMessagesForFailedRuns = exceptionMessagesForFailedRuns;
     this.currentRetryAttempt = currentRetryAttempt;
     this.lastUpdated = lastUpdated;
-    this.createdOn = createdOn;
+    this.createdOn = new Date(createdOn);
 
     switch (this.latestJobState) {
       case 'RUNNING':

--- a/core/templates/pages/exploration-editor-page/modal-templates/exploration-modify-translations-modal.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/modal-templates/exploration-modify-translations-modal.component.spec.ts
@@ -21,8 +21,10 @@ import {
   ComponentFixture,
   waitForAsync,
   TestBed,
+  discardPeriodicTasks,
   tick,
   fakeAsync,
+  flush,
 } from '@angular/core/testing';
 import {
   NgbActiveModal,
@@ -258,6 +260,9 @@ describe('Modify Translations Modal Component', function () {
       'hi',
       changedTranslation
     );
+
+    flush();
+    discardPeriodicTasks();
   }));
 
   it('should mark as needing update in the change list for unchecked translations', fakeAsync(() => {
@@ -289,6 +294,9 @@ describe('Modify Translations Modal Component', function () {
     expect(
       changeListService.markTranslationAsNeedingUpdateForLanguage
     ).toHaveBeenCalledWith(component.contentId, 'hi');
+
+    flush();
+    discardPeriodicTasks();
   }));
 
   it('should dismiss the modal when cancel is called', () => {

--- a/core/templates/pages/exploration-editor-page/modal-templates/exploration-modify-translations-modal.component.ts
+++ b/core/templates/pages/exploration-editor-page/modal-templates/exploration-modify-translations-modal.component.ts
@@ -35,6 +35,7 @@ import {
   TRANSLATION_DATA_FORMAT_SET_OF_NORMALIZED_STRING,
   TRANSLATION_DATA_FORMAT_SET_OF_UNICODE_STRING,
 } from 'domain/exploration/written-translation.model';
+import {AppConstants} from 'app.constants';
 
 interface LanguageCodeToContentTranslations {
   [languageCode: string]: TranslatedContent;
@@ -156,6 +157,10 @@ export class ModifyTranslationsModalComponent extends ConfirmOrCancelModal {
         ].updateTranslation(this.contentId, updatedTranslatedContent);
       }
     }
+    this.changeListService.markVoiceoversAsNeedingUpdate(
+      this.contentId,
+      AppConstants.DEFAULT_LANGUAGE_CODE
+    );
     this.ngbActiveModal.close();
   }
 

--- a/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
@@ -69,7 +69,6 @@ import {
 import {InteractionAnswer} from 'interactions/answer-defs';
 import {EntityTranslationsService} from 'services/entity-translations.services';
 import {EntityVoiceoversService} from 'services/entity-voiceovers.services';
-import constants from 'assets/constants';
 import {AppConstants} from 'app.constants';
 
 interface ContentsMapping {
@@ -291,7 +290,7 @@ export class ExplorationStatesService {
     this.changeListService.markTranslationsAsNeedingUpdate(contentId);
     this.changeListService.markVoiceoversAsNeedingUpdate(
       contentId,
-      constants.DEFAULT_LANGUAGE_CODE
+      AppConstants.DEFAULT_LANGUAGE_CODE
     );
   }
 

--- a/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.ts
+++ b/core/templates/pages/voiceover-admin-page/voiceover-admin-page.component.ts
@@ -337,9 +337,12 @@ export class VoiceoverAdminPageComponent implements OnInit {
       !this.fetchingRegeneratedVoiceoverData;
 
     let startDate = this.range.value.start;
-    let startDateText = startDate ? startDate.toISOString() : '';
-
     let endDate = this.range.value.end;
+
+    startDate.setHours(0, 0, 0, 0);
+    endDate.setHours(23, 59, 59, 999);
+
+    let startDateText = startDate ? startDate.toISOString() : '';
     let endDateText = endDate ? endDate.toISOString() : '';
 
     this.voiceoverBackendApiService


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

The PR fixes the prod ops the following issues raised during testing of the automated voiceover feature (https://github.com/oppia/product-operations-team/issues/48)

- https://github.com/oppia/product-operations-team/issues/54
- https://github.com/oppia/product-operations-team/issues/55
- https://github.com/oppia/product-operations-team/issues/56


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

| video title | Action | Expectation for English content | Expectation for English voiceovers | Expectations for translated content | Expectations for translated voiceovers |
| :--- | :--- | :--- | :--- | :--- | :--- |
| video1 | **Feature flag:** `exploration_editor_can_modify_translations` is on.<br><br>The exploration editor updates the English content and clicks “Modify existing translations”. In the translation modal, they edit the corresponding **translations of Hindi**. | The English content must be updated. | **Manual voiceovers:** Should be marked as stale.<br><br>**Automatic voiceover:** Should match the latest content. | The Hindi translation must be updated. | **Manual voiceovers:** Should be marked as stale.<br><br>**Automatic voiceover:** Should match the latest Hindi translation. |
| video2 | **Feature flag:** `exploration_editor_can_modify_translations` is on.<br><br>The exploration editor updates the English content and clicks “Modify existing translations”. In the translation modal, they do not edit any translations. | The English content must be updated. | **Manual voiceovers:** Should be marked as stale.<br><br>**Automatic voiceover:** Should match the latest content. | The Hindi translation must not be updated **and** marked as stale. | Manual voiceovers and automatic voiceovers are not marked as stale. A message is shown: “The translation for this content is outdated. Please update the translation before updating the voiceovers.” |
| video3 | The exploration editor updates the English content and clicks "Leave as is". | The English content must be updated. | **Manual voiceover:** Might not match the latest content, but not marked as stale.<br><br>**Automatic voiceover:** Should match the latest content. | Hindi translation might not be correct, but **not** marked as stale. | Manual and automatic voiceovers are not marked as stale. |
| video4 | The exploration editor updates the English content and clicks "Remove Existing Translations/Voiceovers". | The English content must be updated. | **Manual voiceovers:** Removed<br><br>**Automatic voiceovers:** Should match the latest content. | Removed | Removed |
| video5 | **Feature flag:** `exploration_editor_can_modify_translations` is off.<br><br>The exploration editor updates the English content and clicks "Mark as stale." | The English content must be updated. | **Manual voiceovers:** Should be marked as stale.<br><br>**Automatic voiceover:** Should match the latest content. | The Hindi translation must not be updated **and** marked as stale. | Manual voiceovers and automatic voiceovers are not marked as stale. A message is shown: “The translation for this content is outdated. Please update the translation before updating the voiceovers.” |



**Video 1**

https://github.com/user-attachments/assets/22b10a2f-a7b7-4d4e-ad06-f83434babeb8

**Video 2**

https://github.com/user-attachments/assets/b88d9aa5-a567-42cc-b0c2-a356eee37edf

**Video 3**

https://github.com/user-attachments/assets/c71ce3ee-af4a-4840-a978-bfc742189f5d

**Video 4**

https://github.com/user-attachments/assets/717fdda5-f2ea-424b-9c9d-568b60bfb938


**Video 5**

https://github.com/user-attachments/assets/fdb31bf7-4cde-445d-94f9-156ff5daa24e



**The video below shows proof of the issue (https://github.com/oppia/product-operations-team/issues/54)**


https://github.com/user-attachments/assets/fda41b4c-1198-4f74-8432-03af6d69919d


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

