### PR TITLE
feat: add local dependency caching to speed up installation script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ debug.log
 
 # Puppeteer acceptance tests.
 jest-runtime-config.json
+
+# Local cache for skipping redundant Python dependency installations.
+# Created by scripts/install_third_party_libs.py to speed up local startup.
+pip_requirements_checksums.json

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -309,6 +309,7 @@
         "core.domain.user_domain_test",
         "core.storage.opportunity.gae_models_test",
         "scripts.build_test",
+        "scripts.dependency_utils_test",
         "scripts.install_third_party_libs_test",
         "core.storage.statistics.gae_models_test",
         "core.storage.exploration.gae_models_test",

--- a/scripts/dependency_utils.py
+++ b/scripts/dependency_utils.py
@@ -4,25 +4,27 @@ import os
 import platform
 import sys
 
+from typing import Optional
+
 # Define where the cache manifest lives (ignored by git)
 MANIFEST_PATH = os.path.join(os.getcwd(), 'pip_requirements_checksums.json')
 REQUIREMENTS_FILES = [
     'requirements.in',
     'requirements_dev.in',
     'requirements.txt',
-    'requirements_dev.txt'
+    'requirements_dev.txt',
 ]
 
 
 class DependencyGatekeeper:
-    def __init__(self, python_libs_dir):
+    def __init__(self, python_libs_dir: str) -> None:
         self.python_libs_dir = python_libs_dir
 
-    def _get_env_metadata(self):
+    def _get_env_metadata(self) -> str:
         """Captures Python version and OS to prevent cross-env drift."""
         return f"{sys.version}_{platform.platform()}_{sys.executable}"
 
-    def calculate_current_fingerprint(self):
+    def calculate_current_fingerprint(self) -> Optional[str]:
         """Generates a SHA256 hash of files and environment metadata."""
         sha256 = hashlib.sha256()
 
@@ -37,7 +39,7 @@ class DependencyGatekeeper:
         sha256.update(self._get_env_metadata().encode('utf-8'))
         return sha256.hexdigest()
 
-    def is_install_required(self):
+    def is_install_required(self) -> bool:
         """Returns True if we MUST run pip install, False if we can skip."""
         # Safety Check 1: Does the library folder even exist?
         if not os.path.exists(self.python_libs_dir) or not os.listdir(
@@ -58,7 +60,7 @@ class DependencyGatekeeper:
         except (json.JSONDecodeError, IOError):
             return True  # If JSON is corrupt, assume we need an install
 
-    def record_success(self):
+    def record_success(self) -> None:
         """Updates the local JSON with the new fingerprint."""
         new_hash = self.calculate_current_fingerprint()
         if new_hash:

--- a/scripts/dependency_utils.py
+++ b/scripts/dependency_utils.py
@@ -1,0 +1,67 @@
+import hashlib
+import json
+import os
+import platform
+import sys
+
+# Define where the cache manifest lives (ignored by git)
+MANIFEST_PATH = os.path.join(os.getcwd(), 'pip_requirements_checksums.json')
+REQUIREMENTS_FILES = [
+    'requirements.in',
+    'requirements_dev.in',
+    'requirements.txt',
+    'requirements_dev.txt'
+]
+
+
+class DependencyGatekeeper:
+    def __init__(self, python_libs_dir):
+        self.python_libs_dir = python_libs_dir
+
+    def _get_env_metadata(self):
+        """Captures Python version and OS to prevent cross-env drift."""
+        return f"{sys.version}_{platform.platform()}_{sys.executable}"
+
+    def calculate_current_fingerprint(self):
+        """Generates a SHA256 hash of files and environment metadata."""
+        sha256 = hashlib.sha256()
+
+        # 1. Hash the contents of the requirement files
+        for file_name in REQUIREMENTS_FILES:
+            if not os.path.exists(file_name):
+                return None  # Force install if files are missing
+            with open(file_name, 'rb') as f:
+                sha256.update(f.read())
+
+        # 2. Add the environment string to the hash
+        sha256.update(self._get_env_metadata().encode('utf-8'))
+        return sha256.hexdigest()
+
+    def is_install_required(self):
+        """Returns True if we MUST run pip install, False if we can skip."""
+        # Safety Check 1: Does the library folder even exist?
+        if not os.path.exists(self.python_libs_dir) or not os.listdir(
+            self.python_libs_dir
+        ):
+            return True
+
+        # Safety Check 2: Does the manifest exist?
+        if not os.path.exists(MANIFEST_PATH):
+            return True
+
+        # Check 3: Do the hashes match?
+        current_hash = self.calculate_current_fingerprint()
+        try:
+            with open(MANIFEST_PATH, 'r') as f:
+                cached_data = json.load(f)
+                return cached_data.get('checksum') != current_hash
+        except (json.JSONDecodeError, IOError):
+            return True  # If JSON is corrupt, assume we need an install
+
+    def record_success(self):
+        """Updates the local JSON with the new fingerprint."""
+        new_hash = self.calculate_current_fingerprint()
+        if new_hash:
+            with open(MANIFEST_PATH, 'w') as f:
+                json.dump({'checksum': new_hash}, f, indent=2)
+            print(f"Dependency manifest updated: {MANIFEST_PATH}")

--- a/scripts/dependency_utils.py
+++ b/scripts/dependency_utils.py
@@ -1,69 +1,89 @@
+# Copyright 2024 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility for caching and validating Python dependency installations."""
+
+from __future__ import annotations
+
 import hashlib
 import json
 import os
 import platform
 import sys
 
+from scripts import common, install_python_dev_dependencies
+
 from typing import Optional
 
-# Define where the cache manifest lives (ignored by git)
+# Define where the cache manifest lives (ignored by git).
 MANIFEST_PATH = os.path.join(os.getcwd(), 'pip_requirements_checksums.json')
 REQUIREMENTS_FILES = [
-    'requirements.in',
-    'requirements_dev.in',
-    'requirements.txt',
-    'requirements_dev.txt',
+    common.REQUIREMENTS_FILE_PATH,
+    install_python_dev_dependencies.REQUIREMENTS_DEV_FILE_PATH,
+    common.COMPILED_REQUIREMENTS_FILE_PATH,
+    install_python_dev_dependencies.COMPILED_REQUIREMENTS_DEV_FILE_PATH,
 ]
 
 
 class DependencyGatekeeper:
+    """Determines whether Python dependency installation can be skipped."""
+
     def __init__(self, python_libs_dir: str) -> None:
         self.python_libs_dir = python_libs_dir
+        self._cached_fingerprint: Optional[str] = None
 
     def _get_env_metadata(self) -> str:
         """Captures Python version and OS to prevent cross-env drift."""
-        return f"{sys.version}_{platform.platform()}_{sys.executable}"
+        return f'{sys.version}_{platform.platform()}_{sys.executable}'
 
     def calculate_current_fingerprint(self) -> Optional[str]:
         """Generates a SHA256 hash of files and environment metadata."""
+        if self._cached_fingerprint is not None:
+            return self._cached_fingerprint
+
         sha256 = hashlib.sha256()
 
-        # 1. Hash the contents of the requirement files
         for file_name in REQUIREMENTS_FILES:
-            if not os.path.exists(file_name):
-                return None  # Force install if files are missing
-            with open(file_name, 'rb') as f:
-                sha256.update(f.read())
+            try:
+                with open(file_name, 'rb') as f:
+                    sha256.update(f.read())
+            except FileNotFoundError:
+                return None
 
-        # 2. Add the environment string to the hash
         sha256.update(self._get_env_metadata().encode('utf-8'))
-        return sha256.hexdigest()
+        self._cached_fingerprint = sha256.hexdigest()
+        return self._cached_fingerprint
 
     def is_install_required(self) -> bool:
         """Returns True if we MUST run pip install, False if we can skip."""
-        # Safety Check 1: Does the library folder even exist?
-        if not os.path.exists(self.python_libs_dir) or not os.listdir(
-            self.python_libs_dir
-        ):
+        if not os.path.exists(self.python_libs_dir):
             return True
 
-        # Safety Check 2: Does the manifest exist?
-        if not os.path.exists(MANIFEST_PATH):
-            return True
-
-        # Check 3: Do the hashes match?
         current_hash = self.calculate_current_fingerprint()
         try:
-            with open(MANIFEST_PATH, 'r') as f:
+            with open(MANIFEST_PATH, 'r', encoding='utf-8') as f:
                 cached_data = json.load(f)
-                return cached_data.get('checksum') != current_hash
+                cached_checksum: Optional[str] = cached_data.get('checksum')
+                return cached_checksum != current_hash
         except (json.JSONDecodeError, IOError):
-            return True  # If JSON is corrupt, assume we need an install
+            # If JSON is corrupt, assume we need an install.
+            return True
 
     def record_success(self) -> None:
         """Updates the local JSON with the new fingerprint."""
         new_hash = self.calculate_current_fingerprint()
         if new_hash:
-            with open(MANIFEST_PATH, 'w') as f:
+            with open(MANIFEST_PATH, 'w', encoding='utf-8') as f:
                 json.dump({'checksum': new_hash}, f, indent=2)
-            print(f"Dependency manifest updated: {MANIFEST_PATH}")
+            print(f'Dependency manifest updated: {MANIFEST_PATH}')

--- a/scripts/dependency_utils_test.py
+++ b/scripts/dependency_utils_test.py
@@ -1,0 +1,31 @@
+# Copyright 2024 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for scripts/dependency_utils.py."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from scripts import dependency_utils
+
+
+class DependencyGatekeeperTests(unittest.TestCase):
+    """Tests for DependencyGatekeeper."""
+
+    def test_gatekeeper_init(self) -> None:
+        """Tests that gatekeeper initializes correctly."""
+        gatekeeper = dependency_utils.DependencyGatekeeper('/tmp/libs')
+        self.assertEqual(gatekeeper.python_libs_dir, '/tmp/libs')

--- a/scripts/dependency_utils_test.py
+++ b/scripts/dependency_utils_test.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import os
 import unittest
 
 from scripts import dependency_utils

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -40,6 +40,9 @@ from scripts import (
     install_python_dev_dependencies,  # pylint: disable=wrong-import-position, wrong-import-order
 )
 from scripts import install_python_prod_dependencies
+from scripts import (
+    dependency_utils,
+)
 
 from typing import Final
 
@@ -50,6 +53,12 @@ TMP_UNZIP_PATH: Final = os.path.join('.', 'tmp_unzip.zip')
 
 _PARSER: Final = argparse.ArgumentParser(
     description='Installation script for Oppia third-party libraries.'
+)
+
+_PARSER.add_argument(
+    '--force',
+    help='Force the installation of all third-party libraries, bypassing the cache.',
+    action='store_true',
 )
 
 
@@ -420,11 +429,28 @@ def install_elasticsearch_dev_server() -> None:
 
 def main() -> None:
     """Set up GAE and install third-party libraries for Oppia."""
+    args = _PARSER.parse_args()
+
+    # Initialize the gatekeeper
+    # Use common.THIRD_PARTY_PYTHON_LIBS_DIR or the specific libs path
+    gatekeeper = dependency_utils.DependencyGatekeeper(
+        python_libs_dir=common.THIRD_PARTY_PYTHON_LIBS_DIR
+    )
+
+    # Check the cache using 'args.force'
+    is_python_install_required = getattr(args, 'force', False) or gatekeeper.is_install_required()
+    if not is_python_install_required:
+        print(
+            "Python dependencies match the local cache. Skipping Python installation."
+        )
+
     print('Running install_third_party_libs script...')
 
     # This ensures dev dependencies are present and compiled before we
     # proceed to other setup tasks that require them.
-    install_python_dev_dependencies.main(['--assert_compiled'])
+    if is_python_install_required:
+        install_python_dev_dependencies.main(['--assert_compiled'])
+
     # Import the hook scripts here (after dev deps are installed) so that
     # they are only loaded when running the installer.
     from . import pre_commit_hook  # pylint: disable=wrong-import-position
@@ -459,16 +485,17 @@ def main() -> None:
 
     # Install third-party libraries in third_party/ directory. Files in this
     # directory will be deployed to production.
-    common.print_each_string_after_two_new_lines(
-        ['Installing third-party Python and JS libs in third_party directory']
-    )
-    common.create_readme(
-        common.THIRD_PARTY_DIR,
-        'This folder contains third-party libraries used in Oppia codebase.\n'
-        'You can regenerate this folder by deleting it and then running '
-        'the start.py script.\n',
-    )
-    install_python_prod_dependencies.main()
+    if is_python_install_required:
+        common.print_each_string_after_two_new_lines(
+            ['Installing third-party Python and JS libs in third_party directory']
+        )
+        common.create_readme(
+            common.THIRD_PARTY_DIR,
+            'This folder contains third-party libraries used in Oppia codebase.\n'
+            'You can regenerate this folder by deleting it and then running '
+            'the start.py script.\n',
+        )
+        install_python_prod_dependencies.main()
 
     # The install_gcloud_sdk() function needs the Python third-party libs
     # "google" folder to exist first, so we only do the installation here after
@@ -490,6 +517,9 @@ def main() -> None:
         'the start.py script.\n',
     )
     subprocess.check_call(['yarn', 'install', '--pure-lockfile'])
+
+    if is_python_install_required:
+        gatekeeper.record_success()
 
 
 # The 'no coverage' pragma is used as this line is un-testable. This is because

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -39,10 +39,7 @@ import tarfile
 from scripts import (
     install_python_dev_dependencies,  # pylint: disable=wrong-import-position, wrong-import-order
 )
-from scripts import install_python_prod_dependencies
-from scripts import (
-    dependency_utils,
-)
+from scripts import dependency_utils, install_python_prod_dependencies
 
 from typing import Final, Optional, Sequence
 
@@ -431,19 +428,17 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     """Set up GAE and install third-party libraries for Oppia."""
     parsed_args = _PARSER.parse_args(args=args if args is not None else [])
 
-    # Initialize the gatekeeper
-    # Use common.THIRD_PARTY_PYTHON_LIBS_DIR or the specific libs path
     gatekeeper = dependency_utils.DependencyGatekeeper(
         python_libs_dir=common.THIRD_PARTY_PYTHON_LIBS_DIR
     )
 
-    # Check the cache using 'args.force'
     is_python_install_required = (
-        getattr(parsed_args, 'force', False) or gatekeeper.is_install_required()
+        parsed_args.force or gatekeeper.is_install_required()
     )
     if not is_python_install_required:
         print(
-            "Python dependencies match the local cache. Skipping Python installation."
+            'Python dependencies match the local cache. Skipping'
+            ' Python installation.'
         )
 
     print('Running install_third_party_libs script...')
@@ -489,7 +484,9 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     # directory will be deployed to production.
     if is_python_install_required:
         common.print_each_string_after_two_new_lines(
-            ['Installing third-party Python and JS libs in third_party directory']
+            [
+                'Installing third-party Python and JS libs in third_party directory'
+            ]
         )
         common.create_readme(
             common.THIRD_PARTY_DIR,

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -44,7 +44,7 @@ from scripts import (
     dependency_utils,
 )
 
-from typing import Final
+from typing import Final, Optional, Sequence
 
 from . import clean, common
 
@@ -427,9 +427,9 @@ def install_elasticsearch_dev_server() -> None:
     print('ElasticSearch installed successfully.')
 
 
-def main() -> None:
+def main(args: Optional[Sequence[str]] = None) -> None:
     """Set up GAE and install third-party libraries for Oppia."""
-    args = _PARSER.parse_args()
+    parsed_args = _PARSER.parse_args(args=args if args is not None else [])
 
     # Initialize the gatekeeper
     # Use common.THIRD_PARTY_PYTHON_LIBS_DIR or the specific libs path
@@ -438,7 +438,9 @@ def main() -> None:
     )
 
     # Check the cache using 'args.force'
-    is_python_install_required = getattr(args, 'force', False) or gatekeeper.is_install_required()
+    is_python_install_required = (
+        getattr(parsed_args, 'force', False) or gatekeeper.is_install_required()
+    )
     if not is_python_install_required:
         print(
             "Python dependencies match the local cache. Skipping Python installation."
@@ -525,4 +527,4 @@ def main() -> None:
 # The 'no coverage' pragma is used as this line is un-testable. This is because
 # it will only be called when this Python file is used as a script.
 if __name__ == '__main__':  # pragma: no cover
-    main()
+    main(args=sys.argv[1:])


### PR DESCRIPTION
## Overview

1. This PR fixes #23864
2. This PR does the following: 
   - Implements `DependencyGatekeeper` to hash both the source requirement files (`requirements.in`, `requirements_dev.in`) and the generated text files (`requirements.txt`, `requirements_dev.txt`).
   - Stores a local SHA256 fingerprint in `pip_requirements_checksums.json` to cache the state of the dependencies.
   - Includes Python version and platform metadata in the hash to prevent environment drift across different developer setups.
   - Updates `install_third_party_libs.py` to securely bypass the slow Python `pip-compile` and `pip-sync` installation steps when the cache is valid, while still ensuring the rest of the script (Node.js, Yarn, JS packages) runs as expected.
   - Adds a `--force` flag to `install_third_party_libs.py` to bypass the cache manually if needed.
   - Updates `.gitignore` to exclude the local checksum file.

   *This reduces the local dependency check time from ~15s to <1s when no changes are detected.*

3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
- Warm Run
<img width="1101" height="189" alt="Screenshot From 2026-03-30 17-30-42" src="https://github.com/user-attachments/assets/155a7c51-68c1-4dd6-9a2a-ab7003245637" />


- Cold Run
<img width="1888" height="872" alt="Screenshot From 2026-03-30 17-31-29" src="https://github.com/user-attachments/assets/1ee32b29-35ad-48bd-90f2-6c50d55f6b2d" />
<img width="1888" height="932" alt="Screenshot From 2026-03-30 17-31-51" src="https://github.com/user-attachments/assets/6d515a44-1a7f-46de-86fa-02771457f0ce" />
<img width="1888" height="567" alt="Screenshot From 2026-03-30 17-32-16" src="https://github.com/user-attachments/assets/f2c83885-3cd7-4030-a5b4-69c6b7bd790a" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
