### PR TITLE
Fix #25795: Replace if-else with handler map

### DIFF
--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -869,403 +869,444 @@ def apply_change_list(
             assert study_guide is not None
             modified_study_guides[study_guide.id] = study_guide
 
-    try:
-        for change in change_list:
-            if change.cmd == topic_domain.CMD_ADD_SUBTOPIC:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                add_subtopic_cmd = cast(topic_domain.AddSubtopicCmd, change)
-                _handle_add_subtopic(
-                    topic,
-                    topic_id,
-                    add_subtopic_cmd,
-                    modified_subtopic_pages,
-                    modified_study_guides,
-                    modified_subtopic_change_cmds,
-                    modified_study_guide_change_cmds,
-                    newly_created_subtopic_ids,
-                )
-            elif change.cmd == topic_domain.CMD_DELETE_SUBTOPIC:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                delete_subtopic_cmd = cast(
-                    topic_domain.DeleteSubtopicCmd, change
-                )
-                _handle_delete_subtopic(
-                    topic,
-                    delete_subtopic_cmd,
-                    newly_created_subtopic_ids,
-                    deleted_subtopic_ids,
-                )
-            elif change.cmd == topic_domain.CMD_ADD_CANONICAL_STORY:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                add_canonical_story_cmd = cast(
-                    topic_domain.AddCanonicalStoryCmd, change
-                )
-                _handle_add_canonical_story(
-                    topic,
-                    add_canonical_story_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_DELETE_CANONICAL_STORY:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                delete_canonical_story_cmd = cast(
-                    topic_domain.DeleteCanonicalStoryCmd, change
-                )
-                _handle_delete_canonical_story(
-                    topic,
-                    delete_canonical_story_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_REARRANGE_CANONICAL_STORY:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                rearrange_canonical_story_cmd = cast(
-                    topic_domain.RearrangeCanonicalStoryCmd, change
-                )
-                _handle_rearrange_canonical_story(
-                    topic,
-                    rearrange_canonical_story_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_ADD_ADDITIONAL_STORY:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                add_additional_story_cmd = cast(
-                    topic_domain.AddAdditionalStoryCmd, change
-                )
-                _handle_add_additional_story(
-                    topic,
-                    add_additional_story_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_DELETE_ADDITIONAL_STORY:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                delete_additional_story_cmd = cast(
-                    topic_domain.DeleteAdditionalStoryCmd, change
-                )
-                _handle_delete_additional_story(
-                    topic,
-                    delete_additional_story_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_ADD_UNCATEGORIZED_SKILL_ID:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                add_uncategorized_skill_id_cmd = cast(
-                    topic_domain.AddUncategorizedSkillIdCmd, change
-                )
-                _handle_add_uncategorized_skill_id(
-                    topic,
-                    add_uncategorized_skill_id_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_REMOVE_UNCATEGORIZED_SKILL_ID:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                remove_uncategorized_skill_id_cmd = cast(
-                    topic_domain.RemoveUncategorizedSkillIdCmd, change
-                )
-                _handle_remove_uncategorized_skill_id(
-                    topic,
-                    remove_uncategorized_skill_id_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_MOVE_SKILL_ID_TO_SUBTOPIC:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                move_skill_id_to_subtopic_cmd = cast(
-                    topic_domain.MoveSkillIdToSubtopicCmd, change
-                )
-                _handle_move_skill_id_to_subtopic(
-                    topic,
-                    move_skill_id_to_subtopic_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_REARRANGE_SKILL_IN_SUBTOPIC:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                rearrange_skill_in_subtopic_cmd = cast(
-                    topic_domain.RearrangeSkillInSubtopicCmd, change
-                )
-                _handle_rearrange_skill_in_subtopic(
-                    topic,
-                    rearrange_skill_in_subtopic_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_REARRANGE_SUBTOPIC:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                rearrange_subtopic_cmd = cast(
-                    topic_domain.RearrangeSubtopicCmd, change
-                )
-                _handle_rearrange_subtopic(
-                    topic,
-                    rearrange_subtopic_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_REMOVE_SKILL_ID_FROM_SUBTOPIC:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                remove_skill_id_from_subtopic_cmd = cast(
-                    topic_domain.RemoveSkillIdFromSubtopicCmd, change
-                )
-                _handle_remove_skill_id_from_subtopic(
-                    topic,
-                    remove_skill_id_from_subtopic_cmd,
-                )
-            elif change.cmd == topic_domain.CMD_UPDATE_TOPIC_PROPERTY:
-                if change.property_name == topic_domain.TOPIC_PROPERTY_NAME:
-                    # Here we use cast because this 'if' condition forces
-                    # change to have type UpdateTopicPropertyNameCmd.
-                    update_topic_name_cmd = cast(
-                        topic_domain.UpdateTopicPropertyNameCmd, change
-                    )
-                    topic.update_name(update_topic_name_cmd.new_value)
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_ABBREVIATED_NAME
-                ):
-                    # Here we use cast because this 'elif' condition forces
-                    # change to have type UpdateTopicPropertyAbbreviatedNameCmd.
-                    update_abbreviated_name_cmd = cast(
-                        topic_domain.UpdateTopicPropertyAbbreviatedNameCmd,
-                        change,
-                    )
-                    topic.update_abbreviated_name(
-                        update_abbreviated_name_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_URL_FRAGMENT
-                ):
-                    # Here we use cast because this 'elif' condition forces
-                    # change to have type UpdateTopicPropertyUrlFragmentCmd.
-                    update_url_fragment_cmd = cast(
-                        topic_domain.UpdateTopicPropertyUrlFragmentCmd, change
-                    )
-                    topic.update_url_fragment(update_url_fragment_cmd.new_value)
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_DESCRIPTION
-                ):
-                    # Here we use cast because this 'elif' condition forces
-                    # change to have type UpdateTopicPropertyDescriptionCmd.
-                    update_topic_description_cmd = cast(
-                        topic_domain.UpdateTopicPropertyDescriptionCmd, change
-                    )
-                    topic.update_description(
-                        update_topic_description_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_LANGUAGE_CODE
-                ):
-                    # Here we use cast because this 'elif' condition forces
-                    # change to have type UpdateTopicPropertyLanguageCodeCmd.
-                    update_topic_language_code_cmd = cast(
-                        topic_domain.UpdateTopicPropertyLanguageCodeCmd, change
-                    )
-                    topic.update_language_code(
-                        update_topic_language_code_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_THUMBNAIL_FILENAME
-                ):
-                    # Here we use cast because this 'elif'
-                    # condition forces change to have type
-                    # UpdateTopicPropertyThumbnailFilenameCmd.
-                    update_topic_thumbnail_filename_cmd = cast(
-                        topic_domain.UpdateTopicPropertyThumbnailFilenameCmd,
-                        change,
-                    )
-                    update_thumbnail_filename(
-                        topic, update_topic_thumbnail_filename_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_THUMBNAIL_BG_COLOR
-                ):
-                    # Here we use cast because this 'elif'
-                    # condition forces change to have type
-                    # UpdateTopicPropertyThumbnailBGColorCmd.
-                    update_topic_thumbnail_bg_color_cmd = cast(
-                        topic_domain.UpdateTopicPropertyThumbnailBGColorCmd,
-                        change,
-                    )
-                    topic.update_thumbnail_bg_color(
-                        update_topic_thumbnail_bg_color_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_META_TAG_CONTENT
-                ):
-                    # Here we use cast because this 'elif'
-                    # condition forces change to have type
-                    # UpdateTopicPropertyMetaTagContentCmd.
-                    update_topic_meta_tag_content_cmd = cast(
-                        topic_domain.UpdateTopicPropertyMetaTagContentCmd,
-                        change,
-                    )
-                    topic.update_meta_tag_content(
-                        update_topic_meta_tag_content_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_PRACTICE_TAB_IS_DISPLAYED
-                ):
-                    # Here we use cast because this 'elif'
-                    # condition forces change to have type
-                    # UpdateTopicPropertyPracticeTabIsDisplayedCmd.
-                    update_practice_tab_is_displayed_cmd = cast(
-                        topic_domain.UpdateTopicPropertyPracticeTabIsDisplayedCmd,  # pylint: disable=line-too-long
-                        change,
-                    )
-                    topic.update_practice_tab_is_displayed(
-                        update_practice_tab_is_displayed_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_PAGE_TITLE_FRAGMENT_FOR_WEB
-                ):
-                    # Here we use cast because this 'elif'
-                    # condition forces change to have type
-                    # UpdateTopicPropertyTitleFragmentForWebCmd.
-                    update_title_fragment_for_web_cmd = cast(
-                        topic_domain.UpdateTopicPropertyTitleFragmentForWebCmd,
-                        change,
-                    )
-                    topic.update_page_title_fragment_for_web(
-                        update_title_fragment_for_web_cmd.new_value
-                    )
-                elif (
-                    change.property_name
-                    == topic_domain.TOPIC_PROPERTY_SKILL_IDS_FOR_DIAGNOSTIC_TEST
-                ):
-                    # Here we use cast because this 'elif'
-                    # condition forces change to have type
-                    # UpdateTopicPropertySkillIdsForDiagnosticTestCmd.
-                    update_skill_ids_for_diagnostic_test_cmd = cast(
-                        topic_domain.UpdateTopicPropertySkillIdsForDiagnosticTestCmd,  # pylint: disable=line-too-long
-                        change,
-                    )
-                    topic.update_skill_ids_for_diagnostic_test(
-                        update_skill_ids_for_diagnostic_test_cmd.new_value
-                    )
-            elif (
-                change.cmd == study_guide_domain.CMD_UPDATE_STUDY_GUIDE_PROPERTY
-            ):
-                _apply_study_guide_change(
-                    change,
-                    topic_id,
-                    modified_study_guides,
-                    deleted_subtopic_ids,
-                    modified_subtopic_pages,
-                    modified_subtopic_change_cmds,
-                )
-            elif (
-                change.cmd
-                == subtopic_page_domain.CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY
-            ):
-                _apply_subtopic_page_change(
-                    change,
-                    topic_id,
-                    deleted_subtopic_ids,
-                    modified_subtopic_pages,
-                    modified_study_guides,
-                )
-            elif change.cmd == topic_domain.CMD_UPDATE_SUBTOPIC_PROPERTY:
-                # Here we use cast because we are narrowing down the type from
-                # TopicChange to a specific change command.
-                update_subtopic_property_cmd = cast(
-                    topic_domain.UpdateSubtopicPropertyCmd, change
-                )
-                if (
-                    update_subtopic_property_cmd.property_name
-                    == topic_domain.SUBTOPIC_PROPERTY_TITLE
-                ):
-                    topic.update_subtopic_title(
-                        update_subtopic_property_cmd.subtopic_id,
-                        update_subtopic_property_cmd.new_value,
-                    )
-                    if not feature_flag_services.is_feature_flag_enabled(
-                        feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
-                        committer_id,
-                    ):
-                        # Here we use cast because we are narrowing down the
-                        # type from TopicChange to a specific change command.
-                        update_study_guide_sections_heading_cmd = cast(
-                            study_guide_domain.UpdateStudyGuidePropertySectionsHeadingCmd,  # pylint: disable=line-too-long
-                            change,
-                        )
-                        study_guide_id = study_guide_domain.StudyGuide.get_study_guide_id(
-                            topic_id,
-                            update_study_guide_sections_heading_cmd.subtopic_id,
-                        )
+    def _handle_add_subtopic_cmd(change: change_domain.BaseChange) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        add_subtopic_cmd = cast(topic_domain.AddSubtopicCmd, change)
+        _handle_add_subtopic(
+            topic,
+            topic_id,
+            add_subtopic_cmd,
+            modified_subtopic_pages,
+            modified_study_guides,
+            modified_subtopic_change_cmds,
+            modified_study_guide_change_cmds,
+            newly_created_subtopic_ids,
+        )
 
-                        # Only update study guide if it exists or can be
-                        # fetched.
-                        existing_study_guide_id = _ensure_study_guide_exists(
-                            update_study_guide_sections_heading_cmd.subtopic_id
-                        )
+    def _handle_delete_subtopic_cmd(change: change_domain.BaseChange) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        delete_subtopic_cmd = cast(topic_domain.DeleteSubtopicCmd, change)
+        _handle_delete_subtopic(
+            topic,
+            delete_subtopic_cmd,
+            newly_created_subtopic_ids,
+            deleted_subtopic_ids,
+        )
 
-                        if existing_study_guide_id is not None:
-                            modified_study_guide_change_cmds[
-                                study_guide_id
-                            ].append(
-                                study_guide_domain.StudyGuideChange(
-                                    {
-                                        'cmd': 'update_study_guide_property',
-                                        'property_name': 'sections_content',
-                                        'new_value': (
-                                            update_study_guide_sections_heading_cmd.new_value
-                                        ),
-                                        'old_value': 'section_heading_0',
-                                        'subtopic_id': (
-                                            update_study_guide_sections_heading_cmd.subtopic_id
-                                        ),
-                                    }
-                                )
-                            )
-                            (
-                                modified_study_guides[
-                                    study_guide_id
-                                ].update_section_heading
-                            )(
-                                (
+    def _handle_add_canonical_story_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        add_canonical_story_cmd = cast(
+            topic_domain.AddCanonicalStoryCmd, change
+        )
+        _handle_add_canonical_story(topic, add_canonical_story_cmd)
+
+    def _handle_delete_canonical_story_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        delete_canonical_story_cmd = cast(
+            topic_domain.DeleteCanonicalStoryCmd, change
+        )
+        _handle_delete_canonical_story(topic, delete_canonical_story_cmd)
+
+    def _handle_rearrange_canonical_story_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        rearrange_canonical_story_cmd = cast(
+            topic_domain.RearrangeCanonicalStoryCmd, change
+        )
+        _handle_rearrange_canonical_story(topic, rearrange_canonical_story_cmd)
+
+    def _handle_add_additional_story_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        add_additional_story_cmd = cast(
+            topic_domain.AddAdditionalStoryCmd, change
+        )
+        _handle_add_additional_story(topic, add_additional_story_cmd)
+
+    def _handle_delete_additional_story_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        delete_additional_story_cmd = cast(
+            topic_domain.DeleteAdditionalStoryCmd, change
+        )
+        _handle_delete_additional_story(topic, delete_additional_story_cmd)
+
+    def _handle_add_uncategorized_skill_id_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        add_uncategorized_skill_id_cmd = cast(
+            topic_domain.AddUncategorizedSkillIdCmd, change
+        )
+        _handle_add_uncategorized_skill_id(
+            topic, add_uncategorized_skill_id_cmd
+        )
+
+    def _handle_remove_uncategorized_skill_id_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        remove_uncategorized_skill_id_cmd = cast(
+            topic_domain.RemoveUncategorizedSkillIdCmd, change
+        )
+        _handle_remove_uncategorized_skill_id(
+            topic, remove_uncategorized_skill_id_cmd
+        )
+
+    def _handle_move_skill_id_to_subtopic_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        move_skill_id_to_subtopic_cmd = cast(
+            topic_domain.MoveSkillIdToSubtopicCmd, change
+        )
+        _handle_move_skill_id_to_subtopic(topic, move_skill_id_to_subtopic_cmd)
+
+    def _handle_rearrange_skill_in_subtopic_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        rearrange_skill_in_subtopic_cmd = cast(
+            topic_domain.RearrangeSkillInSubtopicCmd, change
+        )
+        _handle_rearrange_skill_in_subtopic(
+            topic, rearrange_skill_in_subtopic_cmd
+        )
+
+    def _handle_rearrange_subtopic_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        rearrange_subtopic_cmd = cast(topic_domain.RearrangeSubtopicCmd, change)
+        _handle_rearrange_subtopic(topic, rearrange_subtopic_cmd)
+
+    def _handle_remove_skill_id_from_subtopic_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        remove_skill_id_from_subtopic_cmd = cast(
+            topic_domain.RemoveSkillIdFromSubtopicCmd, change
+        )
+        _handle_remove_skill_id_from_subtopic(
+            topic, remove_skill_id_from_subtopic_cmd
+        )
+
+    def _handle_update_topic_property_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        if change.property_name == topic_domain.TOPIC_PROPERTY_NAME:
+            # Here we use cast because this 'if' condition forces
+            # change to have type UpdateTopicPropertyNameCmd.
+            update_topic_name_cmd = cast(
+                topic_domain.UpdateTopicPropertyNameCmd, change
+            )
+            topic.update_name(update_topic_name_cmd.new_value)
+        elif (
+            change.property_name == topic_domain.TOPIC_PROPERTY_ABBREVIATED_NAME
+        ):
+            # Here we use cast because this 'elif' condition forces
+            # change to have type UpdateTopicPropertyAbbreviatedNameCmd.
+            update_abbreviated_name_cmd = cast(
+                topic_domain.UpdateTopicPropertyAbbreviatedNameCmd,
+                change,
+            )
+            topic.update_abbreviated_name(update_abbreviated_name_cmd.new_value)
+        elif change.property_name == topic_domain.TOPIC_PROPERTY_URL_FRAGMENT:
+            # Here we use cast because this 'elif' condition forces
+            # change to have type UpdateTopicPropertyUrlFragmentCmd.
+            update_url_fragment_cmd = cast(
+                topic_domain.UpdateTopicPropertyUrlFragmentCmd, change
+            )
+            topic.update_url_fragment(update_url_fragment_cmd.new_value)
+        elif change.property_name == topic_domain.TOPIC_PROPERTY_DESCRIPTION:
+            # Here we use cast because this 'elif' condition forces
+            # change to have type UpdateTopicPropertyDescriptionCmd.
+            update_topic_description_cmd = cast(
+                topic_domain.UpdateTopicPropertyDescriptionCmd, change
+            )
+            topic.update_description(update_topic_description_cmd.new_value)
+        elif change.property_name == topic_domain.TOPIC_PROPERTY_LANGUAGE_CODE:
+            # Here we use cast because this 'elif' condition forces
+            # change to have type UpdateTopicPropertyLanguageCodeCmd.
+            update_topic_language_code_cmd = cast(
+                topic_domain.UpdateTopicPropertyLanguageCodeCmd, change
+            )
+            topic.update_language_code(update_topic_language_code_cmd.new_value)
+        elif (
+            change.property_name
+            == topic_domain.TOPIC_PROPERTY_THUMBNAIL_FILENAME
+        ):
+            # Here we use cast because this 'elif'
+            # condition forces change to have type
+            # UpdateTopicPropertyThumbnailFilenameCmd.
+            update_topic_thumbnail_filename_cmd = cast(
+                topic_domain.UpdateTopicPropertyThumbnailFilenameCmd,
+                change,
+            )
+            update_thumbnail_filename(
+                topic, update_topic_thumbnail_filename_cmd.new_value
+            )
+        elif (
+            change.property_name
+            == topic_domain.TOPIC_PROPERTY_THUMBNAIL_BG_COLOR
+        ):
+            # Here we use cast because this 'elif'
+            # condition forces change to have type
+            # UpdateTopicPropertyThumbnailBGColorCmd.
+            update_topic_thumbnail_bg_color_cmd = cast(
+                topic_domain.UpdateTopicPropertyThumbnailBGColorCmd,
+                change,
+            )
+            topic.update_thumbnail_bg_color(
+                update_topic_thumbnail_bg_color_cmd.new_value
+            )
+        elif (
+            change.property_name == topic_domain.TOPIC_PROPERTY_META_TAG_CONTENT
+        ):
+            # Here we use cast because this 'elif'
+            # condition forces change to have type
+            # UpdateTopicPropertyMetaTagContentCmd.
+            update_topic_meta_tag_content_cmd = cast(
+                topic_domain.UpdateTopicPropertyMetaTagContentCmd,
+                change,
+            )
+            topic.update_meta_tag_content(
+                update_topic_meta_tag_content_cmd.new_value
+            )
+        elif (
+            change.property_name
+            == topic_domain.TOPIC_PROPERTY_PRACTICE_TAB_IS_DISPLAYED
+        ):
+            # Here we use cast because this 'elif'
+            # condition forces change to have type
+            # UpdateTopicPropertyPracticeTabIsDisplayedCmd.
+            update_practice_tab_is_displayed_cmd = cast(
+                topic_domain.UpdateTopicPropertyPracticeTabIsDisplayedCmd,  # pylint: disable=line-too-long
+                change,
+            )
+            topic.update_practice_tab_is_displayed(
+                update_practice_tab_is_displayed_cmd.new_value
+            )
+        elif (
+            change.property_name
+            == topic_domain.TOPIC_PROPERTY_PAGE_TITLE_FRAGMENT_FOR_WEB
+        ):
+            # Here we use cast because this 'elif'
+            # condition forces change to have type
+            # UpdateTopicPropertyTitleFragmentForWebCmd.
+            update_title_fragment_for_web_cmd = cast(
+                topic_domain.UpdateTopicPropertyTitleFragmentForWebCmd,
+                change,
+            )
+            topic.update_page_title_fragment_for_web(
+                update_title_fragment_for_web_cmd.new_value
+            )
+        elif (
+            change.property_name
+            == topic_domain.TOPIC_PROPERTY_SKILL_IDS_FOR_DIAGNOSTIC_TEST
+        ):
+            # Here we use cast because this 'elif'
+            # condition forces change to have type
+            # UpdateTopicPropertySkillIdsForDiagnosticTestCmd.
+            update_skill_ids_for_diagnostic_test_cmd = cast(
+                topic_domain.UpdateTopicPropertySkillIdsForDiagnosticTestCmd,  # pylint: disable=line-too-long
+                change,
+            )
+            topic.update_skill_ids_for_diagnostic_test(
+                update_skill_ids_for_diagnostic_test_cmd.new_value
+            )
+
+    def _handle_update_subtopic_property_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        # Here we use cast because we are narrowing down the type from
+        # TopicChange to a specific change command.
+        update_subtopic_property_cmd = cast(
+            topic_domain.UpdateSubtopicPropertyCmd, change
+        )
+        if (
+            update_subtopic_property_cmd.property_name
+            == topic_domain.SUBTOPIC_PROPERTY_TITLE
+        ):
+            topic.update_subtopic_title(
+                update_subtopic_property_cmd.subtopic_id,
+                update_subtopic_property_cmd.new_value,
+            )
+            if not feature_flag_services.is_feature_flag_enabled(
+                feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
+                committer_id,
+            ):
+                # Here we use cast because we are narrowing down the
+                # type from TopicChange to a specific change command.
+                update_study_guide_sections_heading_cmd = cast(
+                    study_guide_domain.UpdateStudyGuidePropertySectionsHeadingCmd,  # pylint: disable=line-too-long
+                    change,
+                )
+                study_guide_id = (
+                    study_guide_domain.StudyGuide.get_study_guide_id(
+                        topic_id,
+                        update_study_guide_sections_heading_cmd.subtopic_id,
+                    )
+                )
+
+                # Only update study guide if it exists or can be
+                # fetched.
+                existing_study_guide_id = _ensure_study_guide_exists(
+                    update_study_guide_sections_heading_cmd.subtopic_id
+                )
+
+                if existing_study_guide_id is not None:
+                    modified_study_guide_change_cmds[study_guide_id].append(
+                        study_guide_domain.StudyGuideChange(
+                            {
+                                'cmd': 'update_study_guide_property',
+                                'property_name': 'sections_content',
+                                'new_value': (
                                     update_study_guide_sections_heading_cmd.new_value
                                 ),
-                                'section_heading_0',
-                            )
-                if (
-                    update_subtopic_property_cmd.property_name
-                    == topic_domain.SUBTOPIC_PROPERTY_THUMBNAIL_FILENAME
-                ):
-                    update_subtopic_thumbnail_filename(
-                        topic,
-                        update_subtopic_property_cmd.subtopic_id,
-                        update_subtopic_property_cmd.new_value,
+                                'old_value': 'section_heading_0',
+                                'subtopic_id': (
+                                    update_study_guide_sections_heading_cmd.subtopic_id
+                                ),
+                            }
+                        )
                     )
-                if (
-                    update_subtopic_property_cmd.property_name
-                    == topic_domain.SUBTOPIC_PROPERTY_THUMBNAIL_BG_COLOR
-                ):
-                    topic.update_subtopic_thumbnail_bg_color(
-                        update_subtopic_property_cmd.subtopic_id,
-                        update_subtopic_property_cmd.new_value,
+                    (
+                        modified_study_guides[
+                            study_guide_id
+                        ].update_section_heading
+                    )(
+                        (update_study_guide_sections_heading_cmd.new_value),
+                        'section_heading_0',
                     )
-                if (
-                    update_subtopic_property_cmd.property_name
-                    == topic_domain.SUBTOPIC_PROPERTY_URL_FRAGMENT
-                ):
-                    topic.update_subtopic_url_fragment(
-                        update_subtopic_property_cmd.subtopic_id,
-                        update_subtopic_property_cmd.new_value,
-                    )
+        if (
+            update_subtopic_property_cmd.property_name
+            == topic_domain.SUBTOPIC_PROPERTY_THUMBNAIL_FILENAME
+        ):
+            update_subtopic_thumbnail_filename(
+                topic,
+                update_subtopic_property_cmd.subtopic_id,
+                update_subtopic_property_cmd.new_value,
+            )
+        if (
+            update_subtopic_property_cmd.property_name
+            == topic_domain.SUBTOPIC_PROPERTY_THUMBNAIL_BG_COLOR
+        ):
+            topic.update_subtopic_thumbnail_bg_color(
+                update_subtopic_property_cmd.subtopic_id,
+                update_subtopic_property_cmd.new_value,
+            )
+        if (
+            update_subtopic_property_cmd.property_name
+            == topic_domain.SUBTOPIC_PROPERTY_URL_FRAGMENT
+        ):
+            topic.update_subtopic_url_fragment(
+                update_subtopic_property_cmd.subtopic_id,
+                update_subtopic_property_cmd.new_value,
+            )
 
-            elif (
-                change.cmd
-                == topic_domain.CMD_MIGRATE_SUBTOPIC_SCHEMA_TO_LATEST_VERSION
-            ):
-                # Loading the topic model from the datastore into a
-                # Topic domain object automatically converts it to use the
-                # latest schema version. As a result, simply resaving the
-                # topic is sufficient to apply the schema migration.
-                continue
+    def _handle_update_study_guide_property_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        _apply_study_guide_change(
+            change,
+            topic_id,
+            modified_study_guides,
+            deleted_subtopic_ids,
+            modified_subtopic_pages,
+            modified_subtopic_change_cmds,
+        )
+
+    def _handle_update_subtopic_page_property_cmd(
+        change: change_domain.BaseChange,
+    ) -> None:
+        _apply_subtopic_page_change(
+            change,
+            topic_id,
+            deleted_subtopic_ids,
+            modified_subtopic_pages,
+            modified_study_guides,
+        )
+
+    def _handle_migrate_subtopic_schema_cmd(
+        _change: change_domain.BaseChange,
+    ) -> None:
+        # Loading the topic model from the datastore into a
+        # Topic domain object automatically converts it to use the
+        # latest schema version. As a result, simply resaving the
+        # topic is sufficient to apply the schema migration.
+        return None
+
+    command_handlers: Dict[str, Callable[[change_domain.BaseChange], None]] = {
+        topic_domain.CMD_ADD_SUBTOPIC: _handle_add_subtopic_cmd,
+        topic_domain.CMD_DELETE_SUBTOPIC: _handle_delete_subtopic_cmd,
+        topic_domain.CMD_ADD_CANONICAL_STORY: _handle_add_canonical_story_cmd,
+        topic_domain.CMD_DELETE_CANONICAL_STORY: (
+            _handle_delete_canonical_story_cmd
+        ),
+        topic_domain.CMD_REARRANGE_CANONICAL_STORY: (
+            _handle_rearrange_canonical_story_cmd
+        ),
+        topic_domain.CMD_ADD_ADDITIONAL_STORY: _handle_add_additional_story_cmd,
+        topic_domain.CMD_DELETE_ADDITIONAL_STORY: (
+            _handle_delete_additional_story_cmd
+        ),
+        topic_domain.CMD_ADD_UNCATEGORIZED_SKILL_ID: (
+            _handle_add_uncategorized_skill_id_cmd
+        ),
+        topic_domain.CMD_REMOVE_UNCATEGORIZED_SKILL_ID: (
+            _handle_remove_uncategorized_skill_id_cmd
+        ),
+        topic_domain.CMD_MOVE_SKILL_ID_TO_SUBTOPIC: (
+            _handle_move_skill_id_to_subtopic_cmd
+        ),
+        topic_domain.CMD_REARRANGE_SKILL_IN_SUBTOPIC: (
+            _handle_rearrange_skill_in_subtopic_cmd
+        ),
+        topic_domain.CMD_REARRANGE_SUBTOPIC: _handle_rearrange_subtopic_cmd,
+        topic_domain.CMD_REMOVE_SKILL_ID_FROM_SUBTOPIC: (
+            _handle_remove_skill_id_from_subtopic_cmd
+        ),
+        topic_domain.CMD_UPDATE_TOPIC_PROPERTY: _handle_update_topic_property_cmd,
+        topic_domain.CMD_UPDATE_SUBTOPIC_PROPERTY: (
+            _handle_update_subtopic_property_cmd
+        ),
+        study_guide_domain.CMD_UPDATE_STUDY_GUIDE_PROPERTY: (
+            _handle_update_study_guide_property_cmd
+        ),
+        subtopic_page_domain.CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY: (
+            _handle_update_subtopic_page_property_cmd
+        ),
+        topic_domain.CMD_MIGRATE_SUBTOPIC_SCHEMA_TO_LATEST_VERSION: (
+            _handle_migrate_subtopic_schema_cmd
+        ),
+    }
+
+    try:
+        for change in change_list:
+            handler = command_handlers.get(change.cmd)
+            if handler is not None:
+                handler(change)
         return (
             topic,
             modified_subtopic_pages,

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -1304,7 +1304,8 @@ def apply_change_list(
 
     try:
         for change in change_list:
-            handler = command_handlers.get(change.cmd)
+            cmd = cast(str, change.cmd)
+            handler = command_handlers.get(cmd)
             if handler is not None:
                 handler(change)
         return (

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -1304,6 +1304,8 @@ def apply_change_list(
 
     try:
         for change in change_list:
+            # Here we use cast because BaseChange defines cmd as a broadly
+            # typed attribute, but our handler map only accepts string keys.
             cmd = cast(str, change.cmd)
             handler = command_handlers.get(cmd)
             if handler is not None:


### PR DESCRIPTION
## Overview

1. This PR fixes #25795 .
2. This PR does the following: Refactor the command dispatch in `apply_change_list` to use a handler map instead of a long if/elif chain. This improves readability and maintainability by centralizing command routing. Also makes it easier to add or modify command handlers without expanding the chain.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
<img width="1247" height="527" alt="image" src="https://github.com/user-attachments/assets/229d5a75-3ec4-4654-98ec-1f31c6c0e653" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.