### PR TITLE
Fix #17219: Remove unnecessary parentheses wrapping in fraction symbol dict

### DIFF
--- a/core/templates/services/guppy-configuration.service.ts
+++ b/core/templates/services/guppy-configuration.service.ts
@@ -62,8 +62,8 @@ const FRACTION_SYMBOL_DICT = {
   output: {
     latex: '\\frac{{$1}}{{$2}}',
     small_latex: '\\frac{{$1}}{{$2}}',
-    asciimath: '({$1})/({$2})',
-    text: '({$1})/({$2})',
+    asciimath: '{$1}/{$2}',
+    text: '{$1}/{$2}',
   },
   input: 1,
   keys: ['/'],


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17219 .
2. This PR does the following: Fixes the `asciimath` output format in `FRACTION_SYMBOL_DICT` inside `guppy-configuration.service.ts` by removing unnecessary parentheses wrapping around the numerator and denominator, changing ({$1})/({$2}) to {$1}/{$2}.
3. The original issue occurred because Oppia's `guppy-configuration.service.ts` registers a custom fraction symbol dict via `Guppy.add_global_symbol` that overrides Guppy's defaults. This dict had `asciimath: '({$1})/({$2})'` which unconditionally wrapped numerator and denominator in parentheses, causing submitted answers to display as (a)/(b) instead of a/b.
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

### Before:
https://github.com/user-attachments/assets/9538f924-358a-4303-ab19-e14142aacc51

### After:

https://github.com/user-attachments/assets/6a7ed1a7-9b13-4655-bad8-4b899c520984

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
