### PR TITLE
Fix #24734: Open forum link in a new tab

### DIFF
--- a/core/templates/base-components/oppia-footer.component.html
+++ b/core/templates/base-components/oppia-footer.component.html
@@ -59,7 +59,7 @@
             </a>
           </li>
           <li>
-            <a href="https://groups.google.com/g/oppia" class="e2e-test-footer-forum-link">
+            <a href="https://groups.google.com/g/oppia" target="_blank" rel="noopener" class="e2e-test-footer-forum-link">
               {{ 'I18N_FOOTER_FORUM' | translate }}
             </a>
           </li>

--- a/core/templates/base-components/oppia-footer.component.spec.ts
+++ b/core/templates/base-components/oppia-footer.component.spec.ts
@@ -344,15 +344,4 @@ describe('OppiaFooterComponent', () => {
       siteAnalyticsService.registerClickFooterButtonEvent
     ).toHaveBeenCalledWith(NavbarAndFooterGATrackingPages.TEACH);
   });
-
-  it('should have forum link with correct target and rel attributes', () => {
-    fixture.detectChanges();
-    const forumLink: HTMLAnchorElement = fixture.nativeElement.querySelector(
-      '.e2e-test-footer-forum-link'
-    );
-
-    expect(forumLink.href).toBe('https://groups.google.com/g/oppia');
-    expect(forumLink.target).toBe('_blank');
-    expect(forumLink.rel).toContain('noopener');
-  });
 });

--- a/core/templates/base-components/oppia-footer.component.spec.ts
+++ b/core/templates/base-components/oppia-footer.component.spec.ts
@@ -344,4 +344,15 @@ describe('OppiaFooterComponent', () => {
       siteAnalyticsService.registerClickFooterButtonEvent
     ).toHaveBeenCalledWith(NavbarAndFooterGATrackingPages.TEACH);
   });
+
+  it('should have forum link with correct target and rel attributes', () => {
+    fixture.detectChanges();
+    const forumLink: HTMLAnchorElement = fixture.nativeElement.querySelector(
+      '.e2e-test-footer-forum-link'
+    );
+
+    expect(forumLink.href).toBe('https://groups.google.com/g/oppia');
+    expect(forumLink.target).toBe('_blank');
+    expect(forumLink.rel).toContain('noopener');
+  });
 });

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-out-user.ts
@@ -1754,9 +1754,12 @@ export class LoggedOutUser extends BaseUser {
     await this.page.waitForSelector(footerForumlink, {
       visible: true,
     });
-    await this.clickAndWaitForNavigation(footerForumlink, true);
-
-    expect(this.page.url()).toBe(googleGroupsOppiaUrl);
+    await this.clickLinkButtonToNewTab(
+      footerForumlink,
+      'Forum',
+      googleGroupsOppiaUrl,
+      'Forum'
+    );
   }
 
   /**


### PR DESCRIPTION
## Overview

1. This PR fixes #24734 .
2. This PR does the following: Open the forum link that is in the footer of the main page in a new tab.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
Before changes

https://github.com/user-attachments/assets/db9d7491-576f-4d85-8f84-e18d30b207ed

After changes

https://github.com/user-attachments/assets/1f63ec20-06f8-4621-91f0-9f467d51f873


#### Proof of changes on desktop with slow/throttled network

https://github.com/user-attachments/assets/562c2f68-f7f1-4726-876b-773c0d2a97ac


#### Proof of changes on mobile phone

https://github.com/user-attachments/assets/3ebf2acd-9b19-4aab-91e6-9de40d823e6b


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
