### PR TITLE
Fix #23384: Added CSS styles for RTL languages for the Creator Dashboard header

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -3393,7 +3393,7 @@ oppia-noninteractive-link {
 
   .oppia-dashboard-aggregated-stats .stats-card {
     font-size: 12px;
-    padding-left: 10px;
+    padding-inline-start: 10px;
   }
 }
 

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1279,9 +1279,9 @@ textarea {
 }
 
 .oppia-dashboard-aggregated-stats .stats-card {
-  border-right: 1px solid #bbb;
+  border-inline-end: 1px solid #bbb;
   margin: 10px 0;
-  padding-left: 35px;
+  padding-inline-start: 35px;
   width: 50%;
 }
 .oppia-dashboard-aggregated-stats .stats-card:last-child {

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
@@ -493,6 +493,17 @@
     padding-right: 10px;
     word-wrap: break-word;
   }
+  :host-context([dir="rtl"]) .oppia-dashboard-aggregated-stats .stats-card {
+    border-left: 2px solid #bbb;
+    border-right: none;
+    padding-right: 35px;
+  }
+  :host-context([dir="rtl"]) .oppia-creator-dashboard-main-content .stats-card .stat-description {
+    padding-right: 0px;
+  }
+  :host-context([dir="rtl"]) .oppia-dashboard-aggregated-stats .stats-card:last-child {
+    border: none;
+  }
   .oppia-creator-dashboard-main-content .stats-card .stat-value-with-rating {
     margin-top: 0;
     position: absolute;

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
@@ -499,7 +499,7 @@
     padding-right: 35px;
   }
   :host-context([dir="rtl"]) .oppia-creator-dashboard-main-content .stats-card .stat-description {
-    padding-right: 0px;
+    padding-right: 0;
   }
   :host-context([dir="rtl"]) .oppia-dashboard-aggregated-stats .stats-card:last-child {
     border: none;

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
@@ -493,17 +493,6 @@
     padding-right: 10px;
     word-wrap: break-word;
   }
-  :host-context([dir="rtl"]) .oppia-dashboard-aggregated-stats .stats-card {
-    border-left: 2px solid #bbb;
-    border-right: none;
-    padding-right: 35px;
-  }
-  :host-context([dir="rtl"]) .oppia-creator-dashboard-main-content .stats-card .stat-description {
-    padding-right: 0;
-  }
-  :host-context([dir="rtl"]) .oppia-dashboard-aggregated-stats .stats-card:last-child {
-    border: none;
-  }
   .oppia-creator-dashboard-main-content .stats-card .stat-value-with-rating {
     margin-top: 0;
     position: absolute;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #23384.
2. This PR does the following: In this PR, I have replaced physical CSS properties with their logical equivalents so the layout adapts correctly to both LTR and RTL:
- border-right → border-inline-end 
- padding-left → padding-inline-start
These logical properties automatically respect the writing direction: border-inline-end renders as border-right in LTR and border-left in RTL; padding-inline-start renders as padding-left in LTR and padding-right in RTL. This fixes the misalignment without needing any separate RTL stylesheets.
3. (For bug-fixing PRs only) The original bug occurred because: The Creator Dashboard's aggregated stats cards were misaligned when viewing in RTL (Arabic) language mode. The border-right and padding-left CSS properties are physical properties that do not flip in RTL layouts, causing the stats cards to break visually.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

Before:

<img width="1911" height="577" alt="image" src="https://github.com/user-attachments/assets/c39b5f0f-0968-45b3-a95f-ea1476e3ff75" />

After:



https://github.com/user-attachments/assets/0dfba457-87aa-4ac2-ac76-d369cf68a66b




## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creator dashboard layout for right-to-left language support with enhanced spacing and alignment of statistics cards in RTL mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->