### PR TITLE
Fix learner story progress auth checks.

### DIFF
--- a/core/controllers/learner_group.py
+++ b/core/controllers/learner_group.py
@@ -27,7 +27,7 @@ from core.domain import (
     user_services,
 )
 
-from typing import Dict, List, TypedDict, Union
+from typing import Dict, List, Set, TypedDict, Union
 
 LEARNER_GROUP_SCHEMA = {
     'group_title': {
@@ -1067,9 +1067,54 @@ class LearnerStoriesChaptersProgressHandler(
     # types of values but in this handler we are rendering List
     # value. Also, once the value type is changed, please remove
     # List[Mapping[str, Any]] from render_json's argument type.
+    def _can_user_access_stories_chapters_progress(
+        self, target_user_id: str, story_ids: List[str]
+    ) -> bool:
+        """Checks whether the current user can access chapter progress.
+
+        A learner can always access their own chapter progress. A facilitator
+        can access a learner's chapter progress only for stories assigned in
+        learner groups they facilitate and only when the learner has enabled
+        progress sharing in at least one such group.
+
+        Args:
+            target_user_id: str. The user id whose progress is being fetched.
+            story_ids: list(str). The story ids whose chapter progress is being
+                fetched.
+
+        Returns:
+            bool. Whether the current user can access the requested progress.
+        """
+        assert self.user_id is not None
+
+        if self.user_id == target_user_id:
+            return True
+
+        accessible_story_ids: Set[str] = set()
+        learner_groups = (
+            learner_group_fetchers.get_learner_groups_of_facilitator(
+                self.user_id
+            )
+        )
+
+        for learner_group in learner_groups:
+            if target_user_id not in learner_group.learner_user_ids:
+                continue
+
+            progress_sharing_permission = (
+                learner_group_fetchers.can_multi_learners_share_progress(
+                    [target_user_id], learner_group.group_id
+                )
+            )[0]
+            if progress_sharing_permission:
+                accessible_story_ids.update(learner_group.story_ids)
+
+        return set(story_ids).issubset(accessible_story_ids)
+
     @acl_decorators.can_access_learner_groups
     def get(self, username: str) -> None:
         """Handles GET requests."""
+        assert self.user_id is not None
         assert self.normalized_request is not None
         story_ids = self.normalized_request['story_ids']
         user_id = user_services.get_user_id_from_username(username)
@@ -1077,6 +1122,13 @@ class LearnerStoriesChaptersProgressHandler(
             raise Exception(
                 'No learner user_id found for the given learner username: %s'
                 % username
+            )
+
+        if not self._can_user_access_stories_chapters_progress(
+            user_id, story_ids
+        ):
+            raise self.UnauthorizedUserException(
+                'You are not allowed to access this learner progress.'
             )
 
         stories_chapters_progress = (

--- a/core/controllers/learner_group_test.py
+++ b/core/controllers/learner_group_test.py
@@ -1506,6 +1506,41 @@ class LearnerStoriesChaptersProgressHandlerTests(test_utils.GenericTestBase):
         self.assertEqual(response[0]['total_checkpoints_count'], 1)
         self.logout()
 
+    def test_facilitator_cannot_fetch_progress_of_learner_not_in_group(
+        self,
+    ) -> None:
+        outsider_id = self.get_user_id_from_email(self.OUTSIDER_EMAIL)
+        learner_group_id = learner_group_fetchers.get_new_learner_group_id()
+        learner_group_services.create_learner_group(
+            learner_group_id,
+            'Learner Group Name',
+            'Description',
+            [self.USER_ID],
+            [outsider_id],
+            [],
+            [self.story_id],
+        )
+
+        self.login(self.NEW_USER_EMAIL)
+        user_services.update_learner_checkpoint_progress(
+            self.LEARNER_ID, self.exp_id_1, 'Introduction', 1
+        )
+
+        params = {'story_ids': json.dumps([self.story_id])}
+        response = self.get_json(
+            '/user_progress_in_stories_chapters_handler/%s'
+            % (self.LEARNER_USERNAME),
+            params=params,
+            expected_status_int=401,
+        )
+
+        self.assertEqual(
+            response['error'],
+            'You are not allowed to access this learner progress.',
+        )
+
+        self.logout()
+
 
 class LearnerGroupsFeatureStatusHandlerTests(test_utils.GenericTestBase):
     """Unit test for LearnerGroupsFeatureStatusHandler."""

--- a/core/controllers/learner_group_test.py
+++ b/core/controllers/learner_group_test.py
@@ -1471,6 +1471,8 @@ class LearnerStoriesChaptersProgressHandlerTests(test_utils.GenericTestBase):
             'You are not allowed to access this learner progress.',
         )
 
+        self.logout()
+
     def test_facilitator_can_fetch_shared_story_progress(self) -> None:
         learner_group_id = learner_group_fetchers.get_new_learner_group_id()
         learner_group_services.create_learner_group(
@@ -1502,6 +1504,7 @@ class LearnerStoriesChaptersProgressHandlerTests(test_utils.GenericTestBase):
         self.assertEqual(response[0]['exploration_id'], self.exp_id_1)
         self.assertEqual(response[0]['visited_checkpoints_count'], 1)
         self.assertEqual(response[0]['total_checkpoints_count'], 1)
+        self.logout()
 
 
 class LearnerGroupsFeatureStatusHandlerTests(test_utils.GenericTestBase):

--- a/core/controllers/learner_group_test.py
+++ b/core/controllers/learner_group_test.py
@@ -1345,13 +1345,20 @@ class LearnerGroupSyllabusHandlerTests(test_utils.GenericTestBase):
 class LearnerStoriesChaptersProgressHandlerTests(test_utils.GenericTestBase):
     """Tests for Learner Stories Chapters Progress Handler."""
 
+    LEARNER_EMAIL: Final = 'learner@example.com'
+    LEARNER_USERNAME: Final = 'learner'
+    OUTSIDER_EMAIL: Final = 'outsider@example.com'
+    OUTSIDER_USERNAME: Final = 'outsider'
     NODE_ID_1: Final = '%s1' % story_domain.NODE_ID_PREFIX
     NODE_ID_2: Final = '%s2' % story_domain.NODE_ID_PREFIX
 
     def setUp(self) -> None:
         super().setUp()
         self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
+        self.signup(self.LEARNER_EMAIL, self.LEARNER_USERNAME)
+        self.signup(self.OUTSIDER_EMAIL, self.OUTSIDER_USERNAME)
         self.USER_ID = self.get_user_id_from_email(self.NEW_USER_EMAIL)
+        self.LEARNER_ID = self.get_user_id_from_email(self.LEARNER_EMAIL)
 
         self.story_id = story_services.get_new_story_id()
         self.TOPIC_ID = topic_fetchers.get_new_topic_id()
@@ -1443,6 +1450,58 @@ class LearnerStoriesChaptersProgressHandlerTests(test_utils.GenericTestBase):
             'No learner user_id found for the given learner username: '
             'Invalid_username',
         )
+
+    def test_cannot_fetch_another_learners_story_progress(self) -> None:
+        self.login(self.OUTSIDER_EMAIL)
+
+        user_services.update_learner_checkpoint_progress(
+            self.LEARNER_ID, self.exp_id_1, 'Introduction', 1
+        )
+
+        params = {'story_ids': json.dumps([self.story_id])}
+        response = self.get_json(
+            '/user_progress_in_stories_chapters_handler/%s'
+            % (self.LEARNER_USERNAME),
+            params=params,
+            expected_status_int=401,
+        )
+
+        self.assertEqual(
+            response['error'],
+            'You are not allowed to access this learner progress.',
+        )
+
+    def test_facilitator_can_fetch_shared_story_progress(self) -> None:
+        learner_group_id = learner_group_fetchers.get_new_learner_group_id()
+        learner_group_services.create_learner_group(
+            learner_group_id,
+            'Learner Group Name',
+            'Description',
+            [self.USER_ID],
+            [self.LEARNER_ID],
+            [],
+            [self.story_id],
+        )
+        learner_group_services.add_learner_to_learner_group(
+            learner_group_id, self.LEARNER_ID, True
+        )
+
+        self.login(self.NEW_USER_EMAIL)
+        user_services.update_learner_checkpoint_progress(
+            self.LEARNER_ID, self.exp_id_1, 'Introduction', 1
+        )
+
+        params = {'story_ids': json.dumps([self.story_id])}
+        response = self.get_json(
+            '/user_progress_in_stories_chapters_handler/%s'
+            % (self.LEARNER_USERNAME),
+            params=params,
+        )
+
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0]['exploration_id'], self.exp_id_1)
+        self.assertEqual(response[0]['visited_checkpoints_count'], 1)
+        self.assertEqual(response[0]['total_checkpoints_count'], 1)
 
 
 class LearnerGroupsFeatureStatusHandlerTests(test_utils.GenericTestBase):


### PR DESCRIPTION
## Overview

1. This PR fixes N/A
2. This PR does the following: Fixes authorization for learner story chapter progress so data is returned only to the learner themselves or an authorized facilitator (with valid progress-sharing and story scope), and adds regression tests for denied/allowed cases.
3. (For bug-fixing PRs only) The original bug occurred because the endpoint trusted a caller-supplied username and used only a broad route-level permission check, without object-level authorization for the target learner and requested stories.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar. (N/A)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

This is API-level and not user facing. See the unit tests for this PR.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added access controls for chapter progress data. Facilitators can access progress for learners in their groups (when enabled), while unauthorized users are blocked from viewing other learners' progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oppia/oppia/pull/26246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->