### PR TITLE
Fix: #16735 Removed all declare global usage from non global files

### DIFF
--- a/core/templates/services/guppy-configuration.service.spec.ts
+++ b/core/templates/services/guppy-configuration.service.spec.ts
@@ -22,12 +22,6 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 
 import {GuppyConfigurationService} from 'services/guppy-configuration.service';
 
-declare global {
-  interface Window {
-    Guppy: Guppy;
-  }
-}
-
 class MockGuppy {
   constructor(id: string, config: Object) {}
 

--- a/core/templates/services/guppy-initialization.service.spec.ts
+++ b/core/templates/services/guppy-initialization.service.spec.ts
@@ -20,12 +20,6 @@ import {TestBed} from '@angular/core/testing';
 
 import {GuppyInitializationService} from 'services/guppy-initialization.service';
 
-declare global {
-  interface Window {
-    Guppy: Guppy;
-  }
-}
-
 class MockGuppy {
   constructor(id: string, config: Object) {}
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -61,17 +61,6 @@ const acceptedBrowserAlerts = [
   'This action is irreversible. If you insist to proceed, please enter the commit message for the update',
 ];
 
-interface ClickDetails {
-  position: {x: number; y: number};
-  timeInMilliseconds: number;
-}
-
-declare global {
-  interface Window {
-    logClick: (clickDetails: ClickDetails) => void;
-  }
-}
-
 export type ModalUserInteractions = (
   _this: BaseUser,
   container: string
@@ -321,7 +310,13 @@ export class BaseUser {
   private async setupClickLogger(): Promise<void> {
     await this.page.exposeFunction(
       'logClick',
-      ({position: {x, y}, timeInMilliseconds}: ClickDetails) => {
+      ({
+        position: {x, y},
+        timeInMilliseconds,
+      }: {
+        position: {x: number; y: number};
+        timeInMilliseconds: number;
+      }) => {
         // eslint-disable-next-line no-console
         console.log(
           `- Click position { x: ${x}, y: ${y} } from top-left corner ` +

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/window-defs.d.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/window-defs.d.ts
@@ -1,7 +1,22 @@
-// Any property defined on window inside core/tests needs to be added
-// here if it is not present on the type of window. This is separate
-// from typings/custom-window-defs.d.ts because files under core/tests
-// are not included in the main tsconfig and cannot see that file.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Type definitions for properties attached to the window
+ * object within core/tests, which is excluded from the main tsconfig
+ * and therefore cannot see typings/custom-window-defs.d.ts.
+ */
 
 interface Window {
   logClick: (clickDetails: {

--- a/core/tests/puppeteer-acceptance-tests/utilities/common/window-defs.d.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/window-defs.d.ts
@@ -1,0 +1,11 @@
+// Any property defined on window inside core/tests needs to be added
+// here if it is not present on the type of window. This is separate
+// from typings/custom-window-defs.d.ts because files under core/tests
+// are not included in the main tsconfig and cannot see that file.
+
+interface Window {
+  logClick: (clickDetails: {
+    position: {x: number; y: number};
+    timeInMilliseconds: number;
+  }) => void;
+}

--- a/core/tests/root-files-config.json
+++ b/core/tests/root-files-config.json
@@ -40,6 +40,7 @@
     "core/tests/ci-test-suite-configs/README.md",
     "core/tests/puppeteer-acceptance-tests/jest.config.js",
     "core/tests/puppeteer-acceptance-tests/custom-jest-environment.js",
+    "core/tests/puppeteer-acceptance-tests/utilities/common/window-defs.d.ts",
     "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/manage-exploration-misconceptions.spec.ts"
   ],
   "RUN_ALL_TESTS_ROOT_FILES": [

--- a/extensions/objects/templates/image-editor.component.ts
+++ b/extensions/objects/templates/image-editor.component.ts
@@ -76,10 +76,6 @@ const gifshot = require('gifshot');
 // We attach GifFrames to the window and use it in our codebase and the
 // default Window interface doesn't contain "GifFrames" property. Hence we want
 // to extend the Window definition here.
-// The "declare global" is needed as we want to augment GifFrames to the
-// global scope Window as Window is a global object. Typescript interfaces only
-// union the interfaces with the same name when presented in the same scope.
-// TODO(#16735): Remove the usage of declare globals in "non-global" files.
 
 interface FilepathData {
   mode: number;

--- a/tsconfig.puppeteer-acceptance-tests.json
+++ b/tsconfig.puppeteer-acceptance-tests.json
@@ -29,6 +29,7 @@
   "include": [
     "core/tests/puppeteer-acceptance-tests/specs",
     "core/tests/puppeteer-acceptance-tests/user-utilities",
+    "core/tests/puppeteer-acceptance-tests/utilities/common/window-defs.d.ts",
     "core/tests/puppeteer-acceptance-tests/functions"
   ],
 }

--- a/typings/custom-window-defs.d.ts
+++ b/typings/custom-window-defs.d.ts
@@ -6,6 +6,10 @@ interface Window {
   __fixtures__: KarmaFixtures;
   decodeURIComponent: (encodedURIComponent: string) => string;
   encodeURIComponent: (decodedURIComponent: string) => string;
+  logClick: (clickDetails: {
+    position: {x: number; y: number};
+    timeInMilliseconds: number;
+  }) => void;
   gtag: Function;
   Base64Binary: Base64Binary;
   dataLayer: object[];

--- a/typings/custom-window-defs.d.ts
+++ b/typings/custom-window-defs.d.ts
@@ -6,10 +6,6 @@ interface Window {
   __fixtures__: KarmaFixtures;
   decodeURIComponent: (encodedURIComponent: string) => string;
   encodeURIComponent: (decodedURIComponent: string) => string;
-  logClick: (clickDetails: {
-    position: {x: number; y: number};
-    timeInMilliseconds: number;
-  }) => void;
   gtag: Function;
   Base64Binary: Base64Binary;
   dataLayer: object[];


### PR DESCRIPTION
## Overview

1. This PR fixes part of https://github.com/oppia/oppia/issues/16735.
2. This PR removes local `declare global` usage from non-global TypeScript files and moves the needed `Window` typing into the shared custom window definitions file.

   The changes are:

   * Removed local `declare global` blocks for `window.Guppy` from:

     * `core/templates/services/guppy-configuration.service.spec.ts`
     * `core/templates/services/guppy-initialization.service.spec.ts`
   * Removed the local `ClickDetails` and `window.logClick` global declaration from:

     * `core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts`
   * Added the `logClick` window typing to:

     * `typings/custom-window-defs.d.ts`
   * Removed outdated comments from:

     * `extensions/objects/templates/image-editor.component.ts`
       This keeps global `Window` type augmentation in the dedicated global typings file instead of defining it locally inside non-global files.
3. N/A. This is a cleanup/refactor PR, not a user-facing bug fix. The issue exists because some files were locally augmenting the global `Window` interface using `declare global`, even though these declarations belong in shared global typings.

## Essential Checklist

Please follow the [[instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request)](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

* [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [x] I have written tests for my code.
* [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
* [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A. This PR does not add or modify Beam jobs, and it does not modify production server data.

* [x] A testing doc has been written: N/A.
* [x] *(To be confirmed by the server admin)* All jobs in this PR have been verified on a live server, and the PR is safe to merge. N/A.

## Proof that changes are correct

This is a TypeScript typing cleanup and does not change any user-facing UI behavior. The proof of correctness is provided through frontend unit tests, TypeScript checks, and lint checks.

Verified with:


```bash
python -m scripts.run_frontend_tests --check_coverage --specs-to-run="core/templates/services/guppy-configuration.service.spec.ts,core/templates/services/guppy-initialization.service.spec.ts"
python -m scripts.run_typescript_checks
python -m scripts.linters.run_lint_checks --files core/templates/services/guppy-configuration.service.spec.ts core/templates/services/guppy-initialization.service.spec.ts core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts extensions/objects/templates/image-editor.component.ts typings/custom-window-defs.d.ts
```
<img width="1920" height="1020" alt="Screenshot 2026-06-11 235804" src="https://github.com/user-attachments/assets/1410f980-4c49-4882-a59e-3db60d26b6cf" />
<img width="1920" height="1020" alt="Screenshot 2026-06-11 235813" src="https://github.com/user-attachments/assets/dbeaa7cd-7da2-41f5-995d-be466c0eb394" />
<img width="1920" height="1020" alt="Screenshot 2026-06-11 235854" src="https://github.com/user-attachments/assets/bd60cf4b-22ee-42ba-a9d7-2e70a03d78bc" />
#### Proof of changes on desktop with slow/throttled network

N/A. This PR only changes TypeScript typings/comments and does not affect user-facing UI or network behavior.

#### Proof of changes on mobile phone

N/A. This PR only changes TypeScript typings/comments and does not affect mobile UI behavior.

#### Proof of changes in Arabic language

N/A. This PR does not change UI text, layout, translations, or RTL behavior.

## PR Pointers

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
* Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the [["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR)](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
* See the [[Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers)](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.