### PR TITLE
Fix #26059: preserve slash-containing branch names in git_changes_utils

### DIFF
--- a/scripts/git_changes_utils.py
+++ b/scripts/git_changes_utils.py
@@ -395,10 +395,15 @@ def get_changed_files(
         if (ref.local_ref.startswith('refs/heads/') or ref.local_ref == 'HEAD')
     ]
     # Get branch name from e.g. local_ref='refs/heads/lint_hook'.
-    branches = [ref.local_ref.split('/')[-1] for ref in ref_heads_only]
+    branches = [ref.local_ref.removeprefix('refs/heads/') for ref in ref_heads_only]
     hashes = [ref.local_sha1 for ref in ref_heads_only]
     remote_branches = [
-        '%s/%s' % (remote, ref.remote_ref.split('/')[-1])
+        '%s/%s' % (
+            remote,
+            ref.remote_ref.removeprefix('refs/heads/')
+            if ref.remote_ref.startswith('refs/heads/')
+            else '/'.join(ref.remote_ref.split('/', 3)[3:]),
+        )
         for ref in ref_heads_only
         if ref.remote_ref
     ]


### PR DESCRIPTION
## Overview

1. This PR fixes #26059.
2. This PR preserves full branch names (including prefixes like `feat/`) when `get_changed_files` resolves local and remote refs, so the pre-push hook no longer looks up truncated names such as `origin/test-branch-name` instead of `origin/feat/test-branch-name`.
3. The original bug occurred because `split('/')[-1]` kept only the segment after the final slash, dropping namespace prefixes from branch names.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a developer-facing git hook utility fix; the issue includes the failing traceback and expected branch name resolution.

### Bug
Pre-push fails for branches like `feat/test-branch-name` with `ValueError: fatal: Not a valid object name origin/test-branch-name`.

### Root cause
`get_changed_files` used `ref.local_ref.split('/')[-1]` and `ref.remote_ref.split('/')[-1]`, truncating `refs/heads/feat/test-branch-name` to `test-branch-name`.

### Why fix is correct
Use `removeprefix('refs/heads/')` to keep the full branch name after the refs prefix, matching git ref semantics and the remote ref format `origin/feat/test-branch-name`.

Made with [Cursor](https://cursor.com)