### PR TITLE
Fix Firebase proxy mangling JSON bodies as form-encoded data

### DIFF
--- a/core/controllers/firebase.py
+++ b/core/controllers/firebase.py
@@ -16,8 +16,6 @@
 
 from __future__ import annotations
 
-import json
-
 from core import feconf
 from core.controllers import acl_decorators, base
 
@@ -61,12 +59,11 @@ class FirebaseProxyPage(base.BaseHandler[Dict[str, str], Dict[str, str]]):
                 f'No firebase domain found for {self.request.domain}.'
             )
 
-        data = json.loads(self.request.body) if self.request.body else None
         response = requests.request(
             self.request.method,
             f'{firebase_domain}{self.request.path}',
             params=dict(self.request.params),
-            data=data,
+            data=self.request.body if self.request.body else None,
             headers=dict(self.request.headers.items()),
             timeout=TIMEOUT_SECS,
         )


### PR DESCRIPTION
## Bug

`FirebaseProxyPage._firebase_proxy` in
`core/controllers/firebase.py` corrupts JSON request bodies when
forwarding them to Firebase: the upstream receives a form-encoded body
even though the forwarded `Content-Type` header still says
`application/json`.

## Root cause

```python
data = json.loads(self.request.body) if self.request.body else None
response = requests.request(
    self.request.method,
    f'{firebase_domain}{self.request.path}',
    params=dict(self.request.params),
    data=data,
    headers=dict(self.request.headers.items()),
    timeout=TIMEOUT_SECS,
)
```

`json.loads(self.request.body)` turns the incoming JSON bytes into a
Python `dict`/`list`. When `requests.request(..., data=<dict>)` gets a
dict/list, it **form-urlencodes** it (documented behaviour of the
`data=` parameter), producing something like `key=value` as the body.

Meanwhile the original `Content-Type: application/json` header is
copied through unchanged on line 65, so Firebase sees
`Content-Type: application/json` with a `key=value` body and rejects
the request.

There is no need to parse the body in a proxy: the whole purpose of
`_firebase_proxy` is pass-through.

## Why the fix is correct

- `requests.request(..., data=<bytes or str>)` sends the given bytes
  verbatim, so forwarding `self.request.body` (which is already the
  raw request body) gives Firebase exactly what the client sent.
- Works for every body shape, not just JSON (binary uploads,
  form-encoded data, empty bodies), because we no longer try to
  interpret the body at all.
- Content-Type is already forwarded from the original request, and
  now matches the body bytes.
- `import json` is no longer needed and is removed.

## Change

`core/controllers/firebase.py`: drop `json.loads(...)`, pass
`self.request.body` directly as `data=`, and remove the unused
`import json`.