### PR TITLE
Fix #24734: Open forum link in a new tab

### DIFF
--- a/core/templates/base-components/oppia-footer.component.html
+++ b/core/templates/base-components/oppia-footer.component.html
@@ -59,7 +59,7 @@
             </a>
           </li>
           <li>
-            <a href="https://groups.google.com/g/oppia" class="e2e-test-footer-forum-link">
+            <a href="https://groups.google.com/g/oppia" target="_blank" rel="noopener" class="e2e-test-footer-forum-link">
               {{ 'I18N_FOOTER_FORUM' | translate }}
             </a>
           </li>

--- a/core/templates/base-components/oppia-footer.component.spec.ts
+++ b/core/templates/base-components/oppia-footer.component.spec.ts
@@ -344,4 +344,15 @@ describe('OppiaFooterComponent', () => {
       siteAnalyticsService.registerClickFooterButtonEvent
     ).toHaveBeenCalledWith(NavbarAndFooterGATrackingPages.TEACH);
   });
+
+  it('should have forum link with correct target and rel attributes', () => {
+    fixture.detectChanges();
+    const forumLink: HTMLAnchorElement = fixture.nativeElement.querySelector(
+      '.e2e-test-footer-forum-link'
+    );
+
+    expect(forumLink.href).toBe('https://groups.google.com/g/oppia');
+    expect(forumLink.target).toBe('_blank');
+    expect(forumLink.rel).toContain('noopener');
+  });
 });


### PR DESCRIPTION
## Overview

1. This PR fixes #24734 .
2. This PR does the following: Open the forum link that is in the footer of the main page in a new tab.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


##  Proof that changes are correct
Before changes
https://github.com/user-attachments/assets/bdc72352-c9d9-46c2-bb9d-8e2f1ba10cbb

After changes
https://github.com/user-attachments/assets/d9790258-c9fb-4db6-92f1-764eead5154b


#### Proof of changes on desktop with slow/throttled network

https://github.com/user-attachments/assets/a5581692-c275-4085-9adf-693837990979



#### Proof of changes on mobile phone

https://github.com/user-attachments/assets/b8186506-0c9b-4302-8d00-a2ace3952468
