### PR TITLE
Fix part of #21970: add domain object and validate() method for UserStatsModel

### DIFF
--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -800,6 +800,289 @@ class UserContributions:
             self.edited_exploration_ids.sort()
 
 
+class WeeklyCreatorStatsDict(TypedDict):
+    """Dictionary representing a single weekly creator stats entry."""
+
+    average_ratings: Optional[float]
+    total_plays: int
+
+
+class UserStatsDict(TypedDict):
+    """Dictionary representation of UserStats domain object."""
+
+    user_id: str
+    impact_score: Optional[float]
+    total_plays: int
+    average_ratings: Optional[float]
+    num_ratings: int
+    weekly_creator_stats_list: List[Dict[str, WeeklyCreatorStatsDict]]
+    schema_version: int
+
+
+class UserStats:
+    """Domain object for the UserStatsModel.
+
+    Attributes:
+        user_id: str. The unique ID of the user.
+        impact_score: float or None. The user's calculated impact score across
+            explorations they contribute to. None when no impact score has
+            been computed yet.
+        total_plays: int. Total plays aggregated across all explorations
+            owned by the user.
+        average_ratings: float or None. Average of average ratings across all
+            explorations owned by the user. None when the user has not
+            received any ratings.
+        num_ratings: int. Total number of ratings received across all
+            explorations owned by the user.
+        weekly_creator_stats_list: list(dict). Historical weekly creator
+            stats. Each entry is a dict with a single date-string key
+            (YYYY-MM-DD) mapping to a dict containing average_ratings and
+            total_plays for that week.
+        schema_version: int. The schema version used to encode the stats.
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        impact_score: Optional[float],
+        total_plays: int,
+        average_ratings: Optional[float],
+        num_ratings: int,
+        weekly_creator_stats_list: List[Dict[str, WeeklyCreatorStatsDict]],
+        schema_version: int,
+    ) -> None:
+        """Constructs a UserStats domain object.
+
+        Args:
+            user_id: str. The unique ID of the user.
+            impact_score: float or None. The user's calculated impact score.
+            total_plays: int. Total plays across all explorations.
+            average_ratings: float or None. Average rating across all
+                explorations.
+            num_ratings: int. Total number of ratings received.
+            weekly_creator_stats_list: list(dict). Historical weekly stats.
+            schema_version: int. The dashboard stats schema version.
+        """
+        self.user_id = user_id
+        self.impact_score = impact_score
+        self.total_plays = total_plays
+        self.average_ratings = average_ratings
+        self.num_ratings = num_ratings
+        self.weekly_creator_stats_list = weekly_creator_stats_list
+        self.schema_version = schema_version
+
+    def to_dict(self) -> UserStatsDict:
+        """Returns a dict representation of the UserStats domain object.
+
+        Returns:
+            dict. A dict mapping all fields of UserStats.
+        """
+        return {
+            'user_id': self.user_id,
+            'impact_score': self.impact_score,
+            'total_plays': self.total_plays,
+            'average_ratings': self.average_ratings,
+            'num_ratings': self.num_ratings,
+            'weekly_creator_stats_list': self.weekly_creator_stats_list,
+            'schema_version': self.schema_version,
+        }
+
+    def validate(self) -> None:
+        """Validates the UserStats domain object.
+
+        Raises:
+            ValidationError. The user_id is not a non-empty string.
+            ValidationError. The impact_score is not None and not a
+                non-negative float.
+            ValidationError. The total_plays is not a non-negative integer.
+            ValidationError. The average_ratings is not None and not a float
+                in the allowed rating range.
+            ValidationError. The num_ratings is not a non-negative integer.
+            ValidationError. The num_ratings and average_ratings fields are
+                inconsistent.
+            ValidationError. The weekly_creator_stats_list is malformed.
+            ValidationError. The schema_version is not in the supported
+                range.
+        """
+        if not isinstance(self.user_id, str):
+            raise utils.ValidationError(
+                'Expected user_id to be a string, received %s' % self.user_id
+            )
+        if not self.user_id:
+            raise utils.ValidationError('No user id specified.')
+
+        if self.impact_score is not None:
+            if not isinstance(self.impact_score, float):
+                raise utils.ValidationError(
+                    'Expected impact_score to be a float, received %s'
+                    % self.impact_score
+                )
+            if self.impact_score < 0:
+                raise utils.ValidationError(
+                    'Expected impact_score to be non-negative, received %s'
+                    % self.impact_score
+                )
+
+        # Booleans are a subclass of int in Python; reject them explicitly so
+        # that True/False can't masquerade as a count.
+        if not isinstance(self.total_plays, int) or isinstance(
+            self.total_plays, bool
+        ):
+            raise utils.ValidationError(
+                'Expected total_plays to be an int, received %s'
+                % self.total_plays
+            )
+        if self.total_plays < 0:
+            raise utils.ValidationError(
+                'Expected total_plays to be non-negative, received %s'
+                % self.total_plays
+            )
+
+        if not isinstance(self.num_ratings, int) or isinstance(
+            self.num_ratings, bool
+        ):
+            raise utils.ValidationError(
+                'Expected num_ratings to be an int, received %s'
+                % self.num_ratings
+            )
+        if self.num_ratings < 0:
+            raise utils.ValidationError(
+                'Expected num_ratings to be non-negative, received %s'
+                % self.num_ratings
+            )
+
+        # Ratings on Oppia are integers in [1, 5] (see ALLOWED_RATINGS in
+        # core/domain/rating_services.py), so the per-user average must land
+        # in [1.0, 5.0] when any ratings have been recorded.
+        min_rating, max_rating = 1.0, 5.0
+        if self.average_ratings is not None:
+            if not isinstance(self.average_ratings, float):
+                raise utils.ValidationError(
+                    'Expected average_ratings to be a float, received %s'
+                    % self.average_ratings
+                )
+            if not min_rating <= self.average_ratings <= max_rating:
+                raise utils.ValidationError(
+                    'Expected average_ratings to be in the range [%s, %s], '
+                    'received %s'
+                    % (min_rating, max_rating, self.average_ratings)
+                )
+
+        # num_ratings and average_ratings must agree: either no ratings have
+        # been recorded (num_ratings == 0 and average_ratings is None) or at
+        # least one has (num_ratings > 0 and average_ratings is not None).
+        # See _refresh_average_ratings_transactional in event_services.py.
+        if (self.num_ratings == 0) != (self.average_ratings is None):
+            raise utils.ValidationError(
+                'Expected num_ratings and average_ratings to be consistent: '
+                'num_ratings=%s but average_ratings=%s'
+                % (self.num_ratings, self.average_ratings)
+            )
+
+        if not isinstance(self.weekly_creator_stats_list, list):
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list to be a list, received %s'
+                % self.weekly_creator_stats_list
+            )
+        for entry in self.weekly_creator_stats_list:
+            self._validate_weekly_stats_entry(entry)
+
+        if not isinstance(self.schema_version, int) or isinstance(
+            self.schema_version, bool
+        ):
+            raise utils.ValidationError(
+                'Expected schema_version to be an int, received %s'
+                % self.schema_version
+            )
+        if not (
+            1
+            <= self.schema_version
+            <= feconf.CURRENT_DASHBOARD_STATS_SCHEMA_VERSION
+        ):
+            raise utils.ValidationError(
+                'Expected schema_version to be in the range [1, %d], '
+                'received %s'
+                % (
+                    feconf.CURRENT_DASHBOARD_STATS_SCHEMA_VERSION,
+                    self.schema_version,
+                )
+            )
+
+    # Here we use object because this validator deliberately runs before
+    # the entry's structure is trusted (e.g. when data is loaded from the
+    # datastore as a plain JsonProperty), so any narrower static type would
+    # be a lie.
+    @staticmethod
+    def _validate_weekly_stats_entry(entry: object) -> None:
+        """Validates a single entry in weekly_creator_stats_list.
+
+        Args:
+            entry: object. The entry to validate. Expected to be a dict with
+                a single date-string key whose value is a dict containing
+                average_ratings and total_plays.
+
+        Raises:
+            ValidationError. The entry is malformed.
+        """
+        if not isinstance(entry, dict):
+            raise utils.ValidationError(
+                'Expected each weekly_creator_stats_list entry to be a '
+                'dict, received %s' % entry
+            )
+        if len(entry) != 1:
+            raise utils.ValidationError(
+                'Expected each weekly_creator_stats_list entry to have '
+                'exactly one date key, received %s' % entry
+            )
+        date_key = next(iter(entry))
+        if not isinstance(date_key, str):
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list entry key to be a '
+                'date string, received %s' % date_key
+            )
+        try:
+            datetime.datetime.strptime(
+                date_key, feconf.DASHBOARD_STATS_DATETIME_STRING_FORMAT
+            )
+        except ValueError as e:
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list entry key to match '
+                'format %s, received %s'
+                % (feconf.DASHBOARD_STATS_DATETIME_STRING_FORMAT, date_key)
+            ) from e
+
+        stats = entry[date_key]
+        if not isinstance(stats, dict):
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list entry value to be a '
+                'dict, received %s' % stats
+            )
+        if 'average_ratings' not in stats or 'total_plays' not in stats:
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list entry value to contain '
+                'average_ratings and total_plays, received %s' % stats
+            )
+        average_ratings = stats['average_ratings']
+        if average_ratings is not None and not isinstance(
+            average_ratings, float
+        ):
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list entry average_ratings '
+                'to be a float or None, received %s' % average_ratings
+            )
+        total_plays = stats['total_plays']
+        if not isinstance(total_plays, int) or isinstance(total_plays, bool):
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list entry total_plays to '
+                'be an int, received %s' % total_plays
+            )
+        if total_plays < 0:
+            raise utils.ValidationError(
+                'Expected weekly_creator_stats_list entry total_plays to '
+                'be non-negative, received %s' % total_plays
+            )
+
+
 class UserGlobalPrefs:
     """Domain object for user global email preferences.
 

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -27,7 +27,7 @@ from core.domain import auth_services, user_domain, user_services
 from core.platform import models
 from core.tests import test_utils
 
-from typing import List, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 MYPY = False
 if MYPY:  # pragma: no cover
@@ -715,6 +715,333 @@ class UserContributionsTests(test_utils.GenericTestBase):
             'present.' % feconf.CURRENT_DASHBOARD_STATS_SCHEMA_VERSION,
         ):
             user_services.update_dashboard_stats_log(self.owner_id)
+
+
+class UserStatsTests(test_utils.GenericTestBase):
+    """Tests for the UserStats domain object."""
+
+    # Here we use object because individual tests intentionally override
+    # fields with values of mismatched types (e.g. a non-string user_id) to
+    # exercise validate() error branches; no narrower type covers them all.
+    def _make_user_stats(self, **overrides: object) -> user_domain.UserStats:
+        """Builds a UserStats with sane defaults, allowing per-test overrides.
+
+        Args:
+            **overrides: object. Field values to override on the returned
+                UserStats instance. May include intentionally-invalid values
+                used to exercise validate() error paths.
+
+        Returns:
+            UserStats. A UserStats domain object built from default fields
+            merged with the supplied overrides.
+        """
+        # Here we use object because individual tests deliberately inject
+        # mismatched-type values into this dict (e.g. an int for user_id)
+        # to exercise validate() error paths; no narrower value type covers
+        # all the field types that UserStats accepts.
+        defaults: Dict[str, object] = {
+            'user_id': 'uid',
+            'impact_score': 0.5,
+            'total_plays': 10,
+            'average_ratings': 4.2,
+            'num_ratings': 3,
+            'weekly_creator_stats_list': [
+                {'2024-01-01': {'average_ratings': 4.2, 'total_plays': 10}}
+            ],
+            'schema_version': feconf.CURRENT_DASHBOARD_STATS_SCHEMA_VERSION,
+        }
+        defaults.update(overrides)
+        # Here we use MyPy ignore because the defaults dict is typed as
+        # Dict[str, object] so tests can inject deliberately-invalid values;
+        # MyPy cannot prove the unpacked kwargs match UserStats's typed
+        # signature, but at runtime they do (or are wrong on purpose).
+        return user_domain.UserStats(**defaults)  # type: ignore[arg-type]
+
+    def test_to_dict_returns_all_fields(self) -> None:
+        stats = self._make_user_stats()
+        self.assertEqual(
+            stats.to_dict(),
+            {
+                'user_id': 'uid',
+                'impact_score': 0.5,
+                'total_plays': 10,
+                'average_ratings': 4.2,
+                'num_ratings': 3,
+                'weekly_creator_stats_list': [
+                    {
+                        '2024-01-01': {
+                            'average_ratings': 4.2,
+                            'total_plays': 10,
+                        }
+                    }
+                ],
+                'schema_version': (
+                    feconf.CURRENT_DASHBOARD_STATS_SCHEMA_VERSION
+                ),
+            },
+        )
+
+    def test_validate_passes_with_valid_data(self) -> None:
+        self._make_user_stats().validate()
+
+    def test_validate_passes_when_no_ratings_yet(self) -> None:
+        self._make_user_stats(
+            num_ratings=0,
+            average_ratings=None,
+            impact_score=None,
+            weekly_creator_stats_list=[],
+        ).validate()
+
+    def test_validate_non_str_user_id(self) -> None:
+        stats = self._make_user_stats(user_id=0)
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected user_id to be a string'
+        ):
+            stats.validate()
+
+    def test_validate_empty_user_id(self) -> None:
+        stats = self._make_user_stats(user_id='')
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'No user id specified.'
+        ):
+            stats.validate()
+
+    def test_validate_non_float_impact_score(self) -> None:
+        stats = self._make_user_stats(impact_score='high')
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected impact_score to be a float'
+        ):
+            stats.validate()
+
+    def test_validate_negative_impact_score(self) -> None:
+        stats = self._make_user_stats(impact_score=-0.1)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected impact_score to be non-negative',
+        ):
+            stats.validate()
+
+    def test_validate_non_int_total_plays(self) -> None:
+        stats = self._make_user_stats(total_plays='10')
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected total_plays to be an int'
+        ):
+            stats.validate()
+
+    # Booleans are rejected explicitly because bool is a subclass of int.
+    def test_validate_bool_total_plays_rejected(self) -> None:
+        stats = self._make_user_stats(total_plays=True)
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected total_plays to be an int'
+        ):
+            stats.validate()
+
+    def test_validate_negative_total_plays(self) -> None:
+        stats = self._make_user_stats(total_plays=-1)
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected total_plays to be non-negative'
+        ):
+            stats.validate()
+
+    def test_validate_non_int_num_ratings(self) -> None:
+        stats = self._make_user_stats(num_ratings='3')
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected num_ratings to be an int'
+        ):
+            stats.validate()
+
+    def test_validate_negative_num_ratings(self) -> None:
+        stats = self._make_user_stats(num_ratings=-1, average_ratings=None)
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Expected num_ratings to be non-negative'
+        ):
+            stats.validate()
+
+    def test_validate_non_float_average_ratings(self) -> None:
+        stats = self._make_user_stats(average_ratings='4.2')
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected average_ratings to be a float',
+        ):
+            stats.validate()
+
+    def test_validate_average_ratings_above_max(self) -> None:
+        stats = self._make_user_stats(average_ratings=5.5)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            r'Expected average_ratings to be in the range \[1.0, 5.0\]',
+        ):
+            stats.validate()
+
+    def test_validate_average_ratings_below_min(self) -> None:
+        stats = self._make_user_stats(average_ratings=0.5)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            r'Expected average_ratings to be in the range \[1.0, 5.0\]',
+        ):
+            stats.validate()
+
+    def test_validate_inconsistent_ratings_present_avg_missing(self) -> None:
+        stats = self._make_user_stats(num_ratings=2, average_ratings=None)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'num_ratings and average_ratings to be consistent',
+        ):
+            stats.validate()
+
+    def test_validate_inconsistent_avg_present_ratings_missing(self) -> None:
+        stats = self._make_user_stats(num_ratings=0, average_ratings=4.0)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'num_ratings and average_ratings to be consistent',
+        ):
+            stats.validate()
+
+    def test_validate_non_list_weekly_creator_stats(self) -> None:
+        stats = self._make_user_stats(weekly_creator_stats_list={})
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected weekly_creator_stats_list to be a list',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_not_dict(self) -> None:
+        stats = self._make_user_stats(weekly_creator_stats_list=['nope'])
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected each weekly_creator_stats_list entry to be a dict',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_multiple_keys(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[
+                {
+                    '2024-01-01': {'average_ratings': 4.0, 'total_plays': 1},
+                    '2024-01-08': {'average_ratings': 4.0, 'total_plays': 2},
+                }
+            ]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'exactly one date key',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_non_string_date_key(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[
+                {1: {'average_ratings': None, 'total_plays': 0}}
+            ]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'entry key to be a date string',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_bad_date_format(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[
+                {'01/01/2024': {'average_ratings': 4.0, 'total_plays': 1}}
+            ]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'to match format',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_value_not_dict(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[{'2024-01-01': 'nope'}]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected weekly_creator_stats_list entry value to be a dict',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_missing_required_keys(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[{'2024-01-01': {'total_plays': 1}}]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'average_ratings and total_plays',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_bad_average_ratings_type(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[
+                {'2024-01-01': {'average_ratings': 'high', 'total_plays': 1}}
+            ]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'entry average_ratings to be a float or None',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_bad_total_plays_type(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[
+                {'2024-01-01': {'average_ratings': None, 'total_plays': '1'}}
+            ]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'entry total_plays to be an int',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_negative_total_plays(self) -> None:
+        stats = self._make_user_stats(
+            weekly_creator_stats_list=[
+                {'2024-01-01': {'average_ratings': None, 'total_plays': -1}}
+            ]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'entry total_plays to be non-negative',
+        ):
+            stats.validate()
+
+    def test_validate_weekly_entry_allows_none_average_ratings(self) -> None:
+        # average_ratings=None is valid for a week where the user has no
+        # ratings yet (mirrors the model-level behaviour).
+        self._make_user_stats(
+            weekly_creator_stats_list=[
+                {'2024-01-01': {'average_ratings': None, 'total_plays': 0}}
+            ]
+        ).validate()
+
+    def test_validate_non_int_schema_version(self) -> None:
+        stats = self._make_user_stats(schema_version='1')
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected schema_version to be an int',
+        ):
+            stats.validate()
+
+    def test_validate_schema_version_below_range(self) -> None:
+        stats = self._make_user_stats(schema_version=0)
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            r'Expected schema_version to be in the range \[1,',
+        ):
+            stats.validate()
+
+    def test_validate_schema_version_above_range(self) -> None:
+        stats = self._make_user_stats(
+            schema_version=(feconf.CURRENT_DASHBOARD_STATS_SCHEMA_VERSION + 1)
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            r'Expected schema_version to be in the range \[1,',
+        ):
+            stats.validate()
 
 
 class UserGlobalPrefsTests(test_utils.GenericTestBase):


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21970.
2. This PR does the following: Adds a `UserStats` domain object (with `to_dict` and a thorough `validate()` method) for `UserStatsModel`, plus unit tests covering every validation branch. Wiring the domain object into `user_services.py` (replacing direct `UserStatsModel.get(...)` callsites with `get_user_stats` / `save_user_stats` conversion methods) is intentionally left for a follow-up PR to keep this diff reviewable.
3. (For bug-fixing PRs only) N/A — this PR adds a missing domain object, not a bug fix.

### Validation rules implemented (per the design discussion in #21970)

- `user_id` is a non-empty `str`
- `impact_score` is `None` or a non-negative `float`
- `total_plays` and `num_ratings` are non-negative `int` (booleans rejected explicitly, since `bool` is a subclass of `int` in Python)
- `average_ratings` is `None` or a `float` in `[1.0, 5.0]`
- `(num_ratings == 0)` iff `(average_ratings is None)` — matches the invariant established by `_refresh_average_ratings_transactional` in `event_services.py`
- `weekly_creator_stats_list` is a list of single-key dicts whose key matches `feconf.DASHBOARD_STATS_DATETIME_STRING_FORMAT` and whose value contains valid `average_ratings` / `total_plays`
- `schema_version` is in `[1, CURRENT_DASHBOARD_STATS_SCHEMA_VERSION]`, matching the migration check in `migrate_dashboard_stats_to_latest_schema` so older models stay valid until migrated

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this PR is a backend-only addition: it introduces a new Python domain class and unit tests with no user-facing UI, no controllers, and no production behaviour change. Verification is in the test suite:

- 31 new tests in `UserStatsTests` (`core/domain/user_domain_test.py`) — all passing
- 100% line coverage on the new `UserStats` block
- Full `user_domain_test` module still passes (141 tests, no regressions)
- `python -m scripts.run_mypy_checks --files core/domain/user_domain.py core/domain/user_domain_test.py` — passes
- `python -m scripts.linters.run_lint_checks --files core/domain/user_domain.py core/domain/user_domain_test.py` — passes