### PR TITLE
Fix #26032: Remove SERVER_CAN_SEND_EMAILS parameter

### DIFF
--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -128,14 +128,7 @@ class CronMailReviewersContributorDashboardSuggestionsHandler(
         their reviewing permissions.
         """
         # Only execute this job if it's possible to send the emails and there
-        # are reviewers to notify.
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
-        if not server_can_send_emails:
-            return self.render_json({})
+        # are reviewers to notify
         if not platform_parameter_services.get_platform_parameter_value(
             platform_parameter_list.ParamName.CONTRIBUTOR_DASHBOARD_REVIEWER_EMAILS_IS_ENABLED.value
         ):

--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -228,13 +228,7 @@ class CronMailReviewerNewSuggestionsHandler(
         """Sends email notifications to reviewers about new
         suggestions on the Contributor Dashboard.
         """
-        server_can_send_emails = (
-            platform_parameter_services.get_platform_parameter_value(
-                platform_parameter_list.ParamName.SERVER_CAN_SEND_EMAILS.value
-            )
-        )
-        if not server_can_send_emails:
-            return self.render_json({})
+        
 
         if not platform_parameter_services.get_platform_parameter_value(
             platform_parameter_list.ParamName.CONTRIBUTOR_DASHBOARD_REVIEWER_EMAILS_IS_ENABLED.value

--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -64,7 +64,7 @@ class ParamName(enum.Enum):
         'unpublish_exploration_email_html_body'
     )
     RECORD_PLAYTHROUGH_PROBABILITY = 'record_playthrough_probability'
-    SERVER_CAN_SEND_EMAILS = 'server_can_send_emails'
+   
     SYSTEM_EMAIL_ADDRESS = 'system_email_address'
     SYSTEM_EMAIL_NAME = 'system_email_name'
     ADMIN_EMAIL_ADDRESS = 'admin_email_address'


### PR DESCRIPTION
## Overview

1. This PR fixes #26032.
2. This PR removes the SERVER_CAN_SEND_EMAILS platform parameter and cleans up related email sending logic.
3. N/A

## Essential Checklist

- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.

## Proof that changes are correct

No proof of changes needed because this is a backend-only change and does not affect the UI. No user-facing behavior is modified.