### PR TITLE
Fix #25428: Handle concatenated search queries

### DIFF
--- a/core/platform/search/elastic_search_services.py
+++ b/core/platform/search/elastic_search_services.py
@@ -87,6 +87,17 @@ class ElasticSearchClient:
 ES = ElasticSearchClient()
 
 
+# The minimum length of a single-token query that triggers split-word
+# generation. This avoids splitting short acronyms or tiny words.
+_MIN_SINGLE_TOKEN_QUERY_LENGTH_FOR_SPLITS = 4
+# The maximum length of a query that triggers split-word generation.
+# A query of length N generates N-3 possible 2-way splits. This limit (50)
+# ensures we generate at most 47 'should' clauses, which is performant
+# and stays well within the default Elasticsearch 'max_clause_count' (1024)
+# while covering almost any practical search concatenation (>10 words).
+_MAX_SINGLE_TOKEN_QUERY_LENGTH_FOR_SPLITS = 50
+
+
 class SearchException(Exception):
     """Exception used when some search operation is unsuccessful."""
 
@@ -323,13 +334,9 @@ def search(
         ],
     }
     if query_string:
-        query_definition['query']['bool']['must'] = [
-            {
-                'multi_match': {
-                    'query': query_string,
-                }
-            }
-        ]
+        query_definition['query']['bool'].update(
+            _build_query_match_clauses(query_string)
+        )
     if categories:
         category_string = ' '.join(['"%s"' % cat for cat in categories])
         query_definition['query']['bool']['filter'].append(
@@ -408,16 +415,14 @@ def blog_post_summaries_search(
         ],
     }
     if query_string:
-        query_definition['query']['bool']['must'] = [
-            {
-                'multi_match': {
-                    'query': query_string,
-                    'fields': ['title', 'summary'],
-                    'type': 'bool_prefix',
-                    'operator': 'and',
-                }
-            }
-        ]
+        query_definition['query']['bool'].update(
+            _build_query_match_clauses(
+                query_string,
+                fields=['title', 'summary'],
+                match_type='bool_prefix',
+                operator='and',
+            )
+        )
     if tags:
         for tag in tags:
             query_definition['query']['bool']['filter'].append(
@@ -430,3 +435,63 @@ def blog_post_summaries_search(
     )
 
     return result_ids, resulting_offset
+
+
+def _build_query_match_clauses(
+    query_string: str,
+    fields: Optional[List[str]] = None,
+    match_type: Optional[str] = None,
+    operator: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Builds the 'must' or 'should' clauses for the given query string.
+
+    For single-token queries, this generates alternative 2-way splits to
+    handle concatenated keywords (e.g. "positivenumbers" -> "positive numbers").
+
+    Args:
+        query_string: str. The terms that the user is searching for.
+        fields: list(str)|None. The fields to search in.
+        match_type: str|None. The type of match (e.g. 'bool_prefix').
+        operator: str|None. The operator to use (e.g. 'and').
+
+    Returns:
+        dict(str, any). A dictionary containing either the 'must' or 'should'
+        Elasticsearch clauses.
+    """
+    multi_match_base: Dict[str, Any] = {
+        'query': query_string,
+    }
+    if fields:
+        multi_match_base['fields'] = fields
+    if match_type:
+        multi_match_base['type'] = match_type
+    if operator:
+        multi_match_base['operator'] = operator
+
+    # Single-token query (no spaces) of reasonable length.
+    if ' ' not in query_string and (
+        _MIN_SINGLE_TOKEN_QUERY_LENGTH_FOR_SPLITS
+        <= len(query_string)
+        <= _MAX_SINGLE_TOKEN_QUERY_LENGTH_FOR_SPLITS
+    ):
+        # Generate all possible 2-way splits.
+        # Examples: "abcde" -> "ab cde", "abc de", "abcd e".
+        # We require each fragment to be at least 2 chars long to avoid
+        # noisy one-letter splits like "p ositivenumbers".
+        splits = []
+        for i in range(2, len(query_string) - 1):
+            splits.append(f'{query_string[:i]} {query_string[i:]}')
+
+        # Build should clauses: the original query + all splits.
+        should_clauses = [{'multi_match': multi_match_base}]
+        for split_query in splits:
+            should_multi_match = multi_match_base.copy()
+            should_multi_match['query'] = split_query
+            should_clauses.append({'multi_match': should_multi_match})
+
+        return {
+            'should': should_clauses,
+            'minimum_should_match': 1,
+        }
+
+    return {'must': [{'multi_match': multi_match_base}]}

--- a/core/platform/search/elastic_search_services_test.py
+++ b/core/platform/search/elastic_search_services_test.py
@@ -215,7 +215,12 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 {
                     'query': {
                         'bool': {
-                            'must': [{'multi_match': {'query': 'query'}}],
+                            'should': [
+                                {'multi_match': {'query': 'query'}},
+                                {'multi_match': {'query': 'qu ery'}},
+                                {'multi_match': {'query': 'que ry'}},
+                            ],
+                            'minimum_should_match': 1,
                             'filter': [
                                 {
                                     'match': {
@@ -385,7 +390,7 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                 {
                     'query': {
                         'bool': {
-                            'must': [
+                            'should': [
                                 {
                                     'multi_match': {
                                         'query': 'query',
@@ -393,8 +398,25 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
                                         'type': 'bool_prefix',
                                         'operator': 'and',
                                     }
-                                }
+                                },
+                                {
+                                    'multi_match': {
+                                        'query': 'qu ery',
+                                        'fields': ['title', 'summary'],
+                                        'type': 'bool_prefix',
+                                        'operator': 'and',
+                                    }
+                                },
+                                {
+                                    'multi_match': {
+                                        'query': 'que ry',
+                                        'fields': ['title', 'summary'],
+                                        'type': 'bool_prefix',
+                                        'operator': 'and',
+                                    }
+                                },
                             ],
+                            'minimum_should_match': 1,
                             'filter': [
                                 {
                                     'match': {
@@ -472,3 +494,42 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
         )
         self.assertEqual(result, [])
         self.assertEqual(new_offset, None)
+
+    def test_build_query_match_clauses_boundary_splitting(self) -> None:
+        # A 50-character query should be split.
+        # Splits start at index 2 and end at len-2.
+        # For N=50, i ranges from 2 up to 48 (exclusive i.e. 2..47).
+        # range(2, 50 - 1) -> range(2, 49) -> 2, 3, ..., 48.
+        # That's 47 split points.
+        # Total clauses = 1 (original) + 47 (splits) = 48.
+        query_50 = 'a' * 50
+        clauses_50 = elastic_search_services._build_query_match_clauses(
+            query_50
+        )
+        self.assertIn('should', clauses_50)
+        self.assertEqual(len(clauses_50['should']), 48)
+
+        # A 51-character query should NOT be split.
+        query_51 = 'a' * 51
+        clauses_51 = elastic_search_services._build_query_match_clauses(
+            query_51
+        )
+        self.assertIn('must', clauses_51)
+        self.assertEqual(len(clauses_51['must']), 1)
+        self.assertEqual(
+            clauses_51['must'][0]['multi_match']['query'], query_51
+        )
+
+        # Short query (3 chars) should NOT be split.
+        query_3 = 'abc'
+        clauses_3 = elastic_search_services._build_query_match_clauses(query_3)
+        self.assertIn('must', clauses_3)
+        self.assertEqual(len(clauses_3['must']), 1)
+
+        # Query with space should NOT be split.
+        query_space = 'hello world'
+        clauses_space = elastic_search_services._build_query_match_clauses(
+            query_space
+        )
+        self.assertIn('must', clauses_space)
+        self.assertEqual(len(clauses_space['must']), 1)


### PR DESCRIPTION
## Overview

1. This PR fixes #25428 .
2. This PR does the following: 
   - Implements a backend query preprocessing strategy in the Elasticsearch service to handle concatenated search queries (e.g., "positivenumbers").
   - When a single-token query (no spaces) of length 4–50 is detected, the service generates alternative 2-way split variations (e.g., "positive numbers", "positiv enumbers", etc.).
   - These variations are added as `should` clauses in a boolean query, allowing Elasticsearch to find matches for the individual keywords even if the user omitted the space.
   - The logic is integrated into both the general exploration search and the blog post search while preserving advanced query parameters like `bool_prefix` and `operator: and`.
   - Added performance guards and boundary tests to ensure the generated query stays within Elasticsearch's `max_clause_count`.
3.  The original bug occurred because: 
 - Users occasionally search for multiple keywords without spaces. By default, Elasticsearch treats "positivenumbers" as a single distinct token, which fails to match the indexed tokens "positive" and "numbers". This PR solves the issue at the query level without requiring complex index mapping changes.


## Essential Checklist

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

https://github.com/user-attachments/assets/4054e612-7529-4dc6-aaa1-cb4f39fb7dfd

#### Proof of changes on desktop with slow/throttled network

https://drive.google.com/file/d/1C3x1TwTvY0I4n5MG6K3ji28NYBoMenwS/view?usp=sharing

#### Proof of changes on mobile phone

https://drive.google.com/file/d/1O6nDMHW_mo4CzY9p5-vnnDemnTnobDvs/view?usp=drive_link

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
