### PR TITLE
Fix #13689: NumericExpression division symbol display per customization arg

### DIFF
--- a/core/templates/services/exploration-html-formatter.service.spec.ts
+++ b/core/templates/services/exploration-html-formatter.service.spec.ts
@@ -253,10 +253,6 @@ describe('Exploration Html Formatter Service', () => {
         'answer="&amp;quot;2÷5&amp;quot;">' +
         '</oppia-response-numeric-expression-input>';
 
-      // This throws "Type '{ value: boolean; }' is not assignable to type
-      // 'boolean'". We need to suppress this error because runtime data can
-      // still be object-shaped for this customization arg.
-      // @ts-expect-error
       expect(
         ehfs.getAnswerHtml(answer, interactionId, interactionCustomizationArgs)
       ).toBe(expectedHtmlTag);
@@ -350,10 +346,6 @@ describe('Exploration Html Formatter Service', () => {
         'answer="&amp;quot;2/5&amp;quot;">' +
         '</oppia-short-response-numeric-expression-input>';
 
-      // This throws "Type '{ value: boolean; }' is not assignable to type
-      // 'boolean'". We need to suppress this error because runtime data can
-      // still be object-shaped for this customization arg.
-      // @ts-expect-error
       expect(
         ehfs.getShortAnswerHtml(
           answer,

--- a/core/templates/services/exploration-html-formatter.service.spec.ts
+++ b/core/templates/services/exploration-html-formatter.service.spec.ts
@@ -217,6 +217,68 @@ describe('Exploration Html Formatter Service', () => {
     }
   );
 
+  it(
+    'should not replace slash with division sign in answer HTML for ' +
+      'NumericExpressionInput when useFractionForDivision is true',
+    () => {
+      const interactionId = 'NumericExpressionInput';
+      const answer = '2/5';
+      const interactionCustomizationArgs = {
+        useFractionForDivision: true,
+        placeholder: {value: new SubtitledUnicode('', '')},
+      };
+      const expectedHtmlTag =
+        '<oppia-response-numeric-expression-input ' +
+        'answer="&amp;quot;2/5&amp;quot;">' +
+        '</oppia-response-numeric-expression-input>';
+
+      expect(
+        ehfs.getAnswerHtml(answer, interactionId, interactionCustomizationArgs)
+      ).toBe(expectedHtmlTag);
+    }
+  );
+
+  it(
+    'should support object-shaped useFractionForDivision in answer HTML ' +
+      'for NumericExpressionInput',
+    () => {
+      const interactionId = 'NumericExpressionInput';
+      const answer = '2/5';
+      const interactionCustomizationArgs = {
+        useFractionForDivision: {value: false},
+        placeholder: {value: new SubtitledUnicode('', '')},
+      };
+      const expectedHtmlTag =
+        '<oppia-response-numeric-expression-input ' +
+        'answer="&amp;quot;2÷5&amp;quot;">' +
+        '</oppia-response-numeric-expression-input>';
+
+      // This throws "Type '{ value: boolean; }' is not assignable to type
+      // 'boolean'". We need to suppress this error because runtime data can
+      // still be object-shaped for this customization arg.
+      // @ts-expect-error
+      expect(
+        ehfs.getAnswerHtml(answer, interactionId, interactionCustomizationArgs)
+      ).toBe(expectedHtmlTag);
+    }
+  );
+
+  it('should not replace answer when NumericExpressionInput answer is non-string', () => {
+    const interactionId = 'NumericExpressionInput';
+    const answer = 5;
+    const interactionCustomizationArgs = {
+      useFractionForDivision: false,
+      placeholder: {value: new SubtitledUnicode('', '')},
+    };
+    const expectedHtmlTag =
+      '<oppia-response-numeric-expression-input ' +
+      'answer="5"></oppia-response-numeric-expression-input>';
+
+    expect(
+      ehfs.getAnswerHtml(answer, interactionId, interactionCustomizationArgs)
+    ).toBe(expectedHtmlTag);
+  });
+
   it('should throw error when interaction id is null', () => {
     expect(() => {
       ehfs.getAnswerHtml('sampleAnswer', null, {});
@@ -263,6 +325,35 @@ describe('Exploration Html Formatter Service', () => {
         'answer="&amp;quot;2÷5&amp;quot;">' +
         '</oppia-short-response-numeric-expression-input>';
 
+      expect(
+        ehfs.getShortAnswerHtml(
+          answer,
+          interactionId,
+          interactionCustomizationArgs
+        )
+      ).toBe(expectedHtmlTag);
+    }
+  );
+
+  it(
+    'should support object-shaped useFractionForDivision in short answer HTML ' +
+      'for NumericExpressionInput',
+    () => {
+      const interactionId = 'NumericExpressionInput';
+      const answer = '2/5';
+      const interactionCustomizationArgs = {
+        useFractionForDivision: {value: true},
+        placeholder: {value: new SubtitledUnicode('', '')},
+      };
+      const expectedHtmlTag =
+        '<oppia-short-response-numeric-expression-input ' +
+        'answer="&amp;quot;2/5&amp;quot;">' +
+        '</oppia-short-response-numeric-expression-input>';
+
+      // This throws "Type '{ value: boolean; }' is not assignable to type
+      // 'boolean'". We need to suppress this error because runtime data can
+      // still be object-shaped for this customization arg.
+      // @ts-expect-error
       expect(
         ehfs.getShortAnswerHtml(
           answer,

--- a/core/templates/services/exploration-html-formatter.service.spec.ts
+++ b/core/templates/services/exploration-html-formatter.service.spec.ts
@@ -197,6 +197,26 @@ describe('Exploration Html Formatter Service', () => {
     ).toBe(expectedHtmlTag);
   });
 
+  it(
+    'should set division sign in answer HTML for ' + 'NumericExpressionInput',
+    () => {
+      const interactionId = 'NumericExpressionInput';
+      const answer = '2/5';
+      const interactionCustomizationArgs = {
+        useFractionForDivision: false,
+        placeholder: {value: new SubtitledUnicode('', '')},
+      };
+      const expectedHtmlTag =
+        '<oppia-response-numeric-expression-input ' +
+        'answer="&amp;quot;2÷5&amp;quot;">' +
+        '</oppia-response-numeric-expression-input>';
+
+      expect(
+        ehfs.getAnswerHtml(answer, interactionId, interactionCustomizationArgs)
+      ).toBe(expectedHtmlTag);
+    }
+  );
+
   it('should throw error when interaction id is null', () => {
     expect(() => {
       ehfs.getAnswerHtml('sampleAnswer', null, {});
@@ -227,4 +247,29 @@ describe('Exploration Html Formatter Service', () => {
       )
     ).toBe(expectedHtmlTag);
   });
+
+  it(
+    'should set division sign in short answer HTML for ' +
+      'NumericExpressionInput',
+    () => {
+      const interactionId = 'NumericExpressionInput';
+      const answer = '2/5';
+      const interactionCustomizationArgs = {
+        useFractionForDivision: false,
+        placeholder: {value: new SubtitledUnicode('', '')},
+      };
+      const expectedHtmlTag =
+        '<oppia-short-response-numeric-expression-input ' +
+        'answer="&amp;quot;2÷5&amp;quot;">' +
+        '</oppia-short-response-numeric-expression-input>';
+
+      expect(
+        ehfs.getShortAnswerHtml(
+          answer,
+          interactionId,
+          interactionCustomizationArgs
+        )
+      ).toBe(expectedHtmlTag);
+    }
+  );
 });

--- a/core/templates/services/exploration-html-formatter.service.ts
+++ b/core/templates/services/exploration-html-formatter.service.ts
@@ -60,6 +60,32 @@ export class ExplorationHtmlFormatterService {
     private htmlEscaper: HtmlEscaperService
   ) {}
 
+  private getDisplayedNumericExpressionAnswer(
+    answer: InteractionAnswer,
+    interactionId: string,
+    interactionCustomizationArgs: InteractionCustomizationArgs
+  ): InteractionAnswer {
+    if (
+      interactionId !== 'NumericExpressionInput' ||
+      !('useFractionForDivision' in interactionCustomizationArgs) ||
+      typeof answer !== 'string'
+    ) {
+      return answer;
+    }
+    const useFractionForDivision =
+      interactionCustomizationArgs.useFractionForDivision as
+        | boolean
+        | {value: boolean};
+    const shouldUseFraction =
+      typeof useFractionForDivision === 'boolean'
+        ? useFractionForDivision
+        : useFractionForDivision.value;
+    if (shouldUseFraction) {
+      return answer;
+    }
+    return answer.replace(/\//g, '÷');
+  }
+
   /**
    * @param {string} interactionId - The interaction id.
    * @param {object} interactionCustomizationArgs - The various
@@ -166,10 +192,18 @@ export class ExplorationHtmlFormatterService {
     if (interactionId === null) {
       throw new Error('InteractionId cannot be null');
     }
+    const displayedAnswer = this.getDisplayedNumericExpressionAnswer(
+      answer,
+      interactionId,
+      interactionCustomizationArgs
+    );
     var element = document.createElement(
       `oppia-response-${this.camelCaseToHyphens.transform(interactionId)}`
     );
-    element.setAttribute('answer', this.htmlEscaper.objToEscapedJson(answer));
+    element.setAttribute(
+      'answer',
+      this.htmlEscaper.objToEscapedJson(displayedAnswer)
+    );
     // TODO(sll): Get rid of this special case for multiple choice.
     if ('choices' in interactionCustomizationArgs) {
       let interactionChoices = interactionCustomizationArgs.choices.value;
@@ -186,10 +220,18 @@ export class ExplorationHtmlFormatterService {
     interactionId: string,
     interactionCustomizationArgs: InteractionCustomizationArgs
   ): string {
+    const displayedAnswer = this.getDisplayedNumericExpressionAnswer(
+      answer,
+      interactionId,
+      interactionCustomizationArgs
+    );
     let element = document.createElement(
       `oppia-short-response-${this.camelCaseToHyphens.transform(interactionId)}`
     );
-    element.setAttribute('answer', this.htmlEscaper.objToEscapedJson(answer));
+    element.setAttribute(
+      'answer',
+      this.htmlEscaper.objToEscapedJson(displayedAnswer)
+    );
     // TODO(sll): Get rid of this special case for multiple choice.
     if ('choices' in interactionCustomizationArgs) {
       let interactionChoices = interactionCustomizationArgs.choices.value;

--- a/core/templates/services/guppy-configuration.service.spec.ts
+++ b/core/templates/services/guppy-configuration.service.spec.ts
@@ -74,6 +74,9 @@ describe('GuppyConfigurationService', () => {
   beforeEach(() => {
     guppyConfigurationService = TestBed.inject(GuppyConfigurationService);
     window.Guppy = MockGuppy as unknown as Guppy;
+    Guppy.kb = {
+      k_syms: {},
+    } as unknown as Object;
   });
 
   describe('Individual service', () => {
@@ -94,6 +97,50 @@ describe('GuppyConfigurationService', () => {
       spyOn(Guppy, 'remove_global_symbol');
       guppyConfigurationService.init();
       expect(Guppy.remove_global_symbol).not.toHaveBeenCalled();
+    });
+
+    it('should configure slash symbol when value is true', () => {
+      spyOn(Guppy, 'add_global_symbol');
+      guppyConfigurationService.changeDivSymbol(true);
+
+      expect(Guppy.add_global_symbol).toHaveBeenCalledWith(
+        '/',
+        jasmine.objectContaining({
+          attrs: jasmine.objectContaining({
+            type: 'fraction',
+          }),
+        })
+      );
+    });
+
+    it('should configure division symbol when value is false', () => {
+      spyOn(Guppy, 'add_global_symbol');
+      guppyConfigurationService.changeDivSymbol({value: false});
+
+      expect(Guppy.add_global_symbol).toHaveBeenCalledWith(
+        '/',
+        jasmine.objectContaining({
+          output: jasmine.objectContaining({
+            latex: '\\div',
+          }),
+        })
+      );
+    });
+
+    it('should use fraction shortcut when value is true', () => {
+      guppyConfigurationService.changeDivSymbol(true);
+
+      expect((Guppy.kb as {k_syms: Record<string, string>}).k_syms['/']).toBe(
+        'fraction'
+      );
+    });
+
+    it('should use slash shortcut when value is false', () => {
+      guppyConfigurationService.changeDivSymbol(false);
+
+      expect((Guppy.kb as {k_syms: Record<string, string>}).k_syms['/']).toBe(
+        '/'
+      );
     });
   });
 });

--- a/core/templates/services/guppy-configuration.service.ts
+++ b/core/templates/services/guppy-configuration.service.ts
@@ -60,8 +60,8 @@ const MULTIPLICATION_SYMBOL_DICT = {
 
 const FRACTION_SYMBOL_DICT = {
   output: {
-    latex: '\\frac{{$1}}{{$2}}',
-    small_latex: '\\frac{{$1}}{{$2}}',
+    latex: '{{$1}}/{{$2}}',
+    small_latex: '{{$1}}/{{$2}}',
     asciimath: '({$1})/({$2})',
     text: '({$1})/({$2})',
   },
@@ -133,9 +133,19 @@ export class GuppyConfigurationService {
   }
 
   changeDivSymbol(useFraction: boolean | {value: boolean} = false): void {
+    const shouldUseFraction =
+      typeof useFraction === 'boolean' ? useFraction : useFraction.value;
     Guppy.add_global_symbol(
       '/',
-      useFraction ? FRACTION_SYMBOL_DICT : DIVISION_SYMBOL_DICT
+      shouldUseFraction ? FRACTION_SYMBOL_DICT : DIVISION_SYMBOL_DICT
     );
+    const guppyKeyboardShortcuts = Guppy.kb as
+      | {
+          k_syms?: Record<string, string>;
+        }
+      | undefined;
+    if (guppyKeyboardShortcuts?.k_syms) {
+      guppyKeyboardShortcuts.k_syms['/'] = shouldUseFraction ? 'fraction' : '/';
+    }
   }
 }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #13689 
2. This PR does the following: It fixes NumericExpressionInput division-symbol handling so useFractionForDivision is applied per state correctly. Specifically, it updates GuppyConfigurationService.changeDivSymbol() to handle both boolean and { value: boolean } inputs (instead of treating any object as truthy), updates Guppy keyboard mapping accordingly, and ensures submitted NumericExpression answers in transcript/answer bubbles render ÷ when useFractionForDivision is false (while keeping fraction-style rendering for true).

3. (For bug-fixing PRs only) The original bug occurred because: useFractionForDivision was being passed through as a wrapped object ({ value: boolean }) in the migrated interaction path, but changeDivSymbol() effectively treated it as a plain boolean. Since non-null objects are truthy, the division symbol config was forced into fraction mode globally for that interaction flow. The regression that caused this behavior in current code was introduced in PR #16597 (commit d106dcf206, where the previous .value extraction was removed when calling changeDivSymbol).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Before :

https://github.com/user-attachments/assets/02b82d71-d9b1-4986-9e92-17e8596c010f

After:


https://github.com/user-attachments/assets/8833a63b-332e-4fd8-beff-c4d1c0e6d07c


#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


