### PR TITLE
Fix #25710: Add Beam jobs to recover orphaned translation data

### DIFF
--- a/core/jobs/batch_jobs/recover_orphaned_translations_jobs.py
+++ b/core/jobs/batch_jobs/recover_orphaned_translations_jobs.py
@@ -60,35 +60,6 @@ class RecoverOrphanedTranslationsJob(base_jobs.JobBase):
     DATASTORE_UPDATES_ALLOWED = True
 
     @staticmethod
-    def _key_translation_model(
-        model: translation_models.EntityTranslationsModel,
-    ) -> Tuple[str, translation_models.EntityTranslationsModel]:
-        """Keys a translation model by its entity_id for grouping.
-
-        Args:
-            model: EntityTranslationsModel. The translation model.
-
-        Returns:
-            tuple(str, EntityTranslationsModel). A key-value pair with
-            the entity_id as the key.
-        """
-        return (model.entity_id, model)
-
-    @staticmethod
-    def _key_exploration_model(
-        model: exp_models.ExplorationModel,
-    ) -> Tuple[str, int]:
-        """Keys an exploration model by its ID, with the version as value.
-
-        Args:
-            model: ExplorationModel. The exploration model.
-
-        Returns:
-            tuple(str, int). A key-value pair of (exploration_id, version).
-        """
-        return (model.id, model.version)
-
-    @staticmethod
     def _merge_and_forward_propagate(
         element: Tuple[
             str,
@@ -198,7 +169,8 @@ class RecoverOrphanedTranslationsJob(base_jobs.JobBase):
             >> ndb_io.GetModels(
                 exp_models.ExplorationModel.get_all(include_deleted=False)
             )
-            | 'Key explorations by ID' >> beam.Map(self._key_exploration_model)
+            | 'Key explorations by ID'
+            >> beam.Map(lambda model: (model.id, model.version))
         )
 
         translation_models_pcoll = (
@@ -211,7 +183,7 @@ class RecoverOrphanedTranslationsJob(base_jobs.JobBase):
                 )
             )
             | 'Key translations by entity_id'
-            >> beam.Map(self._key_translation_model)
+            >> beam.Map(lambda model: (model.entity_id, model))
         )
 
         grouped = {

--- a/core/jobs/batch_jobs/recover_orphaned_translations_jobs.py
+++ b/core/jobs/batch_jobs/recover_orphaned_translations_jobs.py
@@ -1,0 +1,285 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Jobs that recover orphaned translations from old exploration versions.
+
+Due to a historic bug (fixed in PR #24726), accepted translation
+suggestions were sometimes written to an outdated exploration version's
+EntityTranslationsModel instead of the current one. This job scans all
+EntityTranslationsModel entries for explorations, finds translations
+stuck on old versions, and forward-propagates them to the latest
+version so they become visible again on the contributor dashboard.
+"""
+
+from __future__ import annotations
+
+import collections
+
+from core.jobs import base_jobs
+from core.jobs.io import ndb_io
+from core.jobs.transforms import job_result_transforms
+from core.jobs.types import job_run_result
+from core.platform import models
+
+import apache_beam as beam
+from typing import Any, Dict, Iterable, List, Tuple
+
+MYPY = False
+if MYPY:  # pragma: no cover
+    from mypy_imports import exp_models, translation_models
+
+(exp_models, translation_models) = models.Registry.import_models(
+    [models.Names.EXPLORATION, models.Names.TRANSLATION]
+)
+datastore_services = models.Registry.import_datastore_services()
+
+
+class RecoverOrphanedTranslationsJob(base_jobs.JobBase):
+    """Recovers orphaned translations by forward-propagating them to the
+    latest exploration version.
+
+    The job groups all EntityTranslationsModel entries by
+    (entity_id, language_code), merges their translations dictionaries
+    in ascending version order, and writes the merged result to the
+    model for the current exploration version.
+    """
+
+    DATASTORE_UPDATES_ALLOWED = True
+
+    @staticmethod
+    def _key_translation_model(
+        model: translation_models.EntityTranslationsModel,
+    ) -> Tuple[str, translation_models.EntityTranslationsModel]:
+        """Keys a translation model by its entity_id for grouping.
+
+        Args:
+            model: EntityTranslationsModel. The translation model.
+
+        Returns:
+            tuple(str, EntityTranslationsModel). A key-value pair with
+            the entity_id as the key.
+        """
+        return (model.entity_id, model)
+
+    @staticmethod
+    def _key_exploration_model(
+        model: exp_models.ExplorationModel,
+    ) -> Tuple[str, int]:
+        """Keys an exploration model by its ID, with the version as value.
+
+        Args:
+            model: ExplorationModel. The exploration model.
+
+        Returns:
+            tuple(str, int). A key-value pair of (exploration_id, version).
+        """
+        return (model.id, model.version)
+
+    @staticmethod
+    def _merge_and_forward_propagate(
+        element: Tuple[
+            str,
+            # Here we use type Any because the value could be an int (version) or
+            # a list of translation models.
+            Dict[str, Iterable[Any]],
+        ],
+    ) -> Iterable[Tuple[translation_models.EntityTranslationsModel, int]]:
+        """Merges translations from old versions into the latest version.
+
+        For a given exploration, this function groups all
+        EntityTranslationsModel entries by language_code, sorts them by
+        version in ascending order, and merges their translation
+        dictionaries. Translations from newer versions take precedence
+        over those from older versions when content_ids collide. The merged
+        result is written to the model corresponding to the current
+        exploration version.
+
+        Args:
+            element: tuple(str, dict). A tuple of
+                (entity_id, {'exploration_version': [...],
+                'translation_models': [...]}).
+
+        Yields:
+            tuple(EntityTranslationsModel, int). Tuples of
+            (updated_or_new_model, number_of_translations_recovered)
+            for models that were actually changed.
+        """
+        entity_id = element[0]
+        grouped = element[1]
+
+        exploration_versions = list(grouped['exploration_version'])
+        translation_model_list: List[
+            translation_models.EntityTranslationsModel
+        ] = list(grouped['translation_models'])
+
+        # If the exploration no longer exists, skip.
+        if not exploration_versions:
+            return
+
+        current_version = exploration_versions[0]
+
+        # Group translation models by language_code.
+        lang_to_models: Dict[
+            str,
+            List[translation_models.EntityTranslationsModel],
+        ] = collections.defaultdict(list)
+        for t_model in translation_model_list:
+            lang_to_models[t_model.language_code].append(t_model)
+
+        for language_code, models_for_lang in lang_to_models.items():
+            # Sort by entity_version ascending so newer overwrites older.
+            models_for_lang.sort(key=lambda m: int(m.entity_version))
+
+            # Merge all translations into a single dict.
+            # Here we use type Any because the translation dictionary can contain
+            # various nested structures depending on the content type.
+            merged_translations: Dict[str, Any] = {}
+            for t_model in models_for_lang:
+                merged_translations.update(t_model.translations)
+
+            # Find the model at the current version, if it exists.
+            current_version_model = None
+            for t_model in models_for_lang:
+                if t_model.entity_version == current_version:
+                    current_version_model = t_model
+                    break
+
+            if current_version_model is not None:
+                # Check if the merged dict adds anything new.
+                existing_translations = current_version_model.translations
+                if merged_translations == existing_translations:
+                    # Nothing new to add.
+                    continue
+                # Count only newly recovered translations.
+                new_count = len(merged_translations) - len(
+                    existing_translations
+                )
+                current_version_model.translations = merged_translations
+                current_version_model.update_timestamps()
+                yield (current_version_model, max(new_count, 0))
+            else:
+                # No model exists at the current version for this
+                # language. Create a new one.
+                with datastore_services.get_ndb_context():
+                    new_model = (
+                        translation_models.EntityTranslationsModel.create_new(
+                            'exploration',
+                            entity_id,
+                            current_version,
+                            language_code,
+                            merged_translations,
+                        )
+                    )
+                    new_model.update_timestamps()
+                    yield (new_model, len(merged_translations))
+
+    def run(self) -> beam.PCollection[job_run_result.JobRunResult]:
+        """Returns a PCollection of results from the recovery job.
+
+        Returns:
+            PCollection. A PCollection of JobRunResult objects.
+        """
+        exploration_versions = (
+            self.pipeline
+            | 'Get all ExplorationModels'
+            >> ndb_io.GetModels(
+                exp_models.ExplorationModel.get_all(include_deleted=False)
+            )
+            | 'Key explorations by ID' >> beam.Map(self._key_exploration_model)
+        )
+
+        translation_models_pcoll = (
+            self.pipeline
+            | 'Get all Exploration EntityTranslationsModels'
+            >> ndb_io.GetModels(
+                translation_models.EntityTranslationsModel.query(
+                    translation_models.EntityTranslationsModel.entity_type
+                    == 'exploration'
+                )
+            )
+            | 'Key translations by entity_id'
+            >> beam.Map(self._key_translation_model)
+        )
+
+        grouped = {
+            'exploration_version': exploration_versions,
+            'translation_models': translation_models_pcoll,
+        } | 'Group by exploration ID' >> beam.CoGroupByKey()
+
+        model_and_count_pairs = (
+            grouped
+            | 'Merge and forward-propagate translations'
+            >> beam.FlatMap(self._merge_and_forward_propagate)
+        )
+
+        updated_models = model_and_count_pairs | 'Extract models' >> beam.Map(
+            lambda pair: pair[0]
+        )
+
+        recovered_counts = model_and_count_pairs | 'Extract counts' >> beam.Map(
+            lambda pair: pair[1]
+        )
+
+        if self.DATASTORE_UPDATES_ALLOWED:
+            unused_put_result = (
+                updated_models
+                | 'Put updated models into the datastore' >> ndb_io.PutModels()
+            )
+
+        models_updated_job_run_results = (
+            updated_models
+            | 'Count updated models'
+            >> job_result_transforms.CountObjectsToJobRunResult(
+                'TRANSLATION MODELS UPDATED'
+            )
+        )
+
+        translations_recovered_job_run_results = (
+            recovered_counts
+            | 'Sum recovered counts' >> beam.CombineGlobally(sum)
+            | 'Filter zero sums' >> beam.Filter(lambda x: x > 0)
+            | 'Report recovered translations'
+            >> beam.Map(
+                lambda count: job_run_result.JobRunResult.as_stdout(
+                    'TRANSLATIONS RECOVERED SUCCESS: %s' % count
+                )
+            )
+        )
+
+        explorations_traversed_job_run_results = (
+            exploration_versions
+            | 'Count explorations traversed'
+            >> job_result_transforms.CountObjectsToJobRunResult(
+                'EXPLORATIONS TRAVERSED'
+            )
+        )
+
+        return (
+            models_updated_job_run_results,
+            translations_recovered_job_run_results,
+            explorations_traversed_job_run_results,
+        ) | 'Flatten results' >> beam.Flatten()
+
+
+class AuditRecoverOrphanedTranslationsJob(RecoverOrphanedTranslationsJob):
+    """Audit version of RecoverOrphanedTranslationsJob.
+
+    This job performs all the same steps as the recovery job, but does
+    not write any changes to the datastore. Use this to preview the
+    impact of the recovery before running the actual job.
+    """
+
+    DATASTORE_UPDATES_ALLOWED = False

--- a/core/jobs/batch_jobs/recover_orphaned_translations_jobs_test.py
+++ b/core/jobs/batch_jobs/recover_orphaned_translations_jobs_test.py
@@ -1,0 +1,566 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for recover_orphaned_translations_jobs."""
+
+from __future__ import annotations
+
+from core import feconf
+from core.domain import exp_domain, rights_manager
+from core.jobs import job_test_utils
+from core.jobs.batch_jobs import recover_orphaned_translations_jobs
+from core.jobs.types import job_run_result
+from core.platform import models
+from core.tests import test_utils
+
+from typing import Any, Dict, Final, Sequence
+
+MYPY = False
+if MYPY:
+    from mypy_imports import datastore_services, exp_models, translation_models
+
+(exp_models, translation_models) = models.Registry.import_models(
+    [models.Names.EXPLORATION, models.Names.TRANSLATION]
+)
+
+datastore_services = models.Registry.import_datastore_services()
+
+
+class RecoverOrphanedTranslationsJobTests(
+    job_test_utils.JobTestBase, test_utils.GenericTestBase
+):
+
+    JOB_CLASS = (
+        recover_orphaned_translations_jobs.RecoverOrphanedTranslationsJob
+    )
+
+    AUTHOR_EMAIL: Final = 'author@example.com'
+    EXP_ID: Final = 'exp_id_1'
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.signup(self.AUTHOR_EMAIL, 'author')
+        self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
+
+    def _create_exploration(self, exp_id: str, version: int) -> None:
+        """Creates an ExplorationModel with the given ID and version."""
+        rights_manager.create_new_exploration_rights(exp_id, self.author_id)
+        model = self.create_model(
+            exp_models.ExplorationModel,
+            id=exp_id,
+            title='Test Exploration',
+            init_state_name=feconf.DEFAULT_INIT_STATE_NAME,
+            category=feconf.DEFAULT_EXPLORATION_CATEGORY,
+            objective=feconf.DEFAULT_EXPLORATION_OBJECTIVE,
+            language_code='en',
+            tags=['Topic'],
+            blurb='blurb',
+            author_notes='author notes',
+            states_schema_version=feconf.CURRENT_STATE_SCHEMA_VERSION,
+            param_specs={},
+            param_changes=[],
+            auto_tts_enabled=feconf.DEFAULT_AUTO_TTS_ENABLED,
+            states={
+                feconf.DEFAULT_INIT_STATE_NAME: (
+                    exp_domain.Exploration.create_default_exploration(exp_id)
+                    .states[feconf.DEFAULT_INIT_STATE_NAME]
+                    .to_dict()
+                )
+            },
+        )
+        commit_cmd = exp_domain.ExplorationChange(
+            {
+                'cmd': exp_domain.CMD_CREATE_NEW,
+                'title': 'title',
+                'category': 'category',
+            }
+        )
+        model.commit(self.author_id, 'commit_message', [commit_cmd.to_dict()])
+        # Override the version to simulate a specific version number.
+        # After commit, the model version is 1. We update it directly
+        # to simulate an exploration that has been edited many times.
+        if version > 1:
+            model.version = version
+            model.update_timestamps(update_last_updated_time=False)
+            datastore_services.put_multi([model])
+
+    def _create_translation_model(
+        self,
+        entity_id: str,
+        entity_version: int,
+        language_code: str,
+        # Here we use type Any because the translations are stored as
+        # a nested dictionary with varying structures.
+        translations: Dict[str, Any],
+    ) -> None:
+        """Creates an EntityTranslationsModel with the given parameters."""
+        model = translation_models.EntityTranslationsModel.create_new(
+            'exploration',
+            entity_id,
+            entity_version,
+            language_code,
+            translations,
+        )
+        model.update_timestamps()
+        model.put()
+
+    def test_empty_datastore_produces_no_output(self) -> None:
+        self.assert_job_output_is_empty()
+
+    def test_exploration_with_no_translations_produces_no_recovery(
+        self,
+    ) -> None:
+        self._create_exploration(self.EXP_ID, version=5)
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+            ]
+        )
+
+    def test_translations_already_at_current_version_are_not_modified(
+        self,
+    ) -> None:
+        self._create_exploration(self.EXP_ID, version=5)
+        self._create_translation_model(
+            self.EXP_ID,
+            5,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Hola</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+            ]
+        )
+
+        # Verify the model is unchanged.
+        all_models: Sequence[translation_models.EntityTranslationsModel] = (
+            translation_models.EntityTranslationsModel.get_all().fetch()
+        )
+        self.assertEqual(len(all_models), 1)
+        self.assertEqual(all_models[0].entity_version, 5)
+
+    def test_orphaned_translations_are_forward_propagated_to_new_model(
+        self,
+    ) -> None:
+        # Exploration is at version 10, but translations are stuck at
+        # version 3.
+        self._create_exploration(self.EXP_ID, version=10)
+        self._create_translation_model(
+            self.EXP_ID,
+            3,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Hola</p>',
+                    'needs_update': False,
+                },
+                'content_1': {
+                    'content_format': 'html',
+                    'content_value': '<p>Mundo</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATION MODELS UPDATED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATIONS RECOVERED SUCCESS: 2'
+                ),
+            ]
+        )
+
+        # Verify the new model was created at version 10.
+        new_model = translation_models.EntityTranslationsModel.get_model(
+            feconf.TranslatableEntityType.EXPLORATION, self.EXP_ID, 10, 'es'
+        )
+        self.assertIsNotNone(new_model)
+        self.assertEqual(len(new_model.translations), 2)
+        self.assertIn('content_0', new_model.translations)
+        self.assertIn('content_1', new_model.translations)
+
+    def test_translations_from_multiple_old_versions_are_merged(
+        self,
+    ) -> None:
+        # Exploration is at version 20. Translations exist at versions
+        # 5 and 12.
+        self._create_exploration(self.EXP_ID, version=20)
+        self._create_translation_model(
+            self.EXP_ID,
+            5,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Old translation</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+        self._create_translation_model(
+            self.EXP_ID,
+            12,
+            'es',
+            {
+                'content_1': {
+                    'content_format': 'html',
+                    'content_value': '<p>Newer translation</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATION MODELS UPDATED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATIONS RECOVERED SUCCESS: 2'
+                ),
+            ]
+        )
+
+        # Verify merged model at version 20.
+        new_model = translation_models.EntityTranslationsModel.get_model(
+            feconf.TranslatableEntityType.EXPLORATION, self.EXP_ID, 20, 'es'
+        )
+        self.assertIsNotNone(new_model)
+        self.assertEqual(len(new_model.translations), 2)
+        self.assertIn('content_0', new_model.translations)
+        self.assertIn('content_1', new_model.translations)
+
+    def test_newer_version_translation_overwrites_older_on_conflict(
+        self,
+    ) -> None:
+        # Both old versions have the same content_id. The newer one
+        # should win.
+        self._create_exploration(self.EXP_ID, version=15)
+        self._create_translation_model(
+            self.EXP_ID,
+            3,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Old value</p>',
+                    'needs_update': True,
+                },
+            },
+        )
+        self._create_translation_model(
+            self.EXP_ID,
+            10,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>New value</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATION MODELS UPDATED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATIONS RECOVERED SUCCESS: 1'
+                ),
+            ]
+        )
+
+        new_model = translation_models.EntityTranslationsModel.get_model(
+            feconf.TranslatableEntityType.EXPLORATION, self.EXP_ID, 15, 'es'
+        )
+        self.assertIsNotNone(new_model)
+        # The newer translation (version 10) should have won.
+        self.assertEqual(
+            new_model.translations['content_0']['content_value'],
+            '<p>New value</p>',
+        )
+        self.assertFalse(new_model.translations['content_0']['needs_update'])
+
+    def test_orphaned_translations_merged_into_existing_current_model(
+        self,
+    ) -> None:
+        # Exploration is at version 10. A model already exists at
+        # version 10 with one translation, and an old version has
+        # another translation that should be merged in.
+        self._create_exploration(self.EXP_ID, version=10)
+        self._create_translation_model(
+            self.EXP_ID,
+            10,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Already here</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+        self._create_translation_model(
+            self.EXP_ID,
+            5,
+            'es',
+            {
+                'content_1': {
+                    'content_format': 'html',
+                    'content_value': '<p>Orphaned card</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATION MODELS UPDATED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATIONS RECOVERED SUCCESS: 1'
+                ),
+            ]
+        )
+
+        updated_model = translation_models.EntityTranslationsModel.get_model(
+            feconf.TranslatableEntityType.EXPLORATION, self.EXP_ID, 10, 'es'
+        )
+        self.assertIsNotNone(updated_model)
+        self.assertEqual(len(updated_model.translations), 2)
+        self.assertIn('content_0', updated_model.translations)
+        self.assertIn('content_1', updated_model.translations)
+
+    def test_multiple_languages_are_handled_independently(self) -> None:
+        self._create_exploration(self.EXP_ID, version=10)
+        # Spanish orphaned at version 3.
+        self._create_translation_model(
+            self.EXP_ID,
+            3,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Hola</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+        # Portuguese orphaned at version 5.
+        self._create_translation_model(
+            self.EXP_ID,
+            5,
+            'pt',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Olá</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATION MODELS UPDATED SUCCESS: 2'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATIONS RECOVERED SUCCESS: 2'
+                ),
+            ]
+        )
+
+        es_model = translation_models.EntityTranslationsModel.get_model(
+            feconf.TranslatableEntityType.EXPLORATION, self.EXP_ID, 10, 'es'
+        )
+        pt_model = translation_models.EntityTranslationsModel.get_model(
+            feconf.TranslatableEntityType.EXPLORATION, self.EXP_ID, 10, 'pt'
+        )
+        self.assertIsNotNone(es_model)
+        self.assertIsNotNone(pt_model)
+        self.assertIn('content_0', es_model.translations)
+        self.assertIn('content_0', pt_model.translations)
+
+    def test_deleted_exploration_translations_are_skipped(self) -> None:
+        # Create translations with no corresponding exploration.
+        self._create_translation_model(
+            'deleted_exp',
+            5,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Orphan</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is_empty()
+
+
+class AuditRecoverOrphanedTranslationsJobTests(
+    job_test_utils.JobTestBase, test_utils.GenericTestBase
+):
+
+    JOB_CLASS = (
+        recover_orphaned_translations_jobs.AuditRecoverOrphanedTranslationsJob
+    )
+
+    AUTHOR_EMAIL: Final = 'author@example.com'
+    EXP_ID: Final = 'exp_id_1'
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.signup(self.AUTHOR_EMAIL, 'author')
+        self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
+
+    def _create_exploration(self, exp_id: str, version: int) -> None:
+        """Creates an ExplorationModel with the given ID and version."""
+        rights_manager.create_new_exploration_rights(exp_id, self.author_id)
+        model = self.create_model(
+            exp_models.ExplorationModel,
+            id=exp_id,
+            title='Test Exploration',
+            init_state_name=feconf.DEFAULT_INIT_STATE_NAME,
+            category=feconf.DEFAULT_EXPLORATION_CATEGORY,
+            objective=feconf.DEFAULT_EXPLORATION_OBJECTIVE,
+            language_code='en',
+            tags=['Topic'],
+            blurb='blurb',
+            author_notes='author notes',
+            states_schema_version=feconf.CURRENT_STATE_SCHEMA_VERSION,
+            param_specs={},
+            param_changes=[],
+            auto_tts_enabled=feconf.DEFAULT_AUTO_TTS_ENABLED,
+            states={
+                feconf.DEFAULT_INIT_STATE_NAME: (
+                    exp_domain.Exploration.create_default_exploration(exp_id)
+                    .states[feconf.DEFAULT_INIT_STATE_NAME]
+                    .to_dict()
+                )
+            },
+        )
+        commit_cmd = exp_domain.ExplorationChange(
+            {
+                'cmd': exp_domain.CMD_CREATE_NEW,
+                'title': 'title',
+                'category': 'category',
+            }
+        )
+        model.commit(self.author_id, 'commit_message', [commit_cmd.to_dict()])
+        if version > 1:
+            model.version = version
+            model.update_timestamps(update_last_updated_time=False)
+            datastore_services.put_multi([model])
+
+    def _create_translation_model(
+        self,
+        entity_id: str,
+        entity_version: int,
+        language_code: str,
+        # Here we use type Any because the translations are stored as
+        # a nested dictionary with varying structures.
+        translations: Dict[str, Any],
+    ) -> None:
+        """Creates an EntityTranslationsModel with the given parameters."""
+        model = translation_models.EntityTranslationsModel.create_new(
+            'exploration',
+            entity_id,
+            entity_version,
+            language_code,
+            translations,
+        )
+        model.update_timestamps()
+        model.put()
+
+    def test_audit_job_does_not_write_to_datastore(self) -> None:
+        self._create_exploration(self.EXP_ID, version=10)
+        self._create_translation_model(
+            self.EXP_ID,
+            3,
+            'es',
+            {
+                'content_0': {
+                    'content_format': 'html',
+                    'content_value': '<p>Orphaned</p>',
+                    'needs_update': False,
+                },
+            },
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult(
+                    stdout='EXPLORATIONS TRAVERSED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATION MODELS UPDATED SUCCESS: 1'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='TRANSLATIONS RECOVERED SUCCESS: 1'
+                ),
+            ]
+        )
+
+        # Verify that no new model was created at version 10.
+        new_model = translation_models.EntityTranslationsModel.get_model(
+            feconf.TranslatableEntityType.EXPLORATION, self.EXP_ID, 10, 'es'
+        )
+        self.assertIsNone(new_model)
+
+        # Verify the original model is still there, untouched.
+        all_models: Sequence[translation_models.EntityTranslationsModel] = (
+            translation_models.EntityTranslationsModel.get_all().fetch()
+        )
+        self.assertEqual(len(all_models), 1)
+        self.assertEqual(all_models[0].entity_version, 3)

--- a/core/jobs/registry.py
+++ b/core/jobs/registry.py
@@ -63,6 +63,7 @@ from core.jobs.batch_jobs import (  # pylint: disable=unused-import
     number_with_units_audit_jobs,
     opportunity_management_jobs,
     question_migration_jobs,
+    recover_orphaned_translations_jobs,
     skill_inspection_jobs,
     skill_migration_jobs,
     story_migration_jobs,

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -209,7 +209,8 @@
         "core.jobs.batch_jobs.subtopic_migration_jobs_test",
         "core.jobs.batch_jobs.reject_invalid_suggestion_and_delete_invalid_translation_jobs_test",
         "core.domain.voiceover_cloud_task_services_test",
-        "core.jobs.batch_jobs.cleanup_duplicate_translation_suggestions_jobs_test"
+        "core.jobs.batch_jobs.cleanup_duplicate_translation_suggestions_jobs_test",
+        "core.jobs.batch_jobs.recover_orphaned_translations_jobs_test"
     ],
     "4": [
         "core.storage.learner_group.gae_models_test",

--- a/scripts/linters/test_files/valid_job_imports.py
+++ b/scripts/linters/test_files/valid_job_imports.py
@@ -93,6 +93,9 @@ from core.jobs.batch_jobs import (  # pylint: disable=unused-import  # isort: sk
 from core.jobs.batch_jobs import (  # pylint: disable=unused-import  # isort: skip
     cleanup_duplicate_translation_suggestions_jobs,
 )
+from core.jobs.batch_jobs import (  # pylint: disable=unused-import  # isort: skip
+    recover_orphaned_translations_jobs,
+)
 
 
 class FakeClass:


### PR DESCRIPTION
## Overview

1. This PR fixes #25710, fixes #25807 and fixes #21019.
2. This PR does the following: It adds two Apache Beam jobs to identify and recover "orphaned" translations that were saved to historical exploration versions.
   - [AuditRecoverOrphanedTranslationsJob](https://github.com/rohan-Unbeg/oppia/blob/recover-orphaned-translations-beam-job/core/jobs/batch_jobs/recover_orphaned_translations_jobs.py): Identifies EntityTranslationsModels where the version doesn't match the current exploration version and reports the number of translations that can be recovered.
   - [RecoverOrphanedTranslationsJob](https://github.com/rohan-Unbeg/oppia/blob/recover-orphaned-translations-beam-job/core/jobs/batch_jobs/recover_orphaned_translations_jobs.py): Merges translations from all historical versions into the latest version's EntityTranslationsModel.
   - These jobs are registered in [registry.py](https://github.com/rohan-Unbeg/oppia/blob/recover-orphaned-translations-beam-job/core/jobs/registry.py).
3. The original bug occurred because: In `SuggestionTranslateContent.accept()`, the code was saving accepted translations using the exploration version at the time of submission (`self.target_version_at_submission`) instead of the latest version. This resulted in translations being "orphaned" on old versions when an exploration was edited while a suggestion was in review. (The fix for future translations was merged in #24726).

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #25710: Add Beam jobs to recover orphaned translation data".
- [x] I have assigned the correct reviewers to this PR.

## Testing doc (for PRs with Beam jobs that modify production server data)

- [x] A testing doc has been written: https://docs.google.com/document/d/1SqWdXjjlu3iGUh5WAC7uE5Ihlz2v4QdeDFlG1JO426U/edit?tab=t.0
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network
No proof of UI changes needed because this PR adds backend-only Beam jobs. Proof is provided via backend unit tests and local job execution logs.

**Verification via Automated Tests:**
- 9 comprehensive unit tests in [recover_orphaned_translations_jobs_test.py](https://github.com/rohan-Unbeg/oppia/blob/recover-orphaned-translations-beam-job/core/jobs/batch_jobs/recover_orphaned_translations_jobs_test.py) covering success cases, merging logic, and collision handling.
- All backend tests and pre-push hooks (Linting, Mypy) passed locally.

**Verification via Local Run:**
To make sure the job works in a real-world scenario, I ran a manual reproduction locally. I temporarily brought back the historical bug in `suggestion_registry.py` just to demonstrate how the translations get orphaned and then recovered.

Here is what I did in the video:
1. Created an exploration and submitted a translation for it while it was at version 1.
2. Edited the exploration as an admin to bump it to version 2 while the translation was still in review.
3. Accepted the translation. Because of the bug, it got "stuck" on version 1. I checked the contributor dashboard and confirmed the card still looked untranslated (the orphaned state).
4. Ran the `AuditRecoverOrphanedTranslationsJob` to see it correctly detect the 1 orphaned translation.
5. Ran the `RecoverOrphanedTranslationsJob` to perform the actual fix.
6. Refreshed the dashboard and verified that the card is now correctly marked as "Translated."

https://github.com/user-attachments/assets/06216e46-1342-4cf0-a57c-cadf7b53c975

#### Proof of changes on mobile phone
N/A (Backend-only feature)

#### Proof of changes in Arabic language
N/A (Backend-only feature)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.