### PR TITLE
Fix #24807: Fix blog homepage pagination styling

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page.component.css
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.css
@@ -132,6 +132,30 @@ oppia-blog-home-page .search-heading {
   width: unset
 }
 
+ngb-pagination .page-link {
+  border: unset;
+  color: #333;
+  font-size: 22px;
+  font-weight: bold;
+  padding: 0;
+}
+
+ngb-pagination .page-link:hover {
+  background-color: transparent;
+  border-color: unset;
+}
+
+ngb-pagination .page-item {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+ngb-pagination .page-item .page-link {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
 ngb-pagination .page-item .pagination-button {
   background: none;
   border: none;
@@ -140,55 +164,38 @@ ngb-pagination .page-item .pagination-button {
   font-family: 'Roboto', Arial, sans-serif;
   font-size: 22px;
   font-weight: bold;
-  height: 100%;
-  justify-content: center;
   letter-spacing: 0;
   line-height: 25px;
   padding: 0;
-  width: 100%;
 }
 
-ngb-pagination .page-item .page-link {
-  background: transparent;
-  border: none;
-  color: #333;
-  height: auto;
-  width: auto;
-}
-
-ngb-pagination .page-item.active .pagination-button {
-  align-items: center;
-  background: rgba(65, 152, 137, 0.5);
-  border-radius: 50%;
-  color: #333;
-  display: flex;
-  height: 3rem;
-  justify-content: center;
-  width: 3rem;
-}
-
-ngb-pagination .page-link:focus {
-  box-shadow: none;
-  outline: none;
-}
-
-ngb-pagination .page-link:hover {
-  background-color: unset;
-  border-color: unset;
-}
-
-ngb-pagination .page-item.disabled .page-link {
-  color: #aaa;
-  opacity: 0.5;
-  pointer-events: none;
+ngb-pagination ul li:last-child.page-item {
+  margin-left: 4px;
 }
 
 ngb-pagination ul li:first-child.page-item {
   margin-right: 4px;
 }
 
-ngb-pagination ul li:last-child.page-item {
-  margin-left: 4px;
+ngb-pagination .page-item.disabled .page-link {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  color: #aaa;
+}
+
+ngb-pagination .page-item.active .page-link {
+  background: transparent !important;
+  border-radius: 50% !important;
+  box-shadow: none !important;
+  color: #333 !important;
+}
+
+ngb-pagination .page-item.active .pagination-button {
+  background: rgba(65, 152, 137, 0.2);
+  border-radius: 100%;
+  height: 3rem;
+  width: 3rem;
 }
 
 .tag-filter mat-form-field .mat-form-field-flex {

--- a/core/templates/pages/blog-home-page/blog-home-page.component.css
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.css
@@ -12,7 +12,7 @@
 
 @media (max-width: 550px) {
   oppia-blog-home-page .blog-home-page-search-column {
-    width: 335px
+    width: 335px;
   }
 
   
@@ -61,7 +61,7 @@ oppia-blog-home-page .oppia-blog-home-page-card {
   max-width: 1400px;
   padding-left: 3rem;
   padding-right: 3rem;
-  width: 100%
+  width: 100%;
 }
 
 oppia-blog-home-page .oppia-blog-home-page-card-avatar {
@@ -116,7 +116,6 @@ oppia-blog-home-page .search-heading {
   border-right-width: 1px;
   color: #333;
   width: 100%;
-
 }
 
 .input-group-addon.oppia-search-bar-icon {
@@ -129,7 +128,7 @@ oppia-blog-home-page .search-heading {
 }
 
 .input-group {
-  width: unset
+  width: unset;
 }
 
 ngb-pagination .page-link {
@@ -137,36 +136,39 @@ ngb-pagination .page-link {
   color: #333;
   font-size: 22px;
   font-weight: bold;
+  height: 3rem;
   padding: 0;
+  width: 3rem;
 }
 
 ngb-pagination .page-link:hover {
-  background-color: transparent;
+  background-color: unset;
   border-color: unset;
 }
 
-ngb-pagination .page-item {
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-}
-
 ngb-pagination .page-item .page-link {
-  background: transparent !important;
-  box-shadow: none !important;
+  background: transparent;
+  border-radius: 0;
 }
 
-ngb-pagination .page-item .pagination-button {
-  background: none;
-  border: none;
-  border-radius: 0;
+ngb-pagination .page-item:last-child .page-link {
+  border-bottom-right-radius: 100%;
+  border-top-right-radius: 100%;
+}
+
+ngb-pagination .page-item:first-child .page-link {
+  border-bottom-left-radius: 100%;
+  border-top-left-radius: 100%;
+}
+
+ngb-pagination .page-item.active .page-link {
+  background: rgba(65, 152, 137, 0.2);
+  border-radius: 100%;
   color: #333;
-  font-family: 'Roboto', Arial, sans-serif;
-  font-size: 22px;
-  font-weight: bold;
-  letter-spacing: 0;
-  line-height: 25px;
-  padding: 0;
+}
+
+ngb-pagination .page-item.disabled .page-link {
+  color: #aaa;
 }
 
 ngb-pagination ul li:last-child.page-item {
@@ -177,25 +179,20 @@ ngb-pagination ul li:first-child.page-item {
   margin-right: 4px;
 }
 
-ngb-pagination .page-item.disabled .page-link {
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-  color: #aaa;
-}
-
-ngb-pagination .page-item.active .page-link {
-  background: transparent !important;
-  border-radius: 50% !important;
-  box-shadow: none !important;
-  color: #333 !important;
-}
-
-ngb-pagination .page-item.active .pagination-button {
-  background: rgba(65, 152, 137, 0.2);
+ngb-pagination .page-item .pagination-button {
+  background: none;
+  border: none;
   border-radius: 100%;
-  height: 3rem;
-  width: 3rem;
+  color: #333;
+  font-family: 'Roboto', Arial, sans-serif;
+  font-size: 22px;
+  font-weight: bold;
+  height: 100%;
+  justify-content: center;
+  letter-spacing: 0;
+  line-height: 25px;
+  padding: 0;
+  width: 100%;
 }
 
 .tag-filter mat-form-field .mat-form-field-flex {

--- a/core/templates/pages/blog-home-page/blog-home-page.component.css
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.css
@@ -132,49 +132,10 @@ oppia-blog-home-page .search-heading {
   width: unset
 }
 
-ngb-pagination .page-link {
-  border: unset;
-  border-radius: 100%;
-  color: #333;
-  font-size: 22px;
-  font-weight: bold;
-  height: 3rem;
-  padding: 0;
-  width: 3rem;
-}
-
-ngb-pagination .page-link:hover {
-  background-color: unset;
-  border-color: unset;
-}
-
-ngb-pagination .page-item:last-child .page-link {
-  border-bottom-right-radius: 100%;
-  border-top-right-radius: 100%;
-}
-
-ngb-pagination .page-item:first-child .page-link {
-  border-bottom-left-radius: 100%;
-  border-top-left-radius: 100%;
-}
-
-ngb-pagination .page-item.active .page-link {
-  background: rgba(65, 152, 137, 0.2);
-  color: #333;
-}
-
-ngb-pagination ul li:last-child.page-item {
-  margin-left: 4px;
-}
-
-ngb-pagination ul li:first-child.page-item {
-  margin-right: 4px;
-}
-
 ngb-pagination .page-item .pagination-button {
   background: none;
   border: none;
-  border-radius: 100%;
+  border-radius: 0;
   color: #333;
   font-family: 'Roboto', Arial, sans-serif;
   font-size: 22px;
@@ -185,6 +146,49 @@ ngb-pagination .page-item .pagination-button {
   line-height: 25px;
   padding: 0;
   width: 100%;
+}
+
+ngb-pagination .page-item .page-link {
+  background: transparent;
+  border: none;
+  color: #333;
+  height: auto;
+  width: auto;
+}
+
+ngb-pagination .page-item.active .pagination-button {
+  align-items: center;
+  background: rgba(65, 152, 137, 0.5);
+  border-radius: 50%;
+  color: #333;
+  display: flex;
+  height: 3rem;
+  justify-content: center;
+  width: 3rem;
+}
+
+ngb-pagination .page-link:focus {
+  box-shadow: none;
+  outline: none;
+}
+
+ngb-pagination .page-link:hover {
+  background-color: unset;
+  border-color: unset;
+}
+
+ngb-pagination .page-item.disabled .page-link {
+  color: #aaa;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+ngb-pagination ul li:first-child.page-item {
+  margin-right: 4px;
+}
+
+ngb-pagination ul li:last-child.page-item {
+  margin-left: 4px;
 }
 
 .tag-filter mat-form-field .mat-form-field-flex {


### PR DESCRIPTION
## Overview

This PR fixes https://github.com/oppia/oppia/issues/24807.

This update ensures:

• Only the active/current page number has a green circle
• Inactive page numbers are displayed as plain text with no circles
• Prev/Next arrows are greyed out when navigation is not possible (first/last page)

 The original bug occurred because the **.page-link** CSS class in **blog-home-page.component.css** applied circular styling globally to all **ngb-pagination** items, including prev/next arrows and ellipsis placeholders, instead of only the active page number element.

## Essential Checklist

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] Not applicable (CSS-only styling fix; behaviour verified through before/after video proof).
- [x] The PR title starts with "Fix https://github.com/oppia/oppia/issues/24807:"
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@NITISH084 PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

**Before: Attached  video**

https://github.com/user-attachments/assets/728a735b-40b0-4e7d-a4cd-6c55370ceeb2



**After: Attached video** 

https://github.com/user-attachments/assets/f5ebf4a0-22bf-4118-979b-501459feaa6a


The video demonstrate that:
• Only the active page number shows a green circular highlight
• Inactive page numbers appear as plain text 
• Prev/Next arrows are greyed out when navigation is unavailable
 
#### Proof of changes on mobile phone

Verified locally using browser responsive mode.

#### Proof of changes in Arabic language

Not applicable, since this change only updates pagination styling and does not affect RTL layout or text direction.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow the contribution guidelines.
- Some e2e tests are flaky, and may fail for reasons unrelated to this PR.
- See the Code Owner's wiki page for code review expectations.
