### PR TITLE
core/domain: guard get_user_id_from_username against over-long username

### DIFF
--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -166,6 +166,12 @@ def get_user_id_from_username(
     Raises:
         Exception. No user_id found for the given username.
     """
+    if len(username) > constants.MAX_USERNAME_LENGTH:
+        if strict:
+            raise Exception(
+                'No user_id found for the given username: %s' % username
+            )
+        return None
     user_model = user_models.UserSettingsModel.get_by_normalized_username(
         user_domain.UserSettings.normalize_username(username)
     )


### PR DESCRIPTION
## Bug

`get_user_id_from_username` passes the caller-supplied username directly to an NDB indexed-property filter. NDB rejects any indexed string value longer than 1500 bytes with `BadValueError: Indexed value normalized_username must be at most 1500 bytes`, which surfaces as an unhandled 500 on `/blogadminrolehandler` (and any other endpoint that calls this function with unsanitised user input).

Fixes #26017

## Root cause

```python
user_model = user_models.UserSettingsModel.get_by_normalized_username(
    user_domain.UserSettings.normalize_username(username)   # ← crashes if len > 1500 bytes
)
```

`normalize_username` only calls `.lower()`; it does not enforce length. Usernames are capped at `MAX_USERNAME_LENGTH` (30) on creation, so any input beyond that limit can never match a stored user.

## Why the fix is correct

The guard at the top of the function mirrors the existing `if user_model is None` path: return `None` for a missing user, or raise with the same message if `strict=True`. No stored username can exceed `MAX_USERNAME_LENGTH`, so a username longer than that is provably absent from the datastore — the function semantics are preserved without touching the database.