### PR TITLE
Fix part of #26108: Fix strict template checks for blog dashboard files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ tmpcompiledjs*
 uploads/*
 env/
 venv/
-.venv/
 *.db
 .DS_Store
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ tmpcompiledjs*
 uploads/*
 env/
 venv/
+.venv/
 *.db
 .DS_Store
 .idea

--- a/core/templates/domain/blog-admin/blog-admin-backend-api.service.spec.ts
+++ b/core/templates/domain/blog-admin/blog-admin-backend-api.service.spec.ts
@@ -23,6 +23,7 @@ import {
 import {TestBed, fakeAsync, flushMicrotasks} from '@angular/core/testing';
 import {
   BlogAdminPageData,
+  BlogAdminPageDataBackendDict,
   BlogAdminBackendApiService,
 } from './blog-admin-backend-api.service';
 import {CsrfTokenService} from 'services/csrf-token.service';
@@ -33,7 +34,7 @@ describe('Blog Admin backend api service', () => {
   let csrfService: CsrfTokenService;
   let successHandler: jasmine.Spy<jasmine.Func>;
   let failHandler: jasmine.Spy<jasmine.Func>;
-  let blogAdminBackendResponse = {
+  let blogAdminBackendResponse: BlogAdminPageDataBackendDict = {
     role_to_actions: {
       blog_post_editor: ['action for editor'],
     },
@@ -41,7 +42,7 @@ describe('Blog Admin backend api service', () => {
       max_number_of_tags_assigned_to_blog_post: {
         description: 'Max number of tags.',
         value: 10,
-        schema: {type: 'number'},
+        schema: {type: 'float'},
       },
     },
     updatable_roles: {

--- a/core/templates/domain/blog-admin/blog-admin-backend-api.service.ts
+++ b/core/templates/domain/blog-admin/blog-admin-backend-api.service.ts
@@ -18,9 +18,7 @@
 
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-interface PlatformParameterSchema {
-  type: string;
-}
+import {Schema} from 'services/schema-default-value.service';
 
 interface UserRolesBackendResponse {
   [role: string]: string;
@@ -34,7 +32,7 @@ export interface PlatformParameterBackendResponse {
   [property: string]: {
     description: string;
     value: string[] | number;
-    schema: PlatformParameterSchema;
+    schema: Schema;
   };
 }
 

--- a/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
+++ b/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
@@ -35,11 +35,11 @@ import {
 import {PlatformParameter} from 'domain/platform-parameter/platform-parameter.model';
 import {PlatformParameterRule} from 'domain/platform-parameter/platform-parameter-rule.model';
 import {HttpErrorResponse} from '@angular/common/http';
+import {Schema} from 'services/schema-default-value.service';
 
-interface PlatformSchema {
-  type: string;
+type PlatformSchema = Schema & {
   ui_config?: {rows: number};
-}
+};
 
 type FilterType = keyof typeof PlatformParameterFilterType;
 
@@ -64,6 +64,10 @@ export class AdminPlatformParametersTabComponent implements OnInit {
       options?: readonly string[];
       placeholder?: string;
       inputRegex?: RegExp;
+      optionFilter?: (
+        platformParameter: PlatformParameter,
+        option: string
+      ) => boolean;
     };
   } = {
     [PlatformParameterFilterType.PlatformType]: {

--- a/core/templates/pages/android-page/android-page.component.html
+++ b/core/templates/pages/android-page/android-page.component.html
@@ -222,7 +222,7 @@
             <div class="oppia-android-updates-input-padding text-center">
               <oppia-primary-button (onClickPrimaryButton)="subscribeToAndroidList()"
                                     [disabled]="!userCanSubscribe || !validateEmailAddress()"
-                                    [customClasses]="'btn oppia-android-updates-button w-100'"
+                                    [customClasses]="['btn', 'oppia-android-updates-button', 'w-100']"
                                     [buttonText]="'I18N_ANDROID_PAGE_UPDATES_SUBMIT_BUTTON_TEXT' | translate">
               </oppia-primary-button>
             </div>

--- a/core/templates/pages/blog-admin-page/blog-admin-page.component.spec.ts
+++ b/core/templates/pages/blog-admin-page/blog-admin-page.component.spec.ts
@@ -78,7 +78,7 @@ describe('Blog Admin Page component ', () => {
       max_number_of_tags_assigned_to_blog_post: {
         description: 'Max number of tags.',
         value: 10,
-        schema: {type: 'number'},
+        schema: {type: 'float'},
       },
     },
     updatableRoles: {

--- a/core/templates/pages/blog-admin-page/services/blog-admin-data.service.spec.ts
+++ b/core/templates/pages/blog-admin-page/services/blog-admin-data.service.spec.ts
@@ -39,7 +39,7 @@ describe('Blog Admin Data Service', () => {
       max_number_of_tags_assigned_to_blog_post: {
         description: 'Max number of tags.',
         value: 10,
-        schema: {type: 'number'},
+        schema: {type: 'float'},
       },
     },
     updatable_roles: {

--- a/core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.ts
+++ b/core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.ts
@@ -155,9 +155,10 @@ export class BlogAuthorProfilePageComponent implements OnInit {
     );
   }
 
-  onPageChange(): void {
-    this.calculateFirstPostOnPageNum();
-    this.calculateLastPostOnPageNum();
+  onPageChange(page = this.page): void {
+    this.page = page;
+    this.calculateFirstPostOnPageNum(page);
+    this.calculateLastPostOnPageNum(page);
     this.loadPage();
   }
 

--- a/core/templates/pages/blog-dashboard-page/blog-dashboard-tile/blog-dashboard-tile.component.ts
+++ b/core/templates/pages/blog-dashboard-page/blog-dashboard-tile/blog-dashboard-tile.component.ts
@@ -37,6 +37,7 @@ export class BlogDashboardTileComponent implements OnInit {
   @Input() blogPostSummary!: BlogPostSummary;
   @Input() activeView!: string;
   @Input() blogPostIsPublished: boolean = false;
+  @Input() last: boolean = false;
   lastUpdatedDateString: string = '';
   summaryContent!: string;
   @Output() unpublisedBlogPost: EventEmitter<void> = new EventEmitter();

--- a/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.html
+++ b/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.html
@@ -165,7 +165,7 @@
                                        multiple="true"
                                        class="mx-2 my-2 tag">
                 <mat-button-toggle class="text-wrap e2e-test-blog-post-tags"
-                                   (change)="onTagChange($event.value)"
+                                   (change)="onTagChange(tag)"
                                    [value]="tag"
                                    [disabled]="!((blogPostData.tags).includes(tag)) && (blogPostData.tags.length === maxAllowedTags)">
                 {{ tag }}
@@ -255,7 +255,7 @@
                                    multiple="true"
                                    class="mx-2 my-2 tag">
             <mat-button-toggle class="text-wrap e2e-test-blog-post-tags"
-                               (change)="onTagChange($event.value)"
+                               (change)="onTagChange(tag)"
                                [value]="tag"
                                [disabled]="!((blogPostData.tags).includes(tag)) && (blogPostData.tags.length === maxAllowedTags)">
               {{ tag }}

--- a/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
+++ b/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
@@ -16,11 +16,10 @@
  * @fileoverview Component for a blog dashboard card.
  */
 
-interface EditorSchema {
-  type: string;
-  ui_config: object;
-}
-
+import {
+  Schema,
+  SchemaDefaultValue,
+} from 'services/schema-default-value.service';
 import {AppConstants} from 'app.constants';
 import {
   ChangeDetectorRef,
@@ -50,6 +49,11 @@ import {BlogCardPreviewModalComponent} from 'pages/blog-dashboard-page/modal-tem
 import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import {UserService} from 'services/user.service';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
+
+type EditorSchema = Schema & {
+  ui_config: object;
+};
+
 @Component({
   selector: 'oppia-blog-post-editor',
   templateUrl: './blog-post-editor.component.html',
@@ -63,6 +67,7 @@ export class BlogPostEditorComponent implements OnInit {
   blogPostId!: string;
   authorProfilePicPngUrl!: string;
   authorProfilePicWebpUrl!: string;
+  uploadedImage: string | null = null;
   uploadedImageDataUrl!: string;
   title!: string;
   defaultTagsList!: string[];
@@ -78,6 +83,7 @@ export class BlogPostEditorComponent implements OnInit {
   contentEditorIsActive: boolean = false;
   invalidImageWarningIsShown: boolean = false;
   newChangesAreMade: boolean = false;
+  showEditImageIcon: boolean = false;
   lastChangesWerePublished: boolean = false;
   saveInProgress: boolean = false;
   publishingInProgress: boolean = false;
@@ -263,9 +269,16 @@ export class BlogPostEditorComponent implements OnInit {
     }
   }
 
-  updateLocalEditedContent($event: string): void {
-    if (this.localEditedContent !== $event) {
-      this.localEditedContent = $event;
+  cancel(): void {
+    this.showEditImageIcon = false;
+  }
+
+  updateLocalEditedContent(value: SchemaDefaultValue): void {
+    if (typeof value !== 'string') {
+      return;
+    }
+    if (this.localEditedContent !== value) {
+      this.localEditedContent = value;
       this.changeDetectorRef.detectChanges();
     }
   }

--- a/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.html
+++ b/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.html
@@ -22,7 +22,7 @@
       </div>
       <div *ngIf="invalidTagsAndAttributes.tags.length || invalidTagsAndAttributes.attrs.length"
            class="oppia-unsupported-svg-tag-attribute-error"
-           [innerHTML]="'I18N_INVALID_TAGS_AND_ATTRIBUTES_ALERT' | translate: { issueURL: svgSanitizerService.getIssueURL(invalidTagsAndAttributes) }"
+           [innerHTML]="'I18N_INVALID_TAGS_AND_ATTRIBUTES_ALERT' | translate: { issueURL: getInvalidSvgIssueUrl() }"
       ></div>
     </div>
   </div>

--- a/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.ts
+++ b/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.ts
@@ -51,7 +51,7 @@ export class UploadBlogPostThumbnailComponent implements OnInit {
   windowIsNarrow: boolean = false;
   cropppedImageDataUrl: string = '';
   invalidImageWarningIsShown: boolean = false;
-  allowedImageFormats: readonly string[] = AppConstants.ALLOWED_IMAGE_FORMATS;
+  allowedImageFormats: string[] = [...AppConstants.ALLOWED_IMAGE_FORMATS];
   @Output() imageLocallySaved: EventEmitter<string> = new EventEmitter();
   @Output() cancelThumbnailUpload: EventEmitter<void> = new EventEmitter();
   constructor(
@@ -126,6 +126,10 @@ export class UploadBlogPostThumbnailComponent implements OnInit {
       tags: [],
       attrs: [],
     };
+  }
+
+  getInvalidSvgIssueUrl(): string {
+    return this.svgSanitizerService.getIssueURL(this.invalidTagsAndAttributes);
   }
 
   onInvalidImageLoaded(): void {

--- a/core/templates/pages/blog-dashboard-page/navbar/navbar-breadcrumb/blog-dashboard-navbar-breadcrumb.component.html
+++ b/core/templates/pages/blog-dashboard-page/navbar/navbar-breadcrumb/blog-dashboard-navbar-breadcrumb.component.html
@@ -6,7 +6,7 @@
   <div class="d-flex flex-column pt-2 blog-title" *ngIf="activeTab === 'editor_tab'">
     <p class="oppia-blog-dashboard-title"
        role="button"
-       (click)="blogDashboardPageService.navigateToMainTab()">
+       (click)="navigateToMainTab()">
       Blog Dashboard
     </p>
     <p class="oppia-blog-post-title pt-1 blog-title-p">{{ title }}</p>

--- a/core/templates/pages/blog-dashboard-page/navbar/navbar-breadcrumb/blog-dashboard-navbar-breadcrumb.component.ts
+++ b/core/templates/pages/blog-dashboard-page/navbar/navbar-breadcrumb/blog-dashboard-navbar-breadcrumb.component.ts
@@ -55,4 +55,8 @@ export class BlogDashboardNavbarBreadcrumbComponent
   ngOnDestroy(): void {
     return this.directiveSubscriptions.unsubscribe();
   }
+
+  navigateToMainTab(): void {
+    this.blogDashboardPageService.navigateToMainTab();
+  }
 }

--- a/core/templates/pages/blog-dashboard-page/navbar/navbar-pre-logo-action/blog-post-editor-pre-logo-action.component.html
+++ b/core/templates/pages/blog-dashboard-page/navbar/navbar-pre-logo-action/blog-post-editor-pre-logo-action.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="activeTab === 'editor_tab'"
-     (click)="blogDashboardPageService.navigateToMainTab()"
+     (click)="navigateToMainTab()"
      class="oppia-blog-post-editor-back-button e2e-test-back-button">
   <span class="fas fa-arrow-left oppia-navbar-back-button">
   </span>

--- a/core/templates/pages/blog-dashboard-page/navbar/navbar-pre-logo-action/blog-post-editor-pre-logo-action.component.ts
+++ b/core/templates/pages/blog-dashboard-page/navbar/navbar-pre-logo-action/blog-post-editor-pre-logo-action.component.ts
@@ -47,4 +47,8 @@ export class BlogPostEditorNavbarPreLogoActionComponent
   ngOnDestroy(): void {
     return this.directiveSubscriptions.unsubscribe();
   }
+
+  navigateToMainTab(): void {
+    this.blogDashboardPageService.navigateToMainTab();
+  }
 }

--- a/core/templates/pages/blog-home-page/blog-home-page.component.html
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.html
@@ -110,7 +110,7 @@
               <input type="text"
                      class="form-control oppia-search-bar-input oppia-search-bar-text-input e2e-test-search-input"
                      [(ngModel)]="searchQuery"
-                     [ngModelOptions]="{ updateOn: 'change', standalone: 'true' }"
+                     [ngModelOptions]="{ updateOn: 'change', standalone: true }"
                      aria-label="Search bar"
                      (keydown.enter)="onSearchQueryChangeExec()">
             </div>

--- a/scripts/template_strict_exclude_paths.txt
+++ b/scripts/template_strict_exclude_paths.txt
@@ -43,16 +43,7 @@ core/templates/components/version-diff-visualization/version-diff-visualization.
 core/templates/pages/about-page/about-page.component.ts
 core/templates/pages/about-page/cta-section/cta-section.component.ts
 core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.ts
-core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
-core/templates/pages/android-page/android-page.component.ts
-core/templates/pages/blog-admin-page/blog-admin-page.component.ts
-core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.ts
-core/templates/pages/blog-dashboard-page/blog-dashboard-tile/blog-dashboard-tile.component.ts
-core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
-core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.ts
-core/templates/pages/blog-dashboard-page/navbar/navbar-breadcrumb/blog-dashboard-navbar-breadcrumb.component.ts
-core/templates/pages/blog-dashboard-page/navbar/navbar-pre-logo-action/blog-post-editor-pre-logo-action.component.ts
-core/templates/pages/blog-home-page/blog-home-page.component.ts
+
 core/templates/pages/classroom-admin-page/classroom-admin-page.component.ts
 core/templates/pages/collection-editor-page/modals/collection-editor-pre-publish-modal.component.ts
 core/templates/pages/collection-player-page/collection-node-list/collection-node-list.component.ts


### PR DESCRIPTION
## Overview

1. This PR fixes part of #26108.
2. This PR removes the Group 5 files from `scripts/template_strict_exclude_paths.txt` and fixes the Angular strict template type-checking issues for those files. The changes mainly include improving TypeScript typings, adding safer null handling, correcting template input types, replacing unsafe template access patterns with typed wrapper methods, and aligning schema-related types with shared Oppia interfaces. These fixes allow the affected Group 5 components to pass Angular strict template checks without relying on the allowlist.
3. N/A

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

### Files removed from strict template allowlist

- core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
- core/templates/pages/android-page/android-page.component.ts
- core/templates/pages/blog-admin-page/blog-admin-page.component.ts
- core/templates/pages/blog-author-profile-page/blog-author-profile-page.component.ts
- core/templates/pages/blog-dashboard-page/blog-dashboard-tile/blog-dashboard-tile.component.ts
- core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
- core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.ts
- core/templates/pages/blog-dashboard-page/navbar/navbar-breadcrumb/blog-dashboard-navbar-breadcrumb.component.ts
- core/templates/pages/blog-dashboard-page/navbar/navbar-pre-logo-action/blog-post-editor-pre-logo-action.component.ts
- core/templates/pages/blog-home-page/blog-home-page.component.ts

### Main fixes made

#### admin-platform-parameters-tab.component.ts
- Updated schema typings to use shared `Schema` interfaces.
- Added missing optional typing for filter context properties.

#### android-page.component.ts
- Fixed `customClasses` input binding type from `string` to `string[]`.

#### blog-admin-page.component.ts
- Improved backend schema typing consistency.
- Updated affected test fixtures.

#### blog-author-profile-page.component.ts
- Updated pagination handlers to support optional page values safely.

#### blog-dashboard-tile.component.ts
- Added missing `last` input property used in templates.

#### blog-post-editor.component.ts
- Added missing template-bound properties and handlers.
- Improved schema typing and editor value handling.
- Fixed unsafe event usage in template interactions.

#### upload-blog-post-thumbnail.component.ts
- Replaced private service access in templates with public wrapper methods.
- Fixed mutable array typing for image receiver inputs.

#### blog-dashboard-navbar-breadcrumb.component.ts
- Replaced template access to private services with public methods.

#### blog-post-editor-pre-logo-action.component.ts
- Replaced template access to private services with public methods.

#### blog-home-page.component.ts
- Fixed incorrect boolean binding in `ngModelOptions`.

### Verification

Successfully ran:

```bash
python -m scripts.run_typescript_checks --strict_checks
```
<img width="1898" height="750" alt="Screenshot 2026-05-27 124459" src="https://github.com/user-attachments/assets/b4730828-ca6a-4cf5-b5e3-50ff798454f8" />

Proof of changes has been provided above through successful strict template check execution screenshots.

Note: this is pr after filling ClA