### PR TITLE
Initialise classroom before the loop in ClassroomDataHandler.get

### DIFF
--- a/core/controllers/classroom.py
+++ b/core/controllers/classroom.py
@@ -64,6 +64,7 @@ class ClassroomDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         """
         classrooms = classroom_config_services.get_all_classrooms()
         public_classrooms_count = 0
+        classroom = None
 
         for c in classrooms:
             if c.url_fragment == classroom_url_fragment:


### PR DESCRIPTION
## Bug

`ClassroomDataHandler.get()` in `core/controllers/classroom.py` can
raise `UnboundLocalError` instead of the intended `AssertionError`
when its defensive `assert classroom is not None` is reached with no
matching classroom.

## Root cause

```python
classrooms = classroom_config_services.get_all_classrooms()
public_classrooms_count = 0

for c in classrooms:
    if c.url_fragment == classroom_url_fragment:
        classroom = c
    if c.is_published:
        public_classrooms_count += 1
# Here we are asserting that classroom can never be none, because
# in the decorator `does_classroom_exist` we are already handling
# the None case of classroom.
assert classroom is not None
```

`classroom` is only bound inside the `if c.url_fragment == ...:`
branch. If the loop ever runs without a match - empty `classrooms`,
a transient mismatch between the decorator's view and
`get_all_classrooms()`, or any future change that bypasses the decorator -
`classroom` is never defined, and line 76 raises
`UnboundLocalError: local variable 'classroom' referenced before
assignment`, not the documented
`AssertionError` the comment promises.

## Why the fix is correct

- Initialising `classroom = None` before the loop is the direct way to
  make the subsequent assertion actually execute.
- The happy path (decorator guarantees exactly one match) is unchanged:
  `classroom` is still rebound inside the loop.
- No mypy change is required - `classroom` is already `Optional` in
  that branch from the assert's perspective.
- One-line addition, no other logic touched.

## Change

`core/controllers/classroom.py`: add `classroom = None` before the
`for c in classrooms:` loop in `ClassroomDataHandler.get`.