### PR TITLE
Fix #21668: Solve acceptance test flake caused by async save race condition 

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -56,7 +56,6 @@ describe('Topic Manager', function () {
     // Create an exploration with Set Input interaction.
     await curriculumAdmin.navigateToCreatorDashboardPage();
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
-    await curriculumAdmin.waitForPageToFullyLoad();
 
     // Create an exlporation unsupported by mobile.
     unsupportedExplorationId =
@@ -87,8 +86,6 @@ describe('Topic Manager', function () {
     );
 
     await curriculumAdmin.saveStoryDraft();
-    await curriculumAdmin.navigateToTopicAndSkillsDashboardPage();
-    await curriculumAdmin.waitForPageToFullyLoad();
 
     // Create topic Manager.
     topicManager = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -87,6 +87,7 @@ describe('Topic Manager', function () {
     );
 
     await curriculumAdmin.saveStoryDraft();
+    await curriculumAdmin.navigateToTopicAndSkillsDashboardPage();
     await curriculumAdmin.waitForPageToFullyLoad();
 
     // Create topic Manager.

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -87,8 +87,8 @@ describe('Topic Manager', function () {
     );
 
     await curriculumAdmin.saveStoryDraft();
-    await curriculumAdmin.waitForPageToFullyLoad();
     await curriculumAdmin.navigateToTopicAndSkillsDashboardPage();
+    await curriculumAdmin.waitForPageToFullyLoad();
 
     // Create topic Manager.
     topicManager = await UserFactory.createNewUser(

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -57,15 +57,12 @@ describe('Topic Manager', function () {
     await curriculumAdmin.navigateToCreatorDashboardPage();
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
 
-    /// Create an exploration unsupported by mobile.
-    try {
-      unsupportedExplorationId =
-        await curriculumAdmin.createSimpleUnsupportedExploration();
-    } catch (error) {
-      // Retry once to handle intermittent CI/editor race conditions.
-      unsupportedExplorationId =
-        await curriculumAdmin.createSimpleUnsupportedExploration();
-    }
+    // Create an exlporation unsupported by mobile.
+    unsupportedExplorationId =
+      await curriculumAdmin.createSimpleUnsupportedExploration();
+
+    // Add exploration with interaction unsupported on mobile and expect topic can't be updated.
+    await topicManager.createAndSwitchToNewTab();
 
     // Create Topics and add skills.
     await curriculumAdmin.createTopic('Algebra II', 'algebra-ii');

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -87,7 +87,6 @@ describe('Topic Manager', function () {
     );
 
     await curriculumAdmin.saveStoryDraft();
-    await curriculumAdmin.navigateToTopicAndSkillsDashboardPage();
     await curriculumAdmin.waitForPageToFullyLoad();
 
     // Create topic Manager.

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -56,13 +56,11 @@ describe('Topic Manager', function () {
     // Create an exploration with Set Input interaction.
     await curriculumAdmin.navigateToCreatorDashboardPage();
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
+    await curriculumAdmin.waitForPageToFullyLoad();
 
     // Create an exlporation unsupported by mobile.
     unsupportedExplorationId =
       await curriculumAdmin.createSimpleUnsupportedExploration();
-
-    // Add exploration with interaction unsupported on mobile and expect topic can't be updated.
-    await topicManager.createAndSwitchToNewTab();
 
     // Create Topics and add skills.
     await curriculumAdmin.createTopic('Algebra II', 'algebra-ii');
@@ -89,7 +87,8 @@ describe('Topic Manager', function () {
     );
 
     await curriculumAdmin.saveStoryDraft();
-
+    await curriculumAdmin.waitForPageToFullyLoad();
+    await curriculumAdmin.waitForPageToFullyLoad();
     // Create topic Manager.
     topicManager = await UserFactory.createNewUser(
       'topicManager',

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -34,13 +34,16 @@ describe('Topic Manager', function () {
   let unsupportedExplorationId: string | null;
 
   beforeAll(async function () {
+    console.log('STEP 1: Creating curriculum admin');
+
     curriculumAdmin = await UserFactory.createNewUser(
       'curriculumAdm',
       'curriculumAdmin1@example.com',
       [ROLES.CURRICULUM_ADMIN]
     );
 
-    // Create two simple explorations.
+    console.log('STEP 2: Created curriculum admin');
+
     explorationId1 =
       await curriculumAdmin.createAndPublishAMinimalExplorationWithTitle(
         'Exploring Quadratic Equations',
@@ -48,58 +51,75 @@ describe('Topic Manager', function () {
         true
       );
 
+    console.log('STEP 3: Created exploration 1');
+
     explorationId2 =
       await curriculumAdmin.createAndPublishAMinimalExplorationWithTitle(
         'Understanding Polynomial Functions'
       );
 
-    // Create an exploration with Set Input interaction.
+    console.log('STEP 4: Created exploration 2');
+
     await curriculumAdmin.navigateToCreatorDashboardPage();
+
+    console.log('STEP 5: Opened creator dashboard');
+
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
 
-    // Wait for exploration editor to fully load.
-    await curriculumAdmin.expectElementToBeVisible(
-      '.e2e-test-exploration-editor-page'
-    );
+    console.log('STEP 6: Opened exploration editor');
 
-    // Create an exlporation unsupported by mobile.
     unsupportedExplorationId =
       await curriculumAdmin.createSimpleUnsupportedExploration();
 
-    // Create Topics and add skills.
+    console.log('STEP 7: Created unsupported exploration');
+
     await curriculumAdmin.createTopic('Algebra II', 'algebra-ii');
+
+    console.log('STEP 8: Created topic');
+
     await curriculumAdmin.createSkillForTopic(
       'Quadratic Equations',
       'Algebra II',
       false
     );
+
+    console.log('STEP 9: Created skill 1');
+
     await curriculumAdmin.createSkillForTopic(
       'Polynomial Functions',
       'Algebra II',
       false
     );
 
-    // Add story to topic.
+    console.log('STEP 10: Created skill 2');
+
     await curriculumAdmin.addStoryToTopic(
       'Journey into Quadratic Equations',
       'journey-into-quadratic-equations',
       'Algebra II'
     );
+
+    console.log('STEP 11: Added story');
+
     await curriculumAdmin.addChapter(
       'Quadratic Equations Basics',
       explorationId1 as string
     );
 
+    console.log('STEP 12: Added chapter');
+
     await curriculumAdmin.saveStoryDraft();
 
-    // Create topic Manager.
+    console.log('STEP 13: Saved story draft');
+
     topicManager = await UserFactory.createNewUser(
       'topicManager',
       'topicManager1@example.com',
       [ROLES.TOPIC_MANAGER],
       'Algebra II'
     );
-    // Setup is taking longer than the Default timeout of 300000 ms.
+
+    console.log('STEP 14: Created topic manager');
   }, 380000);
 
   it(

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -34,16 +34,13 @@ describe('Topic Manager', function () {
   let unsupportedExplorationId: string | null;
 
   beforeAll(async function () {
-    console.log('STEP 1: Creating curriculum admin');
-
     curriculumAdmin = await UserFactory.createNewUser(
       'curriculumAdm',
       'curriculumAdmin1@example.com',
       [ROLES.CURRICULUM_ADMIN]
     );
 
-    console.log('STEP 2: Created curriculum admin');
-
+    // Create two simple explorations.
     explorationId1 =
       await curriculumAdmin.createAndPublishAMinimalExplorationWithTitle(
         'Exploring Quadratic Equations',
@@ -51,75 +48,56 @@ describe('Topic Manager', function () {
         true
       );
 
-    console.log('STEP 3: Created exploration 1');
-
     explorationId2 =
       await curriculumAdmin.createAndPublishAMinimalExplorationWithTitle(
         'Understanding Polynomial Functions'
       );
 
-    console.log('STEP 4: Created exploration 2');
-
+    // Create an exploration with Set Input interaction.
     await curriculumAdmin.navigateToCreatorDashboardPage();
-
-    console.log('STEP 5: Opened creator dashboard');
-
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
 
-    console.log('STEP 6: Opened exploration editor');
+    // Wait for editor/network stabilization before continuing.
+    await curriculumAdmin.page.waitForNetworkIdle();
 
+    // Create an exlporation unsupported by mobile.
     unsupportedExplorationId =
       await curriculumAdmin.createSimpleUnsupportedExploration();
 
-    console.log('STEP 7: Created unsupported exploration');
-
+    // Create Topics and add skills.
     await curriculumAdmin.createTopic('Algebra II', 'algebra-ii');
-
-    console.log('STEP 8: Created topic');
-
     await curriculumAdmin.createSkillForTopic(
       'Quadratic Equations',
       'Algebra II',
       false
     );
-
-    console.log('STEP 9: Created skill 1');
-
     await curriculumAdmin.createSkillForTopic(
       'Polynomial Functions',
       'Algebra II',
       false
     );
 
-    console.log('STEP 10: Created skill 2');
-
+    // Add story to topic.
     await curriculumAdmin.addStoryToTopic(
       'Journey into Quadratic Equations',
       'journey-into-quadratic-equations',
       'Algebra II'
     );
-
-    console.log('STEP 11: Added story');
-
     await curriculumAdmin.addChapter(
       'Quadratic Equations Basics',
       explorationId1 as string
     );
 
-    console.log('STEP 12: Added chapter');
-
     await curriculumAdmin.saveStoryDraft();
 
-    console.log('STEP 13: Saved story draft');
-
+    // Create topic Manager.
     topicManager = await UserFactory.createNewUser(
       'topicManager',
       'topicManager1@example.com',
       [ROLES.TOPIC_MANAGER],
       'Algebra II'
     );
-
-    console.log('STEP 14: Created topic manager');
+    // Setup is taking longer than the Default timeout of 300000 ms.
   }, 380000);
 
   it(

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -57,12 +57,15 @@ describe('Topic Manager', function () {
     await curriculumAdmin.navigateToCreatorDashboardPage();
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
 
-    // Wait for editor/network stabilization before continuing.
-    await curriculumAdmin.page.waitForNetworkIdle();
-
-    // Create an exlporation unsupported by mobile.
-    unsupportedExplorationId =
-      await curriculumAdmin.createSimpleUnsupportedExploration();
+    /// Create an exploration unsupported by mobile.
+    try {
+      unsupportedExplorationId =
+        await curriculumAdmin.createSimpleUnsupportedExploration();
+    } catch (error) {
+      // Retry once to handle intermittent CI/editor race conditions.
+      unsupportedExplorationId =
+        await curriculumAdmin.createSimpleUnsupportedExploration();
+    }
 
     // Create Topics and add skills.
     await curriculumAdmin.createTopic('Algebra II', 'algebra-ii');

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -88,7 +88,8 @@ describe('Topic Manager', function () {
 
     await curriculumAdmin.saveStoryDraft();
     await curriculumAdmin.waitForPageToFullyLoad();
-    await curriculumAdmin.waitForPageToFullyLoad();
+    await curriculumAdmin.navigateToTopicAndSkillsDashboardPage();
+
     // Create topic Manager.
     topicManager = await UserFactory.createNewUser(
       'topicManager',

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -21,6 +21,7 @@ import {UserFactory} from '../../utilities/common/user-factory';
 import testConstants from '../../utilities/common/test-constants';
 import {TopicManager} from '../../utilities/user/topic-manager';
 import {CurriculumAdmin} from '../../utilities/user/curriculum-admin';
+import {showMessage} from '../../utilities/common/show-message';
 import {ExplorationEditor} from '../../utilities/user/exploration-editor';
 
 const DEFAULT_SPEC_TIMEOUT_MSECS = testConstants.DEFAULT_SPEC_TIMEOUT_MSECS;
@@ -34,66 +35,92 @@ describe('Topic Manager', function () {
   let unsupportedExplorationId: string | null;
 
   beforeAll(async function () {
+    showMessage('beforeAll: create curriculumAdmin');
     curriculumAdmin = await UserFactory.createNewUser(
       'curriculumAdm',
       'curriculumAdmin1@example.com',
       [ROLES.CURRICULUM_ADMIN]
     );
+    showMessage('after: create curriculumAdmin');
 
     // Create two simple explorations.
+    showMessage('before: createAndPublishAMinimalExplorationWithTitle 1');
     explorationId1 =
       await curriculumAdmin.createAndPublishAMinimalExplorationWithTitle(
         'Exploring Quadratic Equations',
         'Algebra',
         true
       );
+    showMessage('after: createAndPublishAMinimalExplorationWithTitle 1');
 
+    showMessage('before: createAndPublishAMinimalExplorationWithTitle 2');
     explorationId2 =
       await curriculumAdmin.createAndPublishAMinimalExplorationWithTitle(
         'Understanding Polynomial Functions'
       );
+    showMessage('after: createAndPublishAMinimalExplorationWithTitle 2');
 
     // Create an exploration with Set Input interaction.
+    showMessage('before: navigateToCreatorDashboardPage');
     await curriculumAdmin.navigateToCreatorDashboardPage();
+    showMessage('after: navigateToCreatorDashboardPage');
+    showMessage('before: navigateToExplorationEditorFromCreatorDashboard');
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
+    showMessage('after: navigateToExplorationEditorFromCreatorDashboard');
 
     // Create an exlporation unsupported by mobile.
+    showMessage('before: createSimpleUnsupportedExploration');
     unsupportedExplorationId =
       await curriculumAdmin.createSimpleUnsupportedExploration();
+    showMessage('after: createSimpleUnsupportedExploration');
 
     // Create Topics and add skills.
+    showMessage('before: createTopic');
     await curriculumAdmin.createTopic('Algebra II', 'algebra-ii');
+    showMessage('after: createTopic');
+    showMessage('before: createSkillForTopic 1');
     await curriculumAdmin.createSkillForTopic(
       'Quadratic Equations',
       'Algebra II',
       false
     );
+    showMessage('after: createSkillForTopic 1');
+    showMessage('before: createSkillForTopic 2');
     await curriculumAdmin.createSkillForTopic(
       'Polynomial Functions',
       'Algebra II',
       false
     );
+    showMessage('after: createSkillForTopic 2');
 
     // Add story to topic.
+    showMessage('before: addStoryToTopic');
     await curriculumAdmin.addStoryToTopic(
       'Journey into Quadratic Equations',
       'journey-into-quadratic-equations',
       'Algebra II'
     );
+    showMessage('after: addStoryToTopic');
+    showMessage('before: addChapter');
     await curriculumAdmin.addChapter(
       'Quadratic Equations Basics',
       explorationId1 as string
     );
+    showMessage('after: addChapter');
 
+    showMessage('before: saveStoryDraft');
     await curriculumAdmin.saveStoryDraft();
+    showMessage('after: saveStoryDraft');
 
     // Create topic Manager.
+    showMessage('before: create topicManager user');
     topicManager = await UserFactory.createNewUser(
       'topicManager',
       'topicManager1@example.com',
       [ROLES.TOPIC_MANAGER],
       'Algebra II'
     );
+    showMessage('after: create topicManager user');
     // Setup is taking longer than the Default timeout of 300000 ms.
   }, 380000);
 

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -87,6 +87,11 @@ describe('Topic Manager', function () {
 
     await curriculumAdmin.saveStoryDraft();
 
+    // Wait for save operation to fully complete before continuing.
+    await curriculumAdmin.expectElementToBeVisible(
+      '.e2e-test-snackbar-success'
+    );
+
     // Create topic Manager.
     topicManager = await UserFactory.createNewUser(
       'topicManager',

--- a/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
+++ b/core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts
@@ -57,6 +57,11 @@ describe('Topic Manager', function () {
     await curriculumAdmin.navigateToCreatorDashboardPage();
     await curriculumAdmin.navigateToExplorationEditorFromCreatorDashboard();
 
+    // Wait for exploration editor to fully load.
+    await curriculumAdmin.expectElementToBeVisible(
+      '.e2e-test-exploration-editor-page'
+    );
+
     // Create an exlporation unsupported by mobile.
     unsupportedExplorationId =
       await curriculumAdmin.createSimpleUnsupportedExploration();
@@ -86,11 +91,6 @@ describe('Topic Manager', function () {
     );
 
     await curriculumAdmin.saveStoryDraft();
-
-    // Wait for save operation to fully complete before continuing.
-    await curriculumAdmin.expectElementToBeVisible(
-      '.e2e-test-snackbar-success'
-    );
 
     // Create topic Manager.
     topicManager = await UserFactory.createNewUser(


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #21668.
2. This PR does the following: This PR fixes a flaky Puppeteer acceptance test caused by intermittent `beforeAll()` timeout failures during CI runs. The issue occurred because the test continued with further setup actions immediately after `saveStoryDraft()` before the page and pending async operations were fully settled. To stabilize the setup flow, navigation to the Topic and Skills Dashboard and an additional `waitForPageToFullyLoad()` call were added after saving the story draft. This ensures the UI and backend state are fully synchronized before proceeding with the remaining setup steps.

3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/42b6b72c-4af4-45a8-882d-2271ea933048" />

Link of the stress test: https://github.com/tanmaygoyal2007/oppia/actions/runs/25908878737

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
