### PR TITLE
fix(blog-admin): add MAX_USERNAME_LENGTH validation to BlogAdminRolesHandler

### DIFF
--- a/core/controllers/blog_admin.py
+++ b/core/controllers/blog_admin.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 
 from core import feconf
+from core.constants import constants
 from core.controllers import acl_decorators, base
 from core.controllers import domain_objects_validator as validation_method
 from core.domain import (
@@ -185,10 +186,30 @@ class BlogAdminRolesHandler(
                     'choices': [BLOG_ADMIN, BLOG_POST_EDITOR],
                 }
             },
-            'username': {'schema': {'type': 'basestring'}},
+            'username': {
+                'schema': {
+                    'type': 'basestring',
+                    'validators': [
+                        {
+                            'id': 'has_length_at_most',
+                            'max_value': constants.MAX_USERNAME_LENGTH,
+                        }
+                    ],
+                }
+            },
         },
         'PUT': {
-            'username': {'schema': {'type': 'basestring'}},
+            'username': {
+                'schema': {
+                    'type': 'basestring',
+                    'validators': [
+                        {
+                            'id': 'has_length_at_most',
+                            'max_value': constants.MAX_USERNAME_LENGTH,
+                        }
+                    ],
+                }
+            },
         },
     }
 


### PR DESCRIPTION
## Bug

`BlogAdminRolesHandler` accepts an unbounded `username` string in both its POST and PUT handlers. When a value exceeding ~1500 bytes is submitted, the framework calls `user_services.get_user_id_from_username(username)`, which normalises the username and passes it to an NDB `filter()` query. NDB rejects indexed string properties longer than 1500 bytes, raising:

```
BadValueError: Indexed value normalized_username must be at most 1500 bytes
```

This crashed on the test server (see #26017).

## Root cause

The `HANDLER_ARGS_SCHEMAS` for both POST and PUT lacked a length validator on `username`:

```python
# Before — no upper bound
'username': {'schema': {'type': 'basestring'}},
```

`admin.py` already applies the correct guard on its own username fields (e.g. line 3040):

```python
'validators': [{'id': 'has_length_at_most', 'max_value': constants.MAX_USERNAME_LENGTH}]
```

`MAX_USERNAME_LENGTH` is 30. Any username longer than that can never match a real user, so rejecting it at the schema layer is both correct and consistent with the existing pattern.

## Fix

- Import `constants` from `core.constants` (already used in `admin.py`).
- Add `has_length_at_most` with `constants.MAX_USERNAME_LENGTH` to both the POST and PUT `username` schemas in `BlogAdminRolesHandler`.

Fixes #26017.