### PR TITLE
fix(scripts): preserve slash-containing branch names in pre-push hook

### DIFF
--- a/scripts/git_changes_utils.py
+++ b/scripts/git_changes_utils.py
@@ -395,10 +395,15 @@ def get_changed_files(
         if (ref.local_ref.startswith('refs/heads/') or ref.local_ref == 'HEAD')
     ]
     # Get branch name from e.g. local_ref='refs/heads/lint_hook'.
-    branches = [ref.local_ref.split('/')[-1] for ref in ref_heads_only]
+    branches = [ref.local_ref.removeprefix('refs/heads/') for ref in ref_heads_only]
     hashes = [ref.local_sha1 for ref in ref_heads_only]
     remote_branches = [
-        '%s/%s' % (remote, ref.remote_ref.split('/')[-1])
+        '%s/%s' % (
+            remote,
+            ref.remote_ref.removeprefix('refs/heads/')
+            if ref.remote_ref.startswith('refs/heads/')
+            else '/'.join(ref.remote_ref.split('/', 3)[3:]),
+        )
         for ref in ref_heads_only
         if ref.remote_ref
     ]


### PR DESCRIPTION
## Bug
`git push` fails for branches like `feat/foo` because the pre-push hook resolves the remote ref as `origin/foo` instead of `origin/feat/foo`.

## Root cause
`get_changed_files` took the last path segment of `refs/heads/feat/foo` via `split('/')[-1]`, dropping the prefix before the slash.

## Why this fix is correct
`removeprefix('refs/heads/')` keeps the full branch name for both local and remote refs, so `git merge-base` receives valid ref names that exist on the remote.

Fixes #26059

Made with [Cursor](https://cursor.com)