### PR TITLE
Fix #21970: Add BlogPostViewedEventLogEntry domain object and tests

### DIFF
--- a/core/domain/blog_domain.py
+++ b/core/domain/blog_domain.py
@@ -848,3 +848,59 @@ class BlogAuthorDetails:
                 'Expected Author Bio to be a string,'
                 ' received %s' % self.author_bio
             )
+
+
+class BlogPostReadEventLogEntry:
+    """Domain object for a blog post read event log entry."""
+
+    def __init__(self, blog_post_id, created_on):
+        """Initializes a BlogPostReadEventLogEntry domain object.
+
+        Args:
+            blog_post_id: str. The unique ID of the blog post that was read.
+            created_on: datetime.datetime. The timestamp when the read event
+                occurred.
+        """
+        self.blog_post_id = blog_post_id
+        self.created_on = created_on
+
+    def validate(self):
+        """Validates the blog post read event log entry."""
+        if not isinstance(self.blog_post_id, str):
+            raise utils.ValidationError(
+                'Expected blog_post_id to be a string, received %s'
+                % self.blog_post_id)
+        if not self.blog_post_id:
+            raise utils.ValidationError(
+                'Expected blog_post_id to be non-empty.')
+
+
+class BlogPostViewedEventLogEntry:
+    """Domain object for a blog post viewed event log entry."""
+
+    def __init__(self, blog_post_id, user_id, created_on):
+        """Initializes a BlogPostViewedEventLogEntry domain object.
+
+        Args:
+            blog_post_id: str. The unique ID of the blog post that was viewed.
+            user_id: str. The ID of the user who viewed the blog post.
+            created_on: datetime.datetime. The timestamp when the view event
+                occurred.
+        """
+        self.blog_post_id = blog_post_id
+        self.user_id = user_id
+        self.created_on = created_on
+
+    def validate(self):
+        """Validates the blog post viewed event log entry."""
+        if not isinstance(self.blog_post_id, str):
+            raise utils.ValidationError(
+                'Expected blog_post_id to be a string, received %s'
+                % self.blog_post_id)
+        if not self.blog_post_id:
+            raise utils.ValidationError(
+                'Expected blog_post_id to be non-empty.')
+        if not isinstance(self.user_id, str):
+            raise utils.ValidationError(
+                'Expected user_id to be a string, received %s'
+                % self.user_id)

--- a/core/domain/blog_domain_test.py
+++ b/core/domain/blog_domain_test.py
@@ -872,3 +872,91 @@ class BlogAuthorDetailsTests(test_utils.GenericTestBase):
             ' received %s' % self.author_details.author_bio,
         ):
             self.author_details.validate()
+
+
+class BlogPostReadEventLogEntryTests(test_utils.GenericTestBase):
+    """Tests for BlogPostReadEventLogEntry domain object."""
+
+    def test_valid_entry_passes_validation(self) -> None:
+        """Tests that a valid entry passes validation."""
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id='valid_id',
+            created_on=datetime.datetime.utcnow()
+        )
+        entry.validate()
+
+    def test_validate_raises_if_blog_post_id_not_string(self) -> None:
+        """Tests that validate raises if blog_post_id is not a string."""
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id=123,
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be a string'
+        ):
+            entry.validate()
+
+    def test_validate_raises_if_blog_post_id_is_empty(self) -> None:
+        """Tests that validate raises if blog_post_id is empty."""
+        entry = blog_domain.BlogPostReadEventLogEntry(
+            blog_post_id='',
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be non-empty'
+        ):
+            entry.validate()
+
+
+class BlogPostViewedEventLogEntryTests(test_utils.GenericTestBase):
+    """Tests for BlogPostViewedEventLogEntry domain object."""
+
+    def test_valid_entry_passes_validation(self) -> None:
+        """Tests that a valid entry passes validation."""
+        entry = blog_domain.BlogPostViewedEventLogEntry(
+            blog_post_id='valid_id',
+            user_id='valid_user_id',
+            created_on=datetime.datetime.utcnow()
+        )
+        entry.validate()
+
+    def test_validate_raises_if_blog_post_id_not_string(self) -> None:
+        """Tests that validate raises if blog_post_id is not a string."""
+        entry = blog_domain.BlogPostViewedEventLogEntry(
+            blog_post_id=123,
+            user_id='valid_user_id',
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be a string'
+        ):
+          entry.validate()
+
+    def test_validate_raises_if_blog_post_id_is_empty(self) -> None:
+        """Tests that validate raises if blog_post_id is empty."""
+        entry = blog_domain.BlogPostViewedEventLogEntry(
+            blog_post_id='',
+            user_id='valid_user_id',
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected blog_post_id to be non-empty'
+        ):
+          entry.validate()
+
+    def test_validate_raises_if_user_id_not_string(self) -> None:
+        """Tests that validate raises if user_id is not a string."""
+        entry = blog_domain.BlogPostViewedEventLogEntry(
+            blog_post_id='valid_id',
+            user_id=123,
+            created_on=datetime.datetime.utcnow()
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected user_id to be a string'
+        ):
+          entry.validate()


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21970
2. This PR adds a new domain object BlogPostViewedEventLogEntry to 
blog_domain.py along with its corresponding unit tests in 
blog_domain_test.py. This object represents an event for when a 
blog post is viewed by a user and includes validation logic for 
its fields.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" 
section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the 
changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix part of #bugnum: "
- [x] I have assigned the correct reviewers to this PR.


## proof of changes
blog_domain.py
<img width="481" height="455" alt="domain viewed" src="https://github.com/user-attachments/assets/a016b83c-0895-47e8-9e8d-9983671c0ce4" />
blog_domain_test.py
<img width="608" height="352" alt="test 1" src="https://github.com/user-attachments/assets/cf64fb56-45a5-4c14-98f4-8157acc5f632" />
<img width="475" height="461" alt="test 2" src="https://github.com/user-attachments/assets/ac7cc817-6988-403e-9f98-d97ca022860a" />



## Proof that changes are correct

No proof of changes needed because this PR only adds backend domain 
objects with no user-facing UI changes.