### PR TITLE
Fix #25975: Prevent ExpressionChangedAfterItHasBeenCheckedError on LTR to RTL switch

### DIFF
--- a/core/templates/components/oppia-angular-root.component.spec.ts
+++ b/core/templates/components/oppia-angular-root.component.spec.ts
@@ -120,6 +120,7 @@ describe('OppiaAngularRootComponent', function () {
     spyOn(CkEditorInitializerService, 'ckEditorInitializer').and.callFake(
       () => {}
     );
+    component.ngOnInit();
     component.ngAfterViewInit();
     TestBed.inject(I18nLanguageCodeService).setI18nLanguageCode('en');
 
@@ -129,7 +130,7 @@ describe('OppiaAngularRootComponent', function () {
   it('should detect change in direction', () => {
     let newDirection = 'rtl';
 
-    component.ngAfterViewInit();
+    component.ngOnInit();
     i18nService.directionChangeEventEmitter.emit(newDirection);
     fixture.detectChanges();
     expect(component.direction).toEqual(newDirection);

--- a/core/templates/components/oppia-angular-root.component.ts
+++ b/core/templates/components/oppia-angular-root.component.ts
@@ -64,6 +64,7 @@
 import {
   Component,
   Output,
+  OnInit,
   AfterViewInit,
   EventEmitter,
   Injector,
@@ -181,7 +182,7 @@ export const registerCustomElements = (injector: Injector): void => {
   selector: 'oppia-angular-root',
   templateUrl: './oppia-angular-root.component.html',
 })
-export class OppiaAngularRootComponent implements AfterViewInit {
+export class OppiaAngularRootComponent implements OnInit, AfterViewInit {
   @Output() public initialized: EventEmitter<void> = new EventEmitter();
   direction: string = 'ltr';
 
@@ -227,6 +228,12 @@ export class OppiaAngularRootComponent implements AfterViewInit {
     OppiaAngularRootComponent.rteElementsAreInitialized = true;
   }
 
+  public ngOnInit(): void {
+    this.i18nService.directionChangeEventEmitter.subscribe(direction => {
+      this.direction = direction;
+    });
+    this.i18nService.initialize();
+  }
   public ngAfterViewInit(): void {
     if (!OppiaAngularRootComponent.pageContextService) {
       OppiaAngularRootComponent.pageContextService = this.pageContextService;
@@ -304,12 +311,6 @@ export class OppiaAngularRootComponent implements AfterViewInit {
         ),
       },
     ]);
-
-    // Initialize translations.
-    this.i18nService.directionChangeEventEmitter.subscribe(direction => {
-      this.direction = direction;
-    });
-    this.i18nService.initialize();
 
     // This emit triggers ajs to start its app.
     this.initialized.emit();


### PR DESCRIPTION
## Overview


1. This PR fixes #25975.
2. This PR moves the `directionChangeEventEmitter` subscription and `i18nService.initialize()` from `ngAfterViewInit()` to `ngOnInit()` in `OppiaAngularRootComponent` to prevent `ExpressionChangedAfterItHasBeenCheckedError` during LTR ↔ RTL language switching.
3. The original bug occurred because the `direction` property was being updated after Angular's change detection cycle had already completed in `ngAfterViewInit()`.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. 
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@mon4our PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Before

A video showing `ExpressionChangedAfterItHasBeenCheckedError` appearing in the console while switching from English to Arabic is attached.


https://github.com/user-attachments/assets/51e16ab6-d710-4002-b5de-584c099bd6db


#### After

A video demonstrating repeated language toggling (English ↔ Arabic) with no console errors after the fix is attached.


https://github.com/user-attachments/assets/ec4c7407-dc2c-4d44-8b0a-809e14f97148



#### Proof of changes on mobile phone

Not applicable.

#### Proof of changes in Arabic language

Verified by repeatedly switching between English and Arabic without triggering `ExpressionChangedAfterItHasBeenCheckedError` in the console.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
