### PR TITLE
fix(jobs): iterate over list copy when removing invalid-topic stats

### DIFF
--- a/core/jobs/batch_jobs/contributor_admin_stats_jobs.py
+++ b/core/jobs/batch_jobs/contributor_admin_stats_jobs.py
@@ -507,7 +507,7 @@ class GenerateContributorAdminStatsJob(base_jobs.JobBase):
 
         entity_id = '%s.%s' % (language_code, contributor_user_id)
 
-        for stat in translation_contribution_stats:
+        for stat in translation_contribution_stats[:]:
             if GenerateContributorAdminStatsJob.not_validate_topic(
                 stat.topic_id
             ):
@@ -756,7 +756,7 @@ class GenerateContributorAdminStatsJob(base_jobs.JobBase):
 
         entity_id = contributor_user_id
 
-        for stat in question_contribution_stats:
+        for stat in question_contribution_stats[:]:
             if GenerateContributorAdminStatsJob.not_validate_topic(
                 stat.topic_id
             ):
@@ -1124,7 +1124,7 @@ class AuditAndLogIncorretDataInContributorAdminStatsJob(base_jobs.JobBase):
         """
         translation_contribution_stats = list(translation_contribution_stats)
         valid_topic_ids_with_contribution_stats: List[str] = []
-        for stat in translation_contribution_stats:
+        for stat in translation_contribution_stats[:]:
             if GenerateContributorAdminStatsJob.not_validate_topic(
                 stat.topic_id
             ):
@@ -1276,7 +1276,7 @@ class AuditAndLogIncorretDataInContributorAdminStatsJob(base_jobs.JobBase):
         """
         question_contribution_stats = list(question_contribution_stats)
         valid_topic_ids_with_contribution_stats: List[str] = []
-        for stat in question_contribution_stats:
+        for stat in question_contribution_stats[:]:
             if GenerateContributorAdminStatsJob.not_validate_topic(
                 stat.topic_id
             ):


### PR DESCRIPTION
## Bug

Four loops in `core/jobs/batch_jobs/contributor_admin_stats_jobs.py` call `.remove()` on the **same list they are currently iterating**:

```python
# Buggy pattern (×4 in file)
for stat in some_stats:
    if GenerateContributorAdminStatsJob.not_validate_topic(stat.topic_id):
        some_stats.remove(stat)   # mutates the list the loop is walking
```

When two consecutive entries both have an invalid `topic_id`, removing the first shifts every remaining element one position back. The loop's internal index then points past the second entry, so it is **silently skipped** and survives into the downstream stat aggregation.

Minimal reproducer:
```python
lst = ['bad1', 'bad2', 'good']
for x in lst:
    if x.startswith('bad'):
        lst.remove(x)
# Result: ['bad2', 'good']  ← 'bad2' was never checked
```

## Root cause

The four affected loops are:
- `GenerateContributorAdminStatsJob._get_translation_contribution_stats` (line 510)
- `GenerateContributorAdminStatsJob._get_question_contribution_stats` (line 759)
- `AuditAndLogIncorretDataInContributorAdminStatsJob._get_translation_contribution_stats` (line 1127)
- `AuditAndLogIncorretDataInContributorAdminStatsJob._get_question_contribution_stats` (line 1279)

All four iterate directly over the list being filtered, instead of a copy.

## Fix

Iterate over a shallow copy (`some_stats[:]`) so the loop cursor is independent of the list being mutated:

```python
for stat in some_stats[:]:   # copy → safe to remove from original
    if GenerateContributorAdminStatsJob.not_validate_topic(stat.topic_id):
        some_stats.remove(stat)
```

**Diff**: 4 lines changed (only `[:]` added to each `for` statement). No logic change, no new variables.