### PR TITLE
Fix #23881 : Solve Flake in snapshot matching RTLArabicHomePage-diff 

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -124,17 +124,13 @@ describe('Logged-In Learner', function () {
   it('should be able to change the site language to an RTL language', async function () {
     await loggedInUser1.changeSiteLanguage('ar');
 
-    await loggedInUser1.navigateToLearnerDashboard();
-    await loggedInUser1.verifyPageIsRTL();
-
-    await loggedInUser1.page.keyboard.press('Escape');
-
-    await loggedInUser1.page.waitForFunction(() => {
-      return (
-        document.readyState === 'complete' &&
-        document.documentElement.getAttribute('dir') === 'rtl'
-      );
+    await loggedInUser1.page.waitForSelector('.mat-mdc-menu-panel', {
+      hidden: true,
     });
+
+    await loggedInUser1.navigateToLearnerDashboard();
+
+    await loggedInUser1.verifyPageIsRTL();
 
     await loggedInUser1.expectScreenshotToMatch(
       'RTLArabicLearnerDashboard',
@@ -142,16 +138,8 @@ describe('Logged-In Learner', function () {
     );
 
     await loggedInUser1.navigateToHome(false);
+
     await loggedInUser1.verifyPageIsRTL();
-
-    await loggedInUser1.page.keyboard.press('Escape');
-
-    await loggedInUser1.page.waitForFunction(() => {
-      return (
-        document.readyState === 'complete' &&
-        document.documentElement.getAttribute('dir') === 'rtl'
-      );
-    });
 
     await loggedInUser1.expectScreenshotToMatch('RTLArabicHomePage', __dirname);
   });

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -126,6 +126,7 @@ describe('Logged-In Learner', function () {
 
     await loggedInUser1.navigateToLearnerDashboard();
     await loggedInUser1.verifyPageIsRTL();
+    await loggedInUser1.page.keyboard.press('Escape');
     await loggedInUser1.expectScreenshotToMatch(
       'RTLArabicLearnerDashboard',
       __dirname
@@ -133,6 +134,7 @@ describe('Logged-In Learner', function () {
 
     await loggedInUser1.navigateToHome(false);
     await loggedInUser1.verifyPageIsRTL();
+    await loggedInUser1.page.keyboard.press('Escape');
     await loggedInUser1.expectScreenshotToMatch('RTLArabicHomePage', __dirname);
   });
 

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -130,21 +130,7 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.page.keyboard.press('Escape');
 
     await loggedInUser1.page.waitForFunction(() => {
-      return (
-        document.documentElement.dir === 'rtl' &&
-        getComputedStyle(document.body).direction === 'rtl'
-      );
-    });
-
-    await loggedInUser1.page.addStyleTag({
-      content: `
-      *,
-      *::before,
-      *::after {
-        animation: none !important;
-        transition: none !important;
-      }
-    `,
+      return document.documentElement.dir === 'rtl';
     });
 
     await loggedInUser1.expectScreenshotToMatch(
@@ -158,21 +144,7 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.page.keyboard.press('Escape');
 
     await loggedInUser1.page.waitForFunction(() => {
-      return (
-        document.documentElement.dir === 'rtl' &&
-        getComputedStyle(document.body).direction === 'rtl'
-      );
-    });
-
-    await loggedInUser1.page.addStyleTag({
-      content: `
-      *,
-      *::before,
-      *::after {
-        animation: none !important;
-        transition: none !important;
-      }
-    `,
+      return document.documentElement.dir === 'rtl';
     });
 
     await loggedInUser1.expectScreenshotToMatch('RTLArabicHomePage', __dirname);

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -129,10 +129,6 @@ describe('Logged-In Learner', function () {
 
     await loggedInUser1.page.keyboard.press('Escape');
 
-    await loggedInUser1.page.evaluate(async () => {
-      await document.fonts.ready;
-    });
-
     await loggedInUser1.page.waitForFunction(() => {
       return (
         document.documentElement.dir === 'rtl' &&
@@ -160,10 +156,6 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.verifyPageIsRTL();
 
     await loggedInUser1.page.keyboard.press('Escape');
-
-    await loggedInUser1.page.evaluate(async () => {
-      await document.fonts.ready;
-    });
 
     await loggedInUser1.page.waitForFunction(() => {
       return (

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -130,7 +130,10 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.page.keyboard.press('Escape');
 
     await loggedInUser1.page.waitForFunction(() => {
-      return document.documentElement.dir === 'rtl';
+      return (
+        document.readyState === 'complete' &&
+        document.documentElement.getAttribute('dir') === 'rtl'
+      );
     });
 
     await loggedInUser1.expectScreenshotToMatch(
@@ -144,7 +147,10 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.page.keyboard.press('Escape');
 
     await loggedInUser1.page.waitForFunction(() => {
-      return document.documentElement.dir === 'rtl';
+      return (
+        document.readyState === 'complete' &&
+        document.documentElement.getAttribute('dir') === 'rtl'
+      );
     });
 
     await loggedInUser1.expectScreenshotToMatch('RTLArabicHomePage', __dirname);

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -128,11 +128,28 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.verifyPageIsRTL();
 
     await loggedInUser1.page.keyboard.press('Escape');
-    await loggedInUser1.page.waitForFunction(
-      () =>
+
+    await loggedInUser1.page.evaluate(async () => {
+      await document.fonts.ready;
+    });
+
+    await loggedInUser1.page.waitForFunction(() => {
+      return (
         document.documentElement.dir === 'rtl' &&
-        !document.querySelector('[aria-expanded="true"]')
-    );
+        getComputedStyle(document.body).direction === 'rtl'
+      );
+    });
+
+    await loggedInUser1.page.addStyleTag({
+      content: `
+      *,
+      *::before,
+      *::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    `,
+    });
 
     await loggedInUser1.expectScreenshotToMatch(
       'RTLArabicLearnerDashboard',
@@ -143,11 +160,28 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.verifyPageIsRTL();
 
     await loggedInUser1.page.keyboard.press('Escape');
-    await loggedInUser1.page.waitForFunction(
-      () =>
+
+    await loggedInUser1.page.evaluate(async () => {
+      await document.fonts.ready;
+    });
+
+    await loggedInUser1.page.waitForFunction(() => {
+      return (
         document.documentElement.dir === 'rtl' &&
-        !document.querySelector('[aria-expanded="true"]')
-    );
+        getComputedStyle(document.body).direction === 'rtl'
+      );
+    });
+
+    await loggedInUser1.page.addStyleTag({
+      content: `
+      *,
+      *::before,
+      *::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    `,
+    });
 
     await loggedInUser1.expectScreenshotToMatch('RTLArabicHomePage', __dirname);
   });

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -126,7 +126,11 @@ describe('Logged-In Learner', function () {
 
     await loggedInUser1.navigateToLearnerDashboard();
     await loggedInUser1.verifyPageIsRTL();
-    await loggedInUser1.page.keyboard.press('Escape');
+
+    await loggedInUser1.page.evaluate(async () => {
+      await document.fonts.ready;
+    });
+
     await loggedInUser1.expectScreenshotToMatch(
       'RTLArabicLearnerDashboard',
       __dirname
@@ -134,7 +138,11 @@ describe('Logged-In Learner', function () {
 
     await loggedInUser1.navigateToHome(false);
     await loggedInUser1.verifyPageIsRTL();
-    await loggedInUser1.page.keyboard.press('Escape');
+
+    await loggedInUser1.page.evaluate(async () => {
+      await document.fonts.ready;
+    });
+
     await loggedInUser1.expectScreenshotToMatch('RTLArabicHomePage', __dirname);
   });
 

--- a/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -127,9 +127,12 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.navigateToLearnerDashboard();
     await loggedInUser1.verifyPageIsRTL();
 
-    await loggedInUser1.page.evaluate(async () => {
-      await document.fonts.ready;
-    });
+    await loggedInUser1.page.keyboard.press('Escape');
+    await loggedInUser1.page.waitForFunction(
+      () =>
+        document.documentElement.dir === 'rtl' &&
+        !document.querySelector('[aria-expanded="true"]')
+    );
 
     await loggedInUser1.expectScreenshotToMatch(
       'RTLArabicLearnerDashboard',
@@ -139,9 +142,12 @@ describe('Logged-In Learner', function () {
     await loggedInUser1.navigateToHome(false);
     await loggedInUser1.verifyPageIsRTL();
 
-    await loggedInUser1.page.evaluate(async () => {
-      await document.fonts.ready;
-    });
+    await loggedInUser1.page.keyboard.press('Escape');
+    await loggedInUser1.page.waitForFunction(
+      () =>
+        document.documentElement.dir === 'rtl' &&
+        !document.querySelector('[aria-expanded="true"]')
+    );
 
     await loggedInUser1.expectScreenshotToMatch('RTLArabicHomePage', __dirname);
   });


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #[fill_in_number_here] or fixes part of #23881.
2. This PR does the following: This fix ensures that the screenshot is captured only after the language dropdown menu has fully closed. Previously, the screenshot was sometimes taken while the menu was still open, causing large visual differences and snapshot failures in CI. Waiting for the menu to become hidden makes the test more stable and prevents flaky RTL screenshot mismatches.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct


<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/7e9814fc-1d73-4c65-8e25-1f3ef4083505" />




Stress Test Link: https://github.com/tanmaygoyal2007/oppia/actions/runs/25622871143


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
