### PR TITLE
Relax timestamp comparison to allow equal timestamps.

### DIFF
--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -5892,11 +5892,11 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
             'Did migration.',
         )
 
-        self.assertLess(
+        self.assertLessEqual(
             original_timestamp,
             exp_services.get_last_updated_by_human_ms(self.EXP_0_ID),
         )
-        self.assertLess(
+        self.assertLessEqual(
             exp_services.get_last_updated_by_human_ms(self.EXP_0_ID),
             timestamp_after_first_edit,
         )


### PR DESCRIPTION
## Overview

1. This PR fixes #20802 
2. This PR does the following: Relaxes time stamp comparison in test_get_last_updated_by_human_ms() to use assertLessEqual() instead of assertLess().
3. (For bug-fixing PRs only) The original bug occurred because: Difference in the way timestamps were timezoned but that was fixed. Remaining Issue: Timestamps generated using datetime.datetime.now() may have low resolution, so fast computers/slow updating os clocks could generate the same timestamp before the os clock is incremented.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

#### Running the test changed
https://github.com/user-attachments/assets/a635cfea-b0aa-468f-8cc8-8f182f96c633

#### Running all CI tests
<img width="1139" height="561" alt="Screenshot 2026-04-23 at 10 27 45 PM" src="https://github.com/user-attachments/assets/7d4070b4-0dd8-4276-9303-c63a3a3fb6c2" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
