### PR TITLE
Fix #25488: Resolve voiceover submission error by fixing accent code state-sync

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.spec.ts
@@ -1036,4 +1036,32 @@ describe('Voiceover card component', () => {
 
     expect(component.automaticVoiceoverGenerationStatus).toEqual('GENERATING');
   }));
+
+  it('should correctly update language accent code from translationLanguageService when active accent changes', fakeAsync(() => {
+    // 1. Simulate the bug's race condition where localStorage returns null.
+    spyOn(
+      localStorageService,
+      'getLastSelectedLanguageAccentCode'
+    ).and.returnValue(null);
+
+    // 2. Provide the single source of truth from the correct service.
+    spyOn(
+      translationLanguageService,
+      'getActiveLanguageAccentCode'
+    ).and.returnValue('en-US');
+
+    spyOn(component, 'updateLanguageAccentCode');
+
+    // 3. Initialize the component to start the subscription.
+    component.ngOnInit();
+
+    // 4. Trigger the translation event.
+    translationLanguageService.onActiveLanguageAccentChanged.emit();
+    flush();
+
+    // 5. The component should update with the service's value ('en-US'), NOT localStorage (null).
+    expect(component.updateLanguageAccentCode).toHaveBeenCalledWith('en-US');
+
+    discardPeriodicTasks();
+  }));
 });

--- a/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/voiceover-card/voiceover-card.component.ts
@@ -171,7 +171,7 @@ export class VoiceoverCardComponent implements OnInit, AfterViewChecked {
       this.translationLanguageService.onActiveLanguageAccentChanged.subscribe(
         () => {
           let newLanguageAccentCode =
-            this.localStorageService.getLastSelectedLanguageAccentCode() as string;
+            this.translationLanguageService.getActiveLanguageAccentCode() as string;
           this.updateLanguageAccentCode(newLanguageAccentCode);
         }
       )


### PR DESCRIPTION
## Overview

1. This PR fixes #25488.
2. This PR does the following: Resolves a state-sync regression that was causing voiceover submissions to fail with a `received null` backend error. It updates the `voiceover-card.component.ts` subscription to pull the `languageAccentCode` from the correct single source of truth (`translationLanguageService`) instead of relying on a potentially stale `localStorageService` read. It also adds a missing regression unit test that explicitly simulates this race condition.
3. The original bug occurred because: A state-sync regression was introduced in commit `fd3b3b62b02`. The `voiceover-card.component.ts` erroneously pulled the `languageAccentCode` from `localStorage` immediately upon the accent change event firing. Because `localStorage` had not yet finished updating, it returned `undefined/null`, which was then baked into the payload sent to the backend.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #25488: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

### UI Reproduction (Before vs After)
Since this issue depends on the browser's localStorage state, I manually injected the corrupted "null" string to demonstrate the bug. As shown below, the buggy state fails, while the fix correctly bypasses the cache.

- Before Fix (Buggy State - Payload corrupted to null)

https://github.com/user-attachments/assets/fbb2175a-b031-4589-af32-8c79ce9a88b0

- After Fix (Fixed State - Payload correctly sends en-US)

https://github.com/user-attachments/assets/66616ba1-7e8a-495a-b139-f92c3129a6e3

I am also providing proof via the frontend unit test suite, which perfectly isolates the regression. 

I discovered the existing spec for `onActiveLanguageAccentChanged` was masking the bug by unconditionally mocking `localStorage`. I added a new regression spec to simulate the race condition, which successfully reproduces the `null` failure state on the old code, and passes flawlessly with the `translationLanguageService` fix.

#### Before (Buggy State - Passing Null):
*<img width="1916" height="890" alt="image" src="https://github.com/user-attachments/assets/a1aa84bd-f880-4877-a8ba-ca06bec7b20a" />*

#### After (Fixed State - Correctly passing 'en-US'):
*<img width="1874" height="918" alt="image" src="https://github.com/user-attachments/assets/c28bd8c9-7935-4623-9105-4ce6838204fd" />*

#### Proof of changes on desktop with slow/throttled network
No proof of changes needed because this is a data-source variable fix, not a UI/rendering change, and UI reproduction is blocked by local exploration constraints.

#### Proof of changes on mobile phone
No proof of changes needed because this is a data-source variable fix, not a UI/rendering change, and UI reproduction is blocked by local exploration constraints.

#### Proof of changes in Arabic language
No proof of changes needed because this is a data-source variable fix, not a UI/rendering change, and UI reproduction is blocked by local exploration constraints.

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
