### PR TITLE
Fix part of #18781: Migrate self.swap() to unittest.mock in 3 core/controllers test files

### DIFF
--- a/core/controllers/question_editor_test.py
+++ b/core/controllers/question_editor_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+from unittest import mock
 
 from core import feconf
 from core.constants import constants
@@ -780,11 +781,9 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTests):
             """Mocks '_get_question_by_id'. Returns None."""
             return None
 
-        question_services_swap = self.swap(
+        with mock.patch.object(
             question_services, 'get_question_by_id', _mock_get_question_by_id
-        )
-
-        with question_services_swap:
+        ):
             self.login(self.EDITOR_EMAIL)
             self.get_json(
                 '%s/%s'

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+from unittest import mock
 
 from core import feature_flag_list, feconf
 from core.constants import constants
@@ -935,11 +936,9 @@ class StoryProgressHandlerTests(BaseStoryViewerControllerTests):
             """Mocks None."""
             return None
 
-        story_fetchers_swap = self.swap(
+        with mock.patch.object(
             story_fetchers, 'get_story_by_id', _mock_none_function
-        )
-
-        with story_fetchers_swap:
+        ):
             with self.capture_logging(min_level=logging.ERROR) as captured_logs:
                 self.post_json(
                     '%s/staging/topic/%s/%s'

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import os
+from unittest import mock
 
 from core import feature_flag_list, feconf, utils
 from core.constants import constants
@@ -321,7 +322,7 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
         def mock_get_current_time_in_millisecs() -> int:
             return 1690555400000
 
-        with self.swap(
+        with mock.patch.object(
             utils,
             'get_current_time_in_millisecs',
             mock_get_current_time_in_millisecs,


### PR DESCRIPTION
## Overview

1. This PR fixes part of #18781.
2. This PR migrates 3 `self.swap()` calls to `unittest.mock.patch.object()` in the following test files:
   - `core/controllers/question_editor_test.py`
   - `core/controllers/story_viewer_test.py`
   - `core/controllers/topic_editor_test.py`

Only function swaps are covered here — module constants need a different approach so I left those alone for now. Planning to do more files in follow-up PRs once the pattern is confirmed.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code. (No new tests — existing tests cover the swapped behavior.)
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Each `self.swap(module, 'attr', value)` was replaced with `unittest.mock.patch.object(module, 'attr', value)` in the same scope, so the target, replacement, and cleanup should behave the same way.

Ran the backend tests for each file locally and they passed:

```bash
python -m scripts.run_backend_tests --test_target=core.controllers.question_editor_test
python -m scripts.run_backend_tests --test_target=core.controllers.story_viewer_test
python -m scripts.run_backend_tests --test_target=core.controllers.topic_editor_test
```

Pre-commit linting also passed. CI should confirm the rest.