### PR TITLE
Fix story publishing in topics dashboard

### DIFF
--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -1258,7 +1258,13 @@ class StoryContents:
         Returns:
             list(str). A list of exploration ids from published nodes.
         """
-        return self.get_all_linked_exp_ids()[: self.get_published_node_count()]
+        published_nodes_exp_ids = []
+        for node in self.get_ordered_nodes():
+            if node.status != constants.STORY_NODE_STATUS_PUBLISHED:
+                break
+            if node.exploration_id is not None:
+                published_nodes_exp_ids.append(node.exploration_id)
+        return published_nodes_exp_ids
 
     def get_published_node_count(self) -> int:
         """Returns the number of published nodes of story content.
@@ -1267,7 +1273,7 @@ class StoryContents:
             int. Number of published nodes.
         """
         published_node_count = 0
-        for node in self.nodes:
+        for node in self.get_ordered_nodes():
             if node.status != constants.STORY_NODE_STATUS_PUBLISHED:
                 break
             published_node_count += 1

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -1759,6 +1759,92 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
 
         self.assertEqual(published_node_count, 2)
 
+    def test_get_published_node_count_respects_connection_order(self) -> None:
+        self.story.story_contents.next_node_id = 'node_4'
+        node_1: story_domain.StoryNodeDict = {
+            'id': 'node_1',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'
+            ][0],
+            'thumbnail_size_in_bytes': 21131,
+            'title': 'Title 1',
+            'description': 'Description 1',
+            'destination_node_ids': ['node_2'],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': [],
+            'outline': 'a',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp_1',
+            'status': 'Published',
+            'planned_publication_date_msecs': 100,
+            'last_modified_msecs': 100,
+            'first_publication_date_msecs': None,
+            'unpublishing_reason': None,
+        }
+        node_2: story_domain.StoryNodeDict = {
+            'id': 'node_2',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'
+            ][0],
+            'thumbnail_size_in_bytes': 21131,
+            'title': 'Title 2',
+            'description': 'Description 2',
+            'destination_node_ids': ['node_3'],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': [],
+            'outline': 'a',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp_2',
+            'status': 'Draft',
+            'planned_publication_date_msecs': 100,
+            'last_modified_msecs': 100,
+            'first_publication_date_msecs': None,
+            'unpublishing_reason': None,
+        }
+        node_3: story_domain.StoryNodeDict = {
+            'id': 'node_3',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'
+            ][0],
+            'thumbnail_size_in_bytes': 21131,
+            'title': 'Title 3',
+            'description': 'Description 3',
+            'destination_node_ids': [],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': [],
+            'outline': 'a',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp_3',
+            'status': 'Published',
+            'planned_publication_date_msecs': 100,
+            'last_modified_msecs': 100,
+            'first_publication_date_msecs': None,
+            'unpublishing_reason': None,
+        }
+        # Place them out of order in the nodes list.
+        # Although node_3 is published, since it is preceded by node_2 (Draft)
+        # in the graph connection order, only node_1 should be counted
+        # as published.
+        self.story.story_contents.initial_node_id = 'node_1'
+        self.story.story_contents.nodes = [
+            story_domain.StoryNode.from_dict(node_3),
+            story_domain.StoryNode.from_dict(node_1),
+            story_domain.StoryNode.from_dict(node_2),
+        ]
+
+        published_node_count = (
+            self.story.story_contents.get_published_node_count()
+        )
+        self.assertEqual(published_node_count, 1)
+
+        exp_ids = (
+            self.story.story_contents.get_linked_exp_ids_of_published_nodes()
+        )
+        self.assertEqual(exp_ids, ['exp_1'])
+
     def test_update_story_contents_from_model_with_all_versions(self) -> None:
         node_1: story_domain.StoryNodeDict = {
             'id': 'node_1',


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes **#26291**.  
2. This PR does the following:  
   - Updates `StoryContents.get_published_node_count()` and `StoryContents.get_linked_exp_ids_of_published_nodes()` to iterate over `self.get_ordered_nodes()` instead of the unordered `self.nodes`.  
   - Adds a unit test (`test_get_published_node_count_respects_connection_order`) to verify that the published‑node count and linked exploration IDs respect the story’s connection order.  
   - Guarantees that newly published story chapters appear correctly on the learner’s dashboard (`/learn/.../story`) and that the order of published chapters matches the story graph.  
   - Improves overall reliability of the topics‑dashboard story‑publishing flow.  
3. (For bug‑fixing PRs only) The original bug occurred because the two methods above were using the raw `self.nodes` list, which does **not** reflect the story’s linear connection order. As a result the logic stopped counting at the first draft node and omitted later published nodes. This regression was introduced in **PR #18988** (commit `0b0676362f`, merged April 2024) when the helper methods were added without switching to the ordered traversal.  

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user‑facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer‑facing feature, provide
videos/screenshots of the developer‑facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single‑line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
*No UI changes; backend‑only fix. The “Proof of changes” is provided by the unit‑test output and the verification script documented in the earlier PR description.*

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend‑only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

*Not applicable – the change is backend‑only.*

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as a language written from right to left).
-->

*Not applicable – no UI modifications.*

---

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.