### PR TITLE
Fix #24714:  Add MachineTranslationProviderMapping domain object and tests 2.1_PR2

### DIFF
--- a/core/domain/translation_domain.py
+++ b/core/domain/translation_domain.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 
 import enum
 
+import json
+
 from core import feconf, utils
 from core.constants import constants
 from core.domain import (  # pylint: disable=invalid-import-from
     translatable_object_registry,
 )
 
-import json
 from typing import Dict, Final, List, Optional, TypedDict, Union
 
 
@@ -587,7 +588,14 @@ class EntityTranslation:
         )
 
     def validate(self) -> None:
-        """Validates the EntityTranslation object."""
+        """Validates the language-to-provider mapping.
+
+        Raises:
+            utils.ValidationError. If the mapping is not a dict.
+            utils.ValidationError. If any language code is invalid.
+            utils.ValidationError. If any provider is not supported for
+                the given language.
+        """
         if not isinstance(self.entity_type, str):
             raise utils.ValidationError(
                 'entity_type must be a string, recieved %r' % self.entity_type

--- a/core/domain/translation_domain.py
+++ b/core/domain/translation_domain.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import enum
-
 import json
 
 from core import feconf, utils
@@ -588,13 +587,11 @@ class EntityTranslation:
         )
 
     def validate(self) -> None:
-        """Validates the language-to-provider mapping.
+        """Validates the EntityTranslation object.
 
         Raises:
-            utils.ValidationError. If the mapping is not a dict.
-            utils.ValidationError. If any language code is invalid.
-            utils.ValidationError. If any provider is not supported for
-                the given language.
+            utils.ValidationError. One or more attributes of the
+                EntityTranslation are invalid.
         """
         if not isinstance(self.entity_type, str):
             raise utils.ValidationError(
@@ -1104,11 +1101,12 @@ class MachineTranslationProviderMapping:
 
     def validate(self) -> None:
         """Validates the language-to-provider mapping.
+
         Raises:
-        ValidationError. If the mapping is not a dict.
-        ValidationError. If any language code is invalid.
-        ValidationError. If any provider is not supported for the
-            given language.
+            utils.ValidationError. If the mapping is not a dictionary.
+            utils.ValidationError. If any language code is invalid.
+            utils.ValidationError. If any provider does not support the
+                given language.
         """
 
         if not isinstance(self.language_to_provider_mapping, dict):

--- a/core/domain/translation_domain.py
+++ b/core/domain/translation_domain.py
@@ -26,6 +26,7 @@ from core.domain import (  # pylint: disable=invalid-import-from
     translatable_object_registry,
 )
 
+import json
 from typing import Dict, Final, List, Optional, TypedDict, Union
 
 
@@ -1076,3 +1077,54 @@ class ContentIdGenerator:
 
         self.next_content_id_index += 1
         return content_id
+
+
+class MachineTranslationProviderMapping:
+    """Domain object representing the mapping of language codes to their
+    configured translation providers.
+    """
+
+    def __init__(self, language_to_provider_mapping: Dict[str, str]) -> None:
+        """Initializes a MachineTranslationProviderMapping instance.
+
+        Args:
+            language_to_provider_mapping: dict. A dict mapping
+                ISO 639-1 language codes to translation provider identifiers.
+                E.g. {'hi': 'azure', 'es': 'gcp'}.
+        """
+        self.language_to_provider_mapping = language_to_provider_mapping
+
+    def validate(self) -> None:
+        """Validates the language-to-provider mapping.
+        Raises:
+        ValidationError. If the mapping is not a dict.
+        ValidationError. If any language code is invalid.
+        ValidationError. If any provider is not supported for the
+            given language.
+        """
+
+        if not isinstance(self.language_to_provider_mapping, dict):
+            raise utils.ValidationError(
+                'language_to_provider_mapping must be a dictionary.'
+            )
+        machine_translation_providers = json.loads(
+            utils.get_file_contents('assets/machine_translation_providers.json')
+        )
+
+        for (
+            language_code,
+            provider,
+        ) in self.language_to_provider_mapping.items():
+            if not utils.is_valid_language_code(language_code):
+                raise utils.ValidationError(
+                    'Invalid language code: %s' % language_code
+                )
+            supported_providers = machine_translation_providers.get(
+                language_code, []
+            )
+
+            if provider not in supported_providers:
+                raise utils.ValidationError(
+                    'Provider %s does not support language %s.'
+                    % (provider, language_code)
+                )

--- a/core/domain/translation_domain_test.py
+++ b/core/domain/translation_domain_test.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 
 from core import feconf, utils
@@ -26,7 +27,6 @@ from core.domain import (
 )
 from core.domain import translation_domain
 from core.tests import test_utils
-import json
 
 from typing import Optional
 

--- a/core/domain/translation_domain_test.py
+++ b/core/domain/translation_domain_test.py
@@ -1114,7 +1114,6 @@ class MachineTranslationProviderMappingTests(test_utils.GenericTestBase):
                 mapping_obj.validate()
 
     def test_validate_with_unsupported_provider_raises_error(self) -> None:
-        # 'aws' is not in our mocked JSON whitelist for 'hi'
         mapping_dict = {'hi': 'aws'}
         mapping_obj = translation_domain.MachineTranslationProviderMapping(
             mapping_dict

--- a/core/domain/translation_domain_test.py
+++ b/core/domain/translation_domain_test.py
@@ -26,6 +26,7 @@ from core.domain import (
 )
 from core.domain import translation_domain
 from core.tests import test_utils
+import json
 
 from typing import Optional
 
@@ -1054,3 +1055,74 @@ class WrittenTranslationsDomainUnitTests(test_utils.GenericTestBase):
         ):
             with self.swap(written_translation, 'data_format', 2):
                 written_translation.validate()
+
+
+class MachineTranslationProviderMappingTests(test_utils.GenericTestBase):
+    """Tests for the MachineTranslationProviderMapping domain object."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # We mock the JSON file contents so the tests run quickly and don't
+        # fail if the actual asset file is modified in the future.
+        self.mock_providers_json = json.dumps(
+            {'hi': ['azure', 'gcp'], 'es': ['azure']}
+        )
+        self.swap_get_file_contents = self.swap(
+            utils, 'get_file_contents', lambda x: self.mock_providers_json
+        )
+
+    def test_initialization(self) -> None:
+        mapping_dict = {'hi': 'azure'}
+        mapping_obj = translation_domain.MachineTranslationProviderMapping(
+            mapping_dict
+        )
+        self.assertEqual(mapping_obj.language_to_provider_mapping, mapping_dict)
+
+    def test_validate_with_valid_mapping_passes(self) -> None:
+        mapping_dict = {'hi': 'azure', 'es': 'azure'}
+        mapping_obj = translation_domain.MachineTranslationProviderMapping(
+            mapping_dict
+        )
+
+        # 'hi' and 'es' are already valid language codes in Oppia, so
+        # we only need to mock the JSON whitelist.
+        with self.swap_get_file_contents:
+            mapping_obj.validate()
+
+    def test_validate_with_non_dict_raises_error(self) -> None:
+        # TODO(#13059): Here we use MyPy ignore because we intentionally test
+        # wrong inputs that we can normally catch by typing.
+        mapping_obj = translation_domain.MachineTranslationProviderMapping(
+            ['hi', 'azure']  # type: ignore[arg-type]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'language_to_provider_mapping must be a dictionary.',
+        ):
+            mapping_obj.validate()
+
+    def test_validate_with_invalid_language_code_raises_error(self) -> None:
+        mapping_dict = {'invalid_lang': 'azure'}
+        mapping_obj = translation_domain.MachineTranslationProviderMapping(
+            mapping_dict
+        )
+
+        with self.swap_get_file_contents:
+            with self.assertRaisesRegex(
+                utils.ValidationError, 'Invalid language code: invalid_lang'
+            ):
+                mapping_obj.validate()
+
+    def test_validate_with_unsupported_provider_raises_error(self) -> None:
+        # 'aws' is not in our mocked JSON whitelist for 'hi'
+        mapping_dict = {'hi': 'aws'}
+        mapping_obj = translation_domain.MachineTranslationProviderMapping(
+            mapping_dict
+        )
+
+        with self.swap_get_file_contents:
+            with self.assertRaisesRegex(
+                utils.ValidationError,
+                'Provider aws does not support language hi.',
+            ):
+                mapping_obj.validate()

--- a/core/domain/translation_services.py
+++ b/core/domain/translation_services.py
@@ -380,3 +380,94 @@ def get_translatable_text(
         )
 
     return state_names_to_content_id_mapping
+
+
+def is_automatic_translation_enabled() -> bool:
+    """Returns whether the automatic translation feature is enabled.
+
+    Returns:
+        bool. True if automatic translation is enabled, False otherwise.
+    """
+    model = translation_models.MachineTranslationPolicyModel.get(
+        translation_models.MACHINE_TRANSLATION_POLICY_ID, strict=False
+    )
+    if model is None:
+        return False
+    return model.automatic_translation_is_enabled
+
+
+def get_machine_translation_provider_mapping() -> Dict[str, str]:
+    """Returns the current language-to-provider mapping.
+
+    Returns:
+        dict. A dict mapping language codes to provider identifiers.
+        Returns an empty dict if no configuration exists yet.
+    """
+    model = translation_models.MachineTranslationPolicyModel.get(
+        translation_models.MACHINE_TRANSLATION_POLICY_ID, strict=False
+    )
+    if model is None:
+        return {}
+    return model.language_to_provider_mapping
+
+
+def update_automatic_translation_status(
+    automatic_translation_is_enabled: bool,
+) -> None:
+    """Updates the automatic translation enabled/disabled flag.
+
+    Args:
+        automatic_translation_is_enabled: bool. Whether to enable or
+            disable automatic translation suggestions.
+    """
+    model = translation_models.MachineTranslationPolicyModel.get(
+        translation_models.MACHINE_TRANSLATION_POLICY_ID, strict=False
+    )
+    if model is None:
+        model = translation_models.MachineTranslationPolicyModel(
+            id=translation_models.MACHINE_TRANSLATION_POLICY_ID,
+            automatic_translation_is_enabled=automatic_translation_is_enabled,
+            language_to_provider_mapping={},
+        )
+    else:
+        model.automatic_translation_is_enabled = (
+            automatic_translation_is_enabled
+        )
+    model.update_timestamps()
+    model.put()
+
+
+def save_machine_translation_provider_mapping(
+    language_to_provider_mapping: Dict[str, str],
+) -> None:
+    """Validates and saves the language-to-provider mapping.
+
+    Args:
+        language_to_provider_mapping: dict. A dict mapping language codes
+            to translation provider identifiers.
+            E.g. {'hi': 'azure', 'es': 'gcp'}.
+
+    Raises:
+        utils.ValidationError. If the mapping contains invalid language
+            codes or unsupported providers.
+    """
+    mapping_domain_object = (
+        translation_domain.MachineTranslationProviderMapping(
+            language_to_provider_mapping
+        )
+    )
+    mapping_domain_object.validate()
+
+    model = translation_models.MachineTranslationPolicyModel.get(
+        translation_models.MACHINE_TRANSLATION_POLICY_ID, strict=False
+    )
+    if model is None:
+        model = translation_models.MachineTranslationPolicyModel(
+            id=translation_models.MACHINE_TRANSLATION_POLICY_ID,
+            automatic_translation_is_enabled=False,
+            language_to_provider_mapping=language_to_provider_mapping,
+        )
+    else:
+        model.language_to_provider_mapping = language_to_provider_mapping
+    model.update_timestamps()
+    model.put()

--- a/core/domain/translation_services.py
+++ b/core/domain/translation_services.py
@@ -393,7 +393,7 @@ def is_automatic_translation_enabled() -> bool:
     )
     if model is None:
         return False
-    return model.automatic_translation_is_enabled
+    return cast(bool, model.automatic_translation_is_enabled)
 
 
 def get_machine_translation_provider_mapping() -> Dict[str, str]:
@@ -408,7 +408,7 @@ def get_machine_translation_provider_mapping() -> Dict[str, str]:
     )
     if model is None:
         return {}
-    return model.language_to_provider_mapping
+    return cast(Dict[str, str], model.language_to_provider_mapping)
 
 
 def update_automatic_translation_status(

--- a/core/domain/translation_services.py
+++ b/core/domain/translation_services.py
@@ -393,6 +393,8 @@ def is_automatic_translation_enabled() -> bool:
     )
     if model is None:
         return False
+    # Here we use cast because BooleanProperty returns Any type at the
+    # type-checking level, but we know the stored value is always bool.
     return cast(bool, model.automatic_translation_is_enabled)
 
 
@@ -408,6 +410,9 @@ def get_machine_translation_provider_mapping() -> Dict[str, str]:
     )
     if model is None:
         return {}
+    # Here we use cast because JsonProperty returns Any type at the
+    # type-checking level, but we know the stored value is always
+    # Dict[str, str].
     return cast(Dict[str, str], model.language_to_provider_mapping)
 
 

--- a/core/domain/translation_services_test.py
+++ b/core/domain/translation_services_test.py
@@ -18,7 +18,11 @@
 
 from __future__ import annotations
 
-from core import feconf
+from core import (
+    feconf,
+    utils,
+)
+from core import utils
 from core.domain import (
     exp_domain,
     exp_fetchers,
@@ -798,3 +802,124 @@ class EntityTranslationServicesTest(test_utils.GenericTestBase):
             list(observed_translatable_text['Introduction'].keys()),
             ['default_outcome_1'],
         )
+
+
+class MachineTranslationPolicyServicesTests(test_utils.GenericTestBase):
+    """Tests for the machine translation policy configuration functions."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.POLICY_ID = translation_models.MACHINE_TRANSLATION_POLICY_ID
+
+    def test_is_automatic_translation_enabled_returns_false_by_default(
+        self,
+    ) -> None:
+        self.assertFalse(
+            translation_services.is_automatic_translation_enabled()
+        )
+
+    def test_is_automatic_translation_enabled_returns_model_status(
+        self,
+    ) -> None:
+        translation_models.MachineTranslationPolicyModel(
+            id=self.POLICY_ID,
+            automatic_translation_is_enabled=True,
+            language_to_provider_mapping={},
+        ).put()
+
+        self.assertTrue(translation_services.is_automatic_translation_enabled())
+
+    def test_get_machine_translation_provider_mapping_returns_empty_by_default(
+        self,
+    ) -> None:
+        self.assertEqual(
+            translation_services.get_machine_translation_provider_mapping(), {}
+        )
+
+    def test_get_machine_translation_provider_mapping_returns_model_mapping(
+        self,
+    ) -> None:
+        expected_mapping = {'hi': 'azure', 'es': 'gcp'}
+        translation_models.MachineTranslationPolicyModel(
+            id=self.POLICY_ID,
+            automatic_translation_is_enabled=False,
+            language_to_provider_mapping=expected_mapping,
+        ).put()
+
+        self.assertEqual(
+            translation_services.get_machine_translation_provider_mapping(),
+            expected_mapping,
+        )
+
+    def test_update_automatic_translation_status_creates_new_model(
+        self,
+    ) -> None:
+        translation_services.update_automatic_translation_status(True)
+
+        model = translation_models.MachineTranslationPolicyModel.get(
+            self.POLICY_ID
+        )
+        self.assertTrue(model.automatic_translation_is_enabled)
+        self.assertEqual(model.language_to_provider_mapping, {})
+
+    def test_update_automatic_translation_status_updates_existing_model(
+        self,
+    ) -> None:
+        existing_mapping = {'hi': 'azure'}
+        translation_models.MachineTranslationPolicyModel(
+            id=self.POLICY_ID,
+            automatic_translation_is_enabled=False,
+            language_to_provider_mapping=existing_mapping,
+        ).put()
+
+        translation_services.update_automatic_translation_status(True)
+
+        model = translation_models.MachineTranslationPolicyModel.get(
+            self.POLICY_ID
+        )
+        self.assertTrue(model.automatic_translation_is_enabled)
+        self.assertEqual(model.language_to_provider_mapping, existing_mapping)
+
+    def test_save_machine_translation_provider_mapping_creates_new_model(
+        self,
+    ) -> None:
+        new_mapping = {'es': 'gcp'}
+        translation_services.save_machine_translation_provider_mapping(
+            new_mapping
+        )
+
+        model = translation_models.MachineTranslationPolicyModel.get(
+            self.POLICY_ID
+        )
+        self.assertFalse(model.automatic_translation_is_enabled)
+        self.assertEqual(model.language_to_provider_mapping, new_mapping)
+
+    def test_save_machine_translation_provider_mapping_updates_existing(
+        self,
+    ) -> None:
+        translation_models.MachineTranslationPolicyModel(
+            id=self.POLICY_ID,
+            automatic_translation_is_enabled=True,
+            language_to_provider_mapping={'hi': 'azure'},
+        ).put()
+
+        new_mapping = {'hi': 'azure', 'es': 'gcp'}
+        translation_services.save_machine_translation_provider_mapping(
+            new_mapping
+        )
+
+        model = translation_models.MachineTranslationPolicyModel.get(
+            self.POLICY_ID
+        )
+        self.assertTrue(model.automatic_translation_is_enabled)
+        self.assertEqual(model.language_to_provider_mapping, new_mapping)
+
+    def test_save_machine_translation_provider_mapping_raises_error(
+        self,
+    ) -> None:
+        invalid_mapping = {'invalid_lang': 'invalid_provider'}
+
+        with self.assertRaisesRegex(utils.ValidationError, 'Invalid'):
+            translation_services.save_machine_translation_provider_mapping(
+                invalid_mapping
+            )

--- a/core/domain/translation_services_test.py
+++ b/core/domain/translation_services_test.py
@@ -18,11 +18,12 @@
 
 from __future__ import annotations
 
+import json
+
 from core import (
     feconf,
     utils,
 )
-from core import utils
 from core.domain import (
     exp_domain,
     exp_fetchers,
@@ -810,6 +811,12 @@ class MachineTranslationPolicyServicesTests(test_utils.GenericTestBase):
     def setUp(self) -> None:
         super().setUp()
         self.POLICY_ID = translation_models.MACHINE_TRANSLATION_POLICY_ID
+        self.mock_providers_json = json.dumps(
+            {'hi': ['azure', 'gcp'], 'es': ['azure', 'gcp']}
+        )
+        self.swap_get_file_contents = self.swap(
+            utils, 'get_file_contents', lambda x: self.mock_providers_json
+        )
 
     def test_is_automatic_translation_enabled_returns_false_by_default(
         self,
@@ -884,9 +891,10 @@ class MachineTranslationPolicyServicesTests(test_utils.GenericTestBase):
         self,
     ) -> None:
         new_mapping = {'es': 'gcp'}
-        translation_services.save_machine_translation_provider_mapping(
-            new_mapping
-        )
+        with self.swap_get_file_contents:
+            translation_services.save_machine_translation_provider_mapping(
+                new_mapping
+            )
 
         model = translation_models.MachineTranslationPolicyModel.get(
             self.POLICY_ID
@@ -904,9 +912,10 @@ class MachineTranslationPolicyServicesTests(test_utils.GenericTestBase):
         ).put()
 
         new_mapping = {'hi': 'azure', 'es': 'gcp'}
-        translation_services.save_machine_translation_provider_mapping(
-            new_mapping
-        )
+        with self.swap_get_file_contents:
+            translation_services.save_machine_translation_provider_mapping(
+                new_mapping
+            )
 
         model = translation_models.MachineTranslationPolicyModel.get(
             self.POLICY_ID
@@ -918,8 +927,8 @@ class MachineTranslationPolicyServicesTests(test_utils.GenericTestBase):
         self,
     ) -> None:
         invalid_mapping = {'invalid_lang': 'invalid_provider'}
-
-        with self.assertRaisesRegex(utils.ValidationError, 'Invalid'):
-            translation_services.save_machine_translation_provider_mapping(
-                invalid_mapping
-            )
+        with self.swap_get_file_contents:
+            with self.assertRaisesRegex(utils.ValidationError, 'Invalid'):
+                translation_services.save_machine_translation_provider_mapping(
+                    invalid_mapping
+                )

--- a/core/domain/translation_services_test.py
+++ b/core/domain/translation_services_test.py
@@ -20,10 +20,7 @@ from __future__ import annotations
 
 import json
 
-from core import (
-    feconf,
-    utils,
-)
+from core import feconf, utils
 from core.domain import (
     exp_domain,
     exp_fetchers,

--- a/core/storage/translation/gae_models.py
+++ b/core/storage/translation/gae_models.py
@@ -403,3 +403,183 @@ class MachineTranslationModel(base_models.BaseModel):
                 'translated_text': base_models.EXPORT_POLICY.NOT_APPLICABLE,
             },
         )
+
+
+class MachineTranslationPolicyModel(base_models.BaseModel):
+    """Singleton model for storing machine translation policy configuration.
+    There should only be one instance of this model, identified by
+    MACHINE_TRANSLATION_POLICY_ID.
+    """
+
+    automatic_translation_is_enabled = datastore_services.BooleanProperty(
+        required=True, indexed=False, default=False
+    )
+    # A dict mapping language codes to their translation provider identifiers.
+    # E.g. {'hi': 'azure', 'es': 'gcp'}
+    language_to_provider_mapping = datastore_services.JsonProperty(
+        required=True, default={}
+    )
+
+    @staticmethod
+    def get_deletion_policy() -> base_models.DELETION_POLICY:
+        """Model doesn't contain any data directly corresponding to a user."""
+        return base_models.DELETION_POLICY.NOT_APPLICABLE
+
+    @staticmethod
+    def get_model_association_to_user() -> (
+        base_models.MODEL_ASSOCIATION_TO_USER
+    ):
+        """Model does not contain user data."""
+        return base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+
+    @classmethod
+    def get_export_policy(cls) -> Dict[str, base_models.EXPORT_POLICY]:
+        """Model doesn't contain any data directly corresponding to a user."""
+        return dict(
+            super(cls, cls).get_export_policy(),
+            **{
+                'automatic_translation_is_enabled': (
+                    base_models.EXPORT_POLICY.NOT_APPLICABLE
+                ),
+                'language_to_provider_mapping': (
+                    base_models.EXPORT_POLICY.NOT_APPLICABLE
+                ),
+            },
+        )
+
+
+class AutoTranslationCacheModel(base_models.BaseModel):
+    """Model for caching AI-generated translations to avoid duplicate
+    API calls. Model instances are mapped by a deterministic key generated
+    from the source and target language codes, followed by a SHA-1 hash
+    of the source text, formatted as:
+
+        [source_language_code].[target_language_code].[hashed_source_text]
+
+    See AutoTranslationCacheModel._generate_id() below for details.
+    """
+
+    # The untranslated source text.
+    source_text = datastore_services.TextProperty(required=True, indexed=False)
+    # The language code for the source text language.
+    source_language_code = datastore_services.StringProperty(
+        required=True, indexed=True
+    )
+    # The language code for the target translation language.
+    target_language_code = datastore_services.StringProperty(
+        required=True, indexed=True
+    )
+    # The AI-generated translation of the source text into the target language.
+    translated_text = datastore_services.TextProperty(
+        required=True, indexed=False
+    )
+
+    @staticmethod
+    def _generate_id(
+        source_language_code: str,
+        target_language_code: str,
+        hashed_source_text: str,
+    ) -> str:
+        """Generates a deterministic key for an AutoTranslationCacheModel
+        instance.
+
+        Args:
+            source_language_code: str. The language code for the source text.
+            target_language_code: str. The language code for the translation.
+            hashed_source_text: str. A SHA-1 hash of the source text.
+
+        Returns:
+            str. The deterministically generated identifier of the form:
+            [source_language_code].[target_language_code].[hashed_source_text]
+        """
+        return '%s.%s.%s' % (
+            source_language_code,
+            target_language_code,
+            hashed_source_text,
+        )
+
+    @classmethod
+    def get_translation(
+        cls,
+        source_language_code: str,
+        target_language_code: str,
+        source_text: str,
+    ) -> Optional[AutoTranslationCacheModel]:
+        """Gets a cached translation by language codes and source text.
+
+        Args:
+            source_language_code: str. The language code for the source text.
+            target_language_code: str. The language code for the translation.
+            source_text: str. The untranslated source text.
+
+        Returns:
+            AutoTranslationCacheModel|None. The cached model instance if
+            found, or None if no cached translation exists.
+        """
+        hashed_source_text = utils.convert_to_hash(source_text, 50)
+        instance_id = cls._generate_id(
+            source_language_code, target_language_code, hashed_source_text
+        )
+        return cls.get(instance_id, strict=False)
+
+    @classmethod
+    def create(
+        cls,
+        source_language_code: str,
+        target_language_code: str,
+        source_text: str,
+        translated_text: str,
+    ) -> str:
+        """Creates a new AutoTranslationCacheModel instance.
+
+        Args:
+            source_language_code: str. The language code for the source text.
+            target_language_code: str. The language code for the translation.
+            source_text: str. The untranslated source text.
+            translated_text: str. The sanitized AI-generated translation.
+
+        Returns:
+            str. The ID of the newly created model instance.
+        """
+        hashed_source_text = utils.convert_to_hash(source_text, 50)
+        entity_id = cls._generate_id(
+            source_language_code, target_language_code, hashed_source_text
+        )
+        cache_entity = cls(
+            id=entity_id,
+            source_text=source_text,
+            source_language_code=source_language_code,
+            target_language_code=target_language_code,
+            translated_text=translated_text,
+        )
+        cache_entity.put()
+        return entity_id
+
+    @staticmethod
+    def get_deletion_policy() -> base_models.DELETION_POLICY:
+        """Model is not associated with users."""
+        return base_models.DELETION_POLICY.NOT_APPLICABLE
+
+    @staticmethod
+    def get_model_association_to_user() -> (
+        base_models.MODEL_ASSOCIATION_TO_USER
+    ):
+        """Model is not associated with users."""
+        return base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+
+    @classmethod
+    def get_export_policy(cls) -> Dict[str, base_models.EXPORT_POLICY]:
+        """Model is not associated with users."""
+        return dict(
+            super(cls, cls).get_export_policy(),
+            **{
+                'source_text': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+                'source_language_code': (
+                    base_models.EXPORT_POLICY.NOT_APPLICABLE
+                ),
+                'target_language_code': (
+                    base_models.EXPORT_POLICY.NOT_APPLICABLE
+                ),
+                'translated_text': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            },
+        )

--- a/core/storage/translation/gae_models.py
+++ b/core/storage/translation/gae_models.py
@@ -238,6 +238,9 @@ class EntityTranslationsModel(base_models.BaseModel):
         )
 
 
+MACHINE_TRANSLATION_POLICY_ID = 'machine_translation_policy'
+
+
 class MachineTranslationModel(base_models.BaseModel):
     """Model for storing machine generated translations for the purpose of
     preventing duplicate generation. Machine translations are used for reference


### PR DESCRIPTION
## Overview


1. This PR fixes part of #24714 .
t introduces the MachineTranslationProviderMapping domain object in core/domain/translation_domain.py, which is responsible for validating the active translation provider configurations set by Translator Admins. 

**Key additions:**
* Added the MachineTranslationProviderMapping domain object.
* Implemented the validate() method to ensure mappings match the assets/machine_translation_providers.json static whitelist, preventing unsupported providers or invalid language codes from reaching the datastore.
* Added comprehensive unit tests in core/domain/translation_domain_test.py covering valid inputs, invalid language codes, unsupported providers, and type mismatches.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No Proof of changes requires as passing unit tests are the proof

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
