### PR TITLE
Fix #21970: Add BlogPostReadEventLogEntry domain object and tests

### DIFF
--- a/core/domain/blog_domain.py
+++ b/core/domain/blog_domain.py
@@ -848,3 +848,30 @@ class BlogAuthorDetails:
                 'Expected Author Bio to be a string,'
                 ' received %s' % self.author_bio
             )
+
+
+class BlogPostReadEventLogEntry:
+    """Domain object for a blog post read event log entry."""
+
+    def __init__(self, blog_post_id, created_on):
+        """Initializes a BlogPostReadEventLogEntry domain object.
+
+        Args:
+            blog_post_id: str. The unique ID of the blog post that was read.
+            created_on: datetime.datetime. The timestamp when the read event
+                occurred.
+        """
+        self.blog_post_id = blog_post_id
+        self.created_on = created_on
+
+    def validate(self):
+        """Validates the blog post read event log entry."""
+        if not isinstance(self.blog_post_id, str):
+            raise utils.ValidationError(
+                'Expected blog_post_id to be a string, received %s'
+                % self.blog_post_id)
+        if not self.blog_post_id:
+            raise utils.ValidationError(
+                'Expected blog_post_id to be non-empty.')
+
+

--- a/core/domain/blog_domain_test.py
+++ b/core/domain/blog_domain_test.py
@@ -872,3 +872,41 @@ class BlogAuthorDetailsTests(test_utils.GenericTestBase):
             ' received %s' % self.author_details.author_bio,
         ):
             self.author_details.validate()
+
+
+class BlogPostReadEventLogEntryTests(test_utils.GenericTestBase):
+    """Tests for BlogPostReadEventLogEntry domain object."""
+
+    def test_valid_entry_passes_validation(self) -> None:
+        """Tests that a valid entry passes validation."""
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id='valid_id',
+            created_on=datetime.datetime.utcnow()
+        )
+        entry.validate()
+
+    def test_validate_raises_if_blog_post_id_not_string(self) -> None:
+        """Tests that validate raises if blog_post_id is not a string."""
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id=123,
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be a string'
+        ):
+            entry.validate()
+
+    def test_validate_raises_if_blog_post_id_is_empty(self) -> None:
+        """Tests that validate raises if blog_post_id is empty."""
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id='',
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be non-empty'
+        ):
+            entry.validate()
+
+


### PR DESCRIPTION
## Overview

1. This PR fixes #21970
2. This PR adds a new domain object BlogPostReadEventLogEntry to 
blog_domain.py along with its corresponding unit tests in 
blog_domain_test.py. This object represents an event for when a 
blog post is read and includes validation logic for its fields.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" 
section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the 
changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: "
- [x] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

No proof of changes needed because this PR only adds backend domain 
objects with no user-facing UI changes.
blog domain,py
<img width="519" height="367" alt="image" src="https://github.com/user-attachments/assets/9e534540-5bd9-4888-9bc3-3d230ed7826b" />
blog_domain_test.py
<img width="517" height="327" alt="image" src="https://github.com/user-attachments/assets/caa4ea2d-424e-4f0a-8aec-5b3120b61c27" />

<img width="558" height="421" alt="image" src="https://github.com/user-attachments/assets/8fc6a054-5d18-4286-be62-7c683600ca52" />



##proof that changes are correct
No proof of changes needed because this PR only adds backend domain 
objects with no user-facing UI changes.