### PR TITLE
Fix part of #12912: Enable consider-using-with pylint rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -138,7 +138,6 @@ disable=abstract-method,
         wrong-import-order,
 # TODO(#12912): Remove these after the Python 3 migration.
         arguments-differ,
-        consider-using-with,
         # Pylint considers imports to be cyclic even when the cycle is
         # broken by putting imports inside functions so they aren't
         # executed upon module import.


### PR DESCRIPTION
## Overview
This PR enables the "consider-using-with" pylint rule by removing it from the disable list in .pylintrc.

## Changes Made
- Removed "consider-using-with" from the disable list in .pylintrc.

## Proof of correctness
- This change enables the lint rule so that all occurrences of file handling without context managers are detected.
- No functional code changes were made.

## Notes
- This PR only enables the lint rule.
- Follow-up PRs will fix the reported lint issues.

Fixes part of #12912