### PR TITLE
Fix timezone handling for naive UTC datetimes

### DIFF
--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -5859,23 +5859,13 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
     SECOND_EMAIL: Final = 'abc123@gmail.com'
 
     def test_get_last_updated_by_human_ms(self) -> None:
-        original_timestamp = (
-            datetime.datetime.now(datetime.timezone.utc)
-            .replace(tzinfo=None)
-            .timestamp()
-            * 1000
-        )
+        original_timestamp = utils.get_current_time_in_millisecs()
 
         self.save_new_valid_exploration(
             self.EXP_0_ID, self.owner_id, end_state_name='End'
         )
 
-        timestamp_after_first_edit = (
-            datetime.datetime.now(datetime.timezone.utc)
-            .replace(tzinfo=None)
-            .timestamp()
-            * 1000
-        )
+        timestamp_after_first_edit = utils.get_current_time_in_millisecs()
 
         exp_services.update_exploration(
             feconf.MIGRATION_BOT_USER_ID,

--- a/core/utils.py
+++ b/core/utils.py
@@ -592,8 +592,13 @@ def get_time_in_millisecs(datetime_obj: datetime.datetime) -> float:
         float. The time in milliseconds since the Epoch.
     """
     if datetime_obj.tzinfo is None:
-        # Naive datetime from datastore. Treat it as UTC.
+        # Naive datetime (no tzinfo). Treated as UTC. This can come from
+        # NDB model fields (e.g. created_on, last_updated) which store
+        # naive UTC in the datastore.
         datetime_obj = datetime_obj.replace(tzinfo=datetime.timezone.utc)
+    else:
+        # Aware datetime. Normalize to UTC before converting.
+        datetime_obj = datetime_obj.astimezone(datetime.timezone.utc)
     return datetime_obj.timestamp() * 1000.0
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -591,6 +591,9 @@ def get_time_in_millisecs(datetime_obj: datetime.datetime) -> float:
     Returns:
         float. The time in milliseconds since the Epoch.
     """
+    if datetime_obj.tzinfo is None:
+        # Naive datetime from datastore. Treat it as UTC.
+        datetime_obj = datetime_obj.replace(tzinfo=datetime.timezone.utc)
     return datetime_obj.timestamp() * 1000.0
 
 

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -787,6 +787,32 @@ class UtilsTests(test_utils.GenericTestBase):
             ).replace(tzinfo=None),
         )
 
+    def test_get_time_in_millisecs_with_utc_aware_datetime(self) -> None:
+        dt = datetime.datetime(2020, 6, 15, tzinfo=datetime.timezone.utc)
+        msecs = utils.get_time_in_millisecs(dt)
+        self.assertEqual(
+            dt,
+            datetime.datetime.fromtimestamp(
+                msecs / 1000.0, datetime.timezone.utc
+            ),
+        )
+
+    def test_get_time_in_millisecs_with_non_utc_aware_datetime(self) -> None:
+        # A non-UTC aware datetime should be normalized to UTC correctly,
+        # not have tzinfo blindly stripped, which would corrupt the time.
+        ist = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
+        dt_ist = datetime.datetime(2020, 6, 15, 5, 30, 0, tzinfo=ist)
+        dt_utc = datetime.datetime(
+            2020, 6, 15, 0, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        msecs = utils.get_time_in_millisecs(dt_ist)
+        self.assertEqual(
+            dt_utc,
+            datetime.datetime.fromtimestamp(
+                msecs / 1000.0, datetime.timezone.utc
+            ),
+        )
+
     def test_convert_millisecs_time_to_datetime_object(self) -> None:
         msecs = 1690761600000
         dt = utils.convert_millisecs_time_to_datetime_object(msecs)

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -770,12 +770,22 @@ class UtilsTests(test_utils.GenericTestBase):
     def test_get_time_in_millisecs(self) -> None:
         dt = datetime.datetime(2020, 6, 15)
         msecs = utils.get_time_in_millisecs(dt)
-        self.assertEqual(dt, datetime.datetime.fromtimestamp(msecs / 1000.0))
+        self.assertEqual(
+            dt,
+            datetime.datetime.fromtimestamp(
+                msecs / 1000.0, datetime.timezone.utc
+            ).replace(tzinfo=None),
+        )
 
     def test_get_time_in_millisecs_with_complicated_time(self) -> None:
         dt = datetime.datetime(2020, 6, 15, 5, 18, 23, microsecond=123456)
         msecs = utils.get_time_in_millisecs(dt)
-        self.assertEqual(dt, datetime.datetime.fromtimestamp(msecs / 1000.0))
+        self.assertEqual(
+            dt,
+            datetime.datetime.fromtimestamp(
+                msecs / 1000.0, datetime.timezone.utc
+            ).replace(tzinfo=None),
+        )
 
     def test_convert_millisecs_time_to_datetime_object(self) -> None:
         msecs = 1690761600000


### PR DESCRIPTION
## Overview

1. This PR fixes  #20802 

2. This PR fixes timezone handling in `utils.get_time_in_millisecs()` for naive datetime values that represent UTC timestamps.

   Previously, `get_time_in_millisecs()` directly called `.timestamp()` on the input datetime. When the datetime object was naive, Python interpreted it using the local system timezone. This caused incorrect millisecond timestamps on non-UTC machines.

   This PR updates `get_time_in_millisecs()` so that naive datetimes are explicitly treated as UTC before being converted to milliseconds.

   This PR also updates the related tests:

   * `core/utils_test.py` now verifies that naive datetimes are converted as UTC.
   * `core/domain/exp_services_test.py` now uses `utils.get_current_time_in_millisecs()` instead of manually stripping timezone information and calling `.timestamp()`.

3. The original bug occurred because some datastore timestamps are created as naive UTC datetimes, for example through `datetime.datetime.utcnow()`. These values are UTC timestamps, but they do not contain timezone information.

   When such a naive UTC datetime was passed to `datetime.timestamp()`, Python treated it as a local-time datetime. On machines using IST, this shifted the generated timestamp by approximately 5.5 hours.

   During investigation, I found that the existing `test_get_last_updated_by_human_ms` did not catch this correctly because the test itself also stripped timezone information and called `.timestamp()` on a naive datetime. As a result, both the expected value and actual value had the same timezone shift, so the test passed even though the timestamp conversion was incorrect.

4. Now after changing `get_last_updated_by_human-ms` it correctly catches the error between the UTC and IST and after correctly catching the error I fixed `test_get_last_updated_by_human_ms` by using `utilis.get_current_time_in_millisecs`

5.While verifying the fix, `core.utils_test` initially failed on my IST setup because the existing tests converted the millisecond timestamp back using `datetime.datetime.fromtimestamp()` without passing a timezone. Python uses the local system timezone in that case, so the returned datetime was shifted by +5:30 on IST.
This failure confirmed that the old test expectation still depended on local timezone behavior. Since `utils.get_time_in_millisecs()` now treats naive datetimes as UTC, I updated the tests to convert the timestamp back using `datetime.timezone.utc` and then remove the timezone info before comparing with the original naive datetime.

<img width="1920" height="1020" alt="Screenshot 2026-06-10 180608" src="https://github.com/user-attachments/assets/58f94228-eaa6-4797-9e79-b076969a6a7c" />


## Essential Checklist

Please follow the [[instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request)](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

* [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [x] I have written tests for my code.
* [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
* [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A. This PR does not add or modify Beam jobs, and it does not directly modify production server data.

* [ ] A testing doc has been written: N/A.
* [ ] *(To be confirmed by the server admin)* All jobs in this PR have been verified on a live server, and the PR is safe to merge. N/A.

## Proof that changes are correct

This is a backend-only change, so there are no user-facing UI screenshots or videos.

I verified the fix locally by checking the timezone behavior on an IST setup. Before the fix, calling `.timestamp()` on a naive UTC datetime produced a value shifted by approximately 5.5 hours. After the fix, `utils.get_time_in_millisecs()` treats naive datetime values as UTC before converting them to milliseconds.

Verified with:

```bash
python -m scripts.run_backend_tests --test_target=core.utils_test
python -m scripts.run_backend_tests --test_target=core.domain.exp_services_test.ExplorationSnapshotUnitTests
python -m scripts.linters.run_lint_checks --files core/utils.py core/utils_test.py core/domain/exp_services_test.py
```

Before 

<img width="1804" height="1022" alt="Screenshot 2026-06-07 174740" src="https://github.com/user-attachments/assets/58b050bd-f607-4253-98d4-4eb8002663ad" />

After 

<img width="1920" height="1020" alt="Screenshot 2026-06-10 170108" src="https://github.com/user-attachments/assets/1371f294-901c-4b81-a9e7-dad1de2a9d90" />
<img width="1920" height="1020" alt="Screenshot 2026-06-10 170116" src="https://github.com/user-attachments/assets/d0676d99-3375-4213-92df-6c5999249f56" />
<img width="1804" height="1022" alt="Screenshot 2026-06-07 175406" src="https://github.com/user-attachments/assets/eec6e704-ad28-4682-ae1a-e2c0b744a27c" />
<img width="1920" height="1020" alt="Screenshot 2026-06-10 173151" src="https://github.com/user-attachments/assets/279e6649-014c-4eec-962e-fe0179e765ca" />



#### Proof of changes on desktop with slow/throttled network

N/A. This PR is backend-only and does not change any user-facing UI or network behavior.

#### Proof of changes on mobile phone

N/A. This PR is backend-only and does not change any mobile UI behavior.

#### Proof of changes in Arabic language

N/A. This PR is backend-only and does not change any UI text, layout, or RTL behavior.

## PR Pointers

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
* Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the [["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR)](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
* See the [[Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers)](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp conversion to properly handle UTC timezone for datetime values, ensuring consistent millisecond-based timestamp computation across the system.

* **Tests**
  * Updated timestamp-related tests to verify corrected timezone handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->