### PR TITLE
Fix #25805: Resolve overlapping UI buttons on translation review modal

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
@@ -348,8 +348,8 @@
     text-align: left;
   }
   .oppia-suggestion-review-exploration-change {
-    padding: 0 10px;
     margin-top: 50px;
+    padding: 0 10px;
   }
   .oppia-suggestion-review-exploration-change-note {
     margin-top: 18px;

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
@@ -349,6 +349,7 @@
   }
   .oppia-suggestion-review-exploration-change {
     padding: 0 10px;
+    margin-top: 50px;
   }
   .oppia-suggestion-review-exploration-change-note {
     margin-top: 18px;


### PR DESCRIPTION
## Overview


1. This PR fixes #25805 
2. This PR does the following: I added a margin-top to the .oppia-suggestion-review-exploration-change

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

https://github.com/user-attachments/assets/bc32cf03-7da9-4cb9-b11f-1b9cb548f291


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
