### PR TITLE
Fix part of #23864: Add requirements checksum cache to skip unnecessary pip installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ debug.log
 
 # Puppeteer acceptance tests.
 jest-runtime-config.json
+
+pip_requirements_checksums.json

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 
 from scripts import install_python_dev_dependencies
+from scripts import pip_install_cache
 
 from packaging import version
 from typing import Dict, Final, List, Optional, Set, Tuple
@@ -732,6 +733,16 @@ def main() -> None:
     mismatches.
     """
     verify_pip_is_installed()
+
+    # Skip the slow pip-compile and install steps if the requirements source
+    # files have not changed since the last successful install. See #23864.
+    if pip_install_cache.installation_is_current():
+        print(
+            'Skipping pip install: requirements.in is unchanged since last '
+            'install (pip_requirements_checksums.json is up to date).'
+        )
+        return
+
     print('Regenerating "requirements.txt" file...')
     install_python_dev_dependencies.compile_pip_requirements(
         'requirements.in', 'requirements.txt'
@@ -746,6 +757,9 @@ def main() -> None:
         print(
             'All third-party Python libraries are already installed correctly.'
         )
+
+    # Persist the new hash so the next run can skip installation.
+    pip_install_cache.save_hash(pip_install_cache.compute_requirements_hash())
 
 
 # The 'no coverage' pragma is used as this line is un-testable. This is because

--- a/scripts/pip_install_cache.py
+++ b/scripts/pip_install_cache.py
@@ -1,0 +1,158 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for caching pip requirements checksums.
+
+This module speeds up backend test runs and dev server startup by skipping
+Python package installation when the requirements files have not changed since
+the last successful install. It works by hashing the contents of
+requirements.in and requirements_dev.in, storing the result in a local JSON
+file (pip_requirements_checksums.json) that is git-ignored, and comparing
+the stored hash against the current hash before each install.
+
+If the hashes match, installation is skipped. If they differ (or no cached
+hash exists), installation proceeds and the new hash is written on success.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+from typing import Optional
+
+# Path (relative to the repo root) where checksums are persisted locally.
+# This file is git-ignored so each developer's cache is independent.
+CHECKSUMS_FILEPATH = 'pip_requirements_checksums.json'
+
+# The requirements source files whose combined hash determines whether
+# a re-install is needed.
+REQUIREMENTS_IN_FILEPATH = 'requirements.in'
+REQUIREMENTS_DEV_IN_FILEPATH = 'requirements_dev.in'
+
+
+def _hash_file_contents(filepath: str) -> str:
+    """Returns the SHA-256 hex digest of the given file's contents.
+
+    Args:
+        filepath: str. Path to the file to hash.
+
+    Returns:
+        str. Lowercase hex-encoded SHA-256 digest.
+
+    Raises:
+        IOError: If the file cannot be read.
+    """
+    hasher = hashlib.sha256()
+    with open(filepath, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def compute_requirements_hash(
+    requirements_in_path: str = REQUIREMENTS_IN_FILEPATH,
+    requirements_dev_in_path: str = REQUIREMENTS_DEV_IN_FILEPATH,
+) -> str:
+    """Computes a combined SHA-256 hash over both requirements source files.
+
+    Concatenating the individual digests (with a separator) and re-hashing
+    ensures a single canonical fingerprint for the pair, regardless of order.
+
+    Args:
+        requirements_in_path: str. Path to requirements.in.
+        requirements_dev_in_path: str. Path to requirements_dev.in.
+
+    Returns:
+        str. Hex-encoded SHA-256 digest of the combined file contents.
+    """
+    hash_prod = _hash_file_contents(requirements_in_path)
+    hash_dev = _hash_file_contents(requirements_dev_in_path)
+    combined = f'{hash_prod}:{hash_dev}'.encode('utf-8')
+    return hashlib.sha256(combined).hexdigest()
+
+
+def load_stored_hash(checksums_path: str = CHECKSUMS_FILEPATH) -> Optional[str]:
+    """Loads the previously stored requirements hash from disk.
+
+    Args:
+        checksums_path: str. Path to the JSON checksums file.
+
+    Returns:
+        str|None. The stored hash string, or None if the file does not exist
+        or cannot be parsed.
+    """
+    if not os.path.isfile(checksums_path):
+        return None
+    try:
+        with open(checksums_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        stored = data.get('requirements_hash')
+        return stored if isinstance(stored, str) else None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_hash(
+    requirements_hash: str, checksums_path: str = CHECKSUMS_FILEPATH
+) -> None:
+    """Persists the given requirements hash to the checksums file.
+
+    Args:
+        requirements_hash: str. The hash to persist.
+        checksums_path: str. Path to the JSON checksums file.
+    """
+    data = {'requirements_hash': requirements_hash}
+    with open(checksums_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+
+def installation_is_current(
+    requirements_in_path: str = REQUIREMENTS_IN_FILEPATH,
+    requirements_dev_in_path: str = REQUIREMENTS_DEV_IN_FILEPATH,
+    checksums_path: str = CHECKSUMS_FILEPATH,
+) -> bool:
+    """Returns True if the installed packages are up-to-date.
+
+    Compares the hash of the current requirements source files against the
+    hash stored from the last successful installation.  Returns False (meaning
+    re-installation is required) in any of the following cases:
+
+    * No checksums file exists yet (first run).
+    * The checksums file is malformed or unreadable.
+    * Either requirements source file is missing.
+    * The computed hash differs from the stored hash.
+
+    Args:
+        requirements_in_path: str. Path to requirements.in.
+        requirements_dev_in_path: str. Path to requirements_dev.in.
+        checksums_path: str. Path to the JSON checksums file.
+
+    Returns:
+        bool. True iff the stored hash matches the current hash of both
+        requirements source files.
+    """
+    stored = load_stored_hash(checksums_path)
+    if stored is None:
+        return False
+    try:
+        current = compute_requirements_hash(
+            requirements_in_path, requirements_dev_in_path
+        )
+    except OSError:
+        return False
+    return stored == current

--- a/scripts/pip_install_cache_test.py
+++ b/scripts/pip_install_cache_test.py
@@ -1,0 +1,324 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for scripts.pip_install_cache."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+from scripts import pip_install_cache
+
+
+class HashFileContentsTests(unittest.TestCase):
+    """Tests for _hash_file_contents."""
+
+    def test_returns_hex_string_of_expected_length(self) -> None:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(b'hello world')
+            tmp_path = tmp.name
+        try:
+            result = pip_install_cache._hash_file_contents(tmp_path)
+            # SHA-256 hex digest is always 64 characters.
+            self.assertEqual(len(result), 64)
+            self.assertRegex(result, r'^[0-9a-f]{64}$')
+        finally:
+            os.unlink(tmp_path)
+
+    def test_same_content_produces_same_hash(self) -> None:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(b'oppia requirements')
+            tmp_path = tmp.name
+        try:
+            hash1 = pip_install_cache._hash_file_contents(tmp_path)
+            hash2 = pip_install_cache._hash_file_contents(tmp_path)
+            self.assertEqual(hash1, hash2)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_different_content_produces_different_hash(self) -> None:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_a:
+            tmp_a.write(b'content A')
+            path_a = tmp_a.name
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_b:
+            tmp_b.write(b'content B')
+            path_b = tmp_b.name
+        try:
+            self.assertNotEqual(
+                pip_install_cache._hash_file_contents(path_a),
+                pip_install_cache._hash_file_contents(path_b),
+            )
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+
+    def test_raises_on_missing_file(self) -> None:
+        with self.assertRaises(OSError):
+            pip_install_cache._hash_file_contents('/nonexistent/path/file.txt')
+
+
+class ComputeRequirementsHashTests(unittest.TestCase):
+    """Tests for compute_requirements_hash."""
+
+    def _make_temp_file(self, content: bytes) -> str:
+        """Helper that writes content to a temp file and returns its path."""
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.write(content)
+        tmp.close()
+        return tmp.name
+
+    def tearDown(self) -> None:
+        super().tearDown()
+
+    def test_returns_64_char_hex_string(self) -> None:
+        path_a = self._make_temp_file(b'prod deps')
+        path_b = self._make_temp_file(b'dev deps')
+        try:
+            result = pip_install_cache.compute_requirements_hash(path_a, path_b)
+            self.assertEqual(len(result), 64)
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+
+    def test_same_files_produce_same_hash(self) -> None:
+        path_a = self._make_temp_file(b'prod deps')
+        path_b = self._make_temp_file(b'dev deps')
+        try:
+            hash1 = pip_install_cache.compute_requirements_hash(path_a, path_b)
+            hash2 = pip_install_cache.compute_requirements_hash(path_a, path_b)
+            self.assertEqual(hash1, hash2)
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+
+    def test_changing_prod_file_changes_hash(self) -> None:
+        path_a = self._make_temp_file(b'prod deps original')
+        path_b = self._make_temp_file(b'dev deps')
+        path_a_modified = self._make_temp_file(b'prod deps MODIFIED')
+        try:
+            original = pip_install_cache.compute_requirements_hash(
+                path_a, path_b
+            )
+            modified = pip_install_cache.compute_requirements_hash(
+                path_a_modified, path_b
+            )
+            self.assertNotEqual(original, modified)
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+            os.unlink(path_a_modified)
+
+    def test_changing_dev_file_changes_hash(self) -> None:
+        path_a = self._make_temp_file(b'prod deps')
+        path_b = self._make_temp_file(b'dev deps original')
+        path_b_modified = self._make_temp_file(b'dev deps MODIFIED')
+        try:
+            original = pip_install_cache.compute_requirements_hash(
+                path_a, path_b
+            )
+            modified = pip_install_cache.compute_requirements_hash(
+                path_a, path_b_modified
+            )
+            self.assertNotEqual(original, modified)
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+            os.unlink(path_b_modified)
+
+    def test_raises_when_requirements_file_missing(self) -> None:
+        path_a = self._make_temp_file(b'prod deps')
+        try:
+            with self.assertRaises(OSError):
+                pip_install_cache.compute_requirements_hash(
+                    path_a, '/nonexistent/requirements_dev.in'
+                )
+        finally:
+            os.unlink(path_a)
+
+
+class LoadStoredHashTests(unittest.TestCase):
+    """Tests for load_stored_hash."""
+
+    def test_returns_none_when_file_does_not_exist(self) -> None:
+        result = pip_install_cache.load_stored_hash(
+            '/nonexistent/checksums.json'
+        )
+        self.assertIsNone(result)
+
+    def test_returns_hash_from_valid_file(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False
+        ) as tmp:
+            json.dump({'requirements_hash': 'abc123'}, tmp)
+            tmp_path = tmp.name
+        try:
+            result = pip_install_cache.load_stored_hash(tmp_path)
+            self.assertEqual(result, 'abc123')
+        finally:
+            os.unlink(tmp_path)
+
+    def test_returns_none_when_key_missing(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False
+        ) as tmp:
+            json.dump({'other_key': 'value'}, tmp)
+            tmp_path = tmp.name
+        try:
+            result = pip_install_cache.load_stored_hash(tmp_path)
+            self.assertIsNone(result)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_returns_none_for_malformed_json(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False
+        ) as tmp:
+            tmp.write('this is not json {{{')
+            tmp_path = tmp.name
+        try:
+            result = pip_install_cache.load_stored_hash(tmp_path)
+            self.assertIsNone(result)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_returns_none_when_hash_value_is_not_string(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False
+        ) as tmp:
+            json.dump({'requirements_hash': 12345}, tmp)
+            tmp_path = tmp.name
+        try:
+            result = pip_install_cache.load_stored_hash(tmp_path)
+            self.assertIsNone(result)
+        finally:
+            os.unlink(tmp_path)
+
+
+class SaveHashTests(unittest.TestCase):
+    """Tests for save_hash."""
+
+    def test_creates_file_with_correct_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'checksums.json')
+            pip_install_cache.save_hash('deadbeef', path)
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            self.assertEqual(data['requirements_hash'], 'deadbeef')
+
+    def test_overwrites_existing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'checksums.json')
+            pip_install_cache.save_hash('first_hash', path)
+            pip_install_cache.save_hash('second_hash', path)
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            self.assertEqual(data['requirements_hash'], 'second_hash')
+
+    def test_roundtrip_with_load_stored_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'checksums.json')
+            pip_install_cache.save_hash('roundtrip_hash', path)
+            result = pip_install_cache.load_stored_hash(path)
+            self.assertEqual(result, 'roundtrip_hash')
+
+
+class InstallationIsCurrentTests(unittest.TestCase):
+    """Tests for installation_is_current."""
+
+    def _make_temp_file(self, content: bytes) -> str:
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.write(content)
+        tmp.close()
+        return tmp.name
+
+    def test_returns_false_when_no_checksums_file(self) -> None:
+        path_a = self._make_temp_file(b'prod')
+        path_b = self._make_temp_file(b'dev')
+        try:
+            result = pip_install_cache.installation_is_current(
+                path_a, path_b, '/nonexistent/checksums.json'
+            )
+            self.assertFalse(result)
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+
+    def test_returns_true_when_hash_matches(self) -> None:
+        path_a = self._make_temp_file(b'prod')
+        path_b = self._make_temp_file(b'dev')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checksums_path = os.path.join(tmpdir, 'checksums.json')
+            current_hash = pip_install_cache.compute_requirements_hash(
+                path_a, path_b
+            )
+            pip_install_cache.save_hash(current_hash, checksums_path)
+            result = pip_install_cache.installation_is_current(
+                path_a, path_b, checksums_path
+            )
+            self.assertTrue(result)
+        os.unlink(path_a)
+        os.unlink(path_b)
+
+    def test_returns_false_when_hash_does_not_match(self) -> None:
+        path_a = self._make_temp_file(b'prod')
+        path_b = self._make_temp_file(b'dev')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checksums_path = os.path.join(tmpdir, 'checksums.json')
+            pip_install_cache.save_hash('stale_hash_value', checksums_path)
+            result = pip_install_cache.installation_is_current(
+                path_a, path_b, checksums_path
+            )
+            self.assertFalse(result)
+        os.unlink(path_a)
+        os.unlink(path_b)
+
+    def test_returns_false_when_requirements_file_missing(self) -> None:
+        path_a = self._make_temp_file(b'prod')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checksums_path = os.path.join(tmpdir, 'checksums.json')
+            pip_install_cache.save_hash('some_hash', checksums_path)
+            result = pip_install_cache.installation_is_current(
+                path_a, '/nonexistent/requirements_dev.in', checksums_path
+            )
+            self.assertFalse(result)
+        os.unlink(path_a)
+
+    def test_returns_false_after_requirements_file_changes(self) -> None:
+        path_a = self._make_temp_file(b'prod original')
+        path_b = self._make_temp_file(b'dev')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checksums_path = os.path.join(tmpdir, 'checksums.json')
+            # Save hash for original content.
+            original_hash = pip_install_cache.compute_requirements_hash(
+                path_a, path_b
+            )
+            pip_install_cache.save_hash(original_hash, checksums_path)
+            # Simulate a requirements change.
+            with open(path_a, 'wb') as f:
+                f.write(b'prod MODIFIED')
+            result = pip_install_cache.installation_is_current(
+                path_a, path_b, checksums_path
+            )
+            self.assertFalse(result)
+        os.unlink(path_a)
+        os.unlink(path_b)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…ry pip installs

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #23864.
2. This PR does the following: This PR adds a lightweight checksum cache to skip the slow pip-compile and pip install steps when requirements.in has not changed since the last successful install. A new module, scripts/pip_install_cache.py, computes a combined SHA-256 hash over requirements.in and requirements_dev.in and compares it to a hash stored locally in pip_requirements_checksums.json (which is git-ignored so each developer's cache is independent). If the hashes match, main() in install_python_prod_dependencies.py returns early without invoking pip-compile or pip install. If they differ, installation proceeds as normal and the new hash is saved on success. Developers can force a reinstall at any time by deleting pip_requirements_checksums.json.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a developer-facing performance improvement with no user-facing UI changes. The new behavior can be verified by running python -m scripts.run_backend_tests twice and observing that the second run skips the pip install step entirely.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
