### PR TITLE
Search bar moves up and down when typing

### DIFF
--- a/core/templates/pages/library-page/library-page.component.html
+++ b/core/templates/pages/library-page/library-page.component.html
@@ -77,7 +77,7 @@
   </div>
 </div>
 <div class="oppia-library-container d-flex e2e-test-library-container e2e-test-community-library">
-  <div class="oppia-library-container-inner m-auto">
+  <div class="oppia-library-container-inner mx-auto">
     <div>
       <div class="oppia-exp-summary-tiles-container" *ngIf="pageMode === LIBRARY_PAGE_MODES.SEARCH">
         <oppia-search-results></oppia-search-results>


### PR DESCRIPTION
The search bar was vertically centered due to the m-auto class on a flex container child. Changed m-auto to mx-auto so that auto margins only apply horizontally, keeping the search bar at the top regardless of the number of search results.

1. This PR fixes #20694.
2. This PR does the following: Fixes the search bar in the Community Library page, which was moving up and down while the user typed in the search field instead of staying fixed at the top of the page.
3. The original bug occurred because the search bar had the m-auto class applied to a flex container child, which caused auto margins to apply both vertically and horizontally, vertically centering the element based on available space. Changing m-auto to mx-auto restricts the auto margins to horizontal only, keeping the search bar anchored at the top regardless of the number of search results displayed.