### PR TITLE
Fix story publishing issue #26291

### DIFF
--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -1258,7 +1258,13 @@ class StoryContents:
         Returns:
             list(str). A list of exploration ids from published nodes.
         """
-        return self.get_all_linked_exp_ids()[: self.get_published_node_count()]
+        exp_ids = []
+        for node in self.get_ordered_nodes():
+            if node.status != constants.STORY_NODE_STATUS_PUBLISHED:
+                break
+            if node.exploration_id is not None:
+                exp_ids.append(node.exploration_id)
+        return exp_ids
 
     def get_published_node_count(self) -> int:
         """Returns the number of published nodes of story content.
@@ -1267,7 +1273,7 @@ class StoryContents:
             int. Number of published nodes.
         """
         published_node_count = 0
-        for node in self.nodes:
+        for node in self.get_ordered_nodes():
             if node.status != constants.STORY_NODE_STATUS_PUBLISHED:
                 break
             published_node_count += 1

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -1601,7 +1601,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             'thumbnail_size_in_bytes': 21131,
             'title': 'Title 1',
             'description': 'Description 1',
-            'destination_node_ids': ['node_4'],
+            'destination_node_ids': [],
             'acquired_skill_ids': [],
             'prerequisite_skill_ids': [],
             'outline': 'a',
@@ -1659,7 +1659,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             'thumbnail_size_in_bytes': 21131,
             'title': 'Title 1',
             'description': 'Description 1',
-            'destination_node_ids': ['node_3'],
+            'destination_node_ids': [],
             'acquired_skill_ids': [],
             'prerequisite_skill_ids': [],
             'outline': 'a',
@@ -1735,7 +1735,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             'thumbnail_size_in_bytes': 21131,
             'title': 'Title 1',
             'description': 'Description 1',
-            'destination_node_ids': ['node_4'],
+            'destination_node_ids': [],
             'acquired_skill_ids': [],
             'prerequisite_skill_ids': [],
             'outline': 'a',
@@ -1758,6 +1758,98 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         )
 
         self.assertEqual(published_node_count, 2)
+
+    def test_get_published_node_count_respects_connection_order(self) -> None:
+        # Regression test for https://github.com/oppia/oppia/issues/26291.
+        # When self.nodes is in a different order than the connection chain,
+        # both methods must follow get_ordered_nodes() so a published node
+        # that appears later in the raw list (node_3) is not counted if a
+        # draft node (node_2) sits between the initial node and it in the
+        # connection chain.
+        self.story.story_contents.next_node_id = 'node_4'
+        node_1: story_domain.StoryNodeDict = {
+            'id': 'node_1',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'
+            ][0],
+            'thumbnail_size_in_bytes': 21131,
+            'title': 'Title 1',
+            'description': 'Description 1',
+            'destination_node_ids': ['node_2'],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': [],
+            'outline': 'a',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp_1',
+            'status': 'Published',
+            'planned_publication_date_msecs': 100,
+            'last_modified_msecs': 100,
+            'first_publication_date_msecs': None,
+            'unpublishing_reason': None,
+        }
+        node_2: story_domain.StoryNodeDict = {
+            'id': 'node_2',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'
+            ][0],
+            'thumbnail_size_in_bytes': 21131,
+            'title': 'Title 2',
+            'description': 'Description 2',
+            'destination_node_ids': ['node_3'],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': [],
+            'outline': 'a',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp_2',
+            'status': 'Ready to Publish',
+            'planned_publication_date_msecs': 100,
+            'last_modified_msecs': 100,
+            'first_publication_date_msecs': None,
+            'unpublishing_reason': None,
+        }
+        node_3: story_domain.StoryNodeDict = {
+            'id': 'node_3',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'
+            ][0],
+            'thumbnail_size_in_bytes': 21131,
+            'title': 'Title 3',
+            'description': 'Description 3',
+            'destination_node_ids': [],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': [],
+            'outline': 'a',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp_3',
+            'status': 'Published',
+            'planned_publication_date_msecs': 100,
+            'last_modified_msecs': 100,
+            'first_publication_date_msecs': None,
+            'unpublishing_reason': None,
+        }
+        # Store nodes out of connection order: node_3 appears before node_1 in
+        # the raw list. Without ordered traversal, node_3 would be counted as
+        # published and the result would be wrong.
+        self.story.story_contents.nodes = [
+            story_domain.StoryNode.from_dict(node_3),
+            story_domain.StoryNode.from_dict(node_1),
+            story_domain.StoryNode.from_dict(node_2),
+        ]
+
+        published_node_count = (
+            self.story.story_contents.get_published_node_count()
+        )
+        exp_ids = (
+            self.story.story_contents.get_linked_exp_ids_of_published_nodes()
+        )
+
+        # Ordered traversal: node_1 (Published) → node_2 (draft, stop).
+        # node_3 is never reached, so only node_1 is counted.
+        self.assertEqual(published_node_count, 1)
+        self.assertEqual(exp_ids, ['exp_1'])
 
     def test_update_story_contents_from_model_with_all_versions(self) -> None:
         node_1: story_domain.StoryNodeDict = {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #26291 
2. This PR does the following: Fixes story chapters not appearing on the learner's dashboard after being published. The two methods responsible for counting published nodes and fetching their exploration IDs (get_published_node_count and get_linked_exp_ids_of_published_nodes) were iterating over self.nodes (unordered raw list) instead of self.get_ordered_nodes() (correct reading order). Both methods are updated to use get_ordered_nodes(), along with a new regression test and fixes to three existing tests that had dangling destination_node_ids.
3. (For bug-fixing PRs only) The original bug occurred because: PR #18988 (commit 0b0676362f, April 2024) refactored these two methods to iterate self.nodes directly instead of using the ordered traversal. Since self.nodes has no guaranteed order, a draft node stored after a published node in the raw list would cause the "stop at first draft" logic to fire too late, making unreachable chapters visible on the learner dashboard — or causing newly published chapters to not show up at all.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
No proof of changes needed because this is a backend-only fix with no user-facing UI changes. The fix is verified by the unit test suite:
SUCCESS   core.domain.story_domain_test: 113 tests (47.9 secs)
All tests passed
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.
N/A
References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
N/A
<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language
N/A
<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected published content identification and exploration linkage to follow learner-facing navigation order instead of raw internal data structures, ensuring nodes are properly enumerated and counted in sequence
  * Improved consistency and accuracy across content traversal operations to prevent incomplete or out-of-order results when gathering published nodes and retrieving linked exploration relationships

<!-- end of auto-generated comment: release notes by coderabbit.ai -->