### PR TITLE
Fix #18726: Add submission state to prevent race conditions during translation review updates

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
@@ -17,6 +17,7 @@
     <button type="button"
             class="btn-close oppia-close-button-position"
             (click)="cancel()"
+            [disabled]="resolvingSuggestion || isSubmitting"
             aria-label="Close">
     </button>
     <h4 class="oppia-translation-modal-author-header">
@@ -65,7 +66,8 @@
         <strong> Translation:</strong>
         <button class="btn btn-sm btn-secondary float-end"
                 *ngIf="!startedEditing && status === 'review' && canEditTranslation"
-                (click)="editSuggestion()">
+                (click)="editSuggestion()"
+                [disabled]="resolvingSuggestion || isSubmitting">
           Edit
         </button>
       </div>
@@ -105,14 +107,16 @@
       <div class="oppia-translation-review-edit-buttons">
         <button class="btn btn-secondary me-2"
                 *ngIf="startedEditing"
+                [disabled]="isSubmitting"
                 (click)="cancelEdit()">
           Cancel
         </button>
         <button class="e2e-test-update-translation-button btn btn-success ms-2"
                 *ngIf="startedEditing"
                 (click)="updateSuggestion()"
-                [disabled]="updateIsDisabled">
-          Update
+                [disabled]="updateIsDisabled || isSubmitting">
+          <i [hidden]="!isSubmitting" class="fa fa-spinner fa-spin"></i>
+          <span [hidden]="isSubmitting">Update</span>
         </button>
       </div>
       <div class="oppia-collapse-content"
@@ -227,13 +231,13 @@
     <button type="button"
             class="oppia-pagination-button e2e-test-pagination-button-previous"
             (click)="goToPreviousItem()"
-            [disabled]="isFirstItem">
+            [disabled]="isFirstItem || isSubmitting || resolvingSuggestion">
       <span class="material-icons">navigate_before</span>Previous
     </button>
     <button type="button"
             class="oppia-pagination-button e2e-test-pagination-button-next"
             (click)="goToNextItem()"
-            [disabled]="isLastItem">
+            [disabled]="isLastItem || isSubmitting || resolvingSuggestion">
       Next<span class="material-icons">navigate_next</span>
     </button>
   </div>

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.spec.ts
@@ -488,6 +488,7 @@ describe('Translation Suggestion Review Modal Component', function () {
       expect(component.activeSuggestionId).toBe('suggestion_1');
       expect(component.activeSuggestion).toEqual(suggestion1);
       expect(component.reviewMessage).toBe('');
+      expect(component.isSubmitting).toBeFalse();
     });
 
     it(
@@ -506,11 +507,13 @@ describe('Translation Suggestion Review Modal Component', function () {
       const error = new Error('Error');
       expect(component.errorFound).toBeFalse();
       expect(component.errorMessage).toBe('');
+      component.isSubmitting = true;
 
       component.showTranslationSuggestionUpdateError(error);
 
       expect(component.errorFound).toBeTrue();
       expect(component.errorMessage).toBe('Invalid Suggestion: Error');
+      expect(component.isSubmitting).toBeFalse();
     });
 
     it('should remove suggestion_id from resolvedSuggestionIds if it exists', () => {
@@ -593,17 +596,21 @@ describe('Translation Suggestion Review Modal Component', function () {
 
     it('should update translation when the update button is clicked', function () {
       component.ngOnInit();
+      let isSubmittingInServiceCall = false;
       spyOn(
         contributionAndReviewService,
         'updateTranslationSuggestionAsync'
       ).and.callFake(
         (suggestionId, translationHtml, successCallback, errorCallback) => {
+          isSubmittingInServiceCall = component.isSubmitting;
           return Promise.resolve(successCallback());
         }
       );
 
       component.updateSuggestion();
 
+      expect(isSubmittingInServiceCall).toBeTrue();
+      expect(component.isSubmitting).toBeFalse();
       expect(
         contributionAndReviewService.updateTranslationSuggestionAsync
       ).toHaveBeenCalledWith(
@@ -940,6 +947,7 @@ describe('Translation Suggestion Review Modal Component', function () {
       expect(component.activeSuggestionId).toBe('suggestion_1');
       expect(component.activeSuggestion).toEqual(suggestion1);
       expect(component.reviewMessage).toBe('');
+      expect(component.isSubmitting).toBeFalse();
     });
 
     it(
@@ -958,11 +966,72 @@ describe('Translation Suggestion Review Modal Component', function () {
       const error = new Error('Error');
       expect(component.errorFound).toBeFalse();
       expect(component.errorMessage).toBe('');
+      component.isSubmitting = true;
 
       component.showTranslationSuggestionUpdateError(error);
 
       expect(component.errorFound).toBeTrue();
       expect(component.errorMessage).toBe('Invalid Suggestion: Error');
+      expect(component.isSubmitting).toBeFalse();
+    });
+
+    it('should reset resolvingSuggestion to false when acceptAndReviewNext fails', function () {
+      component.ngOnInit();
+      spyOn(
+        contributionAndReviewService,
+        'reviewExplorationSuggestion'
+      ).and.callFake(
+        (
+          targetId,
+          suggestionId,
+          action,
+          reviewMessage,
+          commitMessage,
+          successCallback,
+          errorCallback
+        ) => {
+          errorCallback('Error');
+        }
+      );
+      spyOn(alertsService, 'addWarning');
+      component.resolvingSuggestion = true;
+
+      component.acceptAndReviewNext();
+
+      expect(component.resolvingSuggestion).toBeFalse();
+      expect(alertsService.addWarning).toHaveBeenCalledWith(
+        'Invalid Suggestion: Error'
+      );
+    });
+
+    it('should reset resolvingSuggestion to false when rejectAndReviewNext fails', function () {
+      component.ngOnInit();
+      component.reviewMessage = 'Review message';
+      spyOn(
+        contributionAndReviewService,
+        'reviewExplorationSuggestion'
+      ).and.callFake(
+        (
+          targetId,
+          suggestionId,
+          action,
+          reviewMessage,
+          commitMessage,
+          successCallback,
+          errorCallback
+        ) => {
+          errorCallback('Error');
+        }
+      );
+      spyOn(alertsService, 'addWarning');
+      component.resolvingSuggestion = true;
+
+      component.rejectAndReviewNext(component.reviewMessage);
+
+      expect(component.resolvingSuggestion).toBeFalse();
+      expect(alertsService.addWarning).toHaveBeenCalledWith(
+        'Invalid Suggestion: Error'
+      );
     });
 
     it(
@@ -1332,17 +1401,21 @@ describe('Translation Suggestion Review Modal Component', function () {
 
     it('should update translation when the update button is clicked', function () {
       component.ngOnInit();
+      let isSubmittingInServiceCall = false;
       spyOn(
         contributionAndReviewService,
         'updateTranslationSuggestionAsync'
       ).and.callFake(
         (suggestionId, translationHtml, successCallback, errorCallback) => {
+          isSubmittingInServiceCall = component.isSubmitting;
           return Promise.resolve(successCallback());
         }
       );
 
       component.updateSuggestion();
 
+      expect(isSubmittingInServiceCall).toBeTrue();
+      expect(component.isSubmitting).toBeFalse();
       expect(
         contributionAndReviewService.updateTranslationSuggestionAsync
       ).toHaveBeenCalledWith(
@@ -2153,6 +2226,12 @@ describe('Translation Suggestion Review Modal Component', function () {
   });
 
   describe('when set the schema constant', function () {
+    it('should reset isSubmitting to false when refreshActiveContributionState is called', () => {
+      component.isSubmitting = true;
+      component.refreshActiveContributionState();
+      expect(component.isSubmitting).toBeFalse();
+    });
+
     const reviewable = true;
     const subheading = 'topic_1 / story_1 / chapter_1';
     const suggestion1 = {

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.spec.ts
@@ -621,6 +621,31 @@ describe('Translation Suggestion Review Modal Component', function () {
       );
     });
 
+    it('should handle error when updating translation suggestion fails', function () {
+      component.ngOnInit();
+      const error = new Error('Test error');
+      spyOn(
+        component,
+        'showTranslationSuggestionUpdateError'
+      ).and.callThrough();
+      spyOn(
+        contributionAndReviewService,
+        'updateTranslationSuggestionAsync'
+      ).and.callFake(
+        (suggestionId, translationHtml, successCallback, errorCallback) => {
+          errorCallback(error);
+          return Promise.resolve();
+        }
+      );
+
+      component.updateSuggestion();
+
+      expect(
+        component.showTranslationSuggestionUpdateError
+      ).toHaveBeenCalledWith(error);
+      expect(component.isSubmitting).toBeFalse();
+    });
+
     it('should emit queuedSuggestion Emit when suggestions are accepted', () => {
       component.ngOnInit();
       spyOn(component, 'generateCommitMessage').and.returnValue(
@@ -1424,6 +1449,31 @@ describe('Translation Suggestion Review Modal Component', function () {
         jasmine.any(Function),
         jasmine.any(Function)
       );
+    });
+
+    it('should handle error when updating translation suggestion fails', function () {
+      component.ngOnInit();
+      const error = new Error('Test error');
+      spyOn(
+        component,
+        'showTranslationSuggestionUpdateError'
+      ).and.callThrough();
+      spyOn(
+        contributionAndReviewService,
+        'updateTranslationSuggestionAsync'
+      ).and.callFake(
+        (suggestionId, translationHtml, successCallback, errorCallback) => {
+          errorCallback(error);
+          return Promise.resolve();
+        }
+      );
+
+      component.updateSuggestion();
+
+      expect(
+        component.showTranslationSuggestionUpdateError
+      ).toHaveBeenCalledWith(error);
+      expect(component.isSubmitting).toBeFalse();
     });
 
     describe('isHtmlContentEqual', function () {

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
@@ -441,7 +441,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
         this.isSubmitting = false;
         this.contributionOpportunitiesService.reloadOpportunitiesEventEmitter.emit();
       },
-      this.showTranslationSuggestionUpdateError
+      error => this.showTranslationSuggestionUpdateError(error)
     );
     this.suggestionImagesString = this.getImageInfoForSuggestion(
       this.translationHtml

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
@@ -151,6 +151,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
   lastSuggestionToReview: boolean = false;
   firstSuggestionToReview: boolean = true;
   resolvingSuggestion: boolean = false;
+  isSubmitting: boolean = false;
   reviewable: boolean = false;
   canEditTranslation: boolean = false;
   userIsCurriculumAdmin: boolean = false;
@@ -327,6 +328,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
     this.errorFound = false;
     this.startedEditing = false;
     this.resolvingSuggestion = false;
+    this.isSubmitting = false;
     this.lastSuggestionToReview =
       Object.keys(this.allContributions).length <= 1;
     this.translationHtml = this.activeSuggestion.change_cmd.translation_html;
@@ -427,6 +429,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
       return;
     }
 
+    this.isSubmitting = true;
     this.preEditTranslationHtml = this.translationHtml;
     this.translationHtml = updatedTranslation;
     this.contributionAndReviewService.updateTranslationSuggestionAsync(
@@ -435,6 +438,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
       () => {
         this.translationUpdated = true;
         this.startedEditing = false;
+        this.isSubmitting = false;
         this.contributionOpportunitiesService.reloadOpportunitiesEventEmitter.emit();
       },
       this.showTranslationSuggestionUpdateError
@@ -588,6 +592,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
           this.resolveSuggestionAndUpdateModal();
         },
         errorMessage => {
+          this.resolvingSuggestion = false;
           this.alertsService.clearWarnings();
           this.alertsService.addWarning(`Invalid Suggestion: ${errorMessage}`);
         }
@@ -642,6 +647,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
             this.resolveSuggestionAndUpdateModal();
           },
           errorMessage => {
+            this.resolvingSuggestion = false;
             this.alertsService.clearWarnings();
             this.alertsService.addWarning(
               `Invalid Suggestion: ${errorMessage}`
@@ -719,6 +725,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
   }
 
   showTranslationSuggestionUpdateError(error: Error): void {
+    this.isSubmitting = false;
     this.errorMessage = 'Invalid Suggestion: ' + error.message;
     this.errorFound = true;
     this.startedEditing = true;


### PR DESCRIPTION
## Overview

1. This PR fixes #18726.
2. This PR does the following: 
   Introduces an `isSubmitting` state to the translation suggestion review modal. This state disables all interactive elements (Update, Edit, Cancel, Close, and Pagination buttons) while an asynchronous request is in flight. It also ensures that the `resolvingSuggestion` state is correctly reset in error callbacks to prevent the UI from freezing.
3. (For bug-fixing PRs only) The original bug occurred because: 
   The component lacked a submission state for updates and did not properly lock the UI during async Accept/Reject calls. This allowed users with high network latency to trigger concurrent submissions. If a subsequent request failed after the modal was destroyed by a previous successful request, it caused a `TypeError: Cannot set properties of undefined`.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #18726: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

To definitively prove the UI locks correctly during high-latency scenarios, I temporarily introduced a 5-second delay to the backend during local testing.

### Reproduction of the Bug (Before Fix) :

(In this video, I simulate network latency. You can see that after clicking 'Accept', the UI remains interactive. Clicking the 'Edit' pencil and then 'Update' triggers a concurrent request that fails with the stack trace shown in the console.)

https://github.com/user-attachments/assets/c78eb29b-5611-4273-b18e-ddc588c627a0 

### After Fix (Verification):

- **Test 1: Edit button locks during Accept request**
*(In this video, clicking Accept turns the button to a spinner. The user attempts to click the Edit pencil, but it is successfully disabled.)*

https://github.com/user-attachments/assets/0479ff89-50e0-4937-b5f2-7fe0391dbf63 

- **Test 2: Navigation and Cancel buttons lock during Update request**
*(In this video, clicking Update turns the button to a spinner. The user attempts to click Cancel, Next, and Previous, but all are successfully disabled, preventing concurrent state changes.)*

https://github.com/user-attachments/assets/b811653b-ba31-4895-a8be-dd5ea7330278 

#### Proof of changes on mobile phone
*Not applicable as this is a logical state-locking fix rather than a responsive UI fix.*

#### Proof of changes in Arabic language
*Not applicable.*

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
