### PR TITLE
Fix #23452: Fix Take Tour UI bugs on the Create Exploration page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ debug.log
 
 # Puppeteer acceptance tests.
 jest-runtime-config.json
+.venv/

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -52,6 +52,15 @@
 </mat-card>
 
 <div joyrideStep="editorTabTourSlideStateInteractionEditorTab" [stepContent]="StateInteractionEditorTab">
+    <div *ngIf="!interactionIsShown" class="tour-interaction-placeholder">
+        <h3 class="oppia-editor-card-holder-heading"> Interaction </h3>
+        <div class="oppia-editable-section-mask e2e-test-state-edit-content">
+            <p>
+                You can only add interaction once you added a Content in the box above.
+            </p>
+        </div>
+    </div>
+
   <oppia-state-interaction-editor (onSaveStateContent)="sendOnSaveStateContent($event)"
                                   (onSaveInteractionData)="sendOnSaveInteractionData($event)"
                                   (onSaveNextContentIdIndex)="sendOnSaveNextContentIdIndex($event)"
@@ -61,6 +70,16 @@
   </oppia-state-interaction-editor>
 </div>
 <div joyrideStep="editorTabTourStateResponsesTab" [stepContent]="StateResponsesTab">
+
+    <div *ngIf="!interactionIdIsSet" class="tour-interaction-placeholder">
+        <h3 class="oppia-editor-card-holder-heading"> Responses </h3>
+        <div class="oppia-editable-section-mask e2e-test-state-edit-content">
+            <p>
+                You can only add response once you added a Content and Interaction from above.
+            </p>
+        </div>
+   </div>
+
   <div [hidden]="!interactionIdIsSet || currentStateIsTerminal">
     <oppia-state-responses [addState]="addState"
                            (navigateToState)="sendNavigateToState($event)"
@@ -93,9 +112,31 @@
 
 <style>
   .state-content-header-container {
-    display: none;
-    padding: 0 30px;
+    display: block;
   }
+
+  .tour-interaction-placeholder {
+      padding: 16px 16px 36px 16px;
+      border-radius: 4px;
+      text-align: center;
+      margin: 8px 0;
+      border: 1px solid #ccc;
+      background:#fff;
+      box-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
+}
+
+  .oppia-editor-card-holder-heading{
+      text-align: left;
+  }
+
+    .state-content-header{
+        padding:0 !important;
+    }
+
+    .state-content-header h3{
+       margin: 18px 0 18px 0 !important;
+        width: 100%;
+    }
 
   .state-content-header {
     align-content: center;
@@ -103,6 +144,11 @@
     display: flex;
     justify-content: space-between;
     padding: 30px 0 15px;
+  }
+
+  .oppia-editable-section-mask p{
+      color: #707070;
+      font-style: italic;
   }
 
   .state-content-header i {

--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.html
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.html
@@ -96,9 +96,6 @@
     width: -webkit-fill-available;
   }
 
-  .oppia-editor-card-with-avatar {
-    margin-top: 40px;
-  }
   .oppia-exp-interaction-card-header {
     font-size: 18px;
     margin: 0;
@@ -129,11 +126,12 @@
     align-items: center;
     display: flex;
     justify-content: space-between;
-    padding: 15px 20px;
+    padding:0;
+    margin: 18px 0;
   }
 
   .oppia-add-interaction-button-container {
-    padding: 20px 30px;
+    padding:0;
   }
 
   .oppia-exp-interaction-container {

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1573,9 +1573,9 @@ span.sort-explorations-select .sort-order {
 
 .oppia-editor-card-avatar {
   height: 36px;
-  left: -18px;
+  left: 0;
   position: absolute;
-  top: 28px;
+  top: 0;
   width: 36px;
 }
 
@@ -1627,7 +1627,7 @@ pre.oppia-pre-wrapped-text {
 }
 
 .oppia-editor-card-section {
-  padding: 20px 50px 20px 35px;
+  padding: 0 50px 0 48px !important;
   word-break: break-word;
   word-wrap: break-word;
 }
@@ -2374,6 +2374,16 @@ oppia-parameter {
   -webkit-transition: -webkit-transform .3s ease-out;
   -o-transition: -o-transform .3s ease-out;
   transition: transform .3s ease-out;
+}
+
+/* Tour modal size override */
+.joyride-step__container {
+  max-width: 450px !important;
+}
+
+.state-editor-container .mat-card{
+  width:100%;
+  padding-bottom: 36px;
 }
 
 @media(min-width: 768px) {

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
@@ -1,6 +1,8 @@
 <ng-template #EditorTabTourContainer>
-  <h3 class="e2e-test-joyride-title" tabindex="0">Creating in Oppia</h3>
-  <p tabindex="0">Explorations are learning experiences that you create using Oppia. Think of explorations as a conversation between a student and a tutor.</p>
+
+      <h3 class="e2e-test-joyride-title" tabindex="0">Creating in Oppia</h3>
+
+    <p tabindex="0">Explorations are learning experiences that you create using Oppia. Think of explorations as a conversation between a student and a tutor.</p>
 </ng-template>
 
 <ng-template #EditorTabTourTutorialComplete>
@@ -25,8 +27,10 @@
   </div>
 </ng-template>
 
-<div class="exp-editor-content-container"  joyrideStep="editorTabTourContainer" [stepContent]="EditorTabTourContainer">
+<div class="exp-editor-content-container">
   <div class="exp-editor-main-editor">
+      <span joyrideStep="editorTabTourContainer" [stepContent]="EditorTabTourContainer" stepPosition="center" style="display:none;">
+      </span>
     <div class="oppia-editor-cards-container e2e-test-editor-cards-container">
       <div class="oppia-editor-header">
         <oppia-state-name-editor></oppia-state-name-editor>
@@ -59,14 +63,18 @@
                           (onSaveSolicitAnswerDetails)="saveSolicitAnswerDetails($event)"
                           (recomputeGraph)="recomputeGraph()"
                           (navigateToState)="navigateToState($event)"
-                          (refreshWarnings)="refreshWarnings()">
+                          (refreshWarnings)="refreshWarnings()"
+                          class="state-editor-container">
       </oppia-state-editor>
     </div>
   </div>
   <div class="exp-editor-overview">
     <div class="exp-editor-overview-content">
       <oppia-exploration-graph></oppia-exploration-graph>
-      <div class="exp-editor-content-container"  joyrideStep="editorTabTourTutorialComplete" [stepContent]="EditorTabTourTutorialComplete"></div>
+      <div class="exp-editor-content-container"  >
+          <span joyrideStep="editorTabTourTutorialComplete" stepPosition="center" [stepContent]="EditorTabTourTutorialComplete" style="display:none;">
+          </span>
+      </div>
       <oppia-unresolved-answers-overview></oppia-unresolved-answers-overview>
     </div>
     <div class="exp-state-version-history">
@@ -78,11 +86,47 @@
 </div>
 
 <style>
-  .exp-editor-content-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
+
+    .state-editor-container{
+        display: flex;
+        flex-direction: column;
+        gap: 40px;
+    }
+
+    .tour-anchor-top {
+      position: absolute;
+      top: 0;
+      left: 50%;
+      width: 1px;
+      height: 1px;
+    }
+
+    .exp-editor-content-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .tour-step-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .tour-close-btn {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 16px;
+      color: #666;
+      padding: 0 4px;
+      line-height: 1;
+    }
+
+    .tour-close-btn:hover {
+        color: #000;
+    }
+
   .exp-editor-main-editor {
     margin-right: 3%;
     width: 40%;

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.spec.ts
@@ -110,6 +110,7 @@ describe('Exploration editor tab component', () => {
         ) => {
           value1({number: 1});
           value1({number: 2});
+          value1({number: 3});
           value1({number: 4});
           value1({number: 5});
           value1({number: 6});
@@ -1198,5 +1199,30 @@ describe('Exploration editor tab component', () => {
     flush();
 
     expect(component.validationErrorIsShown).toBe(true);
+  }));
+
+  it('should scroll to interaction element when tutorial reaches step 3', fakeAsync(() => {
+    stateEditorService.setActiveStateName('First State');
+    editabilityService.onStartTutorial();
+
+    component.startTutorial();
+    tick(1000);
+
+    expect(document.getElementById).toHaveBeenCalledWith(
+      'tutorialStateInteraction'
+    );
+    flush();
+  }));
+
+  it('should set tutorialInProgress to false when tutorial ends', fakeAsync(() => {
+    stateEditorService.setActiveStateName('First State');
+    editabilityService.onStartTutorial();
+    component.initStateEditor();
+
+    component.leaveTutorial();
+    expect(component.tutorialInProgress).toBe(false);
+
+    flush();
+    flush();
   }));
 });

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.ts
@@ -183,6 +183,13 @@ export class ExplorationEditorTabComponent implements OnInit, OnDestroy {
             joyrideTitle?.focus();
           }
 
+          if (value.number === 3) {
+            const element = document.getElementById('tutorialStateInteraction');
+            if (element) {
+              this.smoothScrollTo(element.offsetTop - 500, 1000);
+            }
+          }
+
           if (value.number === 4) {
             let idToScrollTo = true
               ? this._ID_TUTORIAL_PREVIEW_TAB

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
@@ -65,7 +65,7 @@
         </a>
       </li>
 
-      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'preview', 'oppia-disabled-tab': !connectedToInternet}" id="tutorialPreviewTab" class="nav-item icon nav-list-item e2e-test-preview-tab" joyrideStep="editorTabTourPreviewTab" [stepContent]="EditorTabTourPreviewTab"
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'preview', 'oppia-disabled-tab': !connectedToInternet}" id="tutorialPreviewTab" class="nav-item icon nav-list-item e2e-test-preview-tab"
           (click)="!connectedToInternet || selectPreviewTab()" [ngbTooltip]="'Preview does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
         <a class="nav-link  navbar-tab"
            [ngbTooltip]="'Preview'"
@@ -74,7 +74,7 @@
            aria-label="Exploration Preview Button"
            role="button"
            (keydown.enter)="!connectedToInternet || selectPreviewTab()">
-          <i class="fas fa-play navbar-tab-icon nav-bar-preview-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'preview'}"></i>
+          <i class="fas fa-play navbar-tab-icon nav-bar-preview-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'preview'}"  joyrideStep="editorTabTourPreviewTab" [stepContent]="EditorTabTourPreviewTab" stepPosition="bottom"></i>
         </a>
       </li>
 


### PR DESCRIPTION
## Overview

1. This PR fixes  #23452
2.This PR fixes several UI bugs in the "Take Tour" feature on the  Create Exploration page (`/create`). The tour is powered by 
ngx-joyride and had the following issues:
   - The first tour step had no close/skip button
   - Tour modals appeared in inconsistent/random positions
   - Modals were too large (stretching to 90vw on all screen sizes)
   - The interaction and responses sections were invisible during the tour, causing the modal to point at empty space
   - The preview button step was pointing to the wrong position
   - The page could scroll during the tour causing modals to 
     become misaligned
3. The original bugs occurred because:
   - Steps 1 and 7 used custom `[stepContent]` templates which  bypass joyride's default UI (including the close button), 
     while other steps used joyride's default rendering
   - `stepDefaultPosition: 'top'` was applied globally, causing modals to flip unpredictably when anchor elements were near the top of the page (e.g. the preview button in the navbar)
   - The joyride modal `max-width` of `90vw` was set inline by the library with no CSS override in the codebase
   - The interaction and responses sections used `[hidden]="!interactionIsShown"` with no placeholder, so joyride pointed at empty wrappers when no content had been added yet
   - The scroll handler for step 3 (Interaction) was missing, causing the modal to get stuck when the page was scrolled down
   - The preview `joyrideStep` was attached to a large `<li>` element with no explicit position set

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes 
      part of on line 1 above.
- [x] I have checked the "Files Changed" tab and confirmed that 
      the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #23452: Fix Take Tour UI 
      bugs on the Create Exploration page"
- [x] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

https://github.com/user-attachments/assets/35082a19-b2cd-4041-a45e-94814fb45f51

<img width="1370" height="113" alt="Screenshot 2026-06-04 at 10 24 56 pm" src="https://github.com/user-attachments/assets/7d710ec1-2dc5-4861-9533-8c3f56d3d694" />
<img width="1340" height="178" alt="Screenshot 2026-06-04 at 10 25 20 pm" src="https://github.com/user-attachments/assets/1211d3cf-37bc-4789-b06a-cda5b31ccee8" />
<img width="770" height="337" alt="Screenshot 2026-06-04 at 10 25 30 pm" src="https://github.com/user-attachments/assets/c88dbc1c-da1c-4966-9377-14b303280edf" />


## Proof of changes in Arabic language
- Please note that this is not completed. The creator dashboard has not had anay arabic language approach to it to begin with. 

##Note
* The Welcome modal (`oppia-welcome-modal`) sizing appears large on first load. This is a pre-existing issue unrelated to  this PR — the `.oppia-welcome-modal .modal-content` CSS previously had `min-height: 450px` and `height: 100%` constraints.

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
