### PR TITLE
fix(scripts): preserve slash-containing branch names in pre-push hook

### DIFF
--- a/scripts/git_changes_utils.py
+++ b/scripts/git_changes_utils.py
@@ -395,10 +395,15 @@ def get_changed_files(
         if (ref.local_ref.startswith('refs/heads/') or ref.local_ref == 'HEAD')
     ]
     # Get branch name from e.g. local_ref='refs/heads/lint_hook'.
-    branches = [ref.local_ref.split('/')[-1] for ref in ref_heads_only]
+    branches = [ref.local_ref.removeprefix('refs/heads/') for ref in ref_heads_only]
     hashes = [ref.local_sha1 for ref in ref_heads_only]
     remote_branches = [
-        '%s/%s' % (remote, ref.remote_ref.split('/')[-1])
+        '%s/%s' % (
+            remote,
+            ref.remote_ref.removeprefix('refs/heads/')
+            if ref.remote_ref.startswith('refs/heads/')
+            else '/'.join(ref.remote_ref.split('/', 3)[3:]),
+        )
         for ref in ref_heads_only
         if ref.remote_ref
     ]


### PR DESCRIPTION
## Summary

Fixes `git push` failures for branches whose names contain `/` (e.g. `feat/my-branch`).

Closes #26059

## Bug

Pushing `feat/test-branch` caused the pre-push hook to crash with:

```
ValueError: b'fatal: Not a valid object name origin/test-branch\n'
```

## Root cause

`get_changed_files()` derived branch names with `ref.split('/')[-1]`, which stripped everything before the final slash. `refs/heads/feat/test-branch` became `test-branch`, so `git merge-base` queried a non-existent remote ref.

## Why this fix is correct

Strip the known `refs/heads/` prefix instead of taking the last path segment, and handle `refs/remotes/<remote>/<branch>` refs the same way. `feat/test-branch` is preserved end-to-end, so merge-base compares the actual local and remote branch names.

## Test plan

- [x] Verified branch parsing logic for `refs/heads/feat/test-branch` -> `feat/test-branch`
- [x] Verified existing `refs/remotes/remote/branch-1` path still resolves to `remote/branch-1`

Made with [Cursor](https://cursor.com)