### PR TITLE
[GSoC 2026] M1.2, 1.3, 1.4 - Fix part of #24715: Add Playwright framework support to acceptance test CI pipeline

### DIFF
--- a/core/tests/ci-test-suite-configs/acceptance.json
+++ b/core/tests/ci-test-suite-configs/acceptance.json
@@ -2,555 +2,693 @@
   "suites": [
     {
       "name": "logged-in-learner/serial-chapter",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/serial-chapter.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/serial-chapter.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/track-upcoming-delayed-publish-chapter",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/track-upcoming-delayed-publish-chapter.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/track-upcoming-delayed-publish-chapter.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/deny-access-to-dashboards-and-actions-without-login",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/deny-access-to-dashboards-and-actions-without-login.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/deny-access-to-dashboards-and-actions-without-login.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/play-through-lesson-while-getting-feedback-and-hints",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/play-through-lesson-while-getting-feedback-and-hints.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/play-through-lesson-while-getting-feedback-and-hints.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-partner-organization/submit-a-partnership-application",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-partner-organization/submit-a-partnership-application.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-partner-organization/submit-a-partnership-application.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-partner-organization/view-the-blog",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-partner-organization/view-the-blog.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-partner-organization/view-the-blog.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-volunteer/apply-to-become-a-volunteer",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-volunteer/apply-to-become-a-volunteer.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-volunteer/apply-to-become-a-volunteer.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-donor/learn-about-the-organization",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-donor/learn-about-the-organization.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-donor/learn-about-the-organization.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-donor/make-a-donation",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-donor/make-a-donation.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-donor/make-a-donation.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-parent/attempt-to-contact-the-organization",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/attempt-to-contact-the-organization.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/attempt-to-contact-the-organization.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-parent/check-the-tos-and-privacy-pages",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/check-the-tos-and-privacy-pages.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/check-the-tos-and-privacy-pages.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-parent/download-the-android-app",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/download-the-android-app.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/download-the-android-app.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-parent/learn-about-the-organization",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/learn-about-the-organization.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/learn-about-the-organization.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "interested-parent/sign-up-for-oppias-newsletter",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/sign-up-for-oppias-newsletter.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/interested-parent/sign-up-for-oppias-newsletter.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "blog-editor/try-to-publish-a-duplicate-blog-post-and-get-blocked",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-editor/try-to-publish-a-duplicate-blog-post-and-get-blocked.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-editor/try-to-publish-a-duplicate-blog-post-and-get-blocked.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "curriculum-admin/create-subtopic-study-guide-with-multiple-sections",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-subtopic-study-guide-with-multiple-sections.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-subtopic-study-guide-with-multiple-sections.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "curriculum-admin/create-skill-with-workedexamples",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-skill-with-workedexamples.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-skill-with-workedexamples.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "curriculum-admin/try-to-paste-invalid-components-and-get-error",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/try-to-paste-invalid-components-and-get-error.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/try-to-paste-invalid-components-and-get-error.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/load-complete-and-restart-exploration-preview",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/load-complete-and-restart-exploration-preview.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/load-complete-and-restart-exploration-preview.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/manage-exploration-misconceptions",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/modify-translations-through-modal",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/modify-translations-through-modal.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/modify-translations-through-modal.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/publish-the-exploration-with-an-interaction",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/publish-the-exploration-with-an-interaction.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/publish-the-exploration-with-an-interaction.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/save-draft-publish-and-discard-the-changes",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/save-draft-publish-and-discard-the-changes.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/save-draft-publish-and-discard-the-changes.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/download-any-version-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/download-any-version-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/download-any-version-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/verify-statistics-and-previous-explorations",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/verify-statistics-and-previous-explorations.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/verify-statistics-and-previous-explorations.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-editor/submit-review-and-respond-to-feedback",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/submit-review-and-respond-to-feedback.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/submit-review-and-respond-to-feedback.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "lesson-creator/check-improvements-tab",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/check-improvements-tab.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/check-improvements-tab.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "lesson-creator/create-a-basic-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/create-a-basic-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/create-a-basic-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "lesson-creator/modify-an-existing-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/modify-an-existing-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/modify-an-existing-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "lesson-creator/save-and-publish-the-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/save-and-publish-the-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/save-and-publish-the-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "lesson-creator/view-feedback-and-statistics-of-the-lesson",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/view-feedback-and-statistics-of-the-lesson.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/lesson-creator/view-feedback-and-statistics-of-the-lesson.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-user/add-concept-card-with-workedexample-to-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/add-concept-card-with-workedexample-to-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/add-concept-card-with-workedexample-to-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-user/view-subtopic-study-guides",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/view-subtopic-study-guides.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/view-subtopic-study-guides.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-user/create-and-delete-account",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/create-and-delete-account.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/create-and-delete-account.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-user/edit-avatar-and-view-exploration-from-profile-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/edit-avatar-and-view-exploration-from-profile-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/edit-avatar-and-view-exploration-from-profile-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-user/manage-classroom-progress-in-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/manage-classroom-progress-in-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/manage-classroom-progress-in-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-user/manage-exploration-progress-in-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/manage-exploration-progress-in-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-user/manage-exploration-progress-in-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-links-on-get-started-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-get-started-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-get-started-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-buttons-on-donation-thanks-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-donation-thanks-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-donation-thanks-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/check-all-user-flow-of-parent-teacher",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/check-all-user-flow-of-parent-teacher.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/check-all-user-flow-of-parent-teacher.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/check-all-user-flow-of-partner",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/check-all-user-flow-of-partner.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/check-all-user-flow-of-partner.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-buttons-on-teach-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-teach-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-teach-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-buttons-on-contact-us-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-contact-us-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-contact-us-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/play-lesson-in-different-languages-and-listen-to-voiceovers",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/play-lesson-in-different-languages-and-listen-to-voiceovers.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/play-lesson-in-different-languages-and-listen-to-voiceovers.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/generate-and-play-automated-voiceovers",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/generate-and-play-automated-voiceovers.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/generate-and-play-automated-voiceovers.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/visit-classroom-index-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/visit-classroom-index-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/visit-classroom-index-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-links-in-oppia-footer",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-in-oppia-footer.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-in-oppia-footer.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-links-on-creator-guidelines-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-creator-guidelines-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-creator-guidelines-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-links-on-privacy-policy-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-privacy-policy-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-privacy-policy-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-links-on-terms-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-terms-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-links-on-terms-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/browse-and-search-for-lessons-in-community-library",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/browse-and-search-for-lessons-in-community-library.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/browse-and-search-for-lessons-in-community-library.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/choose-what-to-do-from-the-last-card-of-an-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/choose-what-to-do-from-the-last-card-of-an-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/choose-what-to-do-from-the-last-card-of-an-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/change-site-language-and-engage-with-original-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/change-site-language-and-engage-with-original-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/change-site-language-and-engage-with-original-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/use-keyboard-shortcuts-to-navigate-and-shift-focus",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/use-keyboard-shortcuts-to-navigate-and-shift-focus.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/use-keyboard-shortcuts-to-navigate-and-shift-focus.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/sign-in-and-save-exploration-progress",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/sign-in-and-save-exploration-progress.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/sign-in-and-save-exploration-progress.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/view-and-search-blog-posts",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/view-and-search-blog-posts.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/view-and-search-blog-posts.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-with-different-interactions-and-difficulties.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "super-admin/load-dummy-data-in-dev-mode",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/load-dummy-data-in-dev-mode.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/load-dummy-data-in-dev-mode.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/create-and-delete-questions-in-skill-editor",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/create-and-delete-questions-in-skill-editor.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/create-and-delete-questions-in-skill-editor.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/cannot-do-curriculum-admin-actions",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/cannot-do-curriculum-admin-actions.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/cannot-do-curriculum-admin-actions.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/edit-and-republish-story-with-mobile-supported-explorations",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-story-with-mobile-supported-explorations.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "voiceover-admin/assign-unassign-voiceover-artist-to-an-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/voiceover-admin/assign-unassign-voiceover-artist-to-an-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/voiceover-admin/assign-unassign-voiceover-artist-to-an-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/create-an-exploration-with-all-interactions",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/create-an-exploration-with-all-interactions.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/create-an-exploration-with-all-interactions.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/exploration-history",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-history.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-history.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/exploration-settings",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-settings.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-settings.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/exploration-feedback",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/exploration-help",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-help.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-help.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/exploration-navbar-header",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-navbar-header.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-navbar-header.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/preview-commonly-used-interactions",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/preview-commonly-used-interactions.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/preview-commonly-used-interactions.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "exploration-creator/preview-math-interactions",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/preview-math-interactions.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/preview-math-interactions.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/complete-some-practice-question",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/complete-some-practice-question.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/complete-some-practice-question.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/discover-the-website-and-navigate-to-math-classroom",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/discover-the-website-and-navigate-to-math-classroom.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/discover-the-website-and-navigate-to-math-classroom.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/pick-a-lesson-to-learn",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/pick-a-lesson-to-learn.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/pick-a-lesson-to-learn.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/search-for-a-specific-exploration",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/search-for-a-specific-exploration.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/search-for-a-specific-exploration.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/visits-the-community-library-and-look-around",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/visits-the-community-library-and-look-around.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/visits-the-community-library-and-look-around.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/completes-the-exploration-and-decides-what-to-do-next",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/completes-the-exploration-and-decides-what-to-do-next.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/completes-the-exploration-and-decides-what-to-do-next.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/listen-to-voiceovers-of-the-lessons-in-the-lesson-player",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/listen-to-voiceovers-of-the-lessons-in-the-lesson-player.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/listen-to-voiceovers-of-the-lessons-in-the-lesson-player.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/manage-classroom-progress-in-home-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-classroom-progress-in-home-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-classroom-progress-in-home-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/manage-community-lesson-progress-in-home-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-community-lesson-progress-in-home-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-community-lesson-progress-in-home-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/manage-in-progress-and-completed-lessons-and-skill",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-in-progress-and-completed-lessons-and-skill.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-in-progress-and-completed-lessons-and-skill.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/manage-in-progress-and-completed-community-lessons-and-skill",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-in-progress-and-completed-community-lessons-and-skill.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-in-progress-and-completed-community-lessons-and-skill.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/play-a-complete-community-lesson",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/play-a-complete-community-lesson.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/play-a-complete-community-lesson.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/reaches-a-checkpoint-and-saves-their-progress",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/reaches-a-checkpoint-and-saves-their-progress.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/reaches-a-checkpoint-and-saves-their-progress.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/use-the-feedback-and-help-cards",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/use-the-feedback-and-help-cards.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/use-the-feedback-and-help-cards.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/share-the-lesson-from-the-lesson-player",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/share-the-lesson-from-the-lesson-player.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/share-the-lesson-from-the-lesson-player.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/sets-goal-on-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/sets-goal-on-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/sets-goal-on-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/choose-new-lesson-to-play-from-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/choose-new-lesson-to-play-from-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/choose-new-lesson-to-play-from-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/add-and-remove-exploration-from-play-later",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/add-and-remove-exploration-from-play-later.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/add-and-remove-exploration-from-play-later.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/provide-feedback-on-the-lesson-or-report-it-from-the-lesson-player",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/provide-feedback-on-the-lesson-or-report-it-from-the-lesson-player.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/provide-feedback-on-the-lesson-or-report-it-from-the-lesson-player.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/access-pages-that-require-higher-privileges",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/access-pages-that-require-higher-privileges.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/access-pages-that-require-higher-privileges.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/goes-through-the-sign-in-flow",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/goes-through-the-sign-in-flow.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/goes-through-the-sign-in-flow.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/reaches-a-checkpoint-and-saves-their-progress",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/reaches-a-checkpoint-and-saves-their-progress.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/reaches-a-checkpoint-and-saves-their-progress.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/starts-from-beginning-after-completing-a-lesson",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/starts-from-beginning-after-completing-a-lesson.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/starts-from-beginning-after-completing-a-lesson.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/access-the-lesson-player",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/access-the-lesson-player.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/access-the-lesson-player.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/complete-the-embedded-lesson",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/complete-the-embedded-lesson.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/complete-the-embedded-lesson.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-learner/give-feedback-on-the-lesson-from-the-lesson-player",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/give-feedback-on-the-lesson-from-the-lesson-player.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-learner/give-feedback-on-the-lesson-from-the-lesson-player.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/changes-site-language-to-rtl",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/edit-the-profile",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/edit-the-profile.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/edit-the-profile.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/export-and-delete-account",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/export-and-delete-account.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/export-and-delete-account.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/manage-goals-in-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-in-learner/interact-with-goals-in-learner-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/interact-with-goals-in-learner-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-in-learner/interact-with-goals-in-learner-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "translation-submitter/translate-exploration-in-target-language",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-submitter/translate-exploration-in-target-language.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-submitter/translate-exploration-in-target-language.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "translation-submitter/check-their-accomplishment",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-submitter/check-their-accomplishment.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-submitter/check-their-accomplishment.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "translation-reviewer/review-the-translations",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/review-the-translations.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/review-the-translations.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "translation-reviewer/filter-the-translations",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/filter-the-translations.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-reviewer/filter-the-translations.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "blog-admin/assign-and-remove-blog-editor-and-blog-admin-roles",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-admin/assign-and-remove-blog-editor-and-blog-admin-roles.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-admin/assign-and-remove-blog-editor-and-blog-admin-roles.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "blog-post-writer/register-and-update-blog-profile",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-post-writer/register-and-update-blog-profile.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-post-writer/register-and-update-blog-profile.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "blog-post-writer/create-and-edit-blog-post",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-post-writer/create-and-edit-blog-post.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/blog-post-writer/create-and-edit-blog-post.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "community-library-browser/subscribe-to-a-favourite-creator",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/access-dashboard-using-profile-dropdown",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/access-dashboard-using-profile-dropdown.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/access-dashboard-using-profile-dropdown.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/edit-the-topic",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-the-topic.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-the-topic.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/assign-unassign-and-merge-skills-in-skill-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/assign-unassign-and-merge-skills-in-skill-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/assign-unassign-and-merge-skills-in-skill-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/edit-and-republish-the-skill",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-the-skill.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/edit-and-republish-the-skill.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/add-questions-from-topic-editor",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/add-questions-from-topic-editor.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/add-questions-from-topic-editor.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/add-remove-and-edit-subtopics",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/add-remove-and-edit-subtopics.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/add-remove-and-edit-subtopics.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/create-delete-and-edit-the-stories-and-chapters",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/create-delete-and-edit-the-stories-and-chapters.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/create-delete-and-edit-the-stories-and-chapters.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "topic-manager/create-and-edit-questions-in-skill-dashboard",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/create-and-edit-questions-in-skill-dashboard.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/topic-manager/create-and-edit-questions-in-skill-dashboard.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "practice-question-submitter/submit-practice-questions-for-review-and-check-thier-status",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-for-review-and-check-thier-status.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/submit-practice-questions-for-review-and-check-thier-status.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "practice-question-submitter/check-contribution-stats-download-certificate-and-check-badges-earned",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/check-contribution-stats-download-certificate-and-check-badges-earned.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-submitter/check-contribution-stats-download-certificate-and-check-badges-earned.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "practice-question-reviewer/review-submitted-questions",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/review-submitted-questions.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/review-submitted-questions.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "practice-question-reviewer/view-contribution-stats-and-badges-earned",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/view-contribution-stats-and-badges-earned.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-reviewer/view-contribution-stats-and-badges-earned.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "curriculum-admin/create-publish-unpublish-and-delete-the-topic-and-skill",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-publish-unpublish-and-delete-the-topic-and-skill.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-publish-unpublish-and-delete-the-topic-and-skill.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "curriculum-admin/create-edit-and-delete-a-classroom",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-edit-and-delete-a-classroom.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/curriculum-admin/create-edit-and-delete-a-classroom.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "translation-coordinator/manage-contributors-translation-review-rights",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-coordinator/manage-contributors-translation-review-rights.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/translation-coordinator/manage-contributors-translation-review-rights.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "practice-question-coordinator/manage-contributors-question-review-submission-rights",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-coordinator/manage-contributors-question-review-submission-rights.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/practice-question-coordinator/manage-contributors-question-review-submission-rights.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "release-coordinator/enable-feature-flag",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/enable-feature-flag.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/enable-feature-flag.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "release-coordinator/enable-the-promo-bar",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/enable-the-promo-bar.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/enable-the-promo-bar.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "release-coordinator/flush-the-memory-cache",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/flush-the-memory-cache.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/flush-the-memory-cache.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "super-admin/edit-platform-parameter",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/edit-platform-parameter.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/edit-platform-parameter.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "super-admin/edit-users-role",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/edit-users-role.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/edit-users-role.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "super-admin/use-misc-tab-feature",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/use-misc-tab-feature.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/super-admin/use-misc-tab-feature.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "site-moderator/check-recent-commits",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-commits.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-commits.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "site-moderator/check-recent-feedback-messages",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-feedback-messages.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/site-moderator/check-recent-feedback-messages.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "site-moderator/featured-activities-section",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/site-moderator/featured-activities-section.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/site-moderator/featured-activities-section.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/click-all-buttons-on-partnerships-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-partnerships-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/click-all-buttons-on-partnerships-page.spec.ts",
+      "framework": "puppeteer"
     },
     {
       "name": "logged-out-user/select-and-play-topic-from-classroom-page",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/select-and-play-topic-from-classroom-page.spec.ts"
+      "module": "core/tests/puppeteer-acceptance-tests/specs/logged-out-user/select-and-play-topic-from-classroom-page.spec.ts",
+      "framework": "puppeteer"
     }
   ]
 }

--- a/scripts/check_tests_are_captured_in_ci.py
+++ b/scripts/check_tests_are_captured_in_ci.py
@@ -45,16 +45,27 @@ ACCEPTANCE_TEST_SPECS_DIRECTORY = os.path.join(
 ACCEPTANCE_TEST_SPECS_DIRECTORY_OLD = os.path.join(
     os.getcwd(), 'core', 'tests', 'puppeteer-acceptance-tests', 'specs-old'
 )
+PLAYWRIGHT_ACCEPTANCE_TEST_SPECS_DIRECTORY = os.path.join(
+    os.getcwd(), 'core', 'tests', 'playwright-acceptance-tests', 'specs'
+)
 E2E_WEBDRIVERIO_CONFIG_FILE_PATH = os.path.join(
     os.getcwd(), 'core', 'tests', 'wdio.conf.js'
 )
 
 
-class TestSuiteDict(TypedDict):
-    """Dictionary representing a test suite."""
+class TestSuiteDictBase(TypedDict):
+    """Base dictionary representing a test suite with required fields."""
 
     name: str
     module: str
+
+
+class TestSuiteDict(TestSuiteDictBase, total=False):
+    """Dictionary representing a test suite, with an optional framework field.
+    The framework field is only present for acceptance tests to distinguish
+    between puppeteer and playwright during incremental migration."""
+
+    framework: str
 
 
 def get_acceptance_test_suites_from_ci_config_file() -> List[TestSuiteDict]:
@@ -191,9 +202,10 @@ def get_acceptance_test_suites_from_acceptance_directory() -> (
         specs directory.
     """
     acceptance_test_suites: List[TestSuiteDict] = []
-    for test_specs_directory in [
-        ACCEPTANCE_TEST_SPECS_DIRECTORY,
-        ACCEPTANCE_TEST_SPECS_DIRECTORY_OLD,
+    for test_specs_directory, framework in [
+        (ACCEPTANCE_TEST_SPECS_DIRECTORY, 'puppeteer'),
+        (ACCEPTANCE_TEST_SPECS_DIRECTORY_OLD, 'puppeteer'),
+        (PLAYWRIGHT_ACCEPTANCE_TEST_SPECS_DIRECTORY, 'playwright'),
     ]:
         acceptance_test_files = glob.glob(
             os.path.join(test_specs_directory, '**/*.spec.ts')
@@ -212,6 +224,7 @@ def get_acceptance_test_suites_from_acceptance_directory() -> (
                 {
                     'name': acceptance_test_suite_name,
                     'module': os.path.relpath(module, os.getcwd()),
+                    'framework': framework,
                 }
             )
     return sorted(acceptance_test_suites, key=lambda x: x['name'])

--- a/scripts/check_tests_are_captured_in_ci_test.py
+++ b/scripts/check_tests_are_captured_in_ci_test.py
@@ -31,14 +31,17 @@ ACCEPTANCE_TEST_SUITES: List[check_tests_are_captured_in_ci.TestSuiteDict] = (
         {
             'name': 'test/acceptance_suite1',
             'module': 'acceptance/specs/test/acceptance_suite1.spec.ts',
+            'framework': 'puppeteer',
         },
         {
             'name': 'test2/acceptance_suite2',
             'module': 'acceptance/specs/test2/acceptance_suite2.spec.ts',
+            'framework': 'puppeteer',
         },
         {
             'name': 'test3/acceptance_suite3',
             'module': 'acceptance/specs-old/test3/acceptance_suite3.spec.ts',
+            'framework': 'puppeteer',
         },
     ]
 )
@@ -90,6 +93,10 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
         )
         os.mkdir(self.dummy_acceptance_specs_directory)
         os.mkdir(self.dummy_acceptance_old_directory)
+        self.dummy_playwright_acceptance_specs_directory = os.path.join(
+            self.dummy_acceptance_directory, 'playwright-specs'
+        )
+        os.mkdir(self.dummy_playwright_acceptance_specs_directory)
         for suite in ACCEPTANCE_TEST_SUITES:
             suite_file = os.path.join(self.temp_directory.name, suite['module'])
             os.makedirs(os.path.dirname(suite_file), exist_ok=True)
@@ -136,6 +143,11 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
             'ACCEPTANCE_TEST_SPECS_DIRECTORY_OLD',
             self.dummy_acceptance_old_directory,
         )
+        self.playwright_acceptance_test_specs_directory_swap = self.swap(
+            check_tests_are_captured_in_ci,
+            'PLAYWRIGHT_ACCEPTANCE_TEST_SPECS_DIRECTORY',
+            self.dummy_playwright_acceptance_specs_directory,
+        )
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -143,13 +155,13 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
 
     def test_compute_test_suites_difference(self) -> None:
         test_suites_one: List[check_tests_are_captured_in_ci.TestSuiteDict] = [
-            {'name': 'test1', 'module': 'test1.js'},
-            {'name': 'test2', 'module': 'test2.js'},
+            {'name': 'test1', 'module': 'test1.js', 'framework': 'puppeteer'},
+            {'name': 'test2', 'module': 'test2.js', 'framework': 'puppeteer'},
         ]
 
         test_suites_two: List[check_tests_are_captured_in_ci.TestSuiteDict] = [
-            {'name': 'test1', 'module': 'test1.js'},
-            {'name': 'test3', 'module': 'test3.js'},
+            {'name': 'test1', 'module': 'test1.js', 'framework': 'puppeteer'},
+            {'name': 'test3', 'module': 'test3.js', 'framework': 'puppeteer'},
         ]
 
         test_suites_difference = (
@@ -160,8 +172,16 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
         self.assertEqual(
             test_suites_difference,
             [
-                {'name': 'test3', 'module': 'test3.js'},
-                {'name': 'test2', 'module': 'test2.js'},
+                {
+                    'name': 'test3',
+                    'module': 'test3.js',
+                    'framework': 'puppeteer',
+                },
+                {
+                    'name': 'test2',
+                    'module': 'test2.js',
+                    'framework': 'puppeteer',
+                },
             ],
         )
 
@@ -262,6 +282,7 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
         with (
             self.acceptance_test_specs_directory_swap,
             self.acceptance_test_specs_old_directory_swap,
+            self.playwright_acceptance_test_specs_directory_swap,
             os_getcwd_swap,
         ):
             acceptance_test_suites = (
@@ -285,6 +306,7 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
         with (
             self.acceptance_test_specs_directory_swap,
             self.acceptance_test_specs_old_directory_swap,
+            self.playwright_acceptance_test_specs_directory_swap,
             os_getcwd_swap,
         ):
             with acceptance_test_suites_that_are_not_run_in_ci_swap:
@@ -295,6 +317,40 @@ class CheckTestsAreCapturedInCiTest(test_utils.GenericTestBase):
                     acceptance_test_suites,
                     ACCEPTANCE_TEST_SUITES[:1] + ACCEPTANCE_TEST_SUITES[2:],
                 )
+
+    def test_get_acceptance_test_suites_from_playwright_directory(self) -> None:
+        playwright_suite_file = os.path.join(
+            self.dummy_playwright_acceptance_specs_directory,
+            'test4',
+            'acceptance_suite4.spec.ts',
+        )
+        os.makedirs(os.path.dirname(playwright_suite_file), exist_ok=True)
+        os.mknod(playwright_suite_file)
+
+        def mock_get_cwd() -> str:
+            return self.temp_directory.name
+
+        os_getcwd_swap = self.swap(os, 'getcwd', mock_get_cwd)
+
+        with (
+            self.acceptance_test_specs_directory_swap,
+            self.acceptance_test_specs_old_directory_swap,
+            self.playwright_acceptance_test_specs_directory_swap,
+            os_getcwd_swap,
+        ):
+            acceptance_test_suites = (
+                check_tests_are_captured_in_ci.get_acceptance_test_suites_from_acceptance_directory()
+            )
+            playwright_suites = [
+                s
+                for s in acceptance_test_suites
+                if s['framework'] == 'playwright'
+            ]
+            self.assertEqual(len(playwright_suites), 1)
+            self.assertEqual(
+                playwright_suites[0]['name'], 'test4/acceptance_suite4'
+            )
+            self.assertEqual(playwright_suites[0]['framework'], 'playwright')
 
     def test_check_tests_are_captured_in_ci_with_acceptance_error(self) -> None:
         def mock_get_acceptance_test_suites_from_ci_config_file() -> (

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -51,6 +51,10 @@ CURRENT_PYTHON_BIN = sys.executable
 # Node version.
 NODE_VERSION = '16.13.0'
 
+# Dedicated Node version for Playwright acceptance tests. This is intentionally
+# isolated from NODE_VERSION so existing frontend tooling remains unchanged.
+PLAYWRIGHT_NODE_VERSION = '20.11.1'
+
 # NB: Please ensure that the version is consistent with the version in .yarnrc.
 YARN_VERSION = '1.22.15'
 
@@ -92,6 +96,9 @@ NG_BIN_PATH = os.path.join(CURR_DIR, 'node_modules', '.bin', 'ng')
 DEV_APPSERVER_PATH = os.path.join(GOOGLE_CLOUD_SDK_BIN, 'dev_appserver.py')
 GCLOUD_PATH = os.path.join(GOOGLE_CLOUD_SDK_BIN, 'gcloud')
 NODE_PATH = os.path.join(OPPIA_TOOLS_DIR, 'node-%s' % NODE_VERSION)
+PLAYWRIGHT_NODE_PATH = os.path.join(
+    OPPIA_TOOLS_DIR, 'node-%s' % PLAYWRIGHT_NODE_VERSION
+)
 NODE_MODULES_PATH = os.path.join(CURR_DIR, 'node_modules')
 FRONTEND_DIR = os.path.join(CURR_DIR, 'core', 'templates')
 YARN_PATH = os.path.join(OPPIA_TOOLS_DIR, 'yarn-%s' % YARN_VERSION)
@@ -244,6 +251,10 @@ def is_x64_architecture() -> bool:
 
 NODE_BIN_PATH = os.path.join(NODE_PATH, 'bin', 'node')
 NPX_BIN_PATH = os.path.join(NODE_PATH, 'bin', 'npx')
+
+# Binaries for running Playwright with a newer Node runtime only.
+PLAYWRIGHT_NPM_BIN_PATH = os.path.join(PLAYWRIGHT_NODE_PATH, 'bin', 'npm')
+PLAYWRIGHT_NPX_BIN_PATH = os.path.join(PLAYWRIGHT_NODE_PATH, 'bin', 'npx')
 
 # Add path for node which is required by the node_modules.
 os.environ['PATH'] = os.pathsep.join(

--- a/scripts/common_test.py
+++ b/scripts/common_test.py
@@ -88,6 +88,32 @@ class CommonTests(test_utils.GenericTestBase):
         with maxsize_swap:
             self.assertTrue(common.is_x64_architecture())
 
+    def test_playwright_node_path_uses_playwright_node_version(self) -> None:
+        self.assertIn(
+            common.PLAYWRIGHT_NODE_VERSION,
+            common.PLAYWRIGHT_NODE_PATH,
+        )
+
+    def test_playwright_npm_bin_path_uses_playwright_node_path(self) -> None:
+        self.assertTrue(
+            common.PLAYWRIGHT_NPM_BIN_PATH.startswith(
+                common.PLAYWRIGHT_NODE_PATH
+            )
+        )
+        self.assertTrue(
+            common.PLAYWRIGHT_NPM_BIN_PATH.endswith(os.path.join('bin', 'npm'))
+        )
+
+    def test_playwright_npx_bin_path_uses_playwright_node_path(self) -> None:
+        self.assertTrue(
+            common.PLAYWRIGHT_NPX_BIN_PATH.startswith(
+                common.PLAYWRIGHT_NODE_PATH
+            )
+        )
+        self.assertTrue(
+            common.PLAYWRIGHT_NPX_BIN_PATH.endswith(os.path.join('bin', 'npx'))
+        )
+
     def test_is_mac_os(self) -> None:
         with self.swap(common, 'OS_NAME', 'Darwin'):
             self.assertTrue(common.is_mac_os())

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -166,6 +166,47 @@ def install_node() -> None:
     print('Node is installed.')
 
 
+def install_playwright_node() -> None:
+    """Download and install Node.js for Playwright (Node 20)."""
+
+    if not os.path.exists(common.PLAYWRIGHT_NODE_PATH):
+        print(
+            'Playwright Node not found. Installing Node.js %s...'
+            % common.PLAYWRIGHT_NODE_VERSION
+        )
+
+        outfile_name = 'node-playwright-download'
+
+        if common.is_x64_architecture():
+            if common.is_mac_os():
+                node_file_name = (
+                    'node-v%s-darwin-x64' % common.PLAYWRIGHT_NODE_VERSION
+                )
+            elif common.is_linux_os():
+                node_file_name = (
+                    'node-v%s-linux-x64' % common.PLAYWRIGHT_NODE_VERSION
+                )
+            else:
+                raise Exception('Unsupported OS')
+        else:
+            node_file_name = 'node-v%s' % common.PLAYWRIGHT_NODE_VERSION
+
+        # Download.
+        download_and_install_package(
+            'https://nodejs.org/dist/v%s/%s.tar.gz'
+            % (common.PLAYWRIGHT_NODE_VERSION, node_file_name),
+            outfile_name,
+        )
+
+        # Rename.
+        os.rename(
+            os.path.join(common.OPPIA_TOOLS_DIR, node_file_name),
+            common.PLAYWRIGHT_NODE_PATH,
+        )
+
+    print('Playwright Node is installed.')
+
+
 def install_yarn() -> None:
     """Download and install yarn to Oppia tools directory."""
     if not os.path.exists(common.YARN_PATH):
@@ -445,6 +486,7 @@ def main() -> None:
     pathlib.Path(common.THIRD_PARTY_DIR).mkdir(exist_ok=True)
 
     install_node()
+    install_playwright_node()
     install_yarn()
     install_redis_cli()
     install_elasticsearch_dev_server()

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -179,6 +179,9 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_install_elasticsearch_dev_server() -> None:
             pass
 
+        def mock_install_playwright_node() -> None:
+            pass
+
         def mock_external_script_call() -> None:
             pass
 
@@ -226,6 +229,11 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
             'install_elasticsearch_dev_server',
             mock_install_elasticsearch_dev_server,
         )
+        swap_install_playwright_node = self.swap(
+            install_third_party_libs,
+            'install_playwright_node',
+            mock_install_playwright_node,
+        )
         swap_install_json_deps_main = self.swap(
             install_python_prod_dependencies,
             'main',
@@ -246,7 +254,8 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
                 with pre_commit_hook_main_swap, pre_push_hook_main_swap:
                     with swap_isdir, swap_mkdir, swap_copytree:
                         with swap_install_elasticsearch_dev_server:
-                            install_third_party_libs.main()
+                            with swap_install_playwright_node:
+                                install_third_party_libs.main()
 
         self.assertEqual(check_function_calls, expected_check_function_calls)
 
@@ -746,6 +755,91 @@ class SetupTests(test_utils.GenericTestBase):
         self.assertIn('Node is installed.', print_list)
         self.assertNotIn('Installing Node.js', print_list)
         self.assertNotIn('Removing package-lock.json', print_list)
+
+    def test_install_playwright_node_with_darwin_x64(self) -> None:
+        os_name_swap = self.swap(common, 'OS_NAME', 'Darwin')
+
+        with self.test_py_swap, os_name_swap:
+            with self.download_swap, self.rename_swap, self.exists_false_swap:
+                with self.is_x64_architecture_true_swap:
+                    install_third_party_libs.install_playwright_node()
+
+        self.assertEqual(
+            self.urls,
+            [
+                'https://nodejs.org/dist/v%s/node-v%s-darwin-x64.tar.gz'
+                % (
+                    common.PLAYWRIGHT_NODE_VERSION,
+                    common.PLAYWRIGHT_NODE_VERSION,
+                )
+            ],
+        )
+
+    def test_install_playwright_node_with_linux_x64(self) -> None:
+        os_name_swap = self.swap(common, 'OS_NAME', 'Linux')
+
+        with self.test_py_swap, os_name_swap:
+            with self.download_swap, self.rename_swap, self.exists_false_swap:
+                with self.is_x64_architecture_true_swap:
+                    install_third_party_libs.install_playwright_node()
+
+        self.assertEqual(
+            self.urls,
+            [
+                'https://nodejs.org/dist/v%s/node-v%s-linux-x64.tar.gz'
+                % (
+                    common.PLAYWRIGHT_NODE_VERSION,
+                    common.PLAYWRIGHT_NODE_VERSION,
+                )
+            ],
+        )
+
+    def test_install_playwright_node_with_unsupported_os_raises_exception(
+        self,
+    ) -> None:
+        os_name_swap = self.swap(common, 'OS_NAME', 'Solaris')
+
+        with self.exists_false_swap, self.is_x64_architecture_true_swap:
+            with os_name_swap, self.assertRaisesRegex(
+                Exception, 'Unsupported OS'
+            ):
+                install_third_party_libs.install_playwright_node()
+
+    def test_install_playwright_node_with_non_x64_architecture(
+        self,
+    ) -> None:
+        with self.download_swap, self.rename_swap, self.exists_false_swap:
+            with self.is_x64_architecture_false_swap:
+                install_third_party_libs.install_playwright_node()
+
+        self.assertEqual(
+            self.urls,
+            [
+                'https://nodejs.org/dist/v%s/node-v%s.tar.gz'
+                % (
+                    common.PLAYWRIGHT_NODE_VERSION,
+                    common.PLAYWRIGHT_NODE_VERSION,
+                )
+            ],
+        )
+
+    def test_install_playwright_node_skips_if_already_installed(
+        self,
+    ) -> None:
+        print_list: List[str] = []
+
+        def mock_print(arg: str) -> None:
+            print_list.append(arg)
+
+        print_swap = self.swap(builtins, 'print', mock_print)
+
+        with print_swap, self.exists_true_swap:
+            install_third_party_libs.install_playwright_node()
+
+        self.assertIn('Playwright Node is installed.', print_list)
+        self.assertNotIn(
+            'Playwright Node not found. Installing Node.js', print_list
+        )
 
 
 class GoogleCloudSdkInstallationTests(test_utils.GenericTestBase):

--- a/scripts/run_acceptance_tests.py
+++ b/scripts/run_acceptance_tests.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import json
 import os
 import shutil
 import subprocess
@@ -107,6 +108,33 @@ def compile_test_ts_files() -> None:
     )
 
 
+def install_playwright_dependencies() -> None:
+    """Installs Playwright npm dependencies and browsers."""
+    playwright_dir = os.path.join(
+        common.CURR_DIR, 'core', 'tests', 'playwright-acceptance-tests'
+    )
+    install_env = {
+        **os.environ,
+        'PATH': os.pathsep.join(
+            [
+                os.path.join(common.PLAYWRIGHT_NODE_PATH, 'bin'),
+                os.environ['PATH'],
+            ]
+        ),
+        'NODE': os.path.join(common.PLAYWRIGHT_NODE_PATH, 'bin', 'node'),
+    }
+    subprocess.check_call(
+        [common.PLAYWRIGHT_NPM_BIN_PATH, '--prefix', playwright_dir, 'ci'],
+        env=install_env,
+    )
+    playwright_bin = os.path.join(
+        playwright_dir, 'node_modules', '.bin', 'playwright'
+    )
+    subprocess.check_call(
+        [playwright_bin, 'install', 'chromium'], env=install_env
+    )
+
+
 def run_tests(args: argparse.Namespace) -> Tuple[List[bytes], int]:
     """Run the scripts to start acceptance tests."""
     if common.is_oppia_server_already_running():
@@ -117,10 +145,36 @@ def run_tests(args: argparse.Namespace) -> Tuple[List[bytes], int]:
         """
         )
 
+    with open(
+        common.ACCEPTANCE_TEST_CONFIG_FILE_PATH, 'r', encoding='utf-8'
+    ) as f:
+        filedata = json.load(f)
+    suite_framework = None
+    suite_found = False
+
+    for suites in filedata.values():
+        for suite in suites:
+            if suite['name'] == args.suite:
+                suite_framework = suite['framework']
+                suite_found = True
+                break
+        if suite_found:
+            break
+
+    if not suite_found:
+        raise ValueError(f'Suite \'{args.suite}\' not found in config.')
+
     with contextlib.ExitStack() as stack:
         dev_mode = not args.prod_env
 
-        compile_test_ts_files()
+        # Only compile Puppeteer TypeScript for Puppeteer suites.
+        if suite_framework == 'puppeteer':
+            compile_test_ts_files()
+
+        # Install Playwright deps for Playwright suites.
+        if suite_framework == 'playwright':
+            install_playwright_dependencies()
+
         if args.skip_build:
             common.modify_constants(prod_env=args.prod_env)
         else:

--- a/scripts/run_acceptance_tests_test.py
+++ b/scripts/run_acceptance_tests_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import shutil
 import subprocess
@@ -31,7 +32,7 @@ from scripts import (
     servers,
 )
 
-from typing import ContextManager, List, Optional, Tuple
+from typing import ContextManager, Dict, List, Optional, Tuple
 
 
 class PopenErrorReturn:
@@ -102,6 +103,11 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
         )
         self.compile_test_ts_files_swap = self.swap(
             run_acceptance_tests, 'compile_test_ts_files', lambda: None
+        )
+        self.install_playwright_dependencies_swap = self.swap(
+            run_acceptance_tests,
+            'install_playwright_dependencies',
+            lambda: None,
         )
 
     def tearDown(self) -> None:
@@ -189,6 +195,314 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
             with shutil_copytree_swap, communicate_swap:
                 run_acceptance_tests.compile_test_ts_files()
 
+    def test_install_playwright_dependencies_success(self) -> None:
+        playwright_dir = os.path.join(
+            common.CURR_DIR, 'core', 'tests', 'playwright-acceptance-tests'
+        )
+        playwright_bin = os.path.join(
+            playwright_dir, 'node_modules', '.bin', 'playwright'
+        )
+        expected_install_env = {
+            **os.environ,
+            'PATH': os.pathsep.join(
+                [
+                    os.path.join(common.PLAYWRIGHT_NODE_PATH, 'bin'),
+                    os.environ['PATH'],
+                ]
+            ),
+            'NODE': os.path.join(common.PLAYWRIGHT_NODE_PATH, 'bin', 'node'),
+        }
+        check_call_swap = self.swap_with_checks(
+            subprocess,
+            'check_call',
+            lambda *_, **__: None,
+            expected_args=[
+                (
+                    [
+                        common.PLAYWRIGHT_NPM_BIN_PATH,
+                        '--prefix',
+                        playwright_dir,
+                        'ci',
+                    ],
+                ),
+                ([playwright_bin, 'install', 'chromium'],),
+            ],
+            expected_kwargs=[
+                {'env': expected_install_env},
+                {'env': expected_install_env},
+            ],
+        )
+        with check_call_swap:
+            run_acceptance_tests.install_playwright_dependencies()
+
+    def test_install_playwright_dependencies_failure(self) -> None:
+        def mock_check_call_failure(
+            *unused_args: str, **unused_kwargs: str
+        ) -> None:
+            raise subprocess.CalledProcessError(1, 'npm')
+
+        check_call_swap = self.swap(
+            subprocess, 'check_call', mock_check_call_failure
+        )
+        with check_call_swap:
+            with self.assertRaisesRegex(
+                subprocess.CalledProcessError,
+                'Command \'npm\' returned non-zero exit status 1.',
+            ):
+                run_acceptance_tests.install_playwright_dependencies()
+
+    def test_run_tests_raises_error_when_suite_not_found(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'someOtherSuite',
+                    'framework': 'puppeteer',
+                    'module': 'some/module',
+                }
+            ]
+        }
+
+        def mock_json_load(unused_f: str) -> Dict[str, List[Dict[str, str]]]:
+            return mock_config
+
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                common, 'is_oppia_server_already_running', lambda *_: False
+            )
+        )
+        json_load_swap = self.swap(json, 'load', mock_json_load)
+
+        with json_load_swap:
+            with self.assertRaisesRegex(
+                ValueError, 'Suite \'nonExistentSuite\' not found in config.'
+            ):
+                args = run_acceptance_tests._PARSER.parse_args(  # pylint: disable=protected-access
+                    args=['--suite', 'nonExistentSuite']
+                )
+                run_acceptance_tests.run_tests(args)
+
+    def test_compile_ts_called_for_puppeteer_suite(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'puppeteer',
+                    'module': 'some/module',
+                }
+            ]
+        }
+
+        def mock_json_load(unused_f: str) -> Dict[str, List[Dict[str, str]]]:
+            return mock_config
+
+        compile_called = []
+        playwright_deps_called = []
+
+        def mock_compile_test_ts_files() -> None:
+            compile_called.append(True)
+
+        def mock_install_playwright_dependencies() -> None:
+            playwright_deps_called.append(True)
+
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                common, 'is_oppia_server_already_running', lambda *_: False
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                build,
+                'build_js_files',
+                lambda *_, **__: None,
+                expected_args=[(True,)],
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_redis_server', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers,
+                'managed_elasticsearch_dev_server',
+                mock_managed_process,
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_firebase_auth_emulator', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_dev_appserver', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_portserver', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers,
+                'managed_cloud_datastore_emulator',
+                mock_managed_process,
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers,
+                'managed_acceptance_tests_server',
+                mock_managed_process,
+                expected_kwargs=[
+                    {
+                        'suite_name': 'testSuite',
+                        'headless': False,
+                        'mobile': False,
+                        'prod_env': False,
+                        'stdout': subprocess.PIPE,
+                    }
+                ],
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                sys, 'exit', lambda _: None, expected_args=[(0,)]
+            )
+        )
+
+        json_load_swap = self.swap(json, 'load', mock_json_load)
+        compile_swap = self.swap(
+            run_acceptance_tests,
+            'compile_test_ts_files',
+            mock_compile_test_ts_files,
+        )
+        playwright_swap = self.swap(
+            run_acceptance_tests,
+            'install_playwright_dependencies',
+            mock_install_playwright_dependencies,
+        )
+
+        with self.swap_mock_set_constants_to_default:
+            with json_load_swap, compile_swap, playwright_swap:
+                run_acceptance_tests.main(args=['--suite', 'testSuite'])
+
+        self.assertEqual(compile_called, [True])
+        self.assertEqual(playwright_deps_called, [])
+
+    def test_playwright_deps_called_for_playwright_suite(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'playwright',
+                    'module': 'some/module',
+                }
+            ]
+        }
+
+        def mock_json_load(unused_f: str) -> Dict[str, List[Dict[str, str]]]:
+            return mock_config
+
+        compile_called = []
+        playwright_deps_called = []
+
+        def mock_compile_test_ts_files() -> None:
+            compile_called.append(True)
+
+        def mock_install_playwright_dependencies() -> None:
+            playwright_deps_called.append(True)
+
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                common, 'is_oppia_server_already_running', lambda *_: False
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                build,
+                'build_js_files',
+                lambda *_, **__: None,
+                expected_args=[(True,)],
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_redis_server', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers,
+                'managed_elasticsearch_dev_server',
+                mock_managed_process,
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_firebase_auth_emulator', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_dev_appserver', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers, 'managed_portserver', mock_managed_process
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers,
+                'managed_cloud_datastore_emulator',
+                mock_managed_process,
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                servers,
+                'managed_acceptance_tests_server',
+                mock_managed_process,
+                expected_kwargs=[
+                    {
+                        'suite_name': 'testSuite',
+                        'headless': False,
+                        'mobile': False,
+                        'prod_env': False,
+                        'stdout': subprocess.PIPE,
+                    }
+                ],
+            )
+        )
+        self.exit_stack.enter_context(
+            self.swap_with_checks(
+                sys, 'exit', lambda _: None, expected_args=[(0,)]
+            )
+        )
+
+        json_load_swap = self.swap(json, 'load', mock_json_load)
+        compile_swap = self.swap(
+            run_acceptance_tests,
+            'compile_test_ts_files',
+            mock_compile_test_ts_files,
+        )
+        playwright_swap = self.swap(
+            run_acceptance_tests,
+            'install_playwright_dependencies',
+            mock_install_playwright_dependencies,
+        )
+
+        with self.swap_mock_set_constants_to_default:
+            with json_load_swap, compile_swap, playwright_swap:
+                run_acceptance_tests.main(args=['--suite', 'testSuite'])
+
+        self.assertEqual(compile_called, [])
+        self.assertEqual(playwright_deps_called, [True])
+
     def test_start_tests_when_other_instances_not_stopped(self) -> None:
         self.exit_stack.enter_context(
             self.swap_with_checks(
@@ -211,6 +525,16 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
             run_acceptance_tests.main(args=['--suite', 'testSuite'])
 
     def test_start_tests_when_no_other_instance_running(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'puppeteer',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
         self.exit_stack.enter_context(
             self.swap_with_checks(
                 common, 'is_oppia_server_already_running', lambda *_: False
@@ -281,10 +605,23 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
         )
 
         with self.swap_mock_set_constants_to_default:
-            with self.compile_test_ts_files_swap:
+            with self.compile_test_ts_files_swap, self.install_playwright_dependencies_swap, (
+                json_load_swap
+            ):
                 run_acceptance_tests.main(args=['--suite', 'testSuite'])
 
     def test_work_with_non_ascii_chars(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'puppeteer',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
+
         def mock_managed_acceptance_tests_server(
             **unused_kwargs: str,
         ) -> ContextManager[
@@ -360,7 +697,9 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
         )
 
         with self.swap_mock_set_constants_to_default:
-            with self.compile_test_ts_files_swap:
+            with self.compile_test_ts_files_swap, self.install_playwright_dependencies_swap, (
+                json_load_swap
+            ):
                 lines, _ = run_acceptance_tests.run_tests(args)
 
         self.assertEqual(
@@ -368,6 +707,16 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
         )
 
     def test_start_tests_skip_build(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'puppeteer',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
         self.exit_stack.enter_context(
             self.swap_with_checks(
                 common, 'is_oppia_server_already_running', lambda *_: False
@@ -450,12 +799,24 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
             )
         )
 
-        with self.compile_test_ts_files_swap:
+        with self.compile_test_ts_files_swap, self.install_playwright_dependencies_swap, (
+            json_load_swap
+        ):
             run_acceptance_tests.main(
                 args=['--suite', 'testSuite', '--skip_build']
             )
 
     def test_start_tests_in_jasmine(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'puppeteer',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
         self.exit_stack.enter_context(
             self.swap_with_checks(
                 common, 'is_oppia_server_already_running', lambda *_: False
@@ -526,10 +887,22 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
         )
 
         with self.swap_mock_set_constants_to_default:
-            with self.compile_test_ts_files_swap:
+            with self.compile_test_ts_files_swap, self.install_playwright_dependencies_swap, (
+                json_load_swap
+            ):
                 run_acceptance_tests.main(args=['--suite', 'testSuite'])
 
     def test_start_tests_for_long_lived_process(self) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'puppeteer',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
         self.exit_stack.enter_context(
             self.swap_with_checks(
                 common, 'is_oppia_server_already_running', lambda *_: False
@@ -597,5 +970,7 @@ class RunAcceptanceTestsTests(test_utils.GenericTestBase):
         )
 
         with self.swap_mock_set_constants_to_default:
-            with self.compile_test_ts_files_swap:
+            with self.compile_test_ts_files_swap, self.install_playwright_dependencies_swap, (
+                json_load_swap
+            ):
                 run_acceptance_tests.main(args=['--suite', 'testSuite'])

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -864,38 +864,97 @@ def managed_acceptance_tests_server(
         filedata = json.load(f)
         for suites in filedata.values():
             for suite in suites:
-                available_suites[suite['name']] = suite['module']
+                available_suites[suite['name']] = {
+                    'module': suite['module'],
+                    'framework': suite['framework'],
+                }
+
     if suite_name not in available_suites:
         raise Exception('Invalid suite name: %s' % suite_name)
 
-    os.environ['HEADLESS'] = 'true' if headless else 'false'
-    os.environ['MOBILE'] = 'true' if mobile else 'false'
-    os.environ['SPEC_NAME'] = suite_name
-    os.environ['PROD_ENV'] = 'true' if prod_env else 'false'
+    suite_config = available_suites[suite_name]
+    module = suite_config['module']
+    framework = suite_config['framework']
 
-    nodemodules_jest_bin_path = os.path.join(
-        common.NODE_MODULES_PATH, '.bin', 'jest'
-    )
+    if framework == 'puppeteer':
+        os.environ['HEADLESS'] = 'true' if headless else 'false'
+        os.environ['MOBILE'] = 'true' if mobile else 'false'
+        os.environ['SPEC_NAME'] = suite_name
+        os.environ['PROD_ENV'] = 'true' if prod_env else 'false'
 
-    acceptance_tests_args = [
-        nodemodules_jest_bin_path,
-        '%s' % os.path.join(available_suites[suite_name]),
-        '--config=./core/tests/puppeteer-acceptance-tests/jest.config.js',
-    ]
+        nodemodules_jest_bin_path = os.path.join(
+            common.NODE_MODULES_PATH, '.bin', 'jest'
+        )
 
-    # OK to use shell=True here because we are passing string literals,
-    # and verifying that the passed suite-name are within the list of
-    # the suites we have, so there is no risk of a shell-injection attack.
-    managed_acceptance_tests_proc = managed_process(
-        acceptance_tests_args,
-        human_readable_name='Acceptance Tests Server',
-        shell=True,
-        raise_on_nonzero_exit=False,
-        stdout=stdout,
-    )
+        acceptance_tests_args = [
+            nodemodules_jest_bin_path,
+            '%s' % os.path.join(module),
+            '--config=./core/tests/puppeteer-acceptance-tests/jest.config.js',
+        ]
 
-    with managed_acceptance_tests_proc as proc:
-        yield proc
+        # OK to use shell=True here because we are passing string literals,
+        # and verifying that the passed suite-name are within the list of
+        # the suites we have, so there is no risk of a shell-injection attack.
+        managed_acceptance_tests_proc = managed_process(
+            acceptance_tests_args,
+            human_readable_name='Acceptance Tests Server',
+            shell=True,
+            raise_on_nonzero_exit=False,
+            stdout=stdout,
+        )
+
+        with managed_acceptance_tests_proc as proc:
+            yield proc
+
+    elif framework == 'playwright':
+        playwright_dir = os.path.join(
+            common.CURR_DIR, 'core', 'tests', 'playwright-acceptance-tests'
+        )
+        # Use the local Playwright binary directly instead of npx
+        # to avoid version resolution or download attempts.
+        playwright_bin = os.path.join(
+            playwright_dir, 'node_modules', '.bin', 'playwright'
+        )
+        playwright_env = {
+            **os.environ,
+            # Prepend Node 20 bin so npx uses the correct runtime.
+            'PATH': os.pathsep.join(
+                [
+                    os.path.join(common.PLAYWRIGHT_NODE_PATH, 'bin'),
+                    os.environ['PATH'],
+                ]
+            ),
+            'NODE': os.path.join(common.PLAYWRIGHT_NODE_PATH, 'bin', 'node'),
+            'HEADLESS': 'true' if headless else 'false',
+            'MOBILE': 'true' if mobile else 'false',
+            'PROD_ENV': 'true' if prod_env else 'false',
+        }
+        playwright_args = [
+            playwright_bin,
+            'test',
+            module,
+            '--config=./core/tests/playwright-acceptance-tests/'
+            'playwright.config.ts',
+        ]
+        if headless is False:
+            playwright_args.append('--headed')
+
+        managed_proc = managed_process(
+            playwright_args,
+            human_readable_name='Acceptance Tests Server',
+            shell=False,
+            raise_on_nonzero_exit=False,
+            stdout=stdout,
+            env=playwright_env,
+        )
+        with managed_proc as proc:
+            yield proc
+
+    else:
+        raise Exception(
+            'Suite "%s" has invalid framework: "%s". '
+            'Must be "puppeteer" or "playwright".' % (suite_name, framework)
+        )
 
 
 def run_ng_compilation() -> None:

--- a/scripts/servers_test.py
+++ b/scripts/servers_test.py
@@ -20,6 +20,7 @@ import builtins
 import collections
 import contextlib
 import io
+import json
 import logging
 import os
 import re
@@ -1249,13 +1250,24 @@ class ManagedProcessTests(test_utils.TestBase):
         test_file_path = (
             'blog-admin/assign-and-remove-blog-editor-and-blog-admin-roles'
         )
+        mock_config = {
+            'core': [
+                {
+                    'name': test_file_path,
+                    'framework': 'puppeteer',
+                    'module': test_file_path,
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
 
-        self.exit_stack.enter_context(
-            servers.managed_acceptance_tests_server(
-                suite_name=test_file_path, stdout=subprocess.PIPE
+        with json_load_swap:
+            self.exit_stack.enter_context(
+                servers.managed_acceptance_tests_server(
+                    suite_name=test_file_path, stdout=subprocess.PIPE
+                )
             )
-        )
-        self.exit_stack.close()
+            self.exit_stack.close()
 
         self.assertEqual(len(popen_calls), 1)
         self.assertEqual(
@@ -1281,13 +1293,24 @@ class ManagedProcessTests(test_utils.TestBase):
         suite_name = (
             'blog-admin/assign-and-remove-blog-editor-and-blog-admin-roles'
         )
+        mock_config = {
+            'core': [
+                {
+                    'name': suite_name,
+                    'framework': 'puppeteer',
+                    'module': suite_name,
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
 
-        self.exit_stack.enter_context(
-            servers.managed_acceptance_tests_server(
-                suite_name=suite_name, headless=True, stdout=subprocess.PIPE
+        with json_load_swap:
+            self.exit_stack.enter_context(
+                servers.managed_acceptance_tests_server(
+                    suite_name=suite_name, headless=True, stdout=subprocess.PIPE
+                )
             )
-        )
-        self.exit_stack.close()
+            self.exit_stack.close()
 
         self.assertEqual(os.getenv('HEADLESS'), 'true')
         self.assertEqual(len(popen_calls), 1)
@@ -1303,12 +1326,23 @@ class ManagedProcessTests(test_utils.TestBase):
         suite_name = (
             'blog-admin/assign-and-remove-blog-editor-and-blog-admin-roles'
         )
+        mock_config = {
+            'core': [
+                {
+                    'name': suite_name,
+                    'framework': 'puppeteer',
+                    'module': suite_name,
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
 
-        self.exit_stack.enter_context(
-            servers.managed_acceptance_tests_server(
-                suite_name=suite_name, mobile=True, stdout=subprocess.PIPE
+        with json_load_swap:
+            self.exit_stack.enter_context(
+                servers.managed_acceptance_tests_server(
+                    suite_name=suite_name, mobile=True, stdout=subprocess.PIPE
+                )
             )
-        )
 
         self.assertEqual(os.getenv('MOBILE'), 'true')
         self.assertEqual(len(popen_calls), 1)
@@ -1320,6 +1354,115 @@ class ManagedProcessTests(test_utils.TestBase):
         self.assertEqual(os.getenv('SPEC_NAME'), suite_name)
 
         self.exit_stack.close()
+
+    def test_managed_acceptance_test_server_playwright_suite(self) -> None:
+        popen_calls = self.exit_stack.enter_context(self.swap_popen())
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'playwright',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
+
+        with json_load_swap:
+            self.exit_stack.enter_context(
+                servers.managed_acceptance_tests_server(
+                    suite_name='testSuite', stdout=subprocess.PIPE
+                )
+            )
+            self.exit_stack.close()
+
+        self.assertEqual(len(popen_calls), 1)
+        self.assertEqual(popen_calls[0].kwargs['shell'], False)
+        self.assertEqual(popen_calls[0].kwargs['stdout'], subprocess.PIPE)
+        program_args = popen_calls[0].program_args
+        self.assertIn('some/module', program_args)
+        self.assertIn('--headed', program_args)
+        env = popen_calls[0].kwargs['env']
+        self.assertEqual(env['MOBILE'], 'false')
+        self.assertEqual(env['PROD_ENV'], 'false')
+
+    def test_managed_acceptance_test_server_playwright_headless(self) -> None:
+        popen_calls = self.exit_stack.enter_context(self.swap_popen())
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'playwright',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
+
+        with json_load_swap:
+            self.exit_stack.enter_context(
+                servers.managed_acceptance_tests_server(
+                    suite_name='testSuite',
+                    headless=True,
+                    stdout=subprocess.PIPE,
+                )
+            )
+            self.exit_stack.close()
+
+        program_args = popen_calls[0].program_args
+        self.assertNotIn('--headed', program_args)
+        env = popen_calls[0].kwargs['env']
+        self.assertEqual(env['HEADLESS'], 'true')
+
+    def test_managed_acceptance_test_server_playwright_mobile(self) -> None:
+        popen_calls = self.exit_stack.enter_context(self.swap_popen())
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'playwright',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
+
+        with json_load_swap:
+            self.exit_stack.enter_context(
+                servers.managed_acceptance_tests_server(
+                    suite_name='testSuite', mobile=True, stdout=subprocess.PIPE
+                )
+            )
+            self.exit_stack.close()
+
+        env = popen_calls[0].kwargs['env']
+        self.assertEqual(env['MOBILE'], 'true')
+
+    def test_managed_acceptance_test_server_with_invalid_framework(
+        self,
+    ) -> None:
+        mock_config = {
+            'core': [
+                {
+                    'name': 'testSuite',
+                    'framework': 'invalid_framework',
+                    'module': 'some/module',
+                }
+            ]
+        }
+        json_load_swap = self.swap(json, 'load', lambda _: mock_config)
+
+        with json_load_swap:
+            with self.assertRaisesRegex(
+                Exception,
+                'Suite "testSuite" has invalid framework: "invalid_framework". '
+                'Must be "puppeteer" or "playwright".',
+            ):
+                self.exit_stack.enter_context(
+                    servers.managed_acceptance_tests_server(
+                        suite_name='testSuite', stdout=subprocess.PIPE
+                    )
+                )
 
 
 class GetChromedriverVersionTests(test_utils.TestBase):


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes part of https://github.com/oppia/oppia/issues/24715
2. This PR does the following: Adds a `framework` field to `acceptance.json` and supporting scripts to distinguish between 
`puppeteer` and `playwright` test suites during the incremental migration from Puppeteer to Playwright. Specifically:
- Adds `framework` field to `core/tests/ci-test-suite-configs/acceptance.json` for each suite, with value `puppeteer` or `playwright`.
- Updates `TestSuiteDict` in `check_tests_are_captured_in_ci.py` to make `framework` an optional field (using two-class TypedDict inheritance), since e2e suites don't have this field.
- Updates `servers.py` to read the `framework` field and route the suite to the correct test runner (Jest for Puppeteer, 
  Playwright CLI for Playwright).
- Updates `run_acceptance_tests.py` to detect the framework and install the appropriate dependencies before running the suite.
- Updates tests in `check_tests_are_captured_in_ci_test.py`, `servers_test.py`, and `run_acceptance_tests_test.py` to cover 
  the new behavior.

There is already an open PR that contains the first commit of this branch. This PR can be merged after that.
To look at the diff of this PR just look at the changes made in the second commit (and later commits).

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

No proof of changes needed because these are backend-only changes with no user-facing UI impact.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
