### PR TITLE
Fix #25991: CampaignBannerComponent test failing in frontend unit tests 

### DIFF
--- a/core/templates/components/campaign-banner/campaign-banner.component.spec.ts
+++ b/core/templates/components/campaign-banner/campaign-banner.component.spec.ts
@@ -280,6 +280,11 @@ describe('CampaignBannerComponent', () => {
     platformFeatureService.status.EnableCampaignBannerTestMode.isEnabled = true;
 
     component.setCampaignConfig();
+
+    const config = component.campaignConfig as CampaignConfig;
+    config.startDate = new Date(Date.now() - 100000);
+    config.endDate = new Date(Date.now() + 100000);
+
     component.computeBannerVisibility();
 
     expect(component.shouldShowBanner).toBe(true);


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #25991 or fixes part of #[fill_in_number_here].
2. This PR does the following: patching startDate and endDate to Date.now() relative offsets in the affected test blocks, making the tests time-independent and resilient to future campaign date expiry.
3. (For bug-fixing PRs only) The original bug occurred because: FINANCIAL_LITERACY_CAMPAIGN_CONFIG_PROD and FINANCIAL_LITERACY_CAMPAIGN_CONFIG_TEST in AppConstants have hardcoded end dates (2026-04-30) which expired, causing isCampaignActive() to return false and breaking assertions that expected shouldShowBanner to be true
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
<img width="1158" height="173" alt="image" src="https://github.com/user-attachments/assets/2542536a-c1d0-441b-bed8-621726fe4288" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
