### PR TITLE
Fixes part of #21166: Feature that allows users to unpublish stories temporarily

### DIFF
--- a/core/controllers/story_editor.py
+++ b/core/controllers/story_editor.py
@@ -206,7 +206,7 @@ class StoryPublishHandlerNormalizedPayloadDict(TypedDict):
     normalized_payload dictionary.
     """
 
-    story_unpublish_type: str
+    story_publication_action: str
 
 
 class StoryPublishHandler(
@@ -218,7 +218,7 @@ class StoryPublishHandler(
     URL_PATH_ARGS_SCHEMAS = {'story_id': {'schema': SCHEMA_FOR_STORY_ID}}
     HANDLER_ARGS_SCHEMAS = {
         'PUT': {
-            'story_unpublish_type': {
+            'story_publication_action': {
                 'schema': {
                     'type': 'basestring',
                     'choices': [
@@ -243,10 +243,12 @@ class StoryPublishHandler(
         story = story_fetchers.get_story_by_id(story_id, strict=True)
         topic_id = story.corresponding_topic_id
 
-        story_unpublish_type = self.normalized_payload['story_unpublish_type']
+        story_publication_action = self.normalized_payload[
+            'story_publication_action'
+        ]
 
         if (
-            story_unpublish_type
+            story_publication_action
             == topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
         ):
             topic_services.publish_story(topic_id, story_id, self.user_id)
@@ -255,7 +257,7 @@ class StoryPublishHandler(
                 topic_id,
                 story_id,
                 self.user_id,
-                story_unpublish_type,
+                story_publication_action,
             )
 
         self.render_json(self.values)

--- a/core/controllers/story_editor.py
+++ b/core/controllers/story_editor.py
@@ -30,7 +30,7 @@ from core.domain import (
     topic_services,
 )
 
-from typing import Dict, List, Optional, TypedDict
+from typing import Dict, List, TypedDict
 
 SCHEMA_FOR_STORY_ID = {
     'type': 'basestring',
@@ -206,8 +206,7 @@ class StoryPublishHandlerNormalizedPayloadDict(TypedDict):
     normalized_payload dictionary.
     """
 
-    new_story_status_is_public: bool
-    story_unpublish_type: Optional[str]
+    story_unpublish_type: str
 
 
 class StoryPublishHandler(
@@ -219,18 +218,15 @@ class StoryPublishHandler(
     URL_PATH_ARGS_SCHEMAS = {'story_id': {'schema': SCHEMA_FOR_STORY_ID}}
     HANDLER_ARGS_SCHEMAS = {
         'PUT': {
-            'new_story_status_is_public': {
-                'schema': {'type': 'bool'},
-            },
             'story_unpublish_type': {
                 'schema': {
                     'type': 'basestring',
                     'choices': [
-                        topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
-                        topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+                        topic_domain.STORY_PUBLICATION_ACTION_PUBLISH,
+                        topic_domain.STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
+                        topic_domain.STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH,
                     ],
                 },
-                'default_value': None,
             },
         }
     }
@@ -246,30 +242,15 @@ class StoryPublishHandler(
         assert self.normalized_payload is not None
         story = story_fetchers.get_story_by_id(story_id, strict=True)
         topic_id = story.corresponding_topic_id
-        topic = topic_fetchers.get_topic_by_id(topic_id, strict=True)
 
-        story_reference = next(
-            ref
-            for ref in topic.canonical_story_references
-            if ref.story_id == story_id
-        )
-        story_unpublish_type = story_reference.story_unpublish_type
+        story_unpublish_type = self.normalized_payload['story_unpublish_type']
 
-        new_story_status_is_public = self.normalized_payload[
-            'new_story_status_is_public'
-        ]
-
-        if new_story_status_is_public:
+        if (
+            story_unpublish_type
+            == topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+        ):
             topic_services.publish_story(topic_id, story_id, self.user_id)
         else:
-            story_unpublish_type = self.normalized_payload.get(
-                'story_unpublish_type'
-            )
-            if story_unpublish_type is None:
-                story_unpublish_type = (
-                    topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT
-                )
-
             topic_services.unpublish_story(
                 topic_id,
                 story_id,

--- a/core/controllers/story_editor.py
+++ b/core/controllers/story_editor.py
@@ -25,11 +25,12 @@ from core.domain import (
     story_domain,
     story_fetchers,
     story_services,
+    topic_domain,
     topic_fetchers,
     topic_services,
 )
 
-from typing import Dict, List, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 SCHEMA_FOR_STORY_ID = {
     'type': 'basestring',
@@ -206,6 +207,7 @@ class StoryPublishHandlerNormalizedPayloadDict(TypedDict):
     """
 
     new_story_status_is_public: bool
+    story_unpublish_type: Optional[str]
 
 
 class StoryPublishHandler(
@@ -219,7 +221,17 @@ class StoryPublishHandler(
         'PUT': {
             'new_story_status_is_public': {
                 'schema': {'type': 'bool'},
-            }
+            },
+            'story_unpublish_type': {
+                'schema': {
+                    'type': 'basestring',
+                    'choices': [
+                        topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
+                        topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+                    ],
+                },
+                'default_value': None,
+            },
         }
     }
 
@@ -234,6 +246,14 @@ class StoryPublishHandler(
         assert self.normalized_payload is not None
         story = story_fetchers.get_story_by_id(story_id, strict=True)
         topic_id = story.corresponding_topic_id
+        topic = topic_fetchers.get_topic_by_id(topic_id, strict=True)
+
+        story_reference = next(
+            ref
+            for ref in topic.canonical_story_references
+            if ref.story_id == story_id
+        )
+        story_unpublish_type = story_reference.story_unpublish_type
 
         new_story_status_is_public = self.normalized_payload[
             'new_story_status_is_public'
@@ -242,7 +262,20 @@ class StoryPublishHandler(
         if new_story_status_is_public:
             topic_services.publish_story(topic_id, story_id, self.user_id)
         else:
-            topic_services.unpublish_story(topic_id, story_id, self.user_id)
+            story_unpublish_type = self.normalized_payload.get(
+                'story_unpublish_type'
+            )
+            if story_unpublish_type is None:
+                story_unpublish_type = (
+                    topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT
+                )
+
+            topic_services.unpublish_story(
+                topic_id,
+                story_id,
+                self.user_id,
+                story_unpublish_type,
+            )
 
         self.render_json(self.values)
 

--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -72,7 +72,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, new_story_id),
             {
-                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+                'story_publication_action': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
             },
             csrf_token=csrf_token,
             expected_status_int=404,
@@ -86,7 +86,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, new_story_id),
             {
-                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+                'story_publication_action': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
             },
             csrf_token=csrf_token,
             expected_status_int=404,
@@ -94,7 +94,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.logout()
 
-    def test_put_can_not_publish_story_with_invalid_story_unpublish_type(
+    def test_put_can_not_publish_story_with_invalid_story_publication_action(
         self,
     ) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
@@ -102,7 +102,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
-            {'story_unpublish_type': 'invalid_value'},
+            {'story_publication_action': 'invalid_value'},
             csrf_token=csrf_token,
             expected_status_int=400,
         )
@@ -117,7 +117,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
             {
-                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+                'story_publication_action': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
             },
             csrf_token=csrf_token,
         )
@@ -130,7 +130,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
             {
-                'story_unpublish_type': (
+                'story_publication_action': (
                     topic_domain.STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH
                 )
             },
@@ -148,7 +148,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
             {
-                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+                'story_publication_action': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
             },
             csrf_token=csrf_token,
             expected_status_int=401,
@@ -161,7 +161,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
             {
-                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+                'story_publication_action': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
             },
             csrf_token=csrf_token,
         )
@@ -169,7 +169,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
             {
-                'story_unpublish_type': (
+                'story_publication_action': (
                     topic_domain.STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH
                 ),
             },

--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -71,7 +71,9 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, new_story_id),
-            {'new_story_status_is_public': True},
+            {
+                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+            },
             csrf_token=csrf_token,
             expected_status_int=404,
         )
@@ -83,14 +85,16 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, new_story_id),
-            {'new_story_status_is_public': True},
+            {
+                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+            },
             csrf_token=csrf_token,
             expected_status_int=404,
         )
 
         self.logout()
 
-    def test_put_can_not_publish_story_with_invalid_new_story_status_value(
+    def test_put_can_not_publish_story_with_invalid_story_unpublish_type(
         self,
     ) -> None:
         self.login(self.CURRICULUM_ADMIN_EMAIL)
@@ -98,7 +102,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
-            {'new_story_status_is_public': 'Invalid value'},
+            {'story_unpublish_type': 'invalid_value'},
             csrf_token=csrf_token,
             expected_status_int=400,
         )
@@ -112,7 +116,9 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
-            {'new_story_status_is_public': True},
+            {
+                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+            },
             csrf_token=csrf_token,
         )
 
@@ -123,7 +129,11 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
-            {'new_story_status_is_public': False},
+            {
+                'story_unpublish_type': (
+                    topic_domain.STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH
+                )
+            },
             csrf_token=csrf_token,
         )
 
@@ -137,7 +147,9 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
         # Check that non-admins cannot publish a story.
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
-            {'new_story_status_is_public': True},
+            {
+                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+            },
             csrf_token=csrf_token,
             expected_status_int=401,
         )
@@ -148,16 +160,17 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
-            {'new_story_status_is_public': True},
+            {
+                'story_unpublish_type': topic_domain.STORY_PUBLICATION_ACTION_PUBLISH
+            },
             csrf_token=csrf_token,
         )
 
         self.put_json(
             '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
             {
-                'new_story_status_is_public': False,
                 'story_unpublish_type': (
-                    topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY
+                    topic_domain.STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH
                 ),
             },
             csrf_token=csrf_token,
@@ -169,7 +182,7 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
                 self.assertEqual(reference.story_is_published, False)
                 self.assertEqual(
                     reference.story_unpublish_type,
-                    topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+                    topic_domain.STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH,
                 )
 
         self.logout()

--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -20,6 +20,7 @@ from core import feconf
 from core.domain import (
     story_domain,
     story_services,
+    topic_domain,
     topic_fetchers,
     user_services,
 )
@@ -140,6 +141,38 @@ class StoryPublicationTests(BaseStoryEditorControllerTests):
             csrf_token=csrf_token,
             expected_status_int=401,
         )
+
+    def test_story_unpublish_temporarily(self) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL)
+        csrf_token = self.get_new_csrf_token()
+
+        self.put_json(
+            '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
+            {'new_story_status_is_public': True},
+            csrf_token=csrf_token,
+        )
+
+        self.put_json(
+            '%s/%s' % (feconf.STORY_PUBLISH_HANDLER, self.story_id),
+            {
+                'new_story_status_is_public': False,
+                'story_unpublish_type': (
+                    topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY
+                ),
+            },
+            csrf_token=csrf_token,
+        )
+
+        topic = topic_fetchers.get_topic_by_id(self.topic_id)
+        for reference in topic.canonical_story_references:
+            if reference.story_id == self.story_id:
+                self.assertEqual(reference.story_is_published, False)
+                self.assertEqual(
+                    reference.story_unpublish_type,
+                    topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+                )
+
+        self.logout()
 
 
 class ValidateExplorationsHandlerTests(BaseStoryEditorControllerTests):

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -77,8 +77,8 @@ CMD_PUBLISH_STORY = 'publish_story'
 CMD_UNPUBLISH_STORY = 'unpublish_story'
 
 STORY_PUBLICATION_ACTION_PUBLISH: Final = 'publish'
-STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH: Final = 'permanent'
-STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH: Final = 'temporary'
+STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH: Final = 'permanent_unpublish'
+STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH: Final = 'temporary_unpublish'
 CMD_ADD_UNCATEGORIZED_SKILL_ID = 'add_uncategorized_skill_id'
 CMD_REMOVE_UNCATEGORIZED_SKILL_ID = 'remove_uncategorized_skill_id'
 CMD_MOVE_SKILL_ID_TO_SUBTOPIC = 'move_skill_id_to_subtopic'
@@ -765,7 +765,7 @@ class StoryReference:
             story_id: str. The ID of the story.
             story_is_published: bool. Whether the story is published or not.
             story_unpublish_type: str|None. How the story was unpublished
-                ('permanent' or 'temporary'), or None if currently published.
+                ('permanent_unpublish' or 'temporary_unpublish'), or None if currently published.
         """
         self.story_id = story_id
         self.story_is_published = story_is_published

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -76,8 +76,9 @@ CMD_DELETE_ADDITIONAL_STORY = 'delete_additional_story'
 CMD_PUBLISH_STORY = 'publish_story'
 CMD_UNPUBLISH_STORY = 'unpublish_story'
 
-STORY_UNPUBLISH_TYPE_PERMANENT: Final = 'permanent'
-STORY_UNPUBLISH_TYPE_TEMPORARY: Final = 'temporary'
+STORY_PUBLICATION_ACTION_PUBLISH: Final = 'publish'
+STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH: Final = 'permanent'
+STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH: Final = 'temporary'
 CMD_ADD_UNCATEGORIZED_SKILL_ID = 'add_uncategorized_skill_id'
 CMD_REMOVE_UNCATEGORIZED_SKILL_ID = 'remove_uncategorized_skill_id'
 CMD_MOVE_SKILL_ID_TO_SUBTOPIC = 'move_skill_id_to_subtopic'
@@ -1422,14 +1423,14 @@ class Topic:
     def unpublish_story(
         self,
         story_id: str,
-        unpublish_type: str = STORY_UNPUBLISH_TYPE_PERMANENT,
+        unpublish_type: str = STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
     ) -> None:
         """Marks story with the given id as unpublished.
 
         Args:
             story_id: str. The ID of the story to unpublish.
-            unpublish_type: str. Either STORY_UNPUBLISH_TYPE_PERMANENT or
-                STORY_UNPUBLISH_TYPE_TEMPORARY.
+            unpublish_type: str. Either STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH
+                or STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH.
 
         Raises:
             Exception. Story with given id doesn't exist in the topic.

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -34,7 +34,7 @@ from core.constants import constants
 from core.domain import fs_services  # pylint: disable=invalid-import-from
 from core.domain import change_domain, study_guide_domain, subtopic_page_domain
 
-from typing import Dict, List, Literal, Optional, TypedDict
+from typing import Dict, Final, List, Literal, Optional, TypedDict
 
 CMD_CREATE_NEW = feconf.CMD_CREATE_NEW
 CMD_CHANGE_ROLE = feconf.CMD_CHANGE_ROLE
@@ -75,6 +75,9 @@ CMD_ADD_ADDITIONAL_STORY = 'add_additional_story'
 CMD_DELETE_ADDITIONAL_STORY = 'delete_additional_story'
 CMD_PUBLISH_STORY = 'publish_story'
 CMD_UNPUBLISH_STORY = 'unpublish_story'
+
+STORY_UNPUBLISH_TYPE_PERMANENT: Final = 'permanent'
+STORY_UNPUBLISH_TYPE_TEMPORARY: Final = 'temporary'
 CMD_ADD_UNCATEGORIZED_SKILL_ID = 'add_uncategorized_skill_id'
 CMD_REMOVE_UNCATEGORIZED_SKILL_ID = 'remove_uncategorized_skill_id'
 CMD_MOVE_SKILL_ID_TO_SUBTOPIC = 'move_skill_id_to_subtopic'
@@ -743,20 +746,29 @@ class StoryReferenceDict(TypedDict):
 
     story_id: str
     story_is_published: bool
+    story_unpublish_type: Optional[str]
 
 
 class StoryReference:
     """Domain object for a Story reference."""
 
-    def __init__(self, story_id: str, story_is_published: bool) -> None:
+    def __init__(
+        self,
+        story_id: str,
+        story_is_published: bool,
+        story_unpublish_type: Optional[str] = None,
+    ) -> None:
         """Constructs a StoryReference domain object.
 
         Args:
             story_id: str. The ID of the story.
             story_is_published: bool. Whether the story is published or not.
+            story_unpublish_type: str|None. How the story was unpublished
+                ('permanent' or 'temporary'), or None if currently published.
         """
         self.story_id = story_id
         self.story_is_published = story_is_published
+        self.story_unpublish_type = story_unpublish_type
 
     def to_dict(self) -> StoryReferenceDict:
         """Returns a dict representing this StoryReference domain object.
@@ -767,6 +779,7 @@ class StoryReference:
         return {
             'story_id': self.story_id,
             'story_is_published': self.story_is_published,
+            'story_unpublish_type': self.story_unpublish_type,
         }
 
     @classmethod
@@ -785,6 +798,7 @@ class StoryReference:
         story_reference = cls(
             story_reference_dict['story_id'],
             story_reference_dict['story_is_published'],
+            story_reference_dict.get('story_unpublish_type'),
         )
         return story_reference
 
@@ -1395,16 +1409,27 @@ class Topic:
         for story_reference in self.canonical_story_references:
             if story_reference.story_id == story_id:
                 story_reference.story_is_published = True
+                story_reference.story_unpublish_type = None
                 return
 
         for story_reference in self.additional_story_references:
             if story_reference.story_id == story_id:
                 story_reference.story_is_published = True
+                story_reference.story_unpublish_type = None
                 return
         raise Exception('Story with given id doesn\'t exist in the topic')
 
-    def unpublish_story(self, story_id: str) -> None:
+    def unpublish_story(
+        self,
+        story_id: str,
+        unpublish_type: str = STORY_UNPUBLISH_TYPE_PERMANENT,
+    ) -> None:
         """Marks story with the given id as unpublished.
+
+        Args:
+            story_id: str. The ID of the story to unpublish.
+            unpublish_type: str. Either STORY_UNPUBLISH_TYPE_PERMANENT or
+                STORY_UNPUBLISH_TYPE_TEMPORARY.
 
         Raises:
             Exception. Story with given id doesn't exist in the topic.
@@ -1412,11 +1437,13 @@ class Topic:
         for story_reference in self.canonical_story_references:
             if story_reference.story_id == story_id:
                 story_reference.story_is_published = False
+                story_reference.story_unpublish_type = unpublish_type
                 return
 
         for story_reference in self.additional_story_references:
             if story_reference.story_id == story_id:
                 story_reference.story_is_published = False
+                story_reference.story_unpublish_type = unpublish_type
                 return
         raise Exception('Story with given id doesn\'t exist in the topic')
 

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -1002,6 +1002,7 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
         test_story_dict = {
             'story_id': 'story_id_1',
             'story_is_published': False,
+            'story_unpublish_type': None,
         }
         story_ref_obj = (
             topic_domain.StoryReference.create_default_story_reference(

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -1326,13 +1326,20 @@ def publish_story(topic_id: str, story_id: str, committer_id: str) -> None:
     )
 
 
-def unpublish_story(topic_id: str, story_id: str, committer_id: str) -> None:
+def unpublish_story(
+    topic_id: str,
+    story_id: str,
+    committer_id: str,
+    unpublish_type: str = topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
+) -> None:
     """Marks the given story as unpublished.
 
     Args:
         topic_id: str. The id of the topic.
         story_id: str. The id of the given story.
         committer_id: str. ID of the committer.
+        unpublish_type: str. Either STORY_UNPUBLISH_TYPE_PERMANENT or
+            STORY_UNPUBLISH_TYPE_TEMPORARY. Defaults to permanent.
 
     Raises:
         Exception. The given story does not exist.
@@ -1381,7 +1388,7 @@ def unpublish_story(topic_id: str, story_id: str, committer_id: str) -> None:
                 topic.id,
             )
 
-    topic.unpublish_story(story_id)
+    topic.unpublish_story(story_id, unpublish_type)
     change_list = [
         topic_domain.TopicChange(
             {'cmd': topic_domain.CMD_UNPUBLISH_STORY, 'story_id': story_id}
@@ -1397,9 +1404,12 @@ def unpublish_story(topic_id: str, story_id: str, committer_id: str) -> None:
 
     # Delete corresponding exploration opportunities and reject associated
     # translation suggestions.
-    exp_ids = story.story_contents.get_all_linked_exp_ids()
-    opportunity_services.delete_exploration_opportunities(exp_ids)
-    suggestion_services.auto_reject_translation_suggestions_for_exp_ids(exp_ids)
+    if unpublish_type == topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT:
+        exp_ids = story.story_contents.get_all_linked_exp_ids()
+        opportunity_services.delete_exploration_opportunities(exp_ids)
+        suggestion_services.auto_reject_translation_suggestions_for_exp_ids(
+            exp_ids
+        )
 
 
 def delete_canonical_story(user_id: str, topic_id: str, story_id: str) -> None:

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -1326,11 +1326,27 @@ def publish_story(topic_id: str, story_id: str, committer_id: str) -> None:
     )
 
 
+def _cleanup_permanently_unpublished_story(
+    exp_ids: List[str],
+) -> None:
+    """Deletes exploration opportunities and rejects translation suggestions
+    for a permanently unpublished story. This cleanup is intentionally
+    skipped for temporarily unpublished stories so that the content can be
+    restored without data loss when the story is republished.
+
+    Args:
+        exp_ids: list(str). The exploration IDs linked to the story whose
+            opportunities and suggestions should be cleaned up.
+    """
+    opportunity_services.delete_exploration_opportunities(exp_ids)
+    suggestion_services.auto_reject_translation_suggestions_for_exp_ids(exp_ids)
+
+
 def unpublish_story(
     topic_id: str,
     story_id: str,
     committer_id: str,
-    unpublish_type: str = topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
+    unpublish_type: str = topic_domain.STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
 ) -> None:
     """Marks the given story as unpublished.
 
@@ -1338,8 +1354,8 @@ def unpublish_story(
         topic_id: str. The id of the topic.
         story_id: str. The id of the given story.
         committer_id: str. ID of the committer.
-        unpublish_type: str. Either STORY_UNPUBLISH_TYPE_PERMANENT or
-            STORY_UNPUBLISH_TYPE_TEMPORARY. Defaults to permanent.
+        unpublish_type: str. Either STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH
+            or STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH. Defaults to permanent.
 
     Raises:
         Exception. The given story does not exist.
@@ -1402,13 +1418,12 @@ def unpublish_story(
     )
     generate_topic_summary(topic.id)
 
-    # Delete corresponding exploration opportunities and reject associated
-    # translation suggestions.
-    if unpublish_type == topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT:
-        exp_ids = story.story_contents.get_all_linked_exp_ids()
-        opportunity_services.delete_exploration_opportunities(exp_ids)
-        suggestion_services.auto_reject_translation_suggestions_for_exp_ids(
-            exp_ids
+    if (
+        unpublish_type
+        == topic_domain.STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH
+    ):
+        _cleanup_permanently_unpublished_story(
+            story.story_contents.get_all_linked_exp_ids()
         )
 
 

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -1299,7 +1299,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
             self.TOPIC_ID,
             self.story_id_1,
             self.user_id_admin,
-            topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+            topic_domain.STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH,
         )
         topic = topic_fetchers.get_topic_by_id(self.TOPIC_ID)
         for reference in topic.canonical_story_references:
@@ -1307,7 +1307,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
                 self.assertEqual(reference.story_is_published, False)
                 self.assertEqual(
                     reference.story_unpublish_type,
-                    topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+                    topic_domain.STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH,
                 )
 
     def test_unpublish_story_permanently_sets_unpublish_type(self) -> None:
@@ -1318,7 +1318,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
             self.TOPIC_ID,
             self.story_id_1,
             self.user_id_admin,
-            topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
+            topic_domain.STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
         )
         topic = topic_fetchers.get_topic_by_id(self.TOPIC_ID)
         for reference in topic.canonical_story_references:
@@ -1326,7 +1326,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
                 self.assertEqual(reference.story_is_published, False)
                 self.assertEqual(
                     reference.story_unpublish_type,
-                    topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
+                    topic_domain.STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
                 )
 
     def test_invalid_publish_and_unpublish_story(self) -> None:

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -1291,6 +1291,44 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(topic_summary.canonical_story_count, 0)
         self.assertEqual(topic_summary.additional_story_count, 0)
 
+    def test_unpublish_story_temporarily_sets_unpublish_type(self) -> None:
+        topic_services.publish_story(
+            self.TOPIC_ID, self.story_id_1, self.user_id_admin
+        )
+        topic_services.unpublish_story(
+            self.TOPIC_ID,
+            self.story_id_1,
+            self.user_id_admin,
+            topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+        )
+        topic = topic_fetchers.get_topic_by_id(self.TOPIC_ID)
+        for reference in topic.canonical_story_references:
+            if reference.story_id == self.story_id_1:
+                self.assertEqual(reference.story_is_published, False)
+                self.assertEqual(
+                    reference.story_unpublish_type,
+                    topic_domain.STORY_UNPUBLISH_TYPE_TEMPORARY,
+                )
+
+    def test_unpublish_story_permanently_sets_unpublish_type(self) -> None:
+        topic_services.publish_story(
+            self.TOPIC_ID, self.story_id_1, self.user_id_admin
+        )
+        topic_services.unpublish_story(
+            self.TOPIC_ID,
+            self.story_id_1,
+            self.user_id_admin,
+            topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
+        )
+        topic = topic_fetchers.get_topic_by_id(self.TOPIC_ID)
+        for reference in topic.canonical_story_references:
+            if reference.story_id == self.story_id_1:
+                self.assertEqual(reference.story_is_published, False)
+                self.assertEqual(
+                    reference.story_unpublish_type,
+                    topic_domain.STORY_UNPUBLISH_TYPE_PERMANENT,
+                )
+
     def test_invalid_publish_and_unpublish_story(self) -> None:
         with self.assertRaisesRegex(
             Exception,
@@ -4434,6 +4472,7 @@ class StoryReferenceMigrationTests(test_utils.GenericTestBase):
         story_reference_dict = {
             'story_id': 'story_id',
             'story_is_published': False,
+            'story_unpublish_type': None,
         }
         model = topic_models.TopicModel(
             id='topic_id',

--- a/core/templates/domain/story/editable-story-backend-api.service.spec.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.spec.ts
@@ -279,7 +279,7 @@ describe('Editable story backend API service', () => {
 
     // Send a request to update story.
     editableStoryBackendApiService
-      .changeStoryPublicationStatusAsync('storyId', true)
+      .changeStoryPublicationStatusAsync('storyId', 'publish')
       .then(successHandler, failHandler);
     let req = httpTestingController.expectOne('/story_publish_handler/storyId');
     expect(req.request.method).toEqual('PUT');
@@ -295,7 +295,7 @@ describe('Editable story backend API service', () => {
 
     // Send a request to update story.
     editableStoryBackendApiService
-      .changeStoryPublicationStatusAsync('storyId', false, 'permanent')
+      .changeStoryPublicationStatusAsync('storyId', 'permanent')
       .then(successHandler, failHandler);
     let req = httpTestingController.expectOne('/story_publish_handler/storyId');
     expect(req.request.method).toEqual('PUT');
@@ -416,7 +416,7 @@ describe('Editable story backend API service', () => {
 
     // Loading a story the first time should fetch it from the backend.
     editableStoryBackendApiService
-      .changeStoryPublicationStatusAsync('storyId', true)
+      .changeStoryPublicationStatusAsync('storyId', 'publish')
       .then(successHandler, failHandler);
     let req = httpTestingController.expectOne('/story_publish_handler/storyId');
     expect(req.request.method).toEqual('PUT');

--- a/core/templates/domain/story/editable-story-backend-api.service.spec.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.spec.ts
@@ -289,6 +289,22 @@ describe('Editable story backend API service', () => {
     expect(successHandler).toHaveBeenCalled();
     expect(failHandler).not.toHaveBeenCalled();
   }));
+  it('should unpublish a story', fakeAsync(() => {
+    var successHandler = jasmine.createSpy('success');
+    var failHandler = jasmine.createSpy('fail');
+
+    // Send a request to update story.
+    editableStoryBackendApiService
+      .changeStoryPublicationStatusAsync('storyId', false, 'permanent')
+      .then(successHandler, failHandler);
+    let req = httpTestingController.expectOne('/story_publish_handler/storyId');
+    expect(req.request.method).toEqual('PUT');
+    req.flush(200);
+    flushMicrotasks();
+
+    expect(successHandler).toHaveBeenCalled();
+    expect(failHandler).not.toHaveBeenCalled();
+  }));
 
   it(
     'should call success handler if the story is associated ' +

--- a/core/templates/domain/story/editable-story-backend-api.service.spec.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.spec.ts
@@ -295,7 +295,7 @@ describe('Editable story backend API service', () => {
 
     // Send a request to update story.
     editableStoryBackendApiService
-      .changeStoryPublicationStatusAsync('storyId', 'permanent')
+      .changeStoryPublicationStatusAsync('storyId', 'permanent_unpublish')
       .then(successHandler, failHandler);
     let req = httpTestingController.expectOne('/story_publish_handler/storyId');
     expect(req.request.method).toEqual('PUT');

--- a/core/templates/domain/story/editable-story-backend-api.service.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.ts
@@ -55,6 +55,11 @@ interface ValidationExplorationBackendResponse {
   validation_error_messages: string[];
 }
 
+interface ChangeStoryPublicationStatusRequest {
+  new_story_status_is_public: boolean;
+  story_unpublish_type: 'temporary' | 'permanent';
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -134,7 +139,8 @@ export class EditableStoryBackendApiService {
     storyId: string,
     newStoryStatusIsPublic: boolean,
     successCallback: (value: void) => void,
-    errorCallback: (reason: string) => void
+    errorCallback: (reason: string) => void,
+    mode?: 'temporary' | 'permanent'
   ): void {
     const storyPublishUrl = this.urlInterpolationService.interpolateUrl(
       StoryDomainConstants.STORY_PUBLISH_URL_TEMPLATE,
@@ -142,8 +148,9 @@ export class EditableStoryBackendApiService {
         story_id: storyId,
       }
     );
-    const putData = {
+    const putData: ChangeStoryPublicationStatusRequest = {
       new_story_status_is_public: newStoryStatusIsPublic,
+      story_unpublish_type: mode || 'permanent',
     };
     this.http
       .put(storyPublishUrl, putData)
@@ -273,15 +280,26 @@ export class EditableStoryBackendApiService {
 
   async changeStoryPublicationStatusAsync(
     storyId: string,
-    newStoryStatusIsPublic: boolean
+    newStoryStatusIsPublic: boolean,
+    mode?: 'temporary' | 'permanent'
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      this._changeStoryPublicationStatus(
-        storyId,
-        newStoryStatusIsPublic,
-        resolve,
-        reject
-      );
+      if (mode !== undefined) {
+        this._changeStoryPublicationStatus(
+          storyId,
+          newStoryStatusIsPublic,
+          resolve,
+          reject,
+          mode
+        );
+      } else {
+        this._changeStoryPublicationStatus(
+          storyId,
+          newStoryStatusIsPublic,
+          resolve,
+          reject
+        );
+      }
     });
   }
 

--- a/core/templates/domain/story/editable-story-backend-api.service.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.ts
@@ -56,7 +56,10 @@ interface ValidationExplorationBackendResponse {
 }
 
 interface ChangeStoryPublicationStatusRequest {
-  story_unpublish_type: 'publish' | 'temporary' | 'permanent';
+  story_publication_action:
+    | 'publish'
+    | 'temporary_unpublish'
+    | 'permanent_unpublish';
 }
 
 @Injectable({
@@ -136,7 +139,10 @@ export class EditableStoryBackendApiService {
 
   private _changeStoryPublicationStatus(
     storyId: string,
-    unpublishType: 'publish' | 'temporary' | 'permanent',
+    publicationAction:
+      | 'publish'
+      | 'temporary_unpublish'
+      | 'permanent_unpublish',
     successCallback: (value: void) => void,
     errorCallback: (reason: string) => void
   ): void {
@@ -147,7 +153,7 @@ export class EditableStoryBackendApiService {
       }
     );
     const putData: ChangeStoryPublicationStatusRequest = {
-      story_unpublish_type: unpublishType,
+      story_publication_action: publicationAction,
     };
     this.http
       .put(storyPublishUrl, putData)
@@ -277,12 +283,12 @@ export class EditableStoryBackendApiService {
 
   async changeStoryPublicationStatusAsync(
     storyId: string,
-    unpublishType: 'publish' | 'temporary' | 'permanent'
+    publicationAction: 'publish' | 'temporary_unpublish' | 'permanent_unpublish'
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       this._changeStoryPublicationStatus(
         storyId,
-        unpublishType,
+        publicationAction,
         resolve,
         reject
       );

--- a/core/templates/domain/story/editable-story-backend-api.service.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.ts
@@ -56,8 +56,7 @@ interface ValidationExplorationBackendResponse {
 }
 
 interface ChangeStoryPublicationStatusRequest {
-  new_story_status_is_public: boolean;
-  story_unpublish_type?: 'temporary' | 'permanent';
+  story_unpublish_type: 'publish' | 'temporary' | 'permanent';
 }
 
 @Injectable({
@@ -137,10 +136,9 @@ export class EditableStoryBackendApiService {
 
   private _changeStoryPublicationStatus(
     storyId: string,
-    newStoryStatusIsPublic: boolean,
+    unpublishType: 'publish' | 'temporary' | 'permanent',
     successCallback: (value: void) => void,
-    errorCallback: (reason: string) => void,
-    mode?: 'temporary' | 'permanent'
+    errorCallback: (reason: string) => void
   ): void {
     const storyPublishUrl = this.urlInterpolationService.interpolateUrl(
       StoryDomainConstants.STORY_PUBLISH_URL_TEMPLATE,
@@ -149,8 +147,7 @@ export class EditableStoryBackendApiService {
       }
     );
     const putData: ChangeStoryPublicationStatusRequest = {
-      new_story_status_is_public: newStoryStatusIsPublic,
-      ...(mode !== undefined && {story_unpublish_type: mode}),
+      story_unpublish_type: unpublishType,
     };
     this.http
       .put(storyPublishUrl, putData)
@@ -280,26 +277,15 @@ export class EditableStoryBackendApiService {
 
   async changeStoryPublicationStatusAsync(
     storyId: string,
-    newStoryStatusIsPublic: boolean,
-    mode?: 'temporary' | 'permanent'
+    unpublishType: 'publish' | 'temporary' | 'permanent'
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (mode !== undefined) {
-        this._changeStoryPublicationStatus(
-          storyId,
-          newStoryStatusIsPublic,
-          resolve,
-          reject,
-          mode
-        );
-      } else {
-        this._changeStoryPublicationStatus(
-          storyId,
-          newStoryStatusIsPublic,
-          resolve,
-          reject
-        );
-      }
+      this._changeStoryPublicationStatus(
+        storyId,
+        unpublishType,
+        resolve,
+        reject
+      );
     });
   }
 

--- a/core/templates/domain/story/editable-story-backend-api.service.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.ts
@@ -57,7 +57,7 @@ interface ValidationExplorationBackendResponse {
 
 interface ChangeStoryPublicationStatusRequest {
   new_story_status_is_public: boolean;
-  story_unpublish_type: 'temporary' | 'permanent';
+  story_unpublish_type?: 'temporary' | 'permanent';
 }
 
 @Injectable({
@@ -150,7 +150,7 @@ export class EditableStoryBackendApiService {
     );
     const putData: ChangeStoryPublicationStatusRequest = {
       new_story_status_is_public: newStoryStatusIsPublic,
-      story_unpublish_type: mode || 'permanent',
+      ...(mode !== undefined && {story_unpublish_type: mode}),
     };
     this.http
       .put(storyPublishUrl, putData)

--- a/core/templates/domain/story/editable-story-backend-api.service.ts
+++ b/core/templates/domain/story/editable-story-backend-api.service.ts
@@ -55,11 +55,19 @@ interface ValidationExplorationBackendResponse {
   validation_error_messages: string[];
 }
 
+export const STORY_PUBLICATION_ACTION_PUBLISH = 'publish' as const;
+export const STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH =
+  'temporary_unpublish' as const;
+export const STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH =
+  'permanent_unpublish' as const;
+
+export type StoryPublicationAction =
+  | typeof STORY_PUBLICATION_ACTION_PUBLISH
+  | typeof STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH
+  | typeof STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH;
+
 interface ChangeStoryPublicationStatusRequest {
-  story_publication_action:
-    | 'publish'
-    | 'temporary_unpublish'
-    | 'permanent_unpublish';
+  story_publication_action: StoryPublicationAction;
 }
 
 @Injectable({
@@ -139,10 +147,7 @@ export class EditableStoryBackendApiService {
 
   private _changeStoryPublicationStatus(
     storyId: string,
-    publicationAction:
-      | 'publish'
-      | 'temporary_unpublish'
-      | 'permanent_unpublish',
+    publicationAction: StoryPublicationAction,
     successCallback: (value: void) => void,
     errorCallback: (reason: string) => void
   ): void {
@@ -283,7 +288,7 @@ export class EditableStoryBackendApiService {
 
   async changeStoryPublicationStatusAsync(
     storyId: string,
-    publicationAction: 'publish' | 'temporary_unpublish' | 'permanent_unpublish'
+    publicationAction: StoryPublicationAction
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       this._changeStoryPublicationStatus(

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.html
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.html
@@ -77,25 +77,76 @@
 </div>
 
 <div *ngIf="!isSerialChapterFeatureFlagEnabled()">
-  <div class="modal-header">
-    <p>
-      Are you sure you want to unpublish this story? Unpublishing a story will
-      delete any corresponding translation opportunities from the Contributor
-      Dashboard and reject any related pending translation suggestions.
-    </p>
-  </div>
-  <div class="modal-footer">
-    <button class="btn btn-secondary"
-            (click)="cancel()"
-            (keydown.enter)="cancel()"
-            type="button">
+  <div *ngIf="popup === 'choice'">
+    <div class="modal-header">
+      <p>Are you unpublishing this story temporarily or permanently?</p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary"
+              (click)="cancel()"
+              (keydown.enter)="cancel()"
+              type="button">
             Cancel
-    </button>
-    <button class="btn btn-success e2e-test-close-save-modal-button"
-            (click)="confirm()"
-            (keydown.enter)="confirm()">
-      Unpublish Story
-    </button>
+      </button>
+      <button class="btn btn-success e2e-test-close-save-modal-button"
+              (click)="selectTemporary()"
+              (keydown.enter)="selectTemporary()">
+            Temporarily
+      </button>
+      <button class="btn btn-success e2e-test-close-save-modal-button"
+              (click)="selectPermanent()"
+              (keydown.enter)="selectPermanent()">
+            Permanently
+      </button>
+    </div>
+  </div>
+
+  <div *ngIf="popup === 'temporary'">
+    <div class="modal-header">
+      <p>
+        Are you sure you want to temporarily unpublish this story? Temporarily
+        unpublishing a story will retain any corresponding translation
+        opportunities on the Contributor Dashboard. Please republish the story
+        within 24 hours to avoid disrupting learners currently engaged with it.
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary"
+              (click)="cancel()"
+              (keydown.enter)="cancel()"
+              type="button">
+            Cancel
+      </button>
+      <button class="btn btn-success e2e-test-close-save-modal-button"
+              (click)="confirm()"
+              (keydown.enter)="confirm()">
+            Unpublish Story
+      </button>
+    </div>
+  </div>
+
+  <div *ngIf="popup === 'permanent'">
+    <div class="modal-header">
+      <p>
+        Are you sure you want to permanently unpublish this story? Permanently
+        unpublishing a story will delete any corresponding translation
+        opportunities from the Contributor Dashboard and reject any related
+        pending translation suggestions.
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary"
+              (click)="cancel()"
+              (keydown.enter)="cancel()"
+              type="button">
+            Cancel
+      </button>
+      <button class="btn btn-success e2e-test-close-save-modal-button"
+              (click)="confirm()"
+              (keydown.enter)="confirm()">
+            Unpublish Story
+      </button>
+    </div>
   </div>
 </div>
 

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.html
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.html
@@ -77,7 +77,7 @@
 </div>
 
 <div *ngIf="!isSerialChapterFeatureFlagEnabled()">
-  <div *ngIf="popup === 'choice'">
+  <div *ngIf="showingChoiceScreen">
     <div class="modal-header">
       <p>Are you unpublishing this story temporarily or permanently?</p>
     </div>
@@ -101,33 +101,15 @@
     </div>
   </div>
 
-  <div *ngIf="popup === 'temporary'">
+  <div *ngIf="!showingChoiceScreen">
     <div class="modal-header">
-      <p>
+      <p *ngIf="mode === 'temporary'">
         Are you sure you want to temporarily unpublish this story? Temporarily
         unpublishing a story will retain any corresponding translation
         opportunities on the Contributor Dashboard. Please republish the story
         within 24 hours to avoid disrupting learners currently engaged with it.
       </p>
-    </div>
-    <div class="modal-footer">
-      <button class="btn btn-secondary"
-              (click)="cancel()"
-              (keydown.enter)="cancel()"
-              type="button">
-            Cancel
-      </button>
-      <button class="btn btn-success e2e-test-close-save-modal-button"
-              (click)="confirm()"
-              (keydown.enter)="confirm()">
-            Unpublish Story
-      </button>
-    </div>
-  </div>
-
-  <div *ngIf="popup === 'permanent'">
-    <div class="modal-header">
-      <p>
+      <p *ngIf="mode === 'permanent'">
         Are you sure you want to permanently unpublish this story? Permanently
         unpublishing a story will delete any corresponding translation
         opportunities from the Contributor Dashboard and reject any related

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.html
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.html
@@ -103,13 +103,13 @@
 
   <div *ngIf="!showingChoiceScreen">
     <div class="modal-header">
-      <p *ngIf="mode === 'temporary'">
+      <p *ngIf="mode === 'temporary_unpublish'">
         Are you sure you want to temporarily unpublish this story? Temporarily
         unpublishing a story will retain any corresponding translation
         opportunities on the Contributor Dashboard. Please republish the story
         within 24 hours to avoid disrupting learners currently engaged with it.
       </p>
-      <p *ngIf="mode === 'permanent'">
+      <p *ngIf="mode === 'permanent_unpublish'">
         Are you sure you want to permanently unpublish this story? Permanently
         unpublishing a story will delete any corresponding translation
         opportunities from the Contributor Dashboard and reject any related

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.spec.ts
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.spec.ts
@@ -84,7 +84,7 @@ describe('Story Editor Unpublish Modal Component', () => {
     });
   });
 
-  it('should not close when popup is in choice state', () => {
+  it('should not close when showing the choice screen', () => {
     mockPlatformFeatureService.status.SerialChapterLaunchCurriculumAdminView.isEnabled =
       false;
     const spy = spyOn(ngbActiveModal, 'close');

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.spec.ts
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.spec.ts
@@ -79,7 +79,7 @@ describe('Story Editor Unpublish Modal Component', () => {
     const spy = spyOn(ngbActiveModal, 'close');
     component.confirm();
     expect(spy).toHaveBeenCalledWith({
-      mode: 'permanent',
+      mode: 'permanent_unpublish',
       reason: component.unpublishingReason,
     });
   });
@@ -99,8 +99,8 @@ describe('Story Editor Unpublish Modal Component', () => {
     component.selectTemporary();
     component.confirm();
     expect(spy).toHaveBeenCalledWith({
-      mode: 'temporary',
-      reason: undefined,
+      mode: 'temporary_unpublish',
+      reason: null,
     });
   });
 
@@ -111,8 +111,8 @@ describe('Story Editor Unpublish Modal Component', () => {
     component.selectPermanent();
     component.confirm();
     expect(spy).toHaveBeenCalledWith({
-      mode: 'permanent',
-      reason: undefined,
+      mode: 'permanent_unpublish',
+      reason: null,
     });
   });
 

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.spec.ts
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.spec.ts
@@ -73,17 +73,47 @@ describe('Story Editor Unpublish Modal Component', () => {
     expect(dismissSpy).toHaveBeenCalled();
   });
 
-  it('should close by proceeding with unpublishing', () => {
-    mockPlatformFeatureService.status.SerialChapterLaunchCurriculumAdminView.isEnabled =
-      false;
-    const confirmSpy = spyOn(ngbActiveModal, 'close').and.callThrough();
-    component.confirm();
-    expect(confirmSpy).toHaveBeenCalled();
-
+  it('should close directly when feature flag is enabled', () => {
     mockPlatformFeatureService.status.SerialChapterLaunchCurriculumAdminView.isEnabled =
       true;
+    const spy = spyOn(ngbActiveModal, 'close');
     component.confirm();
-    expect(confirmSpy).toHaveBeenCalledWith(component.unpublishingReason);
+    expect(spy).toHaveBeenCalledWith({
+      mode: 'permanent',
+      reason: component.unpublishingReason,
+    });
+  });
+
+  it('should not close when popup is in choice state', () => {
+    mockPlatformFeatureService.status.SerialChapterLaunchCurriculumAdminView.isEnabled =
+      false;
+    const spy = spyOn(ngbActiveModal, 'close');
+    component.confirm();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should close with temporary mode after selecting temporary', () => {
+    mockPlatformFeatureService.status.SerialChapterLaunchCurriculumAdminView.isEnabled =
+      false;
+    const spy = spyOn(ngbActiveModal, 'close');
+    component.selectTemporary();
+    component.confirm();
+    expect(spy).toHaveBeenCalledWith({
+      mode: 'temporary',
+      reason: undefined,
+    });
+  });
+
+  it('should close with permanent mode after selecting permanent', () => {
+    mockPlatformFeatureService.status.SerialChapterLaunchCurriculumAdminView.isEnabled =
+      false;
+    const spy = spyOn(ngbActiveModal, 'close');
+    component.selectPermanent();
+    component.confirm();
+    expect(spy).toHaveBeenCalledWith({
+      mode: 'permanent',
+      reason: undefined,
+    });
   });
 
   it('should get status of Serial Chapter Launch Feature flag', () => {

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
@@ -41,15 +41,39 @@ export class StoryEditorUnpublishModalComponent {
   selectedReasonText: string = this.badContentReasonText;
   unpublishingReason: string = 'BAD_CONTENT';
 
+  popup: 'choice' | 'temporary' | 'permanent' = 'choice';
+
+  selectTemporary(): void {
+    this.popup = 'temporary';
+  }
+
+  selectPermanent(): void {
+    this.popup = 'permanent';
+  }
+
   cancel(): void {
     this.activeModal.dismiss();
   }
 
   confirm(): void {
     if (this.isSerialChapterFeatureFlagEnabled()) {
-      this.activeModal.close(this.unpublishingReason);
-    } else {
-      this.activeModal.close();
+      this.activeModal.close({
+        mode: 'permanent',
+        reason: this.unpublishingReason,
+      });
+      return;
+    }
+
+    if (this.popup === 'temporary') {
+      this.activeModal.close({
+        mode: 'temporary',
+        reason: undefined,
+      });
+    } else if (this.popup === 'permanent') {
+      this.activeModal.close({
+        mode: 'permanent',
+        reason: undefined,
+      });
     }
   }
 

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
@@ -41,14 +41,17 @@ export class StoryEditorUnpublishModalComponent {
   selectedReasonText: string = this.badContentReasonText;
   unpublishingReason: string = 'BAD_CONTENT';
 
-  popup: 'choice' | 'temporary' | 'permanent' = 'choice';
+  showingChoiceScreen: boolean = true;
+  mode: 'temporary' | 'permanent' = 'permanent';
 
   selectTemporary(): void {
-    this.popup = 'temporary';
+    this.showingChoiceScreen = false;
+    this.mode = 'temporary';
   }
 
   selectPermanent(): void {
-    this.popup = 'permanent';
+    this.showingChoiceScreen = false;
+    this.mode = 'permanent';
   }
 
   cancel(): void {
@@ -64,14 +67,9 @@ export class StoryEditorUnpublishModalComponent {
       return;
     }
 
-    if (this.popup === 'temporary') {
+    if (!this.showingChoiceScreen) {
       this.activeModal.close({
-        mode: 'temporary',
-        reason: undefined,
-      });
-    } else if (this.popup === 'permanent') {
-      this.activeModal.close({
-        mode: 'permanent',
+        mode: this.mode,
         reason: undefined,
       });
     }

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
@@ -42,16 +42,16 @@ export class StoryEditorUnpublishModalComponent {
   unpublishingReason: string = 'BAD_CONTENT';
 
   showingChoiceScreen: boolean = true;
-  mode: 'temporary' | 'permanent' = 'permanent';
+  mode: 'temporary_unpublish' | 'permanent_unpublish' = 'permanent_unpublish';
 
   selectTemporary(): void {
     this.showingChoiceScreen = false;
-    this.mode = 'temporary';
+    this.mode = 'temporary_unpublish';
   }
 
   selectPermanent(): void {
     this.showingChoiceScreen = false;
-    this.mode = 'permanent';
+    this.mode = 'permanent_unpublish';
   }
 
   cancel(): void {
@@ -61,7 +61,7 @@ export class StoryEditorUnpublishModalComponent {
   confirm(): void {
     if (this.isSerialChapterFeatureFlagEnabled()) {
       this.activeModal.close({
-        mode: 'permanent',
+        mode: 'permanent_unpublish',
         reason: this.unpublishingReason,
       });
       return;
@@ -70,7 +70,7 @@ export class StoryEditorUnpublishModalComponent {
     if (!this.showingChoiceScreen) {
       this.activeModal.close({
         mode: this.mode,
-        reason: undefined,
+        reason: null,
       });
     }
   }

--- a/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
+++ b/core/templates/pages/story-editor-page/modal-templates/story-editor-unpublish-modal.component.ts
@@ -18,6 +18,10 @@
 
 import {Component} from '@angular/core';
 import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import {
+  STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
+  STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH,
+} from 'domain/story/editable-story-backend-api.service';
 import {PlatformFeatureService} from 'services/platform-feature.service';
 
 @Component({
@@ -42,16 +46,19 @@ export class StoryEditorUnpublishModalComponent {
   unpublishingReason: string = 'BAD_CONTENT';
 
   showingChoiceScreen: boolean = true;
-  mode: 'temporary_unpublish' | 'permanent_unpublish' = 'permanent_unpublish';
+  mode:
+    | typeof STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH
+    | typeof STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH =
+    STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH;
 
   selectTemporary(): void {
     this.showingChoiceScreen = false;
-    this.mode = 'temporary_unpublish';
+    this.mode = STORY_PUBLICATION_ACTION_TEMPORARY_UNPUBLISH;
   }
 
   selectPermanent(): void {
     this.showingChoiceScreen = false;
-    this.mode = 'permanent_unpublish';
+    this.mode = STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH;
   }
 
   cancel(): void {
@@ -61,7 +68,7 @@ export class StoryEditorUnpublishModalComponent {
   confirm(): void {
     if (this.isSerialChapterFeatureFlagEnabled()) {
       this.activeModal.close({
-        mode: 'permanent_unpublish',
+        mode: STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
         reason: this.unpublishingReason,
       });
       return;

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.spec.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.spec.ts
@@ -479,9 +479,14 @@ describe('Story editor navbar component', () => {
     ).and.returnValue(mockStoryInitializedEventEmitter);
     const modalSpy = spyOn(ngbModal, 'open').and.callFake((dlg, opt) => {
       return {
-        result: Promise.resolve('success'),
+        result: Promise.resolve({mode: 'permanent'}),
       } as NgbModalRef;
     });
+
+    spyOn(
+      storyEditorStateService,
+      'changeStoryPublicationStatus'
+    ).and.callThrough();
 
     component.ngOnInit();
     mockStoryInitializedEventEmitter.emit();

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
@@ -260,7 +260,7 @@ export class StoryEditorNavbarComponent implements OnInit {
   }
 
   publishStory(): void {
-    this.storyEditorStateService.changeStoryPublicationStatus(true, () => {
+    this.storyEditorStateService.changeStoryPublicationStatus('publish', () => {
       this.storyIsPublished = this.storyEditorStateService.isStoryPublished();
     });
   }
@@ -272,14 +272,13 @@ export class StoryEditorNavbarComponent implements OnInit {
         result => {
           if (result?.mode) {
             this.storyEditorStateService.changeStoryPublicationStatus(
-              false,
+              result.mode,
               () => {
                 this.storyIsPublished =
                   this.storyEditorStateService.isStoryPublished();
                 this.forceValidateExplorations = true;
                 this._validateStory();
-              },
-              result.mode
+              }
             );
           }
         },
@@ -348,7 +347,7 @@ export class StoryEditorNavbarComponent implements OnInit {
             }
             if (Number(selectedChapterIndexInPublishUptoDropdown) === -1) {
               this.storyEditorStateService.changeStoryPublicationStatus(
-                false,
+                'permanent',
                 () => {
                   this.storyIsPublished =
                     this.storyEditorStateService.isStoryPublished();

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
@@ -269,16 +269,19 @@ export class StoryEditorNavbarComponent implements OnInit {
     this.ngbModal
       .open(StoryEditorUnpublishModalComponent, {backdrop: 'static'})
       .result.then(
-        () => {
-          this.storyEditorStateService.changeStoryPublicationStatus(
-            false,
-            () => {
-              this.storyIsPublished =
-                this.storyEditorStateService.isStoryPublished();
-              this.forceValidateExplorations = true;
-              this._validateStory();
-            }
-          );
+        result => {
+          if (result?.mode) {
+            this.storyEditorStateService.changeStoryPublicationStatus(
+              false,
+              () => {
+                this.storyIsPublished =
+                  this.storyEditorStateService.isStoryPublished();
+                this.forceValidateExplorations = true;
+                this._validateStory();
+              },
+              result.mode
+            );
+          }
         },
         () => {
           // Note to developers:
@@ -318,7 +321,8 @@ export class StoryEditorNavbarComponent implements OnInit {
         }
         modalRef.componentInstance.unpublishedChapters = unpublishedChapters;
         modalRef.result.then(
-          unpublishingReason => {
+          result => {
+            const unpublishingReason = result?.reason;
             for (
               let i = Number(selectedChapterIndexInPublishUptoDropdown) + 1;
               i <= lastPublishedChapterIndex;

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
@@ -18,7 +18,11 @@
 
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {UndoRedoService} from 'domain/editor/undo_redo/undo-redo.service';
-import {EditableStoryBackendApiService} from 'domain/story/editable-story-backend-api.service';
+import {
+  EditableStoryBackendApiService,
+  STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
+  STORY_PUBLICATION_ACTION_PUBLISH,
+} from 'domain/story/editable-story-backend-api.service';
 import {StoryValidationService} from 'domain/story/story-validation.service';
 import {Story} from 'domain/story/story.model';
 import {StoryNode} from 'domain/story/story-node.model';
@@ -260,9 +264,12 @@ export class StoryEditorNavbarComponent implements OnInit {
   }
 
   publishStory(): void {
-    this.storyEditorStateService.changeStoryPublicationStatus('publish', () => {
-      this.storyIsPublished = this.storyEditorStateService.isStoryPublished();
-    });
+    this.storyEditorStateService.changeStoryPublicationStatus(
+      STORY_PUBLICATION_ACTION_PUBLISH,
+      () => {
+        this.storyIsPublished = this.storyEditorStateService.isStoryPublished();
+      }
+    );
   }
 
   unpublishStory(): void {
@@ -347,7 +354,7 @@ export class StoryEditorNavbarComponent implements OnInit {
             }
             if (Number(selectedChapterIndexInPublishUptoDropdown) === -1) {
               this.storyEditorStateService.changeStoryPublicationStatus(
-                'permanent_unpublish',
+                STORY_PUBLICATION_ACTION_PERMANENT_UNPUBLISH,
                 () => {
                   this.storyIsPublished =
                     this.storyEditorStateService.isStoryPublished();

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.component.ts
@@ -347,7 +347,7 @@ export class StoryEditorNavbarComponent implements OnInit {
             }
             if (Number(selectedChapterIndexInPublishUptoDropdown) === -1) {
               this.storyEditorStateService.changeStoryPublicationStatus(
-                'permanent',
+                'permanent_unpublish',
                 () => {
                   this.storyIsPublished =
                     this.storyEditorStateService.isStoryPublished();

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
@@ -378,6 +378,39 @@ describe('Story editor state service', () => {
     expect(successCallback).toHaveBeenCalled();
   }));
 
+  it('should be able to unpublish the story', fakeAsync(() => {
+    spyOn(
+      fakeEditableStoryBackendApiService,
+      'changeStoryPublicationStatusAsync'
+    ).and.callThrough();
+    var successCallback = jasmine.createSpy('successCallback');
+
+    storyEditorStateService.loadStory('storyId_0');
+    tick(1000);
+
+    storyEditorStateService._storyIsPublished = true;
+    expect(storyEditorStateService.isStoryPublished()).toBe(true);
+    expect(
+      storyEditorStateService.changeStoryPublicationStatus(
+        false,
+        successCallback,
+        'permanent'
+      )
+    ).toBe(true);
+    tick(1000);
+
+    var expectedId = 'storyId_0';
+    var publishStorySpy =
+      fakeEditableStoryBackendApiService.changeStoryPublicationStatusAsync;
+    expect(publishStorySpy).toHaveBeenCalledWith(
+      expectedId,
+      false,
+      'permanent'
+    );
+    expect(storyEditorStateService.isStoryPublished()).toBe(false);
+    expect(successCallback).toHaveBeenCalled();
+  }));
+
   it('should warn user when story is not published', fakeAsync(() => {
     const successCallback = jasmine.createSpy('successCallback');
     spyOn(

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
@@ -364,7 +364,7 @@ describe('Story editor state service', () => {
     expect(storyEditorStateService.isStoryPublished()).toBe(false);
     expect(
       storyEditorStateService.changeStoryPublicationStatus(
-        true,
+        'publish',
         successCallback
       )
     ).toBe(true);
@@ -373,7 +373,7 @@ describe('Story editor state service', () => {
     var expectedId = 'storyId_0';
     var publishStorySpy =
       fakeEditableStoryBackendApiService.changeStoryPublicationStatusAsync;
-    expect(publishStorySpy).toHaveBeenCalledWith(expectedId, true);
+    expect(publishStorySpy).toHaveBeenCalledWith(expectedId, 'publish');
     expect(storyEditorStateService.isStoryPublished()).toBe(true);
     expect(successCallback).toHaveBeenCalled();
   }));
@@ -392,9 +392,8 @@ describe('Story editor state service', () => {
     expect(storyEditorStateService.isStoryPublished()).toBe(true);
     expect(
       storyEditorStateService.changeStoryPublicationStatus(
-        false,
-        successCallback,
-        'permanent'
+        'permanent',
+        successCallback
       )
     ).toBe(true);
     tick(1000);
@@ -402,11 +401,7 @@ describe('Story editor state service', () => {
     var expectedId = 'storyId_0';
     var publishStorySpy =
       fakeEditableStoryBackendApiService.changeStoryPublicationStatusAsync;
-    expect(publishStorySpy).toHaveBeenCalledWith(
-      expectedId,
-      false,
-      'permanent'
-    );
+    expect(publishStorySpy).toHaveBeenCalledWith(expectedId, 'permanent');
     expect(storyEditorStateService.isStoryPublished()).toBe(false);
     expect(successCallback).toHaveBeenCalled();
   }));
@@ -426,7 +421,7 @@ describe('Story editor state service', () => {
     expect(storyEditorStateService.isStoryPublished()).toBe(false);
     expect(
       storyEditorStateService.changeStoryPublicationStatus(
-        true,
+        'publish',
         successCallback
       )
     ).toBe(true);
@@ -435,7 +430,7 @@ describe('Story editor state service', () => {
     var expectedId = 'storyId_0';
     var publishStorySpy =
       fakeEditableStoryBackendApiService.changeStoryPublicationStatusAsync;
-    expect(publishStorySpy).toHaveBeenCalledWith(expectedId, true);
+    expect(publishStorySpy).toHaveBeenCalledWith(expectedId, 'publish');
     expect(storyEditorStateService.isStoryPublished()).toBe(false);
     expect(alertsService.addWarning).toHaveBeenCalledWith(
       'There was an error when publishing/unpublishing the story.'
@@ -450,7 +445,10 @@ describe('Story editor state service', () => {
     spyOn(alertsService, 'fatalWarning');
     storyEditorStateService._storyIsInitialized = false;
 
-    storyEditorStateService.changeStoryPublicationStatus(true, successCallback);
+    storyEditorStateService.changeStoryPublicationStatus(
+      'publish',
+      successCallback
+    );
 
     expect(alertsService.fatalWarning).toHaveBeenCalledWith(
       'Cannot publish a story before one is loaded.'

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
@@ -383,7 +383,7 @@ describe('Story editor state service', () => {
       fakeEditableStoryBackendApiService,
       'changeStoryPublicationStatusAsync'
     ).and.callThrough();
-    var successCallback = jasmine.createSpy('successCallback');
+    const successCallback = jasmine.createSpy('successCallback');
 
     storyEditorStateService.loadStory('storyId_0');
     tick(1000);

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.spec.ts
@@ -392,7 +392,7 @@ describe('Story editor state service', () => {
     expect(storyEditorStateService.isStoryPublished()).toBe(true);
     expect(
       storyEditorStateService.changeStoryPublicationStatus(
-        'permanent',
+        'permanent_unpublish',
         successCallback
       )
     ).toBe(true);
@@ -401,7 +401,10 @@ describe('Story editor state service', () => {
     var expectedId = 'storyId_0';
     var publishStorySpy =
       fakeEditableStoryBackendApiService.changeStoryPublicationStatusAsync;
-    expect(publishStorySpy).toHaveBeenCalledWith(expectedId, 'permanent');
+    expect(publishStorySpy).toHaveBeenCalledWith(
+      expectedId,
+      'permanent_unpublish'
+    );
     expect(storyEditorStateService.isStoryPublished()).toBe(false);
     expect(successCallback).toHaveBeenCalled();
   }));

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
@@ -275,7 +275,10 @@ export class StoryEditorStateService {
   }
 
   changeStoryPublicationStatus(
-    unpublishType: 'publish' | 'temporary' | 'permanent',
+    publicationAction:
+      | 'publish'
+      | 'temporary_unpublish'
+      | 'permanent_unpublish',
     successCallback: (value?: Object) => void
   ): boolean {
     const storyId = this._story.getId();
@@ -287,10 +290,10 @@ export class StoryEditorStateService {
     }
 
     this.editableStoryBackendApiService
-      .changeStoryPublicationStatusAsync(storyId, unpublishType)
+      .changeStoryPublicationStatusAsync(storyId, publicationAction)
       .then(
         () => {
-          this._setStoryPublicationStatus(unpublishType === 'publish');
+          this._setStoryPublicationStatus(publicationAction === 'publish');
           if (successCallback) {
             successCallback();
           }

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
@@ -276,7 +276,8 @@ export class StoryEditorStateService {
 
   changeStoryPublicationStatus(
     newStoryStatusIsPublic: boolean,
-    successCallback: (value?: Object) => void
+    successCallback: (value?: Object) => void,
+    mode?: 'temporary' | 'permanent'
   ): boolean {
     const storyId = this._story.getId();
     if (!storyId || !this._storyIsInitialized) {
@@ -285,22 +286,35 @@ export class StoryEditorStateService {
       );
       return false;
     }
-    this.editableStoryBackendApiService
-      .changeStoryPublicationStatusAsync(storyId, newStoryStatusIsPublic)
-      .then(
-        storyBackendObject => {
-          this._setStoryPublicationStatus(newStoryStatusIsPublic);
-          if (successCallback) {
-            successCallback();
-          }
-        },
-        error => {
-          this.alertsService.addWarning(
-            error ||
-              'There was an error when publishing/unpublishing the story.'
-          );
+
+    let promise: Promise<void>;
+    if (mode !== undefined) {
+      promise =
+        this.editableStoryBackendApiService.changeStoryPublicationStatusAsync(
+          storyId,
+          newStoryStatusIsPublic,
+          mode
+        );
+    } else {
+      promise =
+        this.editableStoryBackendApiService.changeStoryPublicationStatusAsync(
+          storyId,
+          newStoryStatusIsPublic
+        );
+    }
+    promise.then(
+      () => {
+        this._setStoryPublicationStatus(newStoryStatusIsPublic);
+        if (successCallback) {
+          successCallback();
         }
-      );
+      },
+      error => {
+        this.alertsService.addWarning(
+          error || 'There was an error when publishing/unpublishing the story.'
+        );
+      }
+    );
     return true;
   }
 

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
@@ -275,9 +275,8 @@ export class StoryEditorStateService {
   }
 
   changeStoryPublicationStatus(
-    newStoryStatusIsPublic: boolean,
-    successCallback: (value?: Object) => void,
-    mode?: 'temporary' | 'permanent'
+    unpublishType: 'publish' | 'temporary' | 'permanent',
+    successCallback: (value?: Object) => void
   ): boolean {
     const storyId = this._story.getId();
     if (!storyId || !this._storyIsInitialized) {
@@ -287,34 +286,22 @@ export class StoryEditorStateService {
       return false;
     }
 
-    let promise: Promise<void>;
-    if (mode !== undefined) {
-      promise =
-        this.editableStoryBackendApiService.changeStoryPublicationStatusAsync(
-          storyId,
-          newStoryStatusIsPublic,
-          mode
-        );
-    } else {
-      promise =
-        this.editableStoryBackendApiService.changeStoryPublicationStatusAsync(
-          storyId,
-          newStoryStatusIsPublic
-        );
-    }
-    promise.then(
-      () => {
-        this._setStoryPublicationStatus(newStoryStatusIsPublic);
-        if (successCallback) {
-          successCallback();
+    this.editableStoryBackendApiService
+      .changeStoryPublicationStatusAsync(storyId, unpublishType)
+      .then(
+        () => {
+          this._setStoryPublicationStatus(unpublishType === 'publish');
+          if (successCallback) {
+            successCallback();
+          }
+        },
+        error => {
+          this.alertsService.addWarning(
+            error ||
+              'There was an error when publishing/unpublishing the story.'
+          );
         }
-      },
-      error => {
-        this.alertsService.addWarning(
-          error || 'There was an error when publishing/unpublishing the story.'
-        );
-      }
-    );
+      );
     return true;
   }
 

--- a/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
+++ b/core/templates/pages/story-editor-page/services/story-editor-state.service.ts
@@ -24,7 +24,11 @@ import {StoryChange} from 'domain/editor/undo_redo/change.model';
 import {UndoRedoService} from 'domain/editor/undo_redo/undo-redo.service';
 import {SkillSummaryBackendDict} from 'domain/skill/skill-summary.model';
 import {Story, StoryBackendDict} from 'domain/story/story.model';
-import {EditableStoryBackendApiService} from 'domain/story/editable-story-backend-api.service';
+import {
+  EditableStoryBackendApiService,
+  STORY_PUBLICATION_ACTION_PUBLISH,
+  StoryPublicationAction,
+} from 'domain/story/editable-story-backend-api.service';
 import {AlertsService} from 'services/alerts.service';
 import {LoaderService} from 'services/loader.service';
 import cloneDeep from 'lodash/cloneDeep';
@@ -275,10 +279,7 @@ export class StoryEditorStateService {
   }
 
   changeStoryPublicationStatus(
-    publicationAction:
-      | 'publish'
-      | 'temporary_unpublish'
-      | 'permanent_unpublish',
+    publicationAction: StoryPublicationAction,
     successCallback: (value?: Object) => void
   ): boolean {
     const storyId = this._story.getId();
@@ -293,7 +294,9 @@ export class StoryEditorStateService {
       .changeStoryPublicationStatusAsync(storyId, publicationAction)
       .then(
         () => {
-          this._setStoryPublicationStatus(publicationAction === 'publish');
+          this._setStoryPublicationStatus(
+            publicationAction === STORY_PUBLICATION_ACTION_PUBLISH
+          );
           if (successCallback) {
             successCallback();
           }

--- a/requirements.txt
+++ b/requirements.txt
@@ -289,7 +289,9 @@ cryptography==45.0.7 \
     --hash=sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17 \
     --hash=sha256:f5414a788ecc6ee6bc58560e85ca624258a55ca434884445440a810796ea0e0b \
     --hash=sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd
-    # via pyjwt
+    # via
+    #   pyjwt
+    #   secretstorage
 deepdiff==8.6.1 \
     --hash=sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a \
     --hash=sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b
@@ -792,6 +794,12 @@ jaraco-functools==4.3.0 \
     --hash=sha256:227ff8ed6f7b8f62c56deff101545fa7543cf2c8e7b82a7c2116e672f29c26e8 \
     --hash=sha256:cfd13ad0dd2c47a3600b439ef72d8615d482cedcff1632930d6f28924d92f294
     # via keyring
+jeepney==0.9.0 \
+    --hash=sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683 \
+    --hash=sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
+    # via
+    #   keyring
+    #   secretstorage
 jsonpickle==3.4.2 \
     --hash=sha256:2efa2778859b6397d5804b0a98d52cd2a7d9a70fcb873bc5a3ca5acca8f499ba \
     --hash=sha256:fd6c273278a02b3b66e3405db3dd2f4dbc8f4a4a3123bfcab3045177c6feb9c3
@@ -1782,6 +1790,10 @@ rsa==4.7.2 \
     # via
     #   google-auth
     #   oauth2client
+secretstorage==3.4.0 \
+    --hash=sha256:0e3b6265c2c63509fb7415717607e4b2c9ab767b7f344a57473b779ca13bd02e \
+    --hash=sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c
+    # via keyring
 shapely==2.1.1 \
     --hash=sha256:04e4c12a45a1d70aeb266618d8cf81a2de9c4df511b63e105b90bfdfb52146de \
     --hash=sha256:0c062384316a47f776305ed2fa22182717508ffdeb4a56d0ff4087a77b2a0f6d \

--- a/requirements.txt
+++ b/requirements.txt
@@ -289,9 +289,7 @@ cryptography==45.0.7 \
     --hash=sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17 \
     --hash=sha256:f5414a788ecc6ee6bc58560e85ca624258a55ca434884445440a810796ea0e0b \
     --hash=sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd
-    # via
-    #   pyjwt
-    #   secretstorage
+    # via pyjwt
 deepdiff==8.6.1 \
     --hash=sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a \
     --hash=sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b
@@ -794,12 +792,6 @@ jaraco-functools==4.3.0 \
     --hash=sha256:227ff8ed6f7b8f62c56deff101545fa7543cf2c8e7b82a7c2116e672f29c26e8 \
     --hash=sha256:cfd13ad0dd2c47a3600b439ef72d8615d482cedcff1632930d6f28924d92f294
     # via keyring
-jeepney==0.9.0 \
-    --hash=sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683 \
-    --hash=sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
-    # via
-    #   keyring
-    #   secretstorage
 jsonpickle==3.4.2 \
     --hash=sha256:2efa2778859b6397d5804b0a98d52cd2a7d9a70fcb873bc5a3ca5acca8f499ba \
     --hash=sha256:fd6c273278a02b3b66e3405db3dd2f4dbc8f4a4a3123bfcab3045177c6feb9c3
@@ -1790,10 +1782,6 @@ rsa==4.7.2 \
     # via
     #   google-auth
     #   oauth2client
-secretstorage==3.4.0 \
-    --hash=sha256:0e3b6265c2c63509fb7415717607e4b2c9ab767b7f344a57473b779ca13bd02e \
-    --hash=sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c
-    # via keyring
 shapely==2.1.1 \
     --hash=sha256:04e4c12a45a1d70aeb266618d8cf81a2de9c4df511b63e105b90bfdfb52146de \
     --hash=sha256:0c062384316a47f776305ed2fa22182717508ffdeb4a56d0ff4087a77b2a0f6d \


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #21166 .

2. This PR does the following: When a user decides to unpublish a story, they are presented with the option to do so temporarily or permanently, or to cancel. If they choose temporary, they are informed that doing so  will maintain the translation opportunities, and that they should republish within 24 hours. They can then go through with the unpublishing or cancel it.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

https://github.com/user-attachments/assets/69fe3fc2-3b27-4e93-9578-5b6bfb2eca45

https://github.com/user-attachments/assets/2b1200a9-ff31-4f09-94e8-e2c3e271fbf7

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
