### PR TITLE
Fix #25802: Refactored study guide handling from apply_change_list

### DIFF
--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -197,7 +197,7 @@ def _collect_study_guide_changes(
     """
     # Remove union and StudyGuideChange once the study
     # guide logic when updating a subtopic page is
-    # removed from line 478.
+    # removed from line 482.
     update_study_guide_property_cmd: Union[
         study_guide_domain.UpdateStudyGuidePropertyCmd,
         study_guide_domain.StudyGuideChange,
@@ -230,7 +230,11 @@ def _apply_study_guide_change(
         str, List[subtopic_page_domain.SubtopicPageChange]
     ],
 ) -> None:
-    """Applies study guide updates from the second mutation loop.
+    """Applies a study guide property update for an existing subtopic.
+
+    For section updates, this validates and updates the study guide sections,
+    then keeps the linked subtopic page in sync by updating its HTML and
+    recording the matching subtopic page change command.
 
     Args:
         change: BaseChange. Incoming study guide update command.

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -197,7 +197,7 @@ def _collect_study_guide_changes(
     """
     # Remove union and StudyGuideChange once the study
     # guide logic when updating a subtopic page is
-    # removed from line 363.
+    # removed from line 478.
     update_study_guide_property_cmd: Union[
         study_guide_domain.UpdateStudyGuidePropertyCmd,
         study_guide_domain.StudyGuideChange,

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -220,6 +220,121 @@ def _collect_study_guide_changes(
         )
 
 
+def _apply_study_guide_change(
+    change: change_domain.BaseChange,
+    topic_id: str,
+    modified_study_guides: Dict[str, study_guide_domain.StudyGuide],
+    deleted_subtopic_ids: List[int],
+    modified_subtopic_pages: Dict[str, subtopic_page_domain.SubtopicPage],
+    modified_subtopic_change_cmds: Dict[
+        str, List[subtopic_page_domain.SubtopicPageChange]
+    ],
+) -> None:
+    """Applies study guide updates from the second mutation loop.
+
+    Args:
+        change: BaseChange. Incoming study guide update command.
+        topic_id: str. ID of the topic.
+        modified_study_guides: dict(str, StudyGuide). Modified guides map.
+        deleted_subtopic_ids: list(int). IDs of deleted subtopics.
+        modified_subtopic_pages: dict(str, SubtopicPage). Modified pages map.
+        modified_subtopic_change_cmds: dict(str, list(SubtopicPageChange)).
+            Subtopic page commands grouped by id.
+
+    Raises:
+        Exception. The subtopic doesn't exist.
+    """
+    # Ruling out the possibility of any other type for mypy
+    # type checking.
+    assert isinstance(change.subtopic_id, int)
+    study_guide_id = study_guide_domain.StudyGuide.get_study_guide_id(
+        topic_id, change.subtopic_id
+    )
+    subtopic_page_id = subtopic_page_domain.SubtopicPage.get_subtopic_page_id(
+        topic_id, change.subtopic_id
+    )
+    if (modified_study_guides[study_guide_id] is None) or (
+        change.subtopic_id in deleted_subtopic_ids
+    ):
+        raise Exception(
+            'The subtopic with id %s doesn\'t exist' % (change.subtopic_id)
+        )
+
+    if change.property_name == study_guide_domain.STUDY_GUIDE_PROPERTY_SECTIONS:
+        # Here we use cast because this 'if'
+        # condition forces change to have type
+        # UpdateStudyGuidePropertyCmd.
+        update_study_guide_sections_cmd = cast(
+            study_guide_domain.UpdateStudyGuidePropertyCmd, change
+        )
+        new_sections_dict_list: List[
+            study_guide_domain.StudyGuideSectionDict
+        ] = update_study_guide_sections_cmd.new_value
+        new_sections: List[study_guide_domain.StudyGuideSection] = []
+
+        # For updating the page_contents of the subtopic page corresponding
+        # to the study guide.
+        concatenated_html_parts: List[str] = []
+
+        for section_dict in new_sections_dict_list:
+            # For the study guide.
+            section = study_guide_domain.StudyGuideSection.from_dict(
+                section_dict
+            )
+            section.validate()
+            new_sections.append(section)
+
+            # For the subtopic page. (To be deprecated once study guides
+            # become standard.)
+            heading_html = (
+                '<p><strong>'
+                + f'{section_dict["heading"]["unicode_str"]}'
+                + '</strong></p>'
+            )
+            concatenated_html_parts.append(heading_html)
+            concatenated_html_parts.append(section_dict['content']['html'])
+
+        # Updating study guide.
+        modified_study_guides[study_guide_id].update_sections(new_sections)
+
+        # For subtopic page. (To be deprecated once study guides become
+        # standard.) Transforming all sections to a single html field.
+        concatenated_html = '\n\n'.join(concatenated_html_parts)
+        page_contents = state_domain.SubtitledHtml('content', concatenated_html)
+        page_contents.validate()
+        temporary_subtopic_page: Union[
+            subtopic_page_domain.SubtopicPage, None
+        ] = subtopic_page_services.get_subtopic_page_by_id(
+            topic_id, change.subtopic_id, False
+        )
+        if temporary_subtopic_page is not None:
+            modified_subtopic_pages[subtopic_page_id] = temporary_subtopic_page
+            old_value = (
+                temporary_subtopic_page.page_contents.subtitled_html.html
+            )
+            update_subtopic_page_property_cmd = (
+                subtopic_page_domain.SubtopicPageChange
+            )(
+                {
+                    'cmd': 'update_subtopic_page_property',
+                    'property_name': 'page_contents_html',
+                    'new_value': (concatenated_html),
+                    'old_value': old_value,
+                    'subtopic_id': (
+                        # We use update_subtopic_page_property_cmd
+                        # here to avoid mypy errors. We will replace
+                        # this with a study guide alternative once
+                        # we start using study guides exclusively.
+                        change.subtopic_id
+                    ),
+                }
+            )
+            modified_subtopic_change_cmds[subtopic_page_id].append(
+                update_subtopic_page_property_cmd
+            )
+            temporary_subtopic_page.update_page_contents_html(page_contents)
+
+
 def apply_change_list(
     topic_id: str,
     change_list: Sequence[change_domain.BaseChange],
@@ -724,115 +839,14 @@ def apply_change_list(
             elif (
                 change.cmd == study_guide_domain.CMD_UPDATE_STUDY_GUIDE_PROPERTY
             ):
-                # Ruling out the possibility of any other type for mypy
-                # type checking.
-                assert isinstance(change.subtopic_id, int)
-                study_guide_id = (
-                    study_guide_domain.StudyGuide.get_study_guide_id(
-                        topic_id, change.subtopic_id
-                    )
+                _apply_study_guide_change(
+                    change,
+                    topic_id,
+                    modified_study_guides,
+                    deleted_subtopic_ids,
+                    modified_subtopic_pages,
+                    modified_subtopic_change_cmds,
                 )
-                subtopic_page_id = (
-                    subtopic_page_domain.SubtopicPage.get_subtopic_page_id(
-                        topic_id, change.subtopic_id
-                    )
-                )
-                if (modified_study_guides[study_guide_id] is None) or (
-                    change.subtopic_id in deleted_subtopic_ids
-                ):
-                    raise Exception(
-                        'The subtopic with id %s doesn\'t exist'
-                        % (change.subtopic_id)
-                    )
-
-                if (
-                    change.property_name
-                    == study_guide_domain.STUDY_GUIDE_PROPERTY_SECTIONS
-                ):
-                    # Here we use cast because this 'if'
-                    # condition forces change to have type
-                    # UpdateStudyGuidePropertyCmd.
-                    update_study_guide_sections_cmd = cast(
-                        study_guide_domain.UpdateStudyGuidePropertyCmd, change
-                    )
-                    new_sections_dict_list: List[
-                        study_guide_domain.StudyGuideSectionDict
-                    ] = update_study_guide_sections_cmd.new_value
-                    new_sections: List[study_guide_domain.StudyGuideSection] = (
-                        []
-                    )
-
-                    # For updating the page_contents of the subtopic page corresponding to the study guide.
-                    concatenated_html_parts: List[str] = []
-
-                    for section_dict in new_sections_dict_list:
-                        # For the study guide.
-                        section = (
-                            study_guide_domain.StudyGuideSection.from_dict(
-                                section_dict
-                            )
-                        )
-                        section.validate()
-                        new_sections.append(section)
-
-                        # For the subtopic page. (To be deprecated once study guides become standard.)
-                        heading_html = (
-                            '<p><strong>'
-                            + f'{section_dict["heading"]["unicode_str"]}'
-                            + '</strong></p>'
-                        )
-                        concatenated_html_parts.append(heading_html)
-                        concatenated_html_parts.append(
-                            section_dict['content']['html']
-                        )
-
-                    # Updating study guide.
-                    modified_study_guides[study_guide_id].update_sections(
-                        new_sections
-                    )
-
-                    # For subtopic page. (To be deprecated once study guides become standard.)
-                    # Transforming all sections to a single html field.
-                    concatenated_html = '\n\n'.join(concatenated_html_parts)
-                    page_contents = state_domain.SubtitledHtml(
-                        'content', concatenated_html
-                    )
-                    page_contents.validate()
-                    temporary_subtopic_page: Union[
-                        subtopic_page_domain.SubtopicPage, None
-                    ] = subtopic_page_services.get_subtopic_page_by_id(
-                        topic_id, change.subtopic_id, False
-                    )
-                    if temporary_subtopic_page is not None:
-                        modified_subtopic_pages[subtopic_page_id] = (
-                            temporary_subtopic_page
-                        )
-                        old_value = (
-                            temporary_subtopic_page.page_contents.subtitled_html.html
-                        )
-                        update_subtopic_page_property_cmd = (
-                            subtopic_page_domain.SubtopicPageChange
-                        )(
-                            {
-                                'cmd': 'update_subtopic_page_property',
-                                'property_name': 'page_contents_html',
-                                'new_value': (concatenated_html),
-                                'old_value': old_value,
-                                'subtopic_id': (
-                                    # We use update_subtopic_page_property_cmd
-                                    # here to avoid mypy errors. We will replace
-                                    # this with a study guide alternative once
-                                    # we start using study guides exclusively.
-                                    change.subtopic_id
-                                ),
-                            }
-                        )
-                        modified_subtopic_change_cmds[subtopic_page_id].append(
-                            update_subtopic_page_property_cmd
-                        )
-                        temporary_subtopic_page.update_page_contents_html(
-                            page_contents
-                        )
             elif (
                 change.cmd
                 == subtopic_page_domain.CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY


### PR DESCRIPTION
## Overview

1. This PR fixes #25802 .
2. This PR does the following: - Added `_apply_study_guide_change(...)` in `core/domain/topic_services.py`. Also replaced the inline `CMD_UPDATE_STUDY_GUIDE_PROPERTY` block with a call to the new helper. This reduce complexity inside `apply_change_list` while improving readability and maintainability by isolating study-guide-specific logic.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<img width="1281" height="642" alt="image" src="https://github.com/user-attachments/assets/411d39c8-66ca-4b3f-b78a-ce6b59484769" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.