### PR TITLE
Fix #23864: Speed Up Backend Tests Python Package Installation

### DIFF
--- a/scripts/install_python_dev_dependencies.py
+++ b/scripts/install_python_dev_dependencies.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import hashlib
+import json
 import os
 import subprocess
 import sys
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 INSTALLATION_TOOL_VERSIONS = {
     'pip': '25.3',
@@ -33,6 +35,7 @@ INSTALLATION_TOOL_VERSIONS = {
 }
 REQUIREMENTS_DEV_FILE_PATH = 'requirements_dev.in'
 COMPILED_REQUIREMENTS_DEV_FILE_PATH = 'requirements_dev.txt'
+PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH = 'pip_requirements_checksums.json'
 
 _PARSER = argparse.ArgumentParser('Install Python development dependencies')
 _PARSER.add_argument(
@@ -116,6 +119,93 @@ def install_dev_dependencies() -> None:
     )
 
 
+def _get_file_checksum(file_path: str) -> str:
+    """Returns the SHA256 checksum of the given file.
+
+    Args:
+        file_path: str. Path to the file whose checksum should be calculated.
+
+    Returns:
+        str. The SHA256 checksum of the file.
+    """
+    hash_obj = hashlib.sha256()
+    with open(file_path, 'rb') as f:
+        for chunk in iter(lambda: f.read(4096), b''):
+            hash_obj.update(chunk)
+    return hash_obj.hexdigest()
+
+
+def _read_pip_requirements_checksums() -> Dict[str, str]:
+    """Reads the cached requirements file checksums."""
+    if not os.path.exists(PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH):
+        return {}
+
+    try:
+        with open(
+            PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH, 'r', encoding='utf-8'
+        ) as f:
+            checksum_dict = json.load(f)
+    except json.JSONDecodeError:
+        return {}
+
+    if not isinstance(checksum_dict, dict):
+        return {}
+
+    return {
+        str(requirements_path): str(checksum)
+        for requirements_path, checksum in checksum_dict.items()
+    }
+
+
+def _write_pip_requirements_checksums(checksum_dict: Dict[str, str]) -> None:
+    """Writes the cached requirements file checksums."""
+    with open(PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH, 'w', encoding='utf-8') as f:
+        json.dump(checksum_dict, f, indent=2, sort_keys=True)
+        f.write('\n')
+
+
+def should_skip_dependency_install(
+    requirements_path: str, compiled_path: str
+) -> bool:
+    """Checks whether dependency installation can be skipped.
+
+    Dependency installation is skipped only after a previous successful
+    installation recorded a checksum matching the current requirements input
+    file.
+
+    Args:
+        requirements_path: str. Path to the requirements input file.
+        compiled_path: str. Path to the compiled requirements file.
+
+    Returns:
+        bool. Whether dependency installation can be skipped.
+    """
+    if not os.path.exists(compiled_path):
+        return False
+
+    checksum_dict = _read_pip_requirements_checksums()
+    return checksum_dict.get(requirements_path) == _get_file_checksum(
+        requirements_path
+    )
+
+
+def update_pip_requirements_checksum(requirements_path: str) -> None:
+    """Updates the cached checksum for a requirements input file."""
+    checksum_dict = _read_pip_requirements_checksums()
+    checksum_dict[requirements_path] = _get_file_checksum(requirements_path)
+    _write_pip_requirements_checksums(checksum_dict)
+
+
+def remove_pip_requirements_checksum(requirements_path: str) -> None:
+    """Removes the cached checksum for a requirements input file."""
+    checksum_dict = _read_pip_requirements_checksums()
+    if requirements_path not in checksum_dict:
+        return
+
+    del checksum_dict[requirements_path]
+    _write_pip_requirements_checksums(checksum_dict)
+
+
 def uninstall_dev_dependencies() -> None:
     """Uninstall dev dependencies from COMPILED_REQUIREMENTS_DEV_FILE_PATH."""
     subprocess.run(
@@ -193,12 +283,19 @@ def main(cli_args: Optional[List[str]] = None) -> None:
     """Install all dev dependencies."""
     args = _PARSER.parse_args(cli_args)
     check_python_env_is_suitable()
+
+    if not args.uninstall and should_skip_dependency_install(
+        REQUIREMENTS_DEV_FILE_PATH, COMPILED_REQUIREMENTS_DEV_FILE_PATH
+    ):
+        return
+
     install_installation_tools()
     diff = compile_pip_requirements(
         REQUIREMENTS_DEV_FILE_PATH, COMPILED_REQUIREMENTS_DEV_FILE_PATH
     )
     if args.uninstall:
         uninstall_dev_dependencies()
+        remove_pip_requirements_checksum(REQUIREMENTS_DEV_FILE_PATH)
     else:
         install_dev_dependencies()
         if args.assert_compiled and diff:
@@ -210,6 +307,7 @@ def main(cli_args: Optional[List[str]] = None) -> None:
                 'command: python -m scripts.install_python_dev_dependencies'
                 % diff
             )
+        update_pip_requirements_checksum(REQUIREMENTS_DEV_FILE_PATH)
 
 
 # This code cannot be covered by tests since it only runs when this file

--- a/scripts/install_python_dev_dependencies_test.py
+++ b/scripts/install_python_dev_dependencies_test.py
@@ -24,6 +24,7 @@ import io
 import os
 import subprocess
 import sys
+import tempfile
 
 from core.tests import test_utils
 from scripts import install_python_dev_dependencies
@@ -32,6 +33,26 @@ from typing import Dict, Generator, List, Optional
 
 
 class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.checksum_temp_dir = tempfile.TemporaryDirectory()
+        self.original_pip_requirements_checksums_file_path = (
+            install_python_dev_dependencies.PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH
+        )
+        install_python_dev_dependencies.PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH = (
+            os.path.join(
+                self.checksum_temp_dir.name,
+                'pip_requirements_checksums.json',
+            )
+        )
+
+    def tearDown(self) -> None:
+        install_python_dev_dependencies.PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH = (
+            self.original_pip_requirements_checksums_file_path
+        )
+        self.checksum_temp_dir.cleanup()
+        super().tearDown()
 
     @contextlib.contextmanager
     def sys_real_prefix_context(
@@ -324,6 +345,98 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             )
         self.assertTrue(change)
 
+    def test_should_skip_dependency_install_uses_cached_checksum(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            requirements_path = os.path.join(temp_dir, 'requirements.in')
+            compiled_path = os.path.join(temp_dir, 'requirements.txt')
+            checksum_path = os.path.join(
+                temp_dir, 'pip_requirements_checksums.json'
+            )
+            with open(requirements_path, 'w', encoding='utf-8') as f:
+                f.write('flask==1.0.0\n')
+            with open(compiled_path, 'w', encoding='utf-8') as f:
+                f.write('flask==1.0.0\n')
+
+            checksum_path_swap = self.swap(
+                install_python_dev_dependencies,
+                'PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH',
+                checksum_path,
+            )
+
+            with checksum_path_swap:
+                self.assertFalse(
+                    install_python_dev_dependencies.should_skip_dependency_install(
+                        requirements_path, compiled_path
+                    )
+                )
+                install_python_dev_dependencies.update_pip_requirements_checksum(
+                    requirements_path
+                )
+                self.assertTrue(
+                    install_python_dev_dependencies.should_skip_dependency_install(
+                        requirements_path, compiled_path
+                    )
+                )
+
+                with open(requirements_path, 'w', encoding='utf-8') as f:
+                    f.write('flask==2.0.0\n')
+                self.assertFalse(
+                    install_python_dev_dependencies.should_skip_dependency_install(
+                        requirements_path, compiled_path
+                    )
+                )
+
+    def test_main_skips_install_when_requirements_checksum_matches(
+        self,
+    ) -> None:
+        install_tools_calls = []
+        compile_calls = []
+        install_dependencies_calls = []
+
+        def mock_install_tools() -> None:
+            install_tools_calls.append(True)
+
+        def mock_compile(*_args: str) -> bool:
+            compile_calls.append(True)
+            return False
+
+        def mock_install_dependencies() -> None:
+            install_dependencies_calls.append(True)
+
+        assert_swap = self.swap(
+            install_python_dev_dependencies,
+            'check_python_env_is_suitable',
+            lambda: None,
+        )
+        skip_swap = self.swap(
+            install_python_dev_dependencies,
+            'should_skip_dependency_install',
+            lambda *_args: True,
+        )
+        install_tools_swap = self.swap(
+            install_python_dev_dependencies,
+            'install_installation_tools',
+            mock_install_tools,
+        )
+        compile_swap = self.swap(
+            install_python_dev_dependencies,
+            'compile_pip_requirements',
+            mock_compile,
+        )
+        install_dependencies_swap = self.swap(
+            install_python_dev_dependencies,
+            'install_dev_dependencies',
+            mock_install_dependencies,
+        )
+
+        with assert_swap, skip_swap, install_tools_swap, compile_swap:
+            with install_dependencies_swap:
+                install_python_dev_dependencies.main([])
+
+        self.assertEqual(install_tools_calls, [])
+        self.assertEqual(compile_calls, [])
+        self.assertEqual(install_dependencies_calls, [])
+
     def test_main_passes_with_no_assert_and_no_change(self) -> None:
         def mock_func() -> None:
             pass
@@ -351,7 +464,6 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             'install_dev_dependencies',
             mock_func,
         )
-
         with assert_swap, install_tools_swap, compile_swap:
             with install_dependencies_swap:
                 install_python_dev_dependencies.main([])
@@ -380,7 +492,6 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             'uninstall_dev_dependencies',
             lambda: None,
         )
-
         with assert_swap, install_tools_swap, compile_swap:
             with uninstall_dependencies_swap:
                 install_python_dev_dependencies.main(['--uninstall'])
@@ -412,7 +523,6 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             'install_dev_dependencies',
             mock_func,
         )
-
         with assert_swap, install_tools_swap, compile_swap:
             with install_dependencies_swap:
                 install_python_dev_dependencies.main(['--assert_compiled'])
@@ -444,7 +554,6 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             'install_dev_dependencies',
             mock_func,
         )
-
         with assert_swap, install_tools_swap, compile_swap:
             with install_dependencies_swap:
                 install_python_dev_dependencies.main([])
@@ -476,7 +585,6 @@ class InstallPythonDevDependenciesTests(test_utils.GenericTestBase):
             'install_dev_dependencies',
             mock_func,
         )
-
         error_regex = (
             'The Python development requirements file '
             'requirements_dev.txt was changed'

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -731,6 +731,11 @@ def main() -> None:
     mismatches, regenerate the 'requirements.txt' file and correct the
     mismatches.
     """
+    if install_python_dev_dependencies.should_skip_dependency_install(
+        'requirements.in', 'requirements.txt'
+    ) and os.path.isdir(common.THIRD_PARTY_PYTHON_LIBS_DIR):
+        return
+
     verify_pip_is_installed()
     print('Regenerating "requirements.txt" file...')
     install_python_dev_dependencies.compile_pip_requirements(
@@ -746,6 +751,10 @@ def main() -> None:
         print(
             'All third-party Python libraries are already installed correctly.'
         )
+
+    install_python_dev_dependencies.update_pip_requirements_checksum(
+        'requirements.in'
+    )
 
 
 # The 'no coverage' pragma is used as this line is un-testable. This is because

--- a/scripts/install_python_prod_dependencies_test.py
+++ b/scripts/install_python_prod_dependencies_test.py
@@ -30,7 +30,12 @@ import sys
 import tempfile
 
 from core.tests import test_utils
-from scripts import common, install_python_prod_dependencies, scripts_test_utils
+from scripts import (
+    common,
+    install_python_dev_dependencies,
+    install_python_prod_dependencies,
+    scripts_test_utils,
+)
 
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -87,6 +92,16 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.checksum_temp_dir = tempfile.TemporaryDirectory()
+        self.original_pip_requirements_checksums_file_path = (
+            install_python_dev_dependencies.PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH
+        )
+        install_python_dev_dependencies.PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH = (
+            os.path.join(
+                self.checksum_temp_dir.name,
+                'pip_requirements_checksums.json',
+            )
+        )
         self.print_arr: List[str] = []
 
         def mock_print(msg: str) -> None:
@@ -160,6 +175,13 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             subprocess, 'Popen', mock_check_call_error
         )
 
+    def tearDown(self) -> None:
+        install_python_dev_dependencies.PIP_REQUIREMENTS_CHECKSUMS_FILE_PATH = (
+            self.original_pip_requirements_checksums_file_path
+        )
+        self.checksum_temp_dir.cleanup()
+        super().tearDown()
+
     def get_git_version_string(self, name: str, sha1_piece: str) -> str:
         """Utility function for constructing a GitHub URL for testing.
 
@@ -173,6 +195,21 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         """
         sha1 = ''.join(itertools.islice(itertools.cycle(sha1_piece), 40))
         return 'git+git://github.com/oppia/%s@%s' % (name, sha1)
+
+    def test_main_skips_install_when_requirements_checksum_matches(
+        self,
+    ) -> None:
+        skip_swap = self.swap(
+            install_python_dev_dependencies,
+            'should_skip_dependency_install',
+            lambda *_args: True,
+        )
+        isdir_swap = self.swap(os.path, 'isdir', lambda *_args: True)
+
+        with skip_swap, isdir_swap:
+            install_python_prod_dependencies.main()
+
+        self.assertEqual(self.cmd_token_list, [])
 
     def test_invalid_git_dependency_raises_an_exception(self) -> None:
         swap_requirements = self.swap(


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #[23864: Speed Up Backend Tests Python Package Installation].

2. This PR does the following: adds a lightweight checksum-based cache for Python requirements input files. After a successful dependency installation, the script records the SHA256 checksum of the relevant requirements input file in a local `pip_requirements_checksums.json` file. On a later run, if the compiled requirements file exists and the requirements input file checksum still matches the cached checksum, the script can skip the expensive dependency installation path

3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ✓] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [ ✓] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ✓] I have written tests for my code.
- [ ✓] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [✓ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

- [ ✓ ] A testing doc has been written: .install_python_dev_dependencies_test.py
install_python_prod_dependencies_test.py
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct
N/A

#### Proof of changes on desktop with slow/throttled network
N/A
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
