### PR TITLE
Fix git_changes_utils branch name parsing when branch contains slashes

### DIFF
--- a/scripts/git_changes_utils.py
+++ b/scripts/git_changes_utils.py
@@ -395,10 +395,15 @@ def get_changed_files(
         if (ref.local_ref.startswith('refs/heads/') or ref.local_ref == 'HEAD')
     ]
     # Get branch name from e.g. local_ref='refs/heads/lint_hook'.
-    branches = [ref.local_ref.split('/')[-1] for ref in ref_heads_only]
+    branches = [ref.local_ref.removeprefix('refs/heads/') for ref in ref_heads_only]
     hashes = [ref.local_sha1 for ref in ref_heads_only]
     remote_branches = [
-        '%s/%s' % (remote, ref.remote_ref.split('/')[-1])
+        '%s/%s' % (
+            remote,
+            ref.remote_ref.removeprefix('refs/heads/')
+            if ref.remote_ref.startswith('refs/heads/')
+            else '/'.join(ref.remote_ref.split('/', 3)[3:]),
+        )
         for ref in ref_heads_only
         if ref.remote_ref
     ]


### PR DESCRIPTION
## Bug
`get_changed_files` in `scripts/git_changes_utils.py` fails to correctly resolve branch names containing slashes (e.g. `fix/some-bug` or `feature/some-feature`).

## Root cause
The branch name resolution uses `ref.local_ref.split('/')[-1]`. If the local branch reference is `refs/heads/feature/some-feature`, splitting by `/` and taking the last element returns `some-feature`, discarding the `feature/` namespace prefix. This causes discrepancies between the local branch name and remote/tracking references.

## Why fix is correct
Changing the logic to `.removeprefix('refs/heads/')` preserves the full namespace prefix (e.g. `feature/some-feature`) while correctly removing only the git reference prefix. This enables correct, robust diff and file-change comparisons for multi-level branch naming schemes.