### PR TITLE
Migrate self.swap() to unittest.mock in 3 core/controllers test files

### DIFF
--- a/core/controllers/question_editor_test.py
+++ b/core/controllers/question_editor_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+from unittest import mock
 
 from core import feconf
 from core.constants import constants
@@ -780,11 +781,9 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTests):
             """Mocks '_get_question_by_id'. Returns None."""
             return None
 
-        question_services_swap = self.swap(
+        with mock.patch.object(
             question_services, 'get_question_by_id', _mock_get_question_by_id
-        )
-
-        with question_services_swap:
+        ):
             self.login(self.EDITOR_EMAIL)
             self.get_json(
                 '%s/%s'

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+from unittest import mock
 
 from core import feature_flag_list, feconf
 from core.constants import constants
@@ -935,11 +936,9 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             """Mocks None."""
             return None
 
-        story_fetchers_swap = self.swap(
+        with mock.patch.object(
             story_fetchers, 'get_story_by_id', _mock_none_function
-        )
-
-        with story_fetchers_swap:
+        ):
             with self.capture_logging(min_level=logging.ERROR) as captured_logs:
                 self.post_json(
                     '%s/staging/topic/%s/%s'

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import os
+from unittest import mock
 
 from core import feature_flag_list, feconf, utils
 from core.constants import constants
@@ -321,7 +322,7 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
         def mock_get_current_time_in_millisecs() -> int:
             return 1690555400000
 
-        with self.swap(
+        with mock.patch.object(
             utils,
             'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs,


### PR DESCRIPTION
Migration of self.swap() to mock.patch.object (#18781)

This PR migrates three instances of self.swap() to unittest.mock.patch.object() within the core/controllers/ directory. This is a targeted update focusing specifically on function swaps as part of the broader migration strategy for #18781.

I've verified that the logic remains identical and all affected tests pass locally. If this looks good, I'm happy to roll this out to the remaining files in this directory.

Validation:

Ran backend tests for question_editor_test, story_viewer_test, and topic_editor_test.


Confirmed linting passes via pre-commit.

