### PR TITLE
Fix #25804: Add Nepali to supported dashboard languages

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -63,6 +63,10 @@ export default {
     {
       "language_code": "yo",
       "explanation": "For learners in Nigeria."
+    },
+    {
+      "language_code": "ne",
+      "explanation": "For learners in Nepal."
     }],
 
   "RTE_COMPONENT_CONFIGS": {
@@ -5374,6 +5378,12 @@ export default {
     "decimal_separator": ".",
     "ariaLabelInEnglish": "Marathi"
   }, {
+    "code": "ne",
+    "description": "नेपाली (Nepali)",
+    "direction": "ltr",
+    "decimal_separator": ".",
+    "ariaLabelInEnglish": "Nepali"
+  }, {
     "code": "no",
     "description": "Norsk (Norwegian)",
     "direction": "ltr",
@@ -5820,6 +5830,11 @@ export default {
     "id": "mr",
     "description": "मराठी (Marathi)",
     "relatedLanguages": ["mr"],
+    "direction": "ltr"
+  }, {
+    "id": "ne",
+    "description": "नेपाली (Nepali)",
+    "relatedLanguages": ["ne"],
     "direction": "ltr"
   }, {
     "id": "no",

--- a/core/controllers/contributor_dashboard_test.py
+++ b/core/controllers/contributor_dashboard_test.py
@@ -1957,6 +1957,10 @@ class FeaturedTranslationLanguagesHandlerTest(test_utils.GenericTestBase):
                     'language_code': 'yo',
                     'explanation': 'For learners in Nigeria.',
                 },
+                {
+                    'language_code': 'ne',
+                    'explanation': 'For learners in Nepal.',
+                },
             ]
         }
         self.assertEqual(response, expected_response)


### PR DESCRIPTION
## Overview

1. This PR fixes #25804.
2. This PR does the following: Adds Nepali (`ne`) to the list of supported content languages, supported audio languages, and featured translation languages (Most needed) on the Contributor Dashboard. This includes updating corresponding unit tests to verify the presence of the added language in the featured translation languages list.
3. (For bug-fixing PRs only) N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

Below is the video proof demonstrating the correct addition of Nepali on the Contributor Dashboard:
- Listed under **"Most needed"** in the Translation tab dropdown.
- Searchable and selectable in the full list of languages.
- Listed and selectable under the Voiceover tab dropdown.

https://github.com/user-attachments/assets/5992be61-1d5b-4e9a-b1f3-7d0a984d5036

**Verification via Automated Tests:**
I updated backend unit tests in `contributor_dashboard_test.py` to assert that Nepali (`ne`) is returned as a featured translation language.

**Test Logs:**
Ran the controller tests locally to confirm everything passes:
```text
SUCCESS   core.controllers.contributor_dashboard_test: 68 tests (64.2 secs)

Ran 68 tests in 1 test class.
All tests passed.
```

#### Proof of changes on mobile phone
N/A (Dashboard dropdown addition behaves identically across desktop and mobile browsers.)

#### Proof of changes in Arabic language
N/A (No UI text or layout structure changes.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.