### PR TITLE
Fix #25568: Show failing file details in frontend coverage check output

### DIFF
--- a/scripts/check_frontend_test_coverage.py
+++ b/scripts/check_frontend_test_coverage.py
@@ -264,6 +264,7 @@ def check_coverage_changes(files_to_check: Optional[List[str]] = None) -> None:
         print('\nThe following issues were detected:\n')
         print(errors)
         print('------------------------------------')
+        logging.error(errors)
         sys.exit(1)
     else:
         print('------------------------------------')

--- a/scripts/check_frontend_test_coverage.py
+++ b/scripts/check_frontend_test_coverage.py
@@ -261,7 +261,9 @@ def check_coverage_changes(files_to_check: Optional[List[str]] = None) -> None:
         print('------------------------------------')
         print('Frontend Coverage Checks Not Passed.')
         print('------------------------------------')
-        logging.error(errors)
+        print('\nThe following issues were detected:\n')
+        print(errors)
+        print('------------------------------------')
         sys.exit(1)
     else:
         print('------------------------------------')


### PR DESCRIPTION
## Overview


1. This PR fixes #25568.
2. This PR adds a print statement to display the specific files that failed 
   frontend coverage checks. Previously, the CI output only showed 
   "Frontend Coverage Checks Not Passed." with no details about which files 
   caused the failure, requiring contributors to manually scroll through logs 
   to find the issue. Now it shows where all coverage checks fail. 
3. N/A (not a bug-fix PR)


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly). @HardikGoyal2003


## Proof that changes are correct

<!--


-->

<img width="236" height="43" alt="Screenshot 2026-04-17 115606" src="https://github.com/user-attachments/assets/24f4e17f-dbcb-4e4d-a3e1-4b3be5d428ee" />

<img width="448" height="203" alt="image" src="https://github.com/user-attachments/assets/e77540b5-52b5-45b5-93e8-bc1bb4a7c5f8" />



No new tests needed as the existing tests cover this change.
No proof of changes needed because this is a developer-facing CLI change with no UI impact.

