### PR TITLE
Add tests to cover missing branches in html_validation_service

### DIFF
--- a/core/domain/html_validation_service_test.py
+++ b/core/domain/html_validation_service_test.py
@@ -85,6 +85,15 @@ class ContentMigrationTests(test_utils.GenericTestBase):
             html_validation_service.wrap_with_siblings(tag, soup.new_tag('p'))
             self.assertEqual(str(soup), test_case['expected_output'])
 
+    def test_wrap_with_siblings_with_no_next_siblings(self) -> None:
+        # Tests 69->exit: the tag has no next siblings so the
+        # for loop exits immediately without entering.
+        html_content = '<p>hello</p><b>world</b>'
+        soup = bs4.BeautifulSoup(html_content, 'html.parser')
+        tag = soup.find(name='b')
+        html_validation_service.wrap_with_siblings(tag, soup.new_tag('p'))
+        self.assertEqual(str(soup), '<p>hello</p><p><b>world</b></p>')
+
     def test_validate_rte_format(self) -> None:
         test_cases_for_ckeditor = [
             (
@@ -203,6 +212,23 @@ class ContentMigrationTests(test_utils.GenericTestBase):
             actual_output_for_ckeditor, expected_output_for_ckeditor
         )
 
+    def test_validate_rte_format_with_valid_collapsible(self) -> None:
+        # Tests 441->424: collapsible has valid content-with-value
+        # so validate_soup_for_rte returns False, meaning is_invalid
+        # is False and the if is_invalid block at line 441 is skipped.
+        test_cases = [
+            (
+                '<oppia-noninteractive-collapsible content-with-value="&amp;'
+                'quot;&amp;lt;p&amp;gt;lorem ipsum&amp;lt;/p&amp;gt;&amp;quot;"'
+                ' heading-with-value="&amp;quot;hello&amp;quot;">'
+                '</oppia-noninteractive-collapsible>'
+            ),
+        ]
+        actual_output = html_validation_service.validate_rte_format(
+            test_cases, feconf.RTE_FORMAT_CKEDITOR
+        )
+        self.assertEqual(actual_output['strings'], [])
+
     def test_validate_soup_for_rte(self) -> None:
         test_cases_for_textangular = [
             (
@@ -269,6 +295,94 @@ class ContentMigrationTests(test_utils.GenericTestBase):
             self.assertEqual(
                 actual_output_for_ckeditor, expected_output_for_ckeditor[index]
             )
+
+    def test_validate_rte_format_with_valid_tab_content(self) -> None:
+        # Tests 457->449: tab content is valid RTE so is_invalid
+        # is False and the if is_invalid block is skipped.
+        test_cases = [
+            (
+                '<oppia-noninteractive-tabs tab_contents-with-value'
+                '=\"[{&amp;quot;content&amp;quot;:&amp;quot;&amp;lt;p&amp;gt;'
+                'lorem ipsum&amp;lt;/p&amp;gt;&amp;quot;,&amp;quot;title'
+                '&amp;quot;:&amp;quot;tab1&amp;quot;}]\">'
+                '</oppia-noninteractive-tabs>'
+            ),
+        ]
+        actual_output = html_validation_service.validate_rte_format(
+            test_cases, feconf.RTE_FORMAT_CKEDITOR
+        )
+        self.assertEqual(actual_output['strings'], [])
+
+    def test_validate_rte_format_with_valid_workedexample(self) -> None:
+        # Tests 491->460: workedexample has valid question and answer
+        # so is_invalid is False and the if block at line 491 is skipped.
+        test_cases = [
+            (
+                '<oppia-noninteractive-workedexample question-with-value="&amp;'
+                'quot;&amp;lt;p&amp;gt;question&amp;lt;/p&amp;gt;&amp;quot;"'
+                ' answer-with-value="&amp;quot;&amp;lt;p&amp;gt;answer&amp;'
+                'lt;/p&amp;gt;&amp;quot;">'
+                '</oppia-noninteractive-workedexample>'
+            ),
+        ]
+        actual_output = html_validation_service.validate_rte_format(
+            test_cases, feconf.RTE_FORMAT_CKEDITOR
+        )
+        self.assertEqual(actual_output['strings'], [])
+
+    def test_validate_customization_args_with_empty_err_msg(self) -> None:
+        # Tests 582->581: err_msg is empty string so if err_msg is False
+        # and the loop continues to next iteration.
+        # self.swap_to_always_return is Oppia's built-in mocking utility that replaces validate_customization_args_in_tag with a function that always returns ['']
+        html = (
+            '<p><oppia-noninteractive-link text-with-value="&amp;quot;'
+            'What is a link?&amp;quot;" url-with-value="&amp;quot;'
+            'htt://link.com&amp;quot;"></oppia-noninteractive-link></p>'
+        )
+        with self.swap_to_always_return(
+            html_validation_service, 'validate_customization_args_in_tag', ['']
+        ):
+            actual_output = html_validation_service.validate_customization_args(
+                [html]
+            )
+        self.assertEqual(actual_output, {})
+
+    def test_validate_customization_args_with_duplicate_html_string(
+        self,
+    ) -> None:
+        # Tests 585->581: same html_string already exists in err_dict
+        # for the same err_msg so the elif condition is False.
+        duplicate_html = (
+            '<p><oppia-noninteractive-link text-with-value="&amp;quot;What is '
+            'a link?&amp;quot;" url-with-value="&amp;quot;htt://link.com&amp;'
+            'quot;"></oppia-noninteractive-link></p>'
+        )
+        test_cases = [duplicate_html, duplicate_html]
+        actual_output = html_validation_service.validate_customization_args(
+            test_cases
+        )
+        self.assertGreater(len(actual_output), 0)
+
+    def test_validate_customization_args_with_existing_html_string(
+        self,
+    ) -> None:
+        # Tests 585->581: html_string already exists in err_dict[err_msg]
+        # so the elif condition is False and the loop continues.
+        html = (
+            '<p><oppia-noninteractive-link text-with-value="&amp;quot;What is '
+            'a link?&amp;quot;" url-with-value="&amp;quot;htt://link.com&amp;'
+            'quot;"></oppia-noninteractive-link></p>'
+        )
+        err_msg = 'Expected a valid URL, got htt://link.com'
+        with self.swap_to_always_return(
+            html_validation_service,
+            'validate_customization_args_in_tag',
+            [err_msg, err_msg],
+        ):
+            actual_output = html_validation_service.validate_customization_args(
+                [html]
+            )
+        self.assertGreater(len(actual_output), 0)
 
     def test_validate_customization_args(self) -> None:
         test_cases = [
@@ -958,6 +1072,20 @@ class ContentMigrationTests(test_utils.GenericTestBase):
                 ),
                 'expected_output': 'blahblah',
             },
+            {
+                # if math tag has svg_filename-with-value
+                'html_content': (
+                    '<oppia-noninteractive-math raw_latex-with-value="&amp;quot;'
+                    'x^2&amp;quot;" svg_filename-with-value="&amp;quot;'
+                    'img.svg&amp;quot;"></oppia-noninteractive-math>'
+                ),
+                'expected_output': (
+                    '<oppia-noninteractive-math math_content-with-value="{&amp;'
+                    'quot;raw_latex&amp;quot;: &amp;quot;x^2&amp;quot;, &amp;'
+                    'quot;svg_filename&amp;quot;: &amp;quot;img.svg&amp;quot;}">'
+                    '</oppia-noninteractive-math>'
+                ),
+            },
         ]
 
         for test_case in test_cases:
@@ -1629,3 +1757,44 @@ class ContentMigrationTests(test_utils.GenericTestBase):
                 ),
                 test_case['expected_output'],
             )
+
+    def test_fix_incorrectly_encoded_chars_collapsible_without_content(
+        self,
+    ) -> None:
+        # Tests 1102->1101: collapsible does NOT have content-with-value
+        # so the if block is skipped and loop continues.
+        html = (
+            '<oppia-noninteractive-collapsible '
+            'heading-with-value="&amp;quot;hello&amp;quot;">'
+            '</oppia-noninteractive-collapsible>'
+        )
+        result = html_validation_service.fix_incorrectly_encoded_chars(html)
+        self.assertIn('oppia-noninteractive-collapsible', result)
+
+    def test_fix_incorrectly_encoded_chars_workedexample_without_question(
+        self,
+    ) -> None:
+        # Tests 1133->1147: workedexample does NOT have question-with-value
+        # so the if block is skipped and jumps to line 1147.
+        html = (
+            '<oppia-noninteractive-workedexample '
+            'answer-with-value="&amp;quot;&amp;lt;p&amp;gt;'
+            'answer&amp;lt;/p&amp;gt;&amp;quot;">'
+            '</oppia-noninteractive-workedexample>'
+        )
+        result = html_validation_service.fix_incorrectly_encoded_chars(html)
+        self.assertIn('oppia-noninteractive-workedexample', result)
+
+    def test_fix_incorrectly_encoded_chars_workedexample_without_answer(
+        self,
+    ) -> None:
+        # Tests 1147->1130: workedexample does NOT have answer-with-value
+        # so the if block is skipped and loop goes back to line 1130.
+        html = (
+            '<oppia-noninteractive-workedexample '
+            'question-with-value="&amp;quot;&amp;lt;p&amp;gt;'
+            'question&amp;lt;/p&amp;gt;&amp;quot;">'
+            '</oppia-noninteractive-workedexample>'
+        )
+        result = html_validation_service.fix_incorrectly_encoded_chars(html)
+        self.assertIn('oppia-noninteractive-workedexample', result)


### PR DESCRIPTION
## Overview

This PR fixes part of [#21308](https://github.com/oppia/oppia/issues/21308) .

This PR does the following:
This PR improves the branch test coverage for html_validation_service_test.py, making it 100%


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes 

<img width="1363" height="140" alt="full-coverage" src="https://github.com/user-attachments/assets/42e288d0-61d0-4a42-b308-261d06f09e9d" />
## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
