### PR TITLE
Fix #15486: Support non-English decimal separators in NumberWithUnits interaction

### DIFF
--- a/core/templates/domain/objects/number-with-units.model.spec.ts
+++ b/core/templates/domain/objects/number-with-units.model.spec.ts
@@ -293,6 +293,26 @@ describe('NumberWithUnits', () => {
       );
     });
 
+    it('should parse number with comma as decimal separator', () => {
+      expect(NumberWithUnits.fromRawInputString('1,2 hr', ',')).toEqual(
+        new NumberWithUnits(
+          'real',
+          1.2,
+          new Fraction(false, 0, 0, 1),
+          Units.fromRawInputString('hr')
+        )
+      );
+
+      expect(NumberWithUnits.fromRawInputString('2,5 kg / m^3', ',')).toEqual(
+        new NumberWithUnits(
+          'real',
+          2.5,
+          new Fraction(false, 0, 0, 1),
+          Units.fromRawInputString('kg / m^3')
+        )
+      );
+    });
+
     it('should throw errors for invalid number with units', () => {
       expect(() => {
         NumberWithUnits.fromRawInputString('3* kg');

--- a/core/templates/domain/objects/number-with-units.model.ts
+++ b/core/templates/domain/objects/number-with-units.model.ts
@@ -166,7 +166,10 @@ export class NumberWithUnits {
     } catch (parsingError) {}
   }
 
-  static fromRawInputString(rawInput: string): NumberWithUnits {
+  static fromRawInputString(
+    rawInput: string,
+    decimalSeparator: string = '.'
+  ): NumberWithUnits {
     rawInput = rawInput.trim();
     let type = '';
     let real = 0.0;
@@ -276,6 +279,11 @@ export class NumberWithUnits {
         fractionObj = Fraction.fromRawInputString(value);
       } else {
         type = 'real';
+        // Normalize locale-specific decimal separator to English decimal
+        // before parsing (e.g. Portuguese '1,2' becomes '1.2').
+        if (decimalSeparator !== '.') {
+          value = value.replace(decimalSeparator, '.');
+        }
         real = parseFloat(value);
       }
       if (units !== '') {

--- a/extensions/interactions/NumberWithUnits/directives/oppia-interactive-number-with-units.component.spec.ts
+++ b/extensions/interactions/NumberWithUnits/directives/oppia-interactive-number-with-units.component.spec.ts
@@ -26,6 +26,8 @@ import {
 } from '@angular/core/testing';
 import {InteractiveNumberWithUnitsComponent} from './oppia-interactive-number-with-units.component';
 import {CurrentInteractionService} from 'pages/exploration-player-page/services/current-interaction.service';
+import {NumberConversionService} from 'services/number-conversion.service';
+import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {NumberWithUnits} from 'domain/objects/number-with-units.model';
 import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {TranslateModule} from '@ngx-translate/core';
@@ -75,6 +77,8 @@ describe('Number with units interaction component', () => {
           provide: CurrentInteractionService,
           useValue: mockCurrentInteractionService,
         },
+        NumberConversionService,
+        I18nLanguageCodeService,
         NgbModal,
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -253,5 +257,18 @@ describe('Number with units interaction component', () => {
 
     expect(component.componentSubscriptions.unsubscribe).toHaveBeenCalled();
     expect(component.componentSubscriptions.closed).toBeTrue();
+  });
+
+  it('should correctly parse number with comma as decimal separator', () => {
+    const i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
+    i18nLanguageCodeService.setI18nLanguageCode('pt');
+
+    component.answer = '1,2 hr';
+    spyOn(currentInteractionService, 'onSubmit');
+
+    component.submitAnswer();
+
+    expect(component.errorMessageI18nKey).toBe('');
+    expect(currentInteractionService.onSubmit).toHaveBeenCalled();
   });
 });

--- a/extensions/interactions/NumberWithUnits/directives/oppia-interactive-number-with-units.component.spec.ts
+++ b/extensions/interactions/NumberWithUnits/directives/oppia-interactive-number-with-units.component.spec.ts
@@ -261,7 +261,7 @@ describe('Number with units interaction component', () => {
 
   it('should correctly parse number with comma as decimal separator', () => {
     const i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
-    i18nLanguageCodeService.setI18nLanguageCode('pt');
+    i18nLanguageCodeService.setI18nLanguageCode('pt-br');
 
     component.answer = '1,2 hr';
     spyOn(currentInteractionService, 'onSubmit');

--- a/extensions/interactions/NumberWithUnits/directives/oppia-interactive-number-with-units.component.ts
+++ b/extensions/interactions/NumberWithUnits/directives/oppia-interactive-number-with-units.component.ts
@@ -29,6 +29,7 @@ import {
 } from 'interactions/answer-defs';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {HelpModalNumberWithUnitsComponent} from './oppia-help-modal-number-with-units.component';
+import {NumberConversionService} from 'services/number-conversion.service';
 import {NumberWithUnits} from 'domain/objects/number-with-units.model';
 import {NumberWithUnitsRulesService} from './number-with-units-rules.service';
 
@@ -58,7 +59,8 @@ export class InteractiveNumberWithUnitsComponent implements OnInit, OnDestroy {
     private currentInteractionService: CurrentInteractionService,
     private focusManagerService: FocusManagerService,
     private numberWithUnitsRulesService: NumberWithUnitsRulesService,
-    private ngbModal: NgbModal
+    private ngbModal: NgbModal,
+    private numberConversionService: NumberConversionService
   ) {
     this.componentSubscriptions.add(
       this.answerChanged
@@ -119,7 +121,12 @@ export class InteractiveNumberWithUnitsComponent implements OnInit, OnDestroy {
         this.currentInteractionService.updateAnswerIsValid(false);
         return;
       }
-      const numberWithUnits = NumberWithUnits.fromRawInputString(this.answer);
+      const decimalSeparator =
+        this.numberConversionService.currentDecimalSeparator();
+      const numberWithUnits = NumberWithUnits.fromRawInputString(
+        this.answer,
+        decimalSeparator
+      );
       this.currentInteractionService.onSubmit(
         numberWithUnits,
         this.numberWithUnitsRulesService as NumberWithUnitsRulesService

--- a/extensions/objects/templates/number-with-units-editor.component.spec.ts
+++ b/extensions/objects/templates/number-with-units-editor.component.spec.ts
@@ -18,6 +18,8 @@
 
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {NumberConversionService} from 'services/number-conversion.service';
+import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {NumberWithUnitsEditorComponent} from './number-with-units-editor.component';
 import {MockTranslatePipe} from 'tests/unit-test-utils';
 
@@ -28,6 +30,7 @@ describe('NumberWithUnitsEditorComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [MockTranslatePipe, NumberWithUnitsEditorComponent],
+      providers: [NumberConversionService, I18nLanguageCodeService],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
@@ -114,5 +117,18 @@ describe('NumberWithUnitsEditorComponent', () => {
     component.updateValue('23 kf');
 
     expect(component.errorMessageI18nKey).toBe('Unit "kf" not found.');
+  });
+
+  it('should correctly parse number with comma as decimal separator', () => {
+    const i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
+    i18nLanguageCodeService.setI18nLanguageCode('pt');
+    spyOn(component.valueChanged, 'emit');
+
+    component.updateValue('1,5 kg');
+
+    expect(component.value?.real).toBe(1.5);
+    expect(component.value?.units[0].unit).toBe('kg');
+    expect(component.errorMessageI18nKey).toBe('');
+    expect(component.valueChanged.emit).toHaveBeenCalledWith(component.value);
   });
 });

--- a/extensions/objects/templates/number-with-units-editor.component.spec.ts
+++ b/extensions/objects/templates/number-with-units-editor.component.spec.ts
@@ -121,7 +121,7 @@ describe('NumberWithUnitsEditorComponent', () => {
 
   it('should correctly parse number with comma as decimal separator', () => {
     const i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
-    i18nLanguageCodeService.setI18nLanguageCode('pt');
+    i18nLanguageCodeService.setI18nLanguageCode('pt-br');
     spyOn(component.valueChanged, 'emit');
 
     component.updateValue('1,5 kg');

--- a/extensions/objects/templates/number-with-units-editor.component.ts
+++ b/extensions/objects/templates/number-with-units-editor.component.ts
@@ -19,6 +19,8 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {ObjectFormValidityChangeEvent} from 'app-events/app-events';
 import {EventBusGroup, EventBusService} from 'app-events/event-bus.service';
+import {NumberConversionService} from 'services/number-conversion.service';
+import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {NumberWithUnits} from 'domain/objects/number-with-units.model';
 import {NumberWithUnitsAnswer} from 'interactions/answer-defs';
 
@@ -39,7 +41,10 @@ export class NumberWithUnitsEditorComponent implements OnInit {
   errorMessageI18nKey: string = '';
   eventBusGroup: EventBusGroup;
 
-  constructor(private eventBusService: EventBusService) {
+  constructor(
+    private eventBusService: EventBusService,
+    private numberConversionService: NumberConversionService
+  ) {
     this.eventBusGroup = new EventBusGroup(this.eventBusService);
   }
 
@@ -55,7 +60,12 @@ export class NumberWithUnitsEditorComponent implements OnInit {
 
   updateValue(newValue: string): void {
     try {
-      let numberWithUnits = NumberWithUnits.fromRawInputString(newValue);
+      const decimalSeparator =
+        this.numberConversionService.currentDecimalSeparator();
+      let numberWithUnits = NumberWithUnits.fromRawInputString(
+        newValue,
+        decimalSeparator
+      );
       this.value = numberWithUnits;
       this.valueChanged.emit(this.value);
       this.eventBusGroup.emit(

--- a/extensions/objects/templates/number-with-units-editor.component.ts
+++ b/extensions/objects/templates/number-with-units-editor.component.ts
@@ -20,7 +20,6 @@ import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {ObjectFormValidityChangeEvent} from 'app-events/app-events';
 import {EventBusGroup, EventBusService} from 'app-events/event-bus.service';
 import {NumberConversionService} from 'services/number-conversion.service';
-import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
 import {NumberWithUnits} from 'domain/objects/number-with-units.model';
 import {NumberWithUnitsAnswer} from 'interactions/answer-defs';
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #15486 

2. This PR does the following: Adds support for non-English decimal separators (like , in Portuguese) in the `NumberWithUnits` interaction. It uses `NumberConversionService` to get the current locale’s separator and converts it to '.' before parsing.

3. The original bug occurred because: The issue happened because `parseFloat()` only understands `.` as a decimal separator. So inputs like 1,2 hr were read as 1 instead of 1.2.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
### Before:

https://github.com/user-attachments/assets/d1a23bff-6db3-4b4f-a3c9-9bf12f4c3ca0

### After:

https://github.com/user-attachments/assets/43807bc9-9ce2-4357-8126-bf6b87d15989


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
