### PR TITLE
Fix part of #21970: Add BlogPostReadEventLogEntry and BlogPostViewedEventLogEntry domain objects

### DIFF
--- a/core/domain/blog_domain.py
+++ b/core/domain/blog_domain.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+l# coding: utf-8
 #
 # Copyright 2021 The Oppia Authors. All Rights Reserved.
 #
@@ -878,3 +878,72 @@ class BlogPostReadEventLogEntry:
         if not self.blog_post_id:
             raise utils.ValidationError(
                 'Expected blog_post_id to be non-empty.')
+
+class BlogPostViewedEventLogEntry:
+    """Domain object for a blog post viewed event log entry."""
+
+    def __init__(self, blog_post_id, created_on):
+        """Initializes a BlogPostViewedEventLogEntry domain object.
+
+        Args:
+            blog_post_id: str. The unique ID of the blog post that was viewed.
+            created_on: datetime.datetime. The timestamp when the view event
+                occurred.
+        """
+        self.blog_post_id = blog_post_id
+        self.created_on = created_on
+
+    def validate(self):
+        """Validates the blog post viewed event log entry.
+
+        Raises:
+            utils.ValidationError. The blog_post_id is not a string.
+            utils.ValidationError. The blog_post_id is empty.
+        """
+        if not isinstance(self.blog_post_id, str):
+            raise utils.ValidationError(
+                'Expected blog_post_id to be a string, received %s'
+                % self.blog_post_id)
+        if not self.blog_post_id:
+            raise utils.ValidationError(
+                'Expected blog_post_id to be non-empty.')
+
+
+class BlogPostExitedEventLogEntry:
+    """Domain object for a blog post exited event log entry."""
+
+    def __init__(self, blog_post_id, time_spent_msec, created_on):
+        """Initializes a BlogPostExitedEventLogEntry domain object.
+
+        Args:
+            blog_post_id: str. The unique ID of the blog post that was exited.
+            time_spent_msec: float. Milliseconds the user spent on the post.
+            created_on: datetime.datetime. The timestamp when exit occurred.
+        """
+        self.blog_post_id = blog_post_id
+        self.time_spent_msec = time_spent_msec
+        self.created_on = created_on
+
+    def validate(self):
+        """Validates the blog post exited event log entry.
+
+        Raises:
+            utils.ValidationError. The blog_post_id is not a string.
+            utils.ValidationError. The blog_post_id is empty.
+            utils.ValidationError. The time_spent_msec is not a number.
+            utils.ValidationError. The time_spent_msec is negative.
+        """
+        if not isinstance(self.blog_post_id, str):
+            raise utils.ValidationError(
+                'Expected blog_post_id to be a string, received %s'
+                % self.blog_post_id)
+        if not self.blog_post_id:
+            raise utils.ValidationError(
+                'Expected blog_post_id to be non-empty.')
+        if not isinstance(self.time_spent_msec, (int, float)):
+            raise utils.ValidationError(
+                'Expected time_spent_msec to be a number, received %s'
+                % self.time_spent_msec)
+        if self.time_spent_msec < 0:
+            raise utils.ValidationError(
+                'Expected time_spent_msec to be non-negative.')

--- a/core/domain/blog_domain.py
+++ b/core/domain/blog_domain.py
@@ -848,3 +848,33 @@ class BlogAuthorDetails:
                 'Expected Author Bio to be a string,'
                 ' received %s' % self.author_bio
             )
+
+
+class BlogPostReadEventLogEntry:
+    """Domain object for a blog post read event log entry."""
+
+    def __init__(self, blog_post_id, created_on):
+        """Initializes a BlogPostReadEventLogEntry domain object.
+
+        Args:
+            blog_post_id: str. The unique ID of the blog post that was read.
+            created_on: datetime.datetime. The timestamp when the read event
+                occurred.
+        """
+        self.blog_post_id = blog_post_id
+        self.created_on = created_on
+
+    def validate(self):
+        """Validates the blog post read event log entry.
+
+        Raises:
+            utils.ValidationError. The blog_post_id is not a string.
+            utils.ValidationError. The blog_post_id is empty.
+        """
+        if not isinstance(self.blog_post_id, str):
+            raise utils.ValidationError(
+                'Expected blog_post_id to be a string, received %s'
+                % self.blog_post_id)
+        if not self.blog_post_id:
+            raise utils.ValidationError(
+                'Expected blog_post_id to be non-empty.')

--- a/core/domain/blog_domain.py
+++ b/core/domain/blog_domain.py
@@ -854,23 +854,11 @@ class BlogPostReadEventLogEntry:
     """Domain object for a blog post read event log entry."""
 
     def __init__(self, blog_post_id, created_on):
-        """Initializes a BlogPostReadEventLogEntry domain object.
-
-        Args:
-            blog_post_id: str. The unique ID of the blog post that was read.
-            created_on: datetime.datetime. The timestamp when the read event
-                occurred.
-        """
         self.blog_post_id = blog_post_id
         self.created_on = created_on
 
     def validate(self):
-        """Validates the blog post read event log entry.
-
-        Raises:
-            utils.ValidationError. The blog_post_id is not a string.
-            utils.ValidationError. The blog_post_id is empty.
-        """
+        """Validates the blog post read event log entry."""
         if not isinstance(self.blog_post_id, str):
             raise utils.ValidationError(
                 'Expected blog_post_id to be a string, received %s'
@@ -878,28 +866,18 @@ class BlogPostReadEventLogEntry:
         if not self.blog_post_id:
             raise utils.ValidationError(
                 'Expected blog_post_id to be non-empty.')
+
 
 class BlogPostViewedEventLogEntry:
     """Domain object for a blog post viewed event log entry."""
 
-    def __init__(self, blog_post_id, created_on):
-        """Initializes a BlogPostViewedEventLogEntry domain object.
-
-        Args:
-            blog_post_id: str. The unique ID of the blog post that was viewed.
-            created_on: datetime.datetime. The timestamp when the view event
-                occurred.
-        """
+    def __init__(self, blog_post_id, user_id, created_on):
         self.blog_post_id = blog_post_id
+        self.user_id = user_id
         self.created_on = created_on
 
     def validate(self):
-        """Validates the blog post viewed event log entry.
-
-        Raises:
-            utils.ValidationError. The blog_post_id is not a string.
-            utils.ValidationError. The blog_post_id is empty.
-        """
+        """Validates the blog post viewed event log entry."""
         if not isinstance(self.blog_post_id, str):
             raise utils.ValidationError(
                 'Expected blog_post_id to be a string, received %s'
@@ -907,43 +885,7 @@ class BlogPostViewedEventLogEntry:
         if not self.blog_post_id:
             raise utils.ValidationError(
                 'Expected blog_post_id to be non-empty.')
-
-
-class BlogPostExitedEventLogEntry:
-    """Domain object for a blog post exited event log entry."""
-
-    def __init__(self, blog_post_id, time_spent_msec, created_on):
-        """Initializes a BlogPostExitedEventLogEntry domain object.
-
-        Args:
-            blog_post_id: str. The unique ID of the blog post that was exited.
-            time_spent_msec: float. Milliseconds the user spent on the post.
-            created_on: datetime.datetime. The timestamp when exit occurred.
-        """
-        self.blog_post_id = blog_post_id
-        self.time_spent_msec = time_spent_msec
-        self.created_on = created_on
-
-    def validate(self):
-        """Validates the blog post exited event log entry.
-
-        Raises:
-            utils.ValidationError. The blog_post_id is not a string.
-            utils.ValidationError. The blog_post_id is empty.
-            utils.ValidationError. The time_spent_msec is not a number.
-            utils.ValidationError. The time_spent_msec is negative.
-        """
-        if not isinstance(self.blog_post_id, str):
+        if not isinstance(self.user_id, str):
             raise utils.ValidationError(
-                'Expected blog_post_id to be a string, received %s'
-                % self.blog_post_id)
-        if not self.blog_post_id:
-            raise utils.ValidationError(
-                'Expected blog_post_id to be non-empty.')
-        if not isinstance(self.time_spent_msec, (int, float)):
-            raise utils.ValidationError(
-                'Expected time_spent_msec to be a number, received %s'
-                % self.time_spent_msec)
-        if self.time_spent_msec < 0:
-            raise utils.ValidationError(
-                'Expected time_spent_msec to be non-negative.')
+                'Expected user_id to be a string, received %s'
+                % self.user_id)

--- a/core/domain/blog_domain_test.py
+++ b/core/domain/blog_domain_test.py
@@ -875,14 +875,16 @@ class BlogAuthorDetailsTests(test_utils.GenericTestBase):
 class BlogPostReadEventLogEntryTests(test_utils.GenericTestBase):
     """Tests for BlogPostReadEventLogEntry domain object."""
 
-    def test_valid_entry_passes_validation(self):
+    def test_valid_entry_passes_validation(self) -> None:
+        """Tests that a valid entry passes validation."""
         entry = blog_domain.BlogPostReadEventLogEntry(
             blog_post_id='valid_id',
             created_on=datetime.datetime.utcnow()
         )
         entry.validate()  # Should not raise.
 
-    def test_validate_raises_if_blog_post_id_not_string(self):
+    def test_validate_raises_if_blog_post_id_not_string(self) -> None:
+        """Tests that validate raises if blog_post_id is not a string."""
         entry = blog_domain.BlogPostReadEventLogEntry(
             blog_post_id=123,
             created_on=datetime.datetime.utcnow()
@@ -893,7 +895,8 @@ class BlogPostReadEventLogEntryTests(test_utils.GenericTestBase):
         ):
             entry.validate()
 
-    def test_validate_raises_if_blog_post_id_is_empty(self):
+    def test_validate_raises_if_blog_post_id_is_empty(self) -> None:
+        """Tests that validate raises if blog_post_id is empty."""
         entry = blog_domain.BlogPostReadEventLogEntry(
             blog_post_id='',
             created_on=datetime.datetime.utcnow()
@@ -903,3 +906,43 @@ class BlogPostReadEventLogEntryTests(test_utils.GenericTestBase):
             'Expected blog_post_id to be non-empty'
         ):
             entry.validate()
+
+
+class BlogPostViewedEventLogEntryTests(test_utils.GenericTestBase):
+    """Tests for BlogPostViewedEventLogEntry domain object."""
+
+    def test_valid_entry_passes_validation(self) -> None:
+        """Tests that a valid entry passes validation."""
+        entry = blog_domain.BlogPostViewedEventLogEntry(
+            blog_post_id='valid_id',
+            user_id='valid_user_id', # Added missing user_id
+            created_on=datetime.datetime.utcnow()
+        )
+        entry.validate()  # Should not raise.
+
+    def test_validate_raises_if_blog_post_id_not_string(self) -> None:
+        """Tests that validate raises if blog_post_id is not a string."""
+        entry = blog_domain.BlogPostViewedEventLogEntry(
+            blog_post_id=123,
+            user_id='valid_user_id', # Added missing user_id
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be a string'
+        ):
+            entry.validate()
+
+    def test_validate_raises_if_blog_post_id_is_empty(self) -> None:
+        """Tests that validate raises if blog_post_id is empty."""
+        entry = blog_domain.BlogPostViewedEventLogEntry(
+            blog_post_id='',
+            user_id='valid_user_id', # Added missing user_id
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be non-empty'
+        ):
+            entry.validate()
+

--- a/core/domain/blog_domain_test.py
+++ b/core/domain/blog_domain_test.py
@@ -872,3 +872,34 @@ class BlogAuthorDetailsTests(test_utils.GenericTestBase):
             ' received %s' % self.author_details.author_bio,
         ):
             self.author_details.validate()
+class BlogPostReadEventLogEntryTests(test_utils.GenericTestBase):
+    """Tests for BlogPostReadEventLogEntry domain object."""
+
+    def test_valid_entry_passes_validation(self):
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id='valid_id',
+            created_on=datetime.datetime.utcnow()
+        )
+        entry.validate()  # Should not raise.
+
+    def test_validate_raises_if_blog_post_id_not_string(self):
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id=123,
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be a string'
+        ):
+            entry.validate()
+
+    def test_validate_raises_if_blog_post_id_is_empty(self):
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id='',
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be non-empty'
+        ):
+            entry.validate()

--- a/core/domain/blog_services.py
+++ b/core/domain/blog_services.py
@@ -1133,3 +1133,22 @@ def update_blog_author_details(
     blog_author_model.author_bio = author_bio
     blog_author_model.update_timestamps()
     blog_author_model.put()
+def get_blog_post_read_event_log_entry(
+    blog_post_id: str,
+    created_on: datetime.datetime
+) -> blog_domain.BlogPostReadEventLogEntry:
+    """Returns a BlogPostReadEventLogEntry domain object.
+
+    Args:
+        blog_post_id: str. The unique ID of the blog post that was read.
+        created_on: datetime.datetime. The timestamp of the read event.
+
+    Returns:
+        BlogPostReadEventLogEntry. The domain object.
+    """
+    entry = blog_domain.BlogPostReadEventLogEntry(
+        blog_post_id=blog_post_id,
+        created_on=created_on
+    )
+    entry.validate()
+    return entry

--- a/core/domain/collection_domain.py
+++ b/core/domain/collection_domain.py
@@ -1670,3 +1670,146 @@ class CollectionSummary:
             )
 
         self.contributor_ids = list(self.contributors_summary.keys())
+
+class CollectionCommitLogEntry:
+    """Domain object for a collection commit log entry."""
+
+    def __init__(
+            self,
+            instance_id,
+            user_id,
+            commit_type,
+            commit_message,
+            commit_cmds,
+            collection_id,
+            post_commit_status,
+            post_commit_is_private,
+            version,
+            created_on,
+            last_updated):
+        """Initializes a CollectionCommitLogEntry domain object.
+
+        Args:
+            instance_id: str. The unique ID of this commit log entry.
+            user_id: str. The user ID of the committer.
+            commit_type: str. The type of commit e.g. 'create', 'edit'.
+            commit_message: str|None. The message describing the commit.
+            commit_cmds: list. List of commit command dicts.
+            collection_id: str. The ID of the collection that was committed.
+            post_commit_status: str. The status after commit e.g. 'public'.
+            post_commit_is_private: bool. Whether collection is private.
+            version: int. The collection version after this commit.
+            created_on: datetime.datetime. When the commit was created.
+            last_updated: datetime.datetime. When this entry was last updated.
+        """
+        self.id = instance_id
+        self.user_id = user_id
+        self.commit_type = commit_type
+        self.commit_message = commit_message
+        self.commit_cmds = commit_cmds
+        self.collection_id = collection_id
+        self.post_commit_status = post_commit_status
+        self.post_commit_is_private = post_commit_is_private
+        self.version = version
+        self.created_on = created_on
+        self.last_updated = last_updated
+
+    def validate(self):
+        """Validates the CollectionCommitLogEntry domain object.
+
+        Raises:
+            utils.ValidationError. The user_id is not a non-empty string.
+            utils.ValidationError. The commit_type is not a non-empty string.
+            utils.ValidationError. The commit_cmds is not a list.
+            utils.ValidationError. The collection_id is not a non-empty string.
+            utils.ValidationError. The post_commit_status is not a string.
+            utils.ValidationError. The post_commit_is_private is not a bool.
+            utils.ValidationError. The version is not a positive integer.
+        """
+        if not isinstance(self.user_id, str) or not self.user_id:
+            raise utils.ValidationError(
+                'Expected user_id to be a non-empty string, received: %s'
+                % self.user_id)
+        if not isinstance(self.commit_type, str) or not self.commit_type:
+            raise utils.ValidationError(
+                'Expected commit_type to be a non-empty string, received: %s'
+                % self.commit_type)
+        if not isinstance(self.commit_cmds, list):
+            raise utils.ValidationError(
+                'Expected commit_cmds to be a list, received: %s'
+                % self.commit_cmds)
+        if (not isinstance(self.collection_id, str)
+                or not self.collection_id):
+            raise utils.ValidationError(
+                'Expected collection_id to be a non-empty string, '
+                'received: %s' % self.collection_id)
+        if (not isinstance(self.post_commit_status, str)
+                or not self.post_commit_status):
+            raise utils.ValidationError(
+                'Expected post_commit_status to be a non-empty string, '
+                'received: %s' % self.post_commit_status)
+        if not isinstance(self.post_commit_is_private, bool):
+            raise utils.ValidationError(
+                'Expected post_commit_is_private to be a bool, received: %s'
+                % self.post_commit_is_private)
+        if not isinstance(self.version, int) or self.version < 1:
+            raise utils.ValidationError(
+                'Expected version to be a positive integer, received: %s'
+                % self.version)
+        
+class CollectionProgress:
+    """Domain object for a learner's progress through a collection."""
+
+    def __init__(
+            self,
+            instance_id,
+            user_id,
+            collection_id,
+            completed_explorations):
+        """Initializes a CollectionProgress domain object.
+
+        Args:
+            instance_id: str. The unique ID of this progress record.
+            user_id: str. The ID of the learner.
+            collection_id: str. The ID of the collection being tracked.
+            completed_explorations: list(str). List of completed exploration
+                IDs within the collection.
+        """
+        self.id = instance_id
+        self.user_id = user_id
+        self.collection_id = collection_id
+        self.completed_explorations = completed_explorations
+
+    def validate(self):
+        """Validates the CollectionProgress domain object.
+
+        Raises:
+            utils.ValidationError. The user_id is not a non-empty string.
+            utils.ValidationError. The collection_id is not a non-empty string.
+            utils.ValidationError. The completed_explorations is not a list.
+            utils.ValidationError. Any entry in completed_explorations is not
+                a non-empty string.
+            utils.ValidationError. completed_explorations has duplicates.
+        """
+        if not isinstance(self.user_id, str) or not self.user_id:
+            raise utils.ValidationError(
+                'Expected user_id to be a non-empty string, received: %s'
+                % self.user_id)
+        if not isinstance(self.collection_id, str) or not self.collection_id:
+            raise utils.ValidationError(
+                'Expected collection_id to be a non-empty string, '
+                'received: %s' % self.collection_id)
+        if not isinstance(self.completed_explorations, list):
+            raise utils.ValidationError(
+                'Expected completed_explorations to be a list, received: %s'
+                % self.completed_explorations)
+        for exp_id in self.completed_explorations:
+            if not isinstance(exp_id, str) or not exp_id:
+                raise utils.ValidationError(
+                    'Expected each exploration ID to be a non-empty '
+                    'string, received: %s' % exp_id)
+        if len(set(self.completed_explorations)) != len(
+                self.completed_explorations):
+            raise utils.ValidationError(
+                'completed_explorations contains duplicate exploration IDs.')
+        

--- a/core/domain/email_domain.py
+++ b/core/domain/email_domain.py
@@ -1,0 +1,96 @@
+# coding: utf-8
+#
+# Copyright 2024 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain objects relating to emails."""
+
+from __future__ import annotations
+
+import datetime
+
+from core import utils
+
+from typing import List
+
+
+class BulkEmail:
+    """Domain object for a bulk email record."""
+
+    def __init__(
+            self,
+            instance_id,
+            sender_id,
+            sender_email,
+            recipient_ids,
+            intent,
+            subject,
+            html_body,
+            sent_datetime):
+        """Initializes a BulkEmail domain object.
+
+        Args:
+            instance_id: str. The unique ID of this bulk email record.
+            sender_id: str. The user ID of the sender.
+            sender_email: str. The email address of the sender.
+            recipient_ids: list(str). List of user IDs of all recipients.
+            intent: str. The purpose of the email.
+            subject: str. The subject line of the email.
+            html_body: str. The HTML body of the email.
+            sent_datetime: datetime.datetime. When the email was sent.
+        """
+        self.id = instance_id
+        self.sender_id = sender_id
+        self.sender_email = sender_email
+        self.recipient_ids = recipient_ids
+        self.intent = intent
+        self.subject = subject
+        self.html_body = html_body
+        self.sent_datetime = sent_datetime
+
+    def validate(self):
+        """Validates the BulkEmail domain object.
+
+        Raises:
+            utils.ValidationError. The sender_id is not a non-empty string.
+            utils.ValidationError. The sender_email is not a non-empty string.
+            utils.ValidationError. The recipient_ids is not a list.
+            utils.ValidationError. The intent is not a non-empty string.
+            utils.ValidationError. The subject is not a non-empty string.
+            utils.ValidationError. The html_body is not a string.
+        """
+        if not isinstance(self.sender_id, str) or not self.sender_id:
+            raise utils.ValidationError(
+                'Expected sender_id to be a non-empty string, received: %s'
+                % self.sender_id)
+        if not isinstance(self.sender_email, str) or not self.sender_email:
+            raise utils.ValidationError(
+                'Expected sender_email to be a non-empty string, received: %s'
+                % self.sender_email)
+        if not isinstance(self.recipient_ids, list):
+            raise utils.ValidationError(
+                'Expected recipient_ids to be a list, received: %s'
+                % self.recipient_ids)
+        if not isinstance(self.intent, str) or not self.intent:
+            raise utils.ValidationError(
+                'Expected intent to be a non-empty string, received: %s'
+                % self.intent)
+        if not isinstance(self.subject, str) or not self.subject:
+            raise utils.ValidationError(
+                'Expected subject to be a non-empty string, received: %s'
+                % self.subject)
+        if not isinstance(self.html_body, str):
+            raise utils.ValidationError(
+                'Expected html_body to be a string, received: %s'
+                % self.html_body)

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -2388,3 +2388,71 @@ class LearnerAnswerInfo:
         """
         learner_answer_info_dict = self.to_dict()
         return sys.getsizeof(json.dumps(learner_answer_info_dict, default=str))
+
+class AnswerSubmittedEventLogEntry:
+    """Domain object for an answer submitted event log entry."""
+
+    def __init__(
+            self,
+            exp_id,
+            exp_version,
+            state_name,
+            session_id,
+            time_spent_in_state_secs,
+            is_feedback_useful,
+            created_on):
+        """Initializes an AnswerSubmittedEventLogEntry domain object.
+
+        Args:
+            exp_id: str. The ID of the exploration.
+            exp_version: int. The version of the exploration.
+            state_name: str. The name of the state where answer was submitted.
+            session_id: str. The ID of the learner's session.
+            time_spent_in_state_secs: float. Seconds spent on this state.
+            is_feedback_useful: bool. Whether the feedback was useful.
+            created_on: datetime.datetime. When the event was recorded.
+        """
+        self.exp_id = exp_id
+        self.exp_version = exp_version
+        self.state_name = state_name
+        self.session_id = session_id
+        self.time_spent_in_state_secs = time_spent_in_state_secs
+        self.is_feedback_useful = is_feedback_useful
+        self.created_on = created_on
+
+    def validate(self):
+        """Validates the AnswerSubmittedEventLogEntry domain object.
+
+        Raises:
+            utils.ValidationError. The exp_id is not a non-empty string.
+            utils.ValidationError. The exp_version is not a positive integer.
+            utils.ValidationError. The state_name is not a non-empty string.
+            utils.ValidationError. The session_id is not a non-empty string.
+            utils.ValidationError. The time_spent_in_state_secs is negative.
+            utils.ValidationError. The is_feedback_useful is not a bool.
+        """
+        if not isinstance(self.exp_id, str) or not self.exp_id:
+            raise utils.ValidationError(
+                'Expected exp_id to be a non-empty string, received: %s'
+                % self.exp_id)
+        if not isinstance(self.exp_version, int) or self.exp_version < 1:
+            raise utils.ValidationError(
+                'Expected exp_version to be a positive integer, received: %s'
+                % self.exp_version)
+        if not isinstance(self.state_name, str) or not self.state_name:
+            raise utils.ValidationError(
+                'Expected state_name to be a non-empty string, received: %s'
+                % self.state_name)
+        if not isinstance(self.session_id, str) or not self.session_id:
+            raise utils.ValidationError(
+                'Expected session_id to be a non-empty string, received: %s'
+                % self.session_id)
+        if (not isinstance(self.time_spent_in_state_secs, (int, float))
+                or self.time_spent_in_state_secs < 0):
+            raise utils.ValidationError(
+                'Expected time_spent_in_state_secs to be a non-negative '
+                'number, received: %s' % self.time_spent_in_state_secs)
+        if not isinstance(self.is_feedback_useful, bool):
+            raise utils.ValidationError(
+                'Expected is_feedback_useful to be a bool, received: %s'
+                % self.is_feedback_useful)


### PR DESCRIPTION
Overview
This PR fixes part of #21970.

This PR does the following: Implemented the domain objects and validation logic for BlogPostReadEventLogEntry and BlogPostViewedEventLogEntry. This ensures that data retrieved from storage models is correctly structured in the domain layer. Validation for created_on is omitted as it is model-specified.

Essential Checklist
[x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.

[x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.

[x] I have written tests for my code.

[x] The PR title starts with "Fix part of #21970: Add blog read and viewed event domain objects".

[x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@ankita240796 PTAL" if I can't assign them directly).

Proof that changes are correct
Proof of backend tests passing
This is a backend-only change. I have verified that the new domain objects and their validations work correctly by running the backend tests locally using the following command:
python -m scripts.run_backend_tests --module=core.domain.blog_domain_test

All tests for the new domain objects passed successfully.