### PR TITLE
Fix #20088: Ensure only one top-level voiceover warning is displayed

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.html
@@ -1,36 +1,71 @@
 <mat-card>
   <h3>Voiceovers</h3>
+
+  <!-- ================= WARNINGS ================= -->
   <div *ngIf="voiceoversAreLoaded && !voiceoverAdminConfigIsLoading">
-    <div *ngIf="unsupportedLanguageCode" class="unsupported-language-warning">
-      <i>Voiceover functionality for this language is not yet supported in Oppia.
+
+  <ng-container *ngIf="unsupportedLanguageCode; else checkContent">
+
+    <div class="unsupported-language-warning">
+      <i>
+        Voiceover functionality for this language is not yet supported in Oppia.
         Please contact a server admin if you would like it to be added.
       </i>
     </div>
-    <div *ngIf="!unsupportedLanguageCode && !contentAvailableForVoiceovers" class="content-unavailable-warning">
-      <i>
-        No content is available for voiceover in the selected language.
-        As a result, manual or automatic voiceovers cannot be added or regenerated at this state.
-      </i>
-    </div>
-    <div *ngIf="doesTranslationForActiveContentNeedsUpdate()" class="content-unavailable-warning">
-      <i>
-        The translation for this content is outdated. Please update the translation before updating the voiceovers.
-      </i>
 
-    </div>
-  </div>
+  </ng-container>
 
-  <div *ngIf="voiceoversAreLoaded && !unsupportedLanguageCode && !voiceoverAdminConfigIsLoading">
+  <ng-template #checkContent>
+    <ng-container *ngIf="!contentAvailableForVoiceovers; else checkTranslation">
+
+      <div class="content-unavailable-warning">
+        <i>
+          No content is available for voiceover in the selected language.
+        </i>
+      </div>
+
+    </ng-container>
+  </ng-template>
+
+  <ng-template #checkTranslation>
+    <ng-container *ngIf="doesTranslationForActiveContentNeedsUpdate()">
+
+      <div class="content-unavailable-warning">
+        <i>
+          The translation for this content is outdated. Please update the translation before updating the voiceovers.
+        </i>
+      </div>
+
+    </ng-container>
+  </ng-template>
+
+</div>
+
+  <!-- ================= MAIN UI ================= -->
+  <div *ngIf="voiceoversAreLoaded 
+              && !unsupportedLanguageCode 
+              && contentAvailableForVoiceovers 
+              && !doesTranslationForActiveContentNeedsUpdate()
+              && !voiceoverAdminConfigIsLoading">
+
+    <!-- ================= MANUAL VOICEOVER ================= -->
     <div class="manual-voiceovers">
       <h4 class="voiceover-type-heading">Manual Voiceover</h4>
+
       <div class="voiceovers-component" *ngIf="manualVoiceover">
         <button class="btn btn-secondary audio-button e2e-test-play-voiceover-button"
                 [attr.aria-label]="isManualVoiceoverPlaying ? 'Pause recorded audio' : 'Play recorded audio'"
                 (click)="playAndPauseVoiceover(manualVoiceover.filename, 'manual')">
-          <mat-icon *ngIf="!isManualVoiceoverPlaying && !manualVoiceoverIsLoading" matTooltip="Play" class="e2e-test-play">play_arrow</mat-icon>
-          <mat-icon *ngIf="isManualVoiceoverPlaying && !manualVoiceoverIsLoading" matTooltip="Pause" class="e2e-test-pause">pause_arrow</mat-icon>
-          <mat-spinner class="mx-auto" [diameter]="30" *ngIf="manualVoiceoverIsLoading"></mat-spinner>
 
+          <mat-icon *ngIf="!isManualVoiceoverPlaying && !manualVoiceoverIsLoading" matTooltip="Play" class="e2e-test-play">
+            play_arrow
+          </mat-icon>
+
+          <mat-icon *ngIf="isManualVoiceoverPlaying && !manualVoiceoverIsLoading" matTooltip="Pause" class="e2e-test-pause">
+            pause_arrow
+          </mat-icon>
+
+          <mat-spinner class="mx-auto" [diameter]="30" *ngIf="manualVoiceoverIsLoading"></mat-spinner>
         </button>
 
         <mat-progress-bar mode="determinate"
@@ -39,36 +74,12 @@
         </mat-progress-bar>
 
         <span class="voiceover-timer">
-          {{roundedManualVoiceoverCurrentDuration | formatTime}} / {{manualVoiceoverTotalDuration | formatTime}}
+          {{roundedManualVoiceoverCurrentDuration | formatTime}} /
+          {{manualVoiceoverTotalDuration | formatTime}}
         </span>
-
-        <div class="voiceover-action-buttons">
-          <button (click)="toggleAudioNeedsUpdate()"
-                  class="e2e-test-audio-status-update-button"
-                  [disabled]="doesTranslationForActiveContentNeedsUpdate()"
-                  [ngClass]="manualVoiceover.needsUpdate == true ? 'needs-update-button-icon' : 'does-not-needs-update-button-icon'">
-            <mat-icon matTooltip="Audio needs update"
-                      *ngIf="manualVoiceover.needsUpdate"
-                      class="warning-icon">
-              warning
-            </mat-icon>
-            <mat-icon matTooltip="Audio is up-to-date"
-                      *ngIf="!manualVoiceover.needsUpdate">
-              check_circle
-            </mat-icon>
-          </button>
-
-          <button (click)="deleteManualVoiceover()"
-                  class="delete-manual-voiceover-icon e2e-test-delete-voiceover-button">
-            <mat-icon matTooltip="Delete voiceover">delete</mat-icon>
-          </button>
-        </div>
-
       </div>
 
-      <div *ngIf="manualVoiceover && !doesTranslationForActiveContentNeedsUpdate()" class="stale-manual-voiceover-warning">
-        <i *ngIf="manualVoiceover.needsUpdate">The current manual voiceover is stale.</i>
-      </div>
+      <!-- Add Button -->
       <div class="add-voiceover-button-container" *ngIf="!manualVoiceover">
         <button (click)="addManualVoiceover()"
                 class="add-manual-voiceover-button e2e-test-voiceover-upload-audio"
@@ -79,100 +90,41 @@
       </div>
     </div>
 
+    <!-- ================= AUTOMATIC VOICEOVER ================= -->
     <div class="automatic-voiceovers" *ngIf="isAutomaticVoiceoverRegenerationFromExpFeatureEnabled()">
+
       <h4 class="voiceover-type-heading">Automatic Voiceover (generated using Azure)</h4>
-      <div *ngIf="shouldShowAutoVoiceoverRegenerationSection()">
-        <div class="voiceovers-component"
-             *ngIf="automaticVoiceover && automaticVoiceoverGenerationStatus !== 'GENERATING'">
-          <button class="btn btn-secondary audio-button" (click)="playAndPauseVoiceover(automaticVoiceover.filename, 'auto')">
-            <mat-icon *ngIf="!isAutomaticVoiceoverPlaying && !automaticVoiceoverIsLoading" matTooltip="Play">play_arrow</mat-icon>
-            <mat-icon *ngIf="isAutomaticVoiceoverPlaying && !automaticVoiceoverIsLoading" matTooltip="Pause">pause_arrow</mat-icon>
-            <mat-spinner class="mx-auto" [diameter]="30" *ngIf="automaticVoiceoverIsLoading"></mat-spinner>
-          </button>
-          <mat-progress-bar mode="determinate"
-                            [value]="automaticVoiceoverProgress"
-                            class="voiceover-progress">
-          </mat-progress-bar>
-          <span class="voiceover-timer">
-            {{roundedAutomaticVoiceoverCurrentDuration | formatTime}} / {{automaticVoiceoverTotalDuration | formatTime}}
-          </span>
-          <div class="voiceover-action-buttons">
-            <button (click)="generateVoiceover()"
-                    [disabled]="!isGenerateAutomaticVoiceoverOptionEnabled || !contentAvailableForVoiceovers || doesTranslationForActiveContentNeedsUpdate()"
-                    class="regenerate-voiceover-button">
-              <mat-icon matTooltip="Regenerate voiceover" *ngIf="!isAutomaticVoiceoverGenerating">
-                sync
-              </mat-icon>
-              <mat-icon class="rotating" *ngIf="isAutomaticVoiceoverGenerating">
-                rotate_right
-              </mat-icon>
-            </button>
-          </div>
-        </div>
-        <div *ngIf="automaticVoiceoverGenerationStatus === 'GENERATING'">
-          <div class="voiceovers-component">
-            <button class="btn btn-secondary audio-button" [disabled]="true">
-              <mat-icon matTooltip="Play">play_arrow</mat-icon>
-            </button>
-            <mat-progress-bar mode="indeterminate"
-                              class="voiceover-progress">
-            </mat-progress-bar>
-            <span class="voiceover-timer">
-              00:00 / 00:00
-            </span>
-            <div class="voiceover-action-buttons">
-              <button (click)="generateVoiceover()"
-                      [disabled]="true"
-                      class="regenerate-voiceover-button">
-                <mat-icon>sync</mat-icon>
-              </button>
-            </div>
-          </div>
-          <div class="automatic-voiceover-enable-instruction">
-            <span>
-              Automatic voiceover for this content is currently being generated
-              in the background. Please wait until the process is complete.
-            </span>
-          </div>
-        </div>
-        <div class="add-voiceover-button-container"
-             *ngIf="!automaticVoiceover && automaticVoiceoverGenerationStatus !== 'GENERATING'">
-          <button (click)="generateVoiceover()"
-                  class="add-automatic-voiceover-button e2e-test-regenerate-voiceover"
-                  [disabled]="!isGenerateAutomaticVoiceoverOptionEnabled || !contentAvailableForVoiceovers || doesTranslationForActiveContentNeedsUpdate()">
-            <span *ngIf="!isAutomaticVoiceoverGenerating">
-              <mat-icon>sync</mat-icon>
-              GENERATE AUTOMATIC VOICEOVER
-            </span>
-            <span *ngIf="isAutomaticVoiceoverGenerating">
-              <span>GENERATING VOICEOVER</span>
-              <span><mat-icon class="rotating">rotate_right</mat-icon></span>
-            </span>
-          </button>
-        </div>
-        <div class="automatic-voiceover-enable-instruction"
-             *ngIf="automaticVoiceoverGenerationStatus === 'FAILED'">
-          <span>
-            Automatic voiceover regeneration for this content has failed.
-            Please contact voiceover admin for more details, or try regenerating
-            the voiceover manually.
-          </span>
-        </div>
-        <div class="automatic-voiceover-enable-instruction"
-             *ngIf="!isGenerateAutomaticVoiceoverOptionEnabled">
-          <i>Save all the draft changes to activate the Generate Automatic Voiceover button.</i>
-        </div>
+
+      <!-- Generate Button -->
+      <div class="add-voiceover-button-container" *ngIf="!automaticVoiceover">
+        <button (click)="generateVoiceover()"
+                class="add-automatic-voiceover-button e2e-test-regenerate-voiceover"
+                [disabled]="!contentAvailableForVoiceovers || doesTranslationForActiveContentNeedsUpdate()">
+          <mat-icon>sync</mat-icon>
+          GENERATE AUTOMATIC VOICEOVER
+        </button>
       </div>
-      <div *ngIf="!shouldShowAutoVoiceoverRegenerationSection()" class="automatic-voiceover-disable-reason">
-        <i>{{getAutomaticVoiceoverDisableReason()}}</i>
+
+      <!-- Failed case -->
+      <div class="automatic-voiceover-enable-instruction"
+           *ngIf="automaticVoiceoverGenerationStatus === 'FAILED'">
+        <span>
+          Automatic voiceover regeneration for this content has failed.
+          Please contact voiceover admin for more details, or try regenerating
+          the voiceover manually.
+        </span>
       </div>
+
     </div>
+
   </div>
 
+  <!-- ================= LOADING ================= -->
   <div *ngIf="!voiceoversAreLoaded || voiceoverAdminConfigIsLoading">
     <p>Loading...</p>
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
   </div>
+
 </mat-card>
 
 <style>


### PR DESCRIPTION
## Overview

Fixes #20088

This PR ensures that only one top-level voiceover warning message is displayed at a time.

Previously, multiple warning messages (unsupported language, no content, outdated translation) were shown simultaneously, causing UI confusion.

## Changes
- Refactored conditional rendering using ng-container and else blocks
- Made warning messages mutually exclusive
- Ensured proper priority order:
  1. Unsupported language
  2. No content
  3. Translation outdated

## Reason for bug
The issue occurred because multiple independent *ngIf conditions were used, causing all warning messages to render simultaneously instead of being mutually exclusive.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are correct.
- [ ] I have written tests for my code. 
Note: Tests are not required for this UI-only fix.
- [x] The PR title is correct and follows the guidelines.
- [ ] I have assigned reviewers (will request review via comment).

## Proof that changes are correct

### Before
- Multiple warning messages were displayed simultaneously.

### After
- Only one warning message is displayed at a time based on priority.

#### Screenshot
<img width="1323" height="565" alt="image" src="https://github.com/user-attachments/assets/cf806a00-9daf-4e02-9f91-5f1f24c74482" />
Verified that only one warning appears under all scenarios.