### PR TITLE
Fix #24714: Add HTML pre/post-processing engine for machine translation Project 2.1 PR4

### DIFF
--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -30,9 +30,8 @@ import bs4
 from typing import Dict, cast
 
 # TODO(#24933): Oppia-noninteractive-skillreview is excluded because
-# its displayed value is tied to backend mappings. Rohan is working on
-# a project to translate Exploration metadata that will eventually
-# cover these keywords. Once that project is complete, this component
+# its displayed value is tied to backend mappings.
+# Once that project is complete, this component
 # can be updated to support translation.
 # See: https://github.com/oppia/oppia/issues/24933
 #
@@ -63,20 +62,29 @@ _ENCODED_HTML_ATTRS = {
     'oppia-noninteractive-workedexample': ['answer-with-value'],
 }
 
-# Data attribute names used to link extraction elements back to their
-# parent component during post-processing.
-_DATA_COMP_ID = 'data-oi-id'
-_DATA_ATTR_NAME = 'data-oi-attr'
-_DATA_IS_ENCODED = 'data-oi-encoded'
-_DATA_TAB_COUNT = 'data-oi-tab-count'
+# Regex to identify all Oppia non-interactive components in the HTML.
+_OPPIA_COMPONENT_TAG_REGEX = re.compile(r'^oppia-noninteractive-')
+
+# Temporary data attributes injected into the HTML to track extracted strings.
+# This allows the post-processing engine to know exactly which Oppia component
+# and which specific attribute the translated text belongs to so it can be restored.
+
+# The unique ID linking this temporary element back to its parent component tag.
+_TEMP_DATA_COMP_ID = 'data-temp-comp-id'
+# The name of the original attribute where this text belongs (e.g., 'text-with-value').
+_TEMP_DATA_ATTR_NAME = 'data-temp-attr-name'
+# A flag indicating if the original HTML content was encoded and needs re-encoding.
+_TEMP_DATA_IS_ENCODED = 'data-temp-is-encoded'
+# The total number of tabs extracted, needed to reconstruct the original JSON array.
+_TEMP_DATA_TAB_COUNT = 'data-temp-tab-count'
 
 # Regexes to strip all helper attributes injected during pre-processing.
 _CLEANUP_PATTERNS = [
     re.compile(r'\s*translate=["\']no["\']', re.IGNORECASE),
-    re.compile(r'\s*data-oi-id=["\'][^"\']*["\']', re.IGNORECASE),
-    re.compile(r'\s*data-oi-attr=["\'][^"\']*["\']', re.IGNORECASE),
-    re.compile(r'\s*data-oi-encoded=["\'][^"\']*["\']', re.IGNORECASE),
-    re.compile(r'\s*data-oi-tab-count=["\'][^"\']*["\']', re.IGNORECASE),
+    re.compile(r'\s*data-temp-comp-id=["\'][^"\']*["\']', re.IGNORECASE),
+    re.compile(r'\s*data-temp-attr-name=["\'][^"\']*["\']', re.IGNORECASE),
+    re.compile(r'\s*data-temp-is-encoded=["\'][^"\']*["\']', re.IGNORECASE),
+    re.compile(r'\s*data-temp-tab-count=["\'][^"\']*["\']', re.IGNORECASE),
 ]
 
 
@@ -99,7 +107,7 @@ def protect_html_for_translation(source_html: str) -> str:
     - Tabs: the JSON tab_contents array is unpacked into individual temporary
       <span> (titles) and <div> (content) elements, one per tab.
 
-    Note: <a> tags are intentionally left untouched. The Azure API natively
+    Note: <a> tags are intentionally left untouched. The modern cloud translators natively
     translates anchor text while preserving the href attribute byte-for-byte
     when using textType="html".
 
@@ -121,7 +129,7 @@ def protect_html_for_translation(source_html: str) -> str:
         counter[0] += 1
         return comp_id
 
-    for tag in soup.find_all(re.compile(r'^oppia-noninteractive-')):
+    for tag in soup.find_all(_OPPIA_COMPONENT_TAG_REGEX):
         tag_name = tag.name
 
         if tag_name in _SKIP_COMPONENTS:
@@ -137,8 +145,8 @@ def protect_html_for_translation(source_html: str) -> str:
                 attr_val = tag.get(attr_name)
                 if attr_val is not None:
                     temp_span = soup.new_tag('span')
-                    temp_span[_DATA_COMP_ID] = comp_id
-                    temp_span[_DATA_ATTR_NAME] = attr_name
+                    temp_span[_TEMP_DATA_COMP_ID] = comp_id
+                    temp_span[_TEMP_DATA_ATTR_NAME] = attr_name
                     temp_span.string = attr_val
                     tag.insert_before(temp_span)
                     del tag[attr_name]
@@ -151,9 +159,9 @@ def protect_html_for_translation(source_html: str) -> str:
                     decoded = html_module.unescape(attr_val)
                     protected_inner = protect_html_for_translation(decoded)
                     temp_div = soup.new_tag('div')
-                    temp_div[_DATA_COMP_ID] = comp_id
-                    temp_div[_DATA_ATTR_NAME] = attr_name
-                    temp_div[_DATA_IS_ENCODED] = 'true'
+                    temp_div[_TEMP_DATA_COMP_ID] = comp_id
+                    temp_div[_TEMP_DATA_ATTR_NAME] = attr_name
+                    temp_div[_TEMP_DATA_IS_ENCODED] = 'true'
                     inner_soup = bs4.BeautifulSoup(
                         protected_inner, 'html.parser'
                     )
@@ -171,8 +179,8 @@ def protect_html_for_translation(source_html: str) -> str:
                     for i, tab in enumerate(tabs):
                         if 'title' in tab:
                             temp_span = soup.new_tag('span')
-                            temp_span[_DATA_COMP_ID] = comp_id
-                            temp_span[_DATA_ATTR_NAME] = 'tab-title-%d' % i
+                            temp_span[_TEMP_DATA_COMP_ID] = comp_id
+                            temp_span[_TEMP_DATA_ATTR_NAME] = 'tab-title-%d' % i
                             temp_span.string = tab['title']
                             tag.insert_before(temp_span)
                         if 'content' in tab:
@@ -181,16 +189,18 @@ def protect_html_for_translation(source_html: str) -> str:
                                 decoded
                             )
                             temp_div = soup.new_tag('div')
-                            temp_div[_DATA_COMP_ID] = comp_id
-                            temp_div[_DATA_ATTR_NAME] = 'tab-content-%d' % i
-                            temp_div[_DATA_IS_ENCODED] = 'true'
+                            temp_div[_TEMP_DATA_COMP_ID] = comp_id
+                            temp_div[_TEMP_DATA_ATTR_NAME] = (
+                                'tab-content-%d' % i
+                            )
+                            temp_div[_TEMP_DATA_IS_ENCODED] = 'true'
                             inner_soup = bs4.BeautifulSoup(
                                 protected_inner, 'html.parser'
                             )
                             for child in list(inner_soup.contents):
                                 temp_div.append(child)
                             tag.insert_before(temp_div)
-                    tag[_DATA_TAB_COUNT] = str(len(tabs))
+                    tag[_TEMP_DATA_TAB_COUNT] = str(len(tabs))
                     del tag['tab_contents-with-value']
                 except (json.JSONDecodeError, TypeError):
                     # If JSON parsing fails, protect the whole component.
@@ -198,7 +208,7 @@ def protect_html_for_translation(source_html: str) -> str:
                         tag['translate'] = 'no'
                     continue
 
-        tag[_DATA_COMP_ID] = comp_id
+        tag[_TEMP_DATA_COMP_ID] = comp_id
         if tag.get('translate') != 'no':
             tag['translate'] = 'no'
 
@@ -211,7 +221,7 @@ def postprocess_translated_html(translated_html: str) -> str:
     """Reverses protect_html_for_translation after the API call completes.
 
     Steps:
-    1. Finds every temporary <span>/<div> by its data-oi-id and data-oi-attr.
+    1. Finds every temporary <span>/<div> by its data-temp-comp-id and data-temp-attr-name.
     2. Restores plain text values directly to the component attribute.
     3. Re-encodes inner HTML and restores it to the component attribute.
     4. Reconstructs the tabs JSON from individual temp elements.
@@ -232,17 +242,17 @@ def postprocess_translated_html(translated_html: str) -> str:
 
     # Build a map from component ID to its tag for fast restoration lookup.
     comp_id_to_tag = {}
-    for tag in soup.find_all(attrs={_DATA_COMP_ID: True}):
+    for tag in soup.find_all(attrs={_TEMP_DATA_COMP_ID: True}):
         if tag.name and tag.name.startswith('oppia-noninteractive-'):
-            comp_id_to_tag[tag.get(_DATA_COMP_ID)] = tag
+            comp_id_to_tag[tag.get(_TEMP_DATA_COMP_ID)] = tag
 
     # Collect tabs data separately since reconstruction requires all tabs.
     tabs_data: Dict[str, Dict[str, str]] = {}
 
-    for temp_tag in list(soup.find_all(attrs={_DATA_ATTR_NAME: True})):
-        comp_id = temp_tag.get(_DATA_COMP_ID)
-        attr_name = temp_tag.get(_DATA_ATTR_NAME)
-        is_encoded = temp_tag.get(_DATA_IS_ENCODED) == 'true'
+    for temp_tag in list(soup.find_all(attrs={_TEMP_DATA_ATTR_NAME: True})):
+        comp_id = temp_tag.get(_TEMP_DATA_COMP_ID)
+        attr_name = temp_tag.get(_TEMP_DATA_ATTR_NAME)
+        is_encoded = temp_tag.get(_TEMP_DATA_IS_ENCODED) == 'true'
         component_tag = comp_id_to_tag.get(comp_id)
 
         if component_tag is None:
@@ -275,11 +285,14 @@ def postprocess_translated_html(translated_html: str) -> str:
 
         temp_tag.decompose()
 
-    # Reconstruct tabs JSON from collected data.
+    # Reconstruct the tabs JSON for each tabs component. For every tab index
+    # in range(tab_count), the previously collected title and content strings
+    # are assembled into a dict and appended to the tabs list, which is then
+    # serialised back into the tab_contents-with-value attribute.
     for comp_id, tab_attr_data in tabs_data.items():
         component_tag = comp_id_to_tag.get(comp_id)
         assert component_tag is not None
-        tab_count = int(component_tag.get(_DATA_TAB_COUNT, 0))
+        tab_count = int(component_tag.get(_TEMP_DATA_TAB_COUNT, 0))
         tabs = []
         for i in range(tab_count):
             tab = {}
@@ -293,13 +306,13 @@ def postprocess_translated_html(translated_html: str) -> str:
         component_tag['tab_contents-with-value'] = json.dumps(
             tabs, ensure_ascii=False
         )
-        if _DATA_TAB_COUNT in component_tag.attrs:
-            del component_tag[_DATA_TAB_COUNT]
+        if _TEMP_DATA_TAB_COUNT in component_tag.attrs:
+            del component_tag[_TEMP_DATA_TAB_COUNT]
 
-    # Remove the data-oi-id marker from all component tags.
-    for tag in soup.find_all(attrs={_DATA_COMP_ID: True}):
-        if _DATA_COMP_ID in tag.attrs:
-            del tag[_DATA_COMP_ID]
+    # Remove the data-temp-comp-id marker from all component tags.
+    for tag in soup.find_all(attrs={_TEMP_DATA_COMP_ID: True}):
+        if _TEMP_DATA_COMP_ID in tag.attrs:
+            del tag[_TEMP_DATA_COMP_ID]
 
     # Here we use cast because BeautifulSoup's decode_contents() returns Any
     # at the type-checking level, but we know it is always a string here.

--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -88,7 +88,7 @@ _CLEANUP_PATTERNS = [
 ]
 
 
-def protect_html_for_translation(source_html: str) -> str:
+def preprocess_html_for_translation(source_html: str) -> str:
     """Pre-processes HTML to protect Oppia components from the translation
     engine while exposing translatable attribute values as inline elements.
 
@@ -157,7 +157,7 @@ def protect_html_for_translation(source_html: str) -> str:
                 attr_val = tag.get(attr_name)
                 if attr_val is not None:
                     decoded = html_module.unescape(attr_val)
-                    protected_inner = protect_html_for_translation(decoded)
+                    protected_inner = preprocess_html_for_translation(decoded)
                     temp_div = soup.new_tag('div')
                     temp_div[_TEMP_DATA_COMP_ID] = comp_id
                     temp_div[_TEMP_DATA_ATTR_NAME] = attr_name
@@ -185,7 +185,7 @@ def protect_html_for_translation(source_html: str) -> str:
                             tag.insert_before(temp_span)
                         if 'content' in tab:
                             decoded = html_module.unescape(tab['content'])
-                            protected_inner = protect_html_for_translation(
+                            protected_inner = preprocess_html_for_translation(
                                 decoded
                             )
                             temp_div = soup.new_tag('div')
@@ -218,7 +218,7 @@ def protect_html_for_translation(source_html: str) -> str:
 
 
 def postprocess_translated_html(translated_html: str) -> str:
-    """Reverses protect_html_for_translation after the API call completes.
+    """Reverses preprocess_html_for_translation after the API call completes.
 
     Steps:
     1. Finds every temporary <span>/<div> by its data-temp-comp-id and data-temp-attr-name.
@@ -325,7 +325,7 @@ def postprocess_translated_html(translated_html: str) -> str:
     # html_cleaner.clean() reparses and serializes HTML, which causes
     # entities inside the tab_contents-with-value JSON attribute to be
     # double-escaped. Nested tab content has already been recursively
-    # postprocessed and cleaned, so return the result directly when tabs
+    # postprocessed and cleaned, so return result directly when tabs
     # are present.
     if 'tab_contents-with-value' in result:
         return result

--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -1,0 +1,244 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for HTML translation pre/post-processing services."""
+
+from __future__ import annotations
+
+import json
+
+from core.domain import html_translation_services
+from core.tests import test_utils
+
+
+class ProtectHtmlForTranslationTests(test_utils.GenericTestBase):
+    """Tests for protect_html_for_translation."""
+
+    def test_returns_empty_string_unchanged(self) -> None:
+        self.assertEqual(
+            html_translation_services.protect_html_for_translation(''), ''
+        )
+
+    def test_plain_text_is_unchanged(self) -> None:
+        source = '<p>Hello world</p>'
+        self.assertEqual(
+            html_translation_services.protect_html_for_translation(source),
+            source,
+        )
+
+    def test_math_component_gets_translate_no(self) -> None:
+        source = (
+            '<p>Find the area: '
+            '<oppia-noninteractive-math math_content-with-value="x²">'
+            '</oppia-noninteractive-math></p>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('translate="no"', result)
+        self.assertIn('math_content-with-value', result)
+
+    def test_video_component_gets_translate_no(self) -> None:
+        source = (
+            '<oppia-noninteractive-video video_id-with-value="abc123">'
+            '</oppia-noninteractive-video>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('translate="no"', result)
+
+    def test_skillreview_component_gets_translate_no(self) -> None:
+        source = (
+            '<oppia-noninteractive-skillreview skill_id-with-value="abc"'
+            ' text-with-value="Fractions">'
+            '</oppia-noninteractive-skillreview>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('translate="no"', result)
+        # text-with-value should NOT be extracted for skillreview.
+        self.assertNotIn('data-oi-attr', result)
+
+    def test_link_text_extracted_url_preserved(self) -> None:
+        source = (
+            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
+            ' text-with-value="Learn more">'
+            '</oppia-noninteractive-link>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        # text-with-value extracted into a span.
+        self.assertIn('data-oi-attr="text-with-value"', result)
+        self.assertIn('Learn more', result)
+        # url-with-value preserved on the component.
+        self.assertIn('url-with-value="https://oppia.org"', result)
+        # text-with-value removed from component.
+        self.assertNotIn('oppia-noninteractive-link text-with-value', result)
+
+    def test_image_alt_and_caption_extracted(self) -> None:
+        source = (
+            '<oppia-noninteractive-image filepath-with-value="img.png"'
+            ' alt-with-value="A red car"'
+            ' caption-with-value="Figure 1">'
+            '</oppia-noninteractive-image>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="alt-with-value"', result)
+        self.assertIn('data-oi-attr="caption-with-value"', result)
+        self.assertIn('A red car', result)
+        self.assertIn('Figure 1', result)
+        # filepath must be preserved on the component.
+        self.assertIn('filepath-with-value="img.png"', result)
+
+    def test_collapsible_heading_extracted_content_protected(self) -> None:
+        source = (
+            '<oppia-noninteractive-collapsible'
+            ' heading-with-value="Show solution"'
+            ' content-with-value="&lt;p&gt;Step 1&lt;/p&gt;">'
+            '</oppia-noninteractive-collapsible>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="heading-with-value"', result)
+        self.assertIn('Show solution', result)
+        self.assertIn('data-oi-attr="content-with-value"', result)
+        self.assertIn('Step 1', result)
+
+    def test_workedexample_question_extracted_answer_protected(self) -> None:
+        source = (
+            '<oppia-noninteractive-workedexample'
+            ' question-with-value="Solve for x"'
+            ' answer-with-value="&lt;p&gt;x=5&lt;/p&gt;">'
+            '</oppia-noninteractive-workedexample>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="question-with-value"', result)
+        self.assertIn('Solve for x', result)
+        self.assertIn('data-oi-attr="answer-with-value"', result)
+        self.assertIn('x=5', result)
+
+    def test_tabs_json_unpacked_into_temp_elements(self) -> None:
+        tabs = json.dumps(
+            [{'title': 'Hint', 'content': '&lt;p&gt;Try again&lt;/p&gt;'}]
+        )
+        source = (
+            '<oppia-noninteractive-tabs tab_contents-with-value=\'%s\'>'
+            '</oppia-noninteractive-tabs>' % tabs
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="tab-title-0"', result)
+        self.assertIn('Hint', result)
+        self.assertIn('data-oi-attr="tab-content-0"', result)
+        self.assertIn('Try again', result)
+
+    def test_anchor_tag_is_not_protected(self) -> None:
+        source = '<a href="https://example.com">Click here</a>'
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertNotIn('translate="no"', result)
+        self.assertIn('href="https://example.com"', result)
+
+    def test_function_is_idempotent(self) -> None:
+        source = (
+            '<oppia-noninteractive-math math_content-with-value="x²">'
+            '</oppia-noninteractive-math>'
+        )
+        once = html_translation_services.protect_html_for_translation(source)
+        twice = html_translation_services.protect_html_for_translation(once)
+        self.assertEqual(once.count('translate="no"'), 1)
+        self.assertEqual(twice.count('translate="no"'), 1)
+
+
+class PostprocessTranslatedHtmlTests(test_utils.GenericTestBase):
+    """Tests for postprocess_translated_html."""
+
+    def test_empty_string_returns_empty_string(self) -> None:
+        self.assertEqual(
+            html_translation_services.postprocess_translated_html(''), ''
+        )
+
+    def test_strips_translate_no(self) -> None:
+        source = (
+            '<oppia-noninteractive-math translate="no"'
+            ' math_content-with-value="x²">'
+            '</oppia-noninteractive-math>'
+        )
+        result = html_translation_services.postprocess_translated_html(source)
+        self.assertNotIn('translate="no"', result)
+
+    def test_link_text_restored_url_preserved(self) -> None:
+        source = (
+            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
+            ' text-with-value="Learn more">'
+            '</oppia-noninteractive-link>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        # Simulate Azure translating the span text.
+        translated = protected.replace('Learn more', 'यहाँ और जानें')
+        result = html_translation_services.postprocess_translated_html(
+            translated
+        )
+        self.assertIn('text-with-value="यहाँ और जानें"', result)
+        self.assertIn('url-with-value="https://oppia.org"', result)
+        self.assertNotIn('data-oi-id', result)
+        self.assertNotIn('translate="no"', result)
+
+    def test_image_alt_and_caption_restored(self) -> None:
+        source = (
+            '<oppia-noninteractive-image filepath-with-value="img.png"'
+            ' alt-with-value="A red car"'
+            ' caption-with-value="Figure 1">'
+            '</oppia-noninteractive-image>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        translated = protected.replace('A red car', 'एक लाल कार').replace(
+            'Figure 1', 'चित्र 1'
+        )
+        result = html_translation_services.postprocess_translated_html(
+            translated
+        )
+        self.assertIn('alt-with-value="एक लाल कार"', result)
+        self.assertIn('caption-with-value="चित्र 1"', result)
+        self.assertIn('filepath-with-value="img.png"', result)
+
+    def test_math_component_preserved_unchanged(self) -> None:
+        source = (
+            '<oppia-noninteractive-math math_content-with-value="πr²">'
+            '</oppia-noninteractive-math>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        result = html_translation_services.postprocess_translated_html(
+            protected
+        )
+        self.assertIn('math_content-with-value="πr²"', result)
+        self.assertNotIn('translate="no"', result)
+
+    def test_full_roundtrip_with_plain_text(self) -> None:
+        source = (
+            '<p>Find the area</p>'
+            '<oppia-noninteractive-math math_content-with-value="πr²">'
+            '</oppia-noninteractive-math>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        translated = protected.replace('Find the area', 'Finde die Fläche')
+        result = html_translation_services.postprocess_translated_html(
+            translated
+        )
+        self.assertIn('Finde die Fläche', result)
+        self.assertIn('math_content-with-value="πr²"', result)
+        self.assertNotIn('translate="no"', result)
+        self.assertNotIn('data-oi-id', result)

--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -278,8 +278,6 @@ def postprocess_translated_html(translated_html: str) -> str:
     # Reconstruct tabs JSON from collected data.
     for comp_id, tab_attr_data in tabs_data.items():
         component_tag = comp_id_to_tag.get(comp_id)
-        if component_tag is None:
-            continue
         tab_count = int(component_tag.get(_DATA_TAB_COUNT, 0))
         tabs = []
         for i in range(tab_count):

--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -24,25 +24,24 @@ import html as html_module
 import json
 import re
 
-import bs4
-
 from core.domain import html_cleaner
 
+import bs4
 from typing import Dict, cast
 
-
+# TODO(#24933): Oppia-noninteractive-skillreview is excluded because
+# its displayed value is tied to backend mappings. Rohan is working on
+# a project to translate Exploration metadata that will eventually
+# cover these keywords. Once that project is complete, this component
+# can be updated to support translation.
+# See: https://github.com/oppia/oppia/issues/24933
+#
 # Components whose content must never be translated. Their attributes are
 # either technical identifiers, LaTeX expressions, or backend-mapped values.
 _SKIP_COMPONENTS = frozenset(
     [
         'oppia-noninteractive-math',
         'oppia-noninteractive-video',
-        # TODO(#24933): oppia-noninteractive-skillreview is excluded because
-        # its displayed value is tied to backend mappings. Rohan is working on
-        # a project to translate Exploration metadata that will eventually
-        # cover these keywords. Once that project is complete, this component
-        # can be updated to support translation.
-        # See: https://github.com/oppia/oppia/issues/24933
         'oppia-noninteractive-skillreview',
     ]
 )
@@ -203,7 +202,9 @@ def protect_html_for_translation(source_html: str) -> str:
         if tag.get('translate') != 'no':
             tag['translate'] = 'no'
 
-    return soup.decode_contents()
+    # Here we use cast because BeautifulSoup's decode_contents() is typed as
+    # returning Any in the bs4 stubs, but it always returns a str in practice.
+    return cast(str, soup.decode_contents())
 
 
 def postprocess_translated_html(translated_html: str) -> str:
@@ -301,14 +302,14 @@ def postprocess_translated_html(translated_html: str) -> str:
         if _DATA_COMP_ID in tag.attrs:
             del tag[_DATA_COMP_ID]
 
-    result = soup.decode_contents()
+    # Here we use cast because BeautifulSoup's decode_contents() returns Any
+    # at the type-checking level, but we know it is always a string here.
+    result = cast(str, soup.decode_contents())
 
     # Strip all temporary helper attributes using regex.
     for pattern in _CLEANUP_PATTERNS:
         result = pattern.sub('', result)
-        # Here we use cast because html_cleaner.clean() returns Any at the
-        #  type-checking level, but we know the returned value is always str.
-        return cast(str, html_cleaner.clean(result))
+    return html_cleaner.clean(result)
 
 
 def _encode_attr_html(html_fragment: str) -> str:

--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -268,7 +268,7 @@ def postprocess_translated_html(translated_html: str) -> str:
         # Restore encoded HTML attributes.
         if is_encoded:
             inner_html = postprocess_translated_html(temp_tag.decode_contents())
-            component_tag[attr_name] = _encode_attr_html(inner_html)
+            component_tag[attr_name] = inner_html
         else:
             # Restore plain text attributes.
             component_tag[attr_name] = temp_tag.get_text()
@@ -289,7 +289,7 @@ def postprocess_translated_html(translated_html: str) -> str:
             if title_val is not None:
                 tab['title'] = title_val
             if content_val is not None:
-                tab['content'] = _encode_attr_html(content_val)
+                tab['content'] = content_val
             tabs.append(tab)
         component_tag['tab_contents-with-value'] = json.dumps(
             tabs, ensure_ascii=False
@@ -309,21 +309,12 @@ def postprocess_translated_html(translated_html: str) -> str:
     # Strip all temporary helper attributes using regex.
     for pattern in _CLEANUP_PATTERNS:
         result = pattern.sub('', result)
+
+    # html_cleaner.clean() reparses and serializes HTML, which causes
+    # entities inside the tab_contents-with-value JSON attribute to be
+    # double-escaped. Nested tab content has already been recursively
+    # postprocessed and cleaned, so return the result directly when tabs
+    # are present.
+    if 'tab_contents-with-value' in result:
+        return result
     return html_cleaner.clean(result)
-
-
-def _encode_attr_html(html_fragment: str) -> str:
-    """HTML-encodes a string for safe storage inside an attribute value.
-
-    Args:
-        html_fragment: str. A raw HTML string.
-
-    Returns:
-        str. The HTML-entity-encoded string.
-    """
-    return (
-        html_fragment.replace('&', '&amp;')
-        .replace('<', '&lt;')
-        .replace('>', '&gt;')
-        .replace('"', '&quot;')
-    )

--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -278,6 +278,7 @@ def postprocess_translated_html(translated_html: str) -> str:
     # Reconstruct tabs JSON from collected data.
     for comp_id, tab_attr_data in tabs_data.items():
         component_tag = comp_id_to_tag.get(comp_id)
+        assert component_tag is not None
         tab_count = int(component_tag.get(_DATA_TAB_COUNT, 0))
         tabs = []
         for i in range(tab_count):

--- a/core/domain/html_translation_services.py
+++ b/core/domain/html_translation_services.py
@@ -14,231 +14,315 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for HTML translation pre/post-processing services."""
+"""Services for HTML pre-processing and post-processing for machine
+translation.
+"""
 
 from __future__ import annotations
 
+import html as html_module
 import json
+import re
 
-from core.domain import html_translation_services
-from core.tests import test_utils
+import bs4
 
+from core.domain import html_cleaner
 
-class ProtectHtmlForTranslationTests(test_utils.GenericTestBase):
-    """Tests for protect_html_for_translation."""
-
-    def test_returns_empty_string_unchanged(self) -> None:
-        self.assertEqual(
-            html_translation_services.protect_html_for_translation(''), ''
-        )
-
-    def test_plain_text_is_unchanged(self) -> None:
-        source = '<p>Hello world</p>'
-        self.assertEqual(
-            html_translation_services.protect_html_for_translation(source),
-            source,
-        )
-
-    def test_math_component_gets_translate_no(self) -> None:
-        source = (
-            '<p>Find the area: '
-            '<oppia-noninteractive-math math_content-with-value="x²">'
-            '</oppia-noninteractive-math></p>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('translate="no"', result)
-        self.assertIn('math_content-with-value', result)
-
-    def test_video_component_gets_translate_no(self) -> None:
-        source = (
-            '<oppia-noninteractive-video video_id-with-value="abc123">'
-            '</oppia-noninteractive-video>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('translate="no"', result)
-
-    def test_skillreview_component_gets_translate_no(self) -> None:
-        source = (
-            '<oppia-noninteractive-skillreview skill_id-with-value="abc"'
-            ' text-with-value="Fractions">'
-            '</oppia-noninteractive-skillreview>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('translate="no"', result)
-        # text-with-value should NOT be extracted for skillreview.
-        self.assertNotIn('data-oi-attr', result)
-
-    def test_link_text_extracted_url_preserved(self) -> None:
-        source = (
-            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
-            ' text-with-value="Learn more">'
-            '</oppia-noninteractive-link>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        # text-with-value extracted into a span.
-        self.assertIn('data-oi-attr="text-with-value"', result)
-        self.assertIn('Learn more', result)
-        # url-with-value preserved on the component.
-        self.assertIn('url-with-value="https://oppia.org"', result)
-        # text-with-value removed from component.
-        self.assertNotIn('oppia-noninteractive-link text-with-value', result)
-
-    def test_image_alt_and_caption_extracted(self) -> None:
-        source = (
-            '<oppia-noninteractive-image filepath-with-value="img.png"'
-            ' alt-with-value="A red car"'
-            ' caption-with-value="Figure 1">'
-            '</oppia-noninteractive-image>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="alt-with-value"', result)
-        self.assertIn('data-oi-attr="caption-with-value"', result)
-        self.assertIn('A red car', result)
-        self.assertIn('Figure 1', result)
-        # filepath must be preserved on the component.
-        self.assertIn('filepath-with-value="img.png"', result)
-
-    def test_collapsible_heading_extracted_content_protected(self) -> None:
-        source = (
-            '<oppia-noninteractive-collapsible'
-            ' heading-with-value="Show solution"'
-            ' content-with-value="&lt;p&gt;Step 1&lt;/p&gt;">'
-            '</oppia-noninteractive-collapsible>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="heading-with-value"', result)
-        self.assertIn('Show solution', result)
-        self.assertIn('data-oi-attr="content-with-value"', result)
-        self.assertIn('Step 1', result)
-
-    def test_workedexample_question_extracted_answer_protected(self) -> None:
-        source = (
-            '<oppia-noninteractive-workedexample'
-            ' question-with-value="Solve for x"'
-            ' answer-with-value="&lt;p&gt;x=5&lt;/p&gt;">'
-            '</oppia-noninteractive-workedexample>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="question-with-value"', result)
-        self.assertIn('Solve for x', result)
-        self.assertIn('data-oi-attr="answer-with-value"', result)
-        self.assertIn('x=5', result)
-
-    def test_tabs_json_unpacked_into_temp_elements(self) -> None:
-        tabs = json.dumps(
-            [{'title': 'Hint', 'content': '&lt;p&gt;Try again&lt;/p&gt;'}]
-        )
-        source = (
-            '<oppia-noninteractive-tabs tab_contents-with-value=\'%s\'>'
-            '</oppia-noninteractive-tabs>' % tabs
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="tab-title-0"', result)
-        self.assertIn('Hint', result)
-        self.assertIn('data-oi-attr="tab-content-0"', result)
-        self.assertIn('Try again', result)
-
-    def test_anchor_tag_is_not_protected(self) -> None:
-        source = '<a href="https://example.com">Click here</a>'
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertNotIn('translate="no"', result)
-        self.assertIn('href="https://example.com"', result)
-
-    def test_function_is_idempotent(self) -> None:
-        source = (
-            '<oppia-noninteractive-math math_content-with-value="x²">'
-            '</oppia-noninteractive-math>'
-        )
-        once = html_translation_services.protect_html_for_translation(source)
-        twice = html_translation_services.protect_html_for_translation(once)
-        self.assertEqual(once.count('translate="no"'), 1)
-        self.assertEqual(twice.count('translate="no"'), 1)
+from typing import Dict, cast
 
 
-class PostprocessTranslatedHtmlTests(test_utils.GenericTestBase):
-    """Tests for postprocess_translated_html."""
+# Components whose content must never be translated. Their attributes are
+# either technical identifiers, LaTeX expressions, or backend-mapped values.
+_SKIP_COMPONENTS = frozenset(
+    [
+        'oppia-noninteractive-math',
+        'oppia-noninteractive-video',
+        # TODO(#24933): oppia-noninteractive-skillreview is excluded because
+        # its displayed value is tied to backend mappings. Rohan is working on
+        # a project to translate Exploration metadata that will eventually
+        # cover these keywords. Once that project is complete, this component
+        # can be updated to support translation.
+        # See: https://github.com/oppia/oppia/issues/24933
+        'oppia-noninteractive-skillreview',
+    ]
+)
 
-    def test_empty_string_returns_empty_string(self) -> None:
-        self.assertEqual(
-            html_translation_services.postprocess_translated_html(''), ''
-        )
+# Maps each component to the attribute names that hold plain learner-visible
+# text. These values are extracted before translation and restored after.
+_TRANSLATABLE_TEXT_ATTRS = {
+    'oppia-noninteractive-link': ['text-with-value'],
+    'oppia-noninteractive-image': ['alt-with-value', 'caption-with-value'],
+    'oppia-noninteractive-collapsible': ['heading-with-value'],
+    'oppia-noninteractive-workedexample': ['question-with-value'],
+}
 
-    def test_strips_translate_no(self) -> None:
-        source = (
-            '<oppia-noninteractive-math translate="no"'
-            ' math_content-with-value="x²">'
-            '</oppia-noninteractive-math>'
-        )
-        result = html_translation_services.postprocess_translated_html(source)
-        self.assertNotIn('translate="no"', result)
+# Maps each component to the attribute names that hold HTML-encoded strings.
+# These must be decoded, recursively pre-processed, then re-encoded on
+# the way back.
+_ENCODED_HTML_ATTRS = {
+    'oppia-noninteractive-collapsible': ['content-with-value'],
+    'oppia-noninteractive-workedexample': ['answer-with-value'],
+}
 
-    def test_link_text_restored_url_preserved(self) -> None:
-        source = (
-            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
-            ' text-with-value="Learn more">'
-            '</oppia-noninteractive-link>'
-        )
-        protected = html_translation_services.protect_html_for_translation(
-            source
-        )
-        # Simulate Azure translating the span text.
-        translated = protected.replace('Learn more', 'यहाँ और जानें')
-        result = html_translation_services.postprocess_translated_html(
-            translated
-        )
-        self.assertIn('text-with-value="यहाँ और जानें"', result)
-        self.assertIn('url-with-value="https://oppia.org"', result)
-        self.assertNotIn('data-oi-id', result)
-        self.assertNotIn('translate="no"', result)
+# Data attribute names used to link extraction elements back to their
+# parent component during post-processing.
+_DATA_COMP_ID = 'data-oi-id'
+_DATA_ATTR_NAME = 'data-oi-attr'
+_DATA_IS_ENCODED = 'data-oi-encoded'
+_DATA_TAB_COUNT = 'data-oi-tab-count'
 
-    def test_image_alt_and_caption_restored(self) -> None:
-        source = (
-            '<oppia-noninteractive-image filepath-with-value="img.png"'
-            ' alt-with-value="A red car"'
-            ' caption-with-value="Figure 1">'
-            '</oppia-noninteractive-image>'
-        )
-        protected = html_translation_services.protect_html_for_translation(
-            source
-        )
-        translated = protected.replace('A red car', 'एक लाल कार').replace(
-            'Figure 1', 'चित्र 1'
-        )
-        result = html_translation_services.postprocess_translated_html(
-            translated
-        )
-        self.assertIn('alt-with-value="एक लाल कार"', result)
-        self.assertIn('caption-with-value="चित्र 1"', result)
-        self.assertIn('filepath-with-value="img.png"', result)
+# Regexes to strip all helper attributes injected during pre-processing.
+_CLEANUP_PATTERNS = [
+    re.compile(r'\s*translate=["\']no["\']', re.IGNORECASE),
+    re.compile(r'\s*data-oi-id=["\'][^"\']*["\']', re.IGNORECASE),
+    re.compile(r'\s*data-oi-attr=["\'][^"\']*["\']', re.IGNORECASE),
+    re.compile(r'\s*data-oi-encoded=["\'][^"\']*["\']', re.IGNORECASE),
+    re.compile(r'\s*data-oi-tab-count=["\'][^"\']*["\']', re.IGNORECASE),
+]
 
-    def test_math_component_preserved_unchanged(self) -> None:
-        source = (
-            '<oppia-noninteractive-math math_content-with-value="πr²">'
-            '</oppia-noninteractive-math>'
-        )
-        protected = html_translation_services.protect_html_for_translation(
-            source
-        )
-        result = html_translation_services.postprocess_translated_html(
-            protected
-        )
-        self.assertIn('math_content-with-value="πr²"', result)
-        self.assertNotIn('translate="no"', result)
 
-    def test_full_roundtrip_with_plain_text(self) -> None:
-        source = (
-            '<p>Find the area</p>'
-            '<oppia-noninteractive-math math_content-with-value="πr²">'
-            '</oppia-noninteractive-math>'
+def protect_html_for_translation(source_html: str) -> str:
+    """Pre-processes HTML to protect Oppia components from the translation
+    engine while exposing translatable attribute values as inline elements.
+
+    Strategy per component type:
+    - Skip components (math, video, skillreview): marked with translate="no",
+      their entire subtree is skipped by the API.
+    - Components with translatable text attributes (link, image, collapsible,
+      workedexample): each translatable attribute value is extracted into a
+      temporary <span> inserted before the component, and the attribute is
+      removed from the component tag itself. The component receives
+      translate="no" so only its structural attributes are preserved.
+    - Components with encoded HTML attributes (collapsible content,
+      workedexample answer): decoded, recursively pre-processed, and
+      placed in a temporary <div> before the component. Re-encoded on
+      the way back in post-processing.
+    - Tabs: the JSON tab_contents array is unpacked into individual temporary
+      <span> (titles) and <div> (content) elements, one per tab.
+
+    Note: <a> tags are intentionally left untouched. The Azure API natively
+    translates anchor text while preserving the href attribute byte-for-byte
+    when using textType="html".
+
+    Args:
+        source_html: str. The raw HTML string to pre-process.
+
+    Returns:
+        str. The modified HTML string ready to be sent to the translation API.
+    """
+    if not source_html or not source_html.strip():
+        return source_html
+
+    soup = bs4.BeautifulSoup(source_html, 'html.parser')
+    counter = [0]
+
+    def _next_id() -> str:
+        """Returns the next unique component ID."""
+        comp_id = str(counter[0])
+        counter[0] += 1
+        return comp_id
+
+    for tag in soup.find_all(re.compile(r'^oppia-noninteractive-')):
+        tag_name = tag.name
+
+        if tag_name in _SKIP_COMPONENTS:
+            if tag.get('translate') != 'no':
+                tag['translate'] = 'no'
+            continue
+
+        comp_id = _next_id()
+
+        # Extract simple text attributes into temp spans.
+        if tag_name in _TRANSLATABLE_TEXT_ATTRS:
+            for attr_name in _TRANSLATABLE_TEXT_ATTRS[tag_name]:
+                attr_val = tag.get(attr_name)
+                if attr_val is not None:
+                    temp_span = soup.new_tag('span')
+                    temp_span[_DATA_COMP_ID] = comp_id
+                    temp_span[_DATA_ATTR_NAME] = attr_name
+                    temp_span.string = attr_val
+                    tag.insert_before(temp_span)
+                    del tag[attr_name]
+
+        # Extract encoded HTML attributes into temp divs.
+        if tag_name in _ENCODED_HTML_ATTRS:
+            for attr_name in _ENCODED_HTML_ATTRS[tag_name]:
+                attr_val = tag.get(attr_name)
+                if attr_val is not None:
+                    decoded = html_module.unescape(attr_val)
+                    protected_inner = protect_html_for_translation(decoded)
+                    temp_div = soup.new_tag('div')
+                    temp_div[_DATA_COMP_ID] = comp_id
+                    temp_div[_DATA_ATTR_NAME] = attr_name
+                    temp_div[_DATA_IS_ENCODED] = 'true'
+                    inner_soup = bs4.BeautifulSoup(
+                        protected_inner, 'html.parser'
+                    )
+                    for child in list(inner_soup.contents):
+                        temp_div.append(child)
+                    tag.insert_before(temp_div)
+                    del tag[attr_name]
+
+        # Unpack tabs JSON into individual temp elements.
+        if tag_name == 'oppia-noninteractive-tabs':
+            tabs_raw = tag.get('tab_contents-with-value')
+            if tabs_raw is not None:
+                try:
+                    tabs = json.loads(tabs_raw)
+                    for i, tab in enumerate(tabs):
+                        if 'title' in tab:
+                            temp_span = soup.new_tag('span')
+                            temp_span[_DATA_COMP_ID] = comp_id
+                            temp_span[_DATA_ATTR_NAME] = 'tab-title-%d' % i
+                            temp_span.string = tab['title']
+                            tag.insert_before(temp_span)
+                        if 'content' in tab:
+                            decoded = html_module.unescape(tab['content'])
+                            protected_inner = protect_html_for_translation(
+                                decoded
+                            )
+                            temp_div = soup.new_tag('div')
+                            temp_div[_DATA_COMP_ID] = comp_id
+                            temp_div[_DATA_ATTR_NAME] = 'tab-content-%d' % i
+                            temp_div[_DATA_IS_ENCODED] = 'true'
+                            inner_soup = bs4.BeautifulSoup(
+                                protected_inner, 'html.parser'
+                            )
+                            for child in list(inner_soup.contents):
+                                temp_div.append(child)
+                            tag.insert_before(temp_div)
+                    tag[_DATA_TAB_COUNT] = str(len(tabs))
+                    del tag['tab_contents-with-value']
+                except (json.JSONDecodeError, TypeError):
+                    # If JSON parsing fails, protect the whole component.
+                    if tag.get('translate') != 'no':
+                        tag['translate'] = 'no'
+                    continue
+
+        tag[_DATA_COMP_ID] = comp_id
+        if tag.get('translate') != 'no':
+            tag['translate'] = 'no'
+
+    return soup.decode_contents()
+
+
+def postprocess_translated_html(translated_html: str) -> str:
+    """Reverses protect_html_for_translation after the API call completes.
+
+    Steps:
+    1. Finds every temporary <span>/<div> by its data-oi-id and data-oi-attr.
+    2. Restores plain text values directly to the component attribute.
+    3. Re-encodes inner HTML and restores it to the component attribute.
+    4. Reconstructs the tabs JSON from individual temp elements.
+    5. Removes all temporary elements and helper data attributes.
+    6. Strips any remaining translate="no" via regex.
+    7. Runs the result through html_cleaner.clean() for final sanitization.
+
+    Args:
+        translated_html: str. The raw HTML returned by the translation API.
+
+    Returns:
+        str. The cleaned and restored HTML string safe for datastore storage.
+    """
+    if not translated_html:
+        return translated_html
+
+    soup = bs4.BeautifulSoup(translated_html, 'html.parser')
+
+    # Build a map from component ID to its tag for fast restoration lookup.
+    comp_id_to_tag = {}
+    for tag in soup.find_all(attrs={_DATA_COMP_ID: True}):
+        if tag.name and tag.name.startswith('oppia-noninteractive-'):
+            comp_id_to_tag[tag.get(_DATA_COMP_ID)] = tag
+
+    # Collect tabs data separately since reconstruction requires all tabs.
+    tabs_data: Dict[str, Dict[str, str]] = {}
+
+    for temp_tag in list(soup.find_all(attrs={_DATA_ATTR_NAME: True})):
+        comp_id = temp_tag.get(_DATA_COMP_ID)
+        attr_name = temp_tag.get(_DATA_ATTR_NAME)
+        is_encoded = temp_tag.get(_DATA_IS_ENCODED) == 'true'
+        component_tag = comp_id_to_tag.get(comp_id)
+
+        if component_tag is None:
+            temp_tag.decompose()
+            continue
+
+        # Collect tabs data for later JSON reconstruction.
+        if attr_name and (
+            attr_name.startswith('tab-title-')
+            or attr_name.startswith('tab-content-')
+        ):
+            if comp_id not in tabs_data:
+                tabs_data[comp_id] = {}
+            if is_encoded:
+                tabs_data[comp_id][attr_name] = postprocess_translated_html(
+                    temp_tag.decode_contents()
+                )
+            else:
+                tabs_data[comp_id][attr_name] = temp_tag.get_text()
+            temp_tag.decompose()
+            continue
+
+        # Restore encoded HTML attributes.
+        if is_encoded:
+            inner_html = postprocess_translated_html(temp_tag.decode_contents())
+            component_tag[attr_name] = _encode_attr_html(inner_html)
+        else:
+            # Restore plain text attributes.
+            component_tag[attr_name] = temp_tag.get_text()
+
+        temp_tag.decompose()
+
+    # Reconstruct tabs JSON from collected data.
+    for comp_id, tab_attr_data in tabs_data.items():
+        component_tag = comp_id_to_tag.get(comp_id)
+        if component_tag is None:
+            continue
+        tab_count = int(component_tag.get(_DATA_TAB_COUNT, 0))
+        tabs = []
+        for i in range(tab_count):
+            tab = {}
+            title_val = tab_attr_data.get('tab-title-%d' % i)
+            content_val = tab_attr_data.get('tab-content-%d' % i)
+            if title_val is not None:
+                tab['title'] = title_val
+            if content_val is not None:
+                tab['content'] = _encode_attr_html(content_val)
+            tabs.append(tab)
+        component_tag['tab_contents-with-value'] = json.dumps(
+            tabs, ensure_ascii=False
         )
-        protected = html_translation_services.protect_html_for_translation(
-            source
-        )
-        translated = protected.replace('Find the area', 'Finde die Fläche')
-        result = html_translation_services.postprocess_translated_html(
-            translated
-        )
-        self.assertIn('Finde die Fläche', result)
-        self.assertIn('math_content-with-value="πr²"', result)
-        self.assertNotIn('translate="no"', result)
-        self.assertNotIn('data-oi-id', result)
+        if _DATA_TAB_COUNT in component_tag.attrs:
+            del component_tag[_DATA_TAB_COUNT]
+
+    # Remove the data-oi-id marker from all component tags.
+    for tag in soup.find_all(attrs={_DATA_COMP_ID: True}):
+        if _DATA_COMP_ID in tag.attrs:
+            del tag[_DATA_COMP_ID]
+
+    result = soup.decode_contents()
+
+    # Strip all temporary helper attributes using regex.
+    for pattern in _CLEANUP_PATTERNS:
+        result = pattern.sub('', result)
+        # Here we use cast because html_cleaner.clean() returns Any at the
+        #  type-checking level, but we know the returned value is always str.
+        return cast(str, html_cleaner.clean(result))
+
+
+def _encode_attr_html(html_fragment: str) -> str:
+    """HTML-encodes a string for safe storage inside an attribute value.
+
+    Args:
+        html_fragment: str. A raw HTML string.
+
+    Returns:
+        str. The HTML-entity-encoded string.
+    """
+    return (
+        html_fragment.replace('&', '&amp;')
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')
+        .replace('"', '&quot;')
+    )

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -204,15 +204,6 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertNotIn('data-oi-id', result)
         self.assertNotIn('Orphan', result)
 
-    def test_missing_component_tag_for_tabs_data_skips_gracefully(self) -> None:
-        source = (
-            '<span data-oi-id="100" data-oi-attr="tab-title-0">Title</span>'
-            '<div data-oi-id="100" data-oi-attr="tab-content-0" '
-            'data-oi-encoded="true">&lt;p&gt;Content&lt;/p&gt;</div>'
-        )
-        restored = html_translation_services.postprocess_translated_html(source)
-        self.assertEqual(restored, '')
-
     def test_translatable_text_attr_with_none_value_is_skipped(self) -> None:
         soup = bs4.BeautifulSoup(
             '<oppia-noninteractive-link></oppia-noninteractive-link>',

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -31,10 +31,11 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
 
     def test_protect_html_with_empty_string_returns_empty_string(self) -> None:
         self.assertEqual(
-            html_translation_services.protect_html_for_translation(''), ''
+            html_translation_services.preprocess_html_for_translation(''), ''
         )
         self.assertEqual(
-            html_translation_services.protect_html_for_translation('   '), '   '
+            html_translation_services.preprocess_html_for_translation('   '),
+            '   ',
         )
         self.assertEqual(
             html_translation_services.postprocess_translated_html(''), ''
@@ -52,7 +53,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '</oppia-noninteractive-skillreview>'
             '<oppia-noninteractive-math translate="no"></oppia-noninteractive-math>'
         )
-        result = html_translation_services.protect_html_for_translation(source)
+        result = html_translation_services.preprocess_html_for_translation(
+            source
+        )
         self.assertEqual(result.count('translate="no"'), 4)
 
     def test_process_html_with_translatable_text_attributes_extracts_and_restores_values(
@@ -62,7 +65,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-link url-with-value="https://oppia.org" '
             'text-with-value="Learn more"></oppia-noninteractive-link>'
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertIn('data-temp-attr-name="text-with-value"', protected)
@@ -81,7 +84,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             'alt-with-value="A red car" caption-with-value="Figure 1">'
             '</oppia-noninteractive-image>'
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         restored = html_translation_services.postprocess_translated_html(
@@ -98,7 +101,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             'content-with-value="&lt;p&gt;Step 1&lt;/p&gt;">'
             '</oppia-noninteractive-collapsible>'
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertIn('data-temp-is-encoded="true"', protected)
@@ -118,7 +121,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             'answer-with-value="&lt;p&gt;A1&lt;/p&gt;">'
             '</oppia-noninteractive-workedexample>'
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         restored = html_translation_services.postprocess_translated_html(
@@ -140,7 +143,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-tabs tab_contents-with-value=\'%s\'>'
             '</oppia-noninteractive-tabs>' % tabs
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertIn('tab-title-0', protected)
@@ -159,7 +162,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-tabs tab_contents-with-value="invalid">'
             '</oppia-noninteractive-tabs>'
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertIn('translate="no"', protected)
@@ -168,7 +171,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-tabs tab_contents-with-value="invalid" '
             'translate="no"></oppia-noninteractive-tabs>'
         )
-        protected2 = html_translation_services.protect_html_for_translation(
+        protected2 = html_translation_services.preprocess_html_for_translation(
             source_with_no
         )
         self.assertIn('translate="no"', protected2)
@@ -182,7 +185,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-tabs tab_contents-with-value="null">'
             '</oppia-noninteractive-tabs>'
         )
-        result = html_translation_services.protect_html_for_translation(source)
+        result = html_translation_services.preprocess_html_for_translation(
+            source
+        )
         self.assertIn('translate="no"', result)
         self.assertNotIn('data-temp-attr-name', result)
 
@@ -239,7 +244,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         tag = soup.find('oppia-noninteractive-link')
         self.assertIsNone(tag.get('text-with-value'))
         source = '<oppia-noninteractive-link></oppia-noninteractive-link>'
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertNotIn('data-temp-attr-name', protected)
@@ -251,7 +256,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-collapsible>'
             '</oppia-noninteractive-collapsible>'
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertNotIn('data-temp-attr-name', protected)
@@ -269,7 +274,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-tabs tab_contents-with-value=\'%s\'>'
             '</oppia-noninteractive-tabs>' % tabs
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertIn('tab-content-0', protected)
@@ -309,7 +314,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             '<oppia-noninteractive-tabs tab_contents-with-value="123">'
             '</oppia-noninteractive-tabs>'
         )
-        protected = html_translation_services.protect_html_for_translation(
+        protected = html_translation_services.preprocess_html_for_translation(
             source
         )
         self.assertIn('translate="no"', protected)

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -23,6 +23,8 @@ import json
 from core.domain import html_translation_services
 from core.tests import test_utils
 
+import bs4
+
 
 class HtmlTranslationServicesTests(test_utils.GenericTestBase):
     """Tests for HTML translation services."""
@@ -210,3 +212,73 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         )
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
+
+    def test_translatable_text_attr_with_none_value_is_skipped(self) -> None:
+        soup = bs4.BeautifulSoup(
+            '<oppia-noninteractive-link></oppia-noninteractive-link>',
+            'html.parser',
+        )
+        tag = soup.find('oppia-noninteractive-link')
+        self.assertIsNone(tag.get('text-with-value'))
+        source = '<oppia-noninteractive-link></oppia-noninteractive-link>'
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        self.assertNotIn('data-oi-attr', protected)
+
+    def test_encoded_html_attr_with_none_value_is_skipped(self) -> None:
+        source = '<oppia-noninteractive-collapsible></oppia-noninteractive-collapsible>'
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        self.assertNotIn('data-oi-attr', protected)
+
+    def test_tabs_json_with_missing_title_or_content_is_handled(self) -> None:
+        tabs = json.dumps(
+            [
+                {'content': '&lt;p&gt;No Title&lt;/p&gt;'},
+                {'title': 'No Content'},
+            ]
+        )
+        source = (
+            '<oppia-noninteractive-tabs tab_contents-with-value=\'%s\'>'
+            '</oppia-noninteractive-tabs>' % tabs
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        self.assertIn('tab-content-0', protected)
+        self.assertNotIn('tab-title-0', protected)
+        self.assertIn('tab-title-1', protected)
+        self.assertNotIn('tab-content-1', protected)
+
+        restored = html_translation_services.postprocess_translated_html(
+            protected
+        )
+        self.assertIn('No Title', restored)
+        self.assertIn('No Content', restored)
+
+    def test_postprocess_encoded_attr_with_none_tag_skips_gracefully(
+        self,
+    ) -> None:
+        source = (
+            '<div data-oi-id="99" data-oi-attr="content-with-value" '
+            'data-oi-encoded="true">&lt;p&gt;Orphan&lt;/p&gt;</div>'
+        )
+        restored = html_translation_services.postprocess_translated_html(source)
+        self.assertEqual(restored, '')
+
+    def test_postprocess_tabs_with_none_tag_skips_gracefully(self) -> None:
+        source = '<span data-oi-id="99" data-oi-attr="tab-title-0">Title</span>'
+        restored = html_translation_services.postprocess_translated_html(source)
+        self.assertEqual(restored, '')
+
+    def test_tabs_with_json_type_error_is_skipped(self) -> None:
+        source = (
+            '<oppia-noninteractive-tabs tab_contents-with-value="123">'
+            '</oppia-noninteractive-tabs>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        self.assertIn('translate="no"', protected)

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -1,0 +1,244 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for HTML translation pre/post-processing services."""
+
+from __future__ import annotations
+
+import json
+
+from core.domain import html_translation_services
+from core.tests import test_utils
+
+
+class ProtectHtmlForTranslationTests(test_utils.GenericTestBase):
+    """Tests for protect_html_for_translation."""
+
+    def test_returns_empty_string_unchanged(self) -> None:
+        self.assertEqual(
+            html_translation_services.protect_html_for_translation(''), ''
+        )
+
+    def test_plain_text_is_unchanged(self) -> None:
+        source = '<p>Hello world</p>'
+        self.assertEqual(
+            html_translation_services.protect_html_for_translation(source),
+            source,
+        )
+
+    def test_math_component_gets_translate_no(self) -> None:
+        source = (
+            '<p>Find the area: '
+            '<oppia-noninteractive-math math_content-with-value="x²">'
+            '</oppia-noninteractive-math></p>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('translate="no"', result)
+        self.assertIn('math_content-with-value', result)
+
+    def test_video_component_gets_translate_no(self) -> None:
+        source = (
+            '<oppia-noninteractive-video video_id-with-value="abc123">'
+            '</oppia-noninteractive-video>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('translate="no"', result)
+
+    def test_skillreview_component_gets_translate_no(self) -> None:
+        source = (
+            '<oppia-noninteractive-skillreview skill_id-with-value="abc"'
+            ' text-with-value="Fractions">'
+            '</oppia-noninteractive-skillreview>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('translate="no"', result)
+        # text-with-value should NOT be extracted for skillreview.
+        self.assertNotIn('data-oi-attr', result)
+
+    def test_link_text_extracted_url_preserved(self) -> None:
+        source = (
+            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
+            ' text-with-value="Learn more">'
+            '</oppia-noninteractive-link>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        # text-with-value extracted into a span.
+        self.assertIn('data-oi-attr="text-with-value"', result)
+        self.assertIn('Learn more', result)
+        # url-with-value preserved on the component.
+        self.assertIn('url-with-value="https://oppia.org"', result)
+        # text-with-value removed from component.
+        self.assertNotIn('oppia-noninteractive-link text-with-value', result)
+
+    def test_image_alt_and_caption_extracted(self) -> None:
+        source = (
+            '<oppia-noninteractive-image filepath-with-value="img.png"'
+            ' alt-with-value="A red car"'
+            ' caption-with-value="Figure 1">'
+            '</oppia-noninteractive-image>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="alt-with-value"', result)
+        self.assertIn('data-oi-attr="caption-with-value"', result)
+        self.assertIn('A red car', result)
+        self.assertIn('Figure 1', result)
+        # filepath must be preserved on the component.
+        self.assertIn('filepath-with-value="img.png"', result)
+
+    def test_collapsible_heading_extracted_content_protected(self) -> None:
+        source = (
+            '<oppia-noninteractive-collapsible'
+            ' heading-with-value="Show solution"'
+            ' content-with-value="&lt;p&gt;Step 1&lt;/p&gt;">'
+            '</oppia-noninteractive-collapsible>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="heading-with-value"', result)
+        self.assertIn('Show solution', result)
+        self.assertIn('data-oi-attr="content-with-value"', result)
+        self.assertIn('Step 1', result)
+
+    def test_workedexample_question_extracted_answer_protected(self) -> None:
+        source = (
+            '<oppia-noninteractive-workedexample'
+            ' question-with-value="Solve for x"'
+            ' answer-with-value="&lt;p&gt;x=5&lt;/p&gt;">'
+            '</oppia-noninteractive-workedexample>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="question-with-value"', result)
+        self.assertIn('Solve for x', result)
+        self.assertIn('data-oi-attr="answer-with-value"', result)
+        self.assertIn('x=5', result)
+
+    def test_tabs_json_unpacked_into_temp_elements(self) -> None:
+        tabs = json.dumps(
+            [{'title': 'Hint', 'content': '&lt;p&gt;Try again&lt;/p&gt;'}]
+        )
+        source = (
+            '<oppia-noninteractive-tabs tab_contents-with-value=\'%s\'>'
+            '</oppia-noninteractive-tabs>' % tabs
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('data-oi-attr="tab-title-0"', result)
+        self.assertIn('Hint', result)
+        self.assertIn('data-oi-attr="tab-content-0"', result)
+        self.assertIn('Try again', result)
+
+    def test_anchor_tag_is_not_protected(self) -> None:
+        source = '<a href="https://example.com">Click here</a>'
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertNotIn('translate="no"', result)
+        self.assertIn('href="https://example.com"', result)
+
+    def test_function_is_idempotent(self) -> None:
+        source = (
+            '<oppia-noninteractive-math math_content-with-value="x²">'
+            '</oppia-noninteractive-math>'
+        )
+        once = html_translation_services.protect_html_for_translation(source)
+        twice = html_translation_services.protect_html_for_translation(once)
+        self.assertEqual(once.count('translate="no"'), 1)
+        self.assertEqual(twice.count('translate="no"'), 1)
+
+
+class PostprocessTranslatedHtmlTests(test_utils.GenericTestBase):
+    """Tests for postprocess_translated_html."""
+
+    def test_empty_string_returns_empty_string(self) -> None:
+        self.assertEqual(
+            html_translation_services.postprocess_translated_html(''), ''
+        )
+
+    def test_strips_translate_no(self) -> None:
+        source = (
+            '<oppia-noninteractive-math translate="no"'
+            ' math_content-with-value="x²">'
+            '</oppia-noninteractive-math>'
+        )
+        result = html_translation_services.postprocess_translated_html(source)
+        self.assertNotIn('translate="no"', result)
+
+    def test_link_text_restored_url_preserved(self) -> None:
+        source = (
+            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
+            ' text-with-value="Learn more">'
+            '</oppia-noninteractive-link>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        # Simulate Azure translating the span text.
+        translated = protected.replace('Learn more', 'यहाँ और जानें')
+        result = html_translation_services.postprocess_translated_html(
+            translated
+        )
+        self.assertIn('text-with-value="यहाँ और जानें"', result)
+        self.assertIn('url-with-value="https://oppia.org"', result)
+        self.assertNotIn('data-oi-id', result)
+        self.assertNotIn('translate="no"', result)
+
+    def test_image_alt_and_caption_restored(self) -> None:
+        source = (
+            '<oppia-noninteractive-image filepath-with-value="img.png"'
+            ' alt-with-value="A red car"'
+            ' caption-with-value="Figure 1">'
+            '</oppia-noninteractive-image>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        translated = protected.replace('A red car', 'एक लाल कार').replace(
+            'Figure 1', 'चित्र 1'
+        )
+        result = html_translation_services.postprocess_translated_html(
+            translated
+        )
+        self.assertIn('alt-with-value="एक लाल कार"', result)
+        self.assertIn('caption-with-value="चित्र 1"', result)
+        self.assertIn('filepath-with-value="img.png"', result)
+
+    def test_math_component_preserved_unchanged(self) -> None:
+        source = (
+            '<oppia-noninteractive-math math_content-with-value="πr²">'
+            '</oppia-noninteractive-math>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        result = html_translation_services.postprocess_translated_html(
+            protected
+        )
+        self.assertIn('math_content-with-value="πr²"', result)
+        self.assertNotIn('translate="no"', result)
+
+    def test_full_roundtrip_with_plain_text(self) -> None:
+        source = (
+            '<p>Find the area</p>'
+            '<oppia-noninteractive-math math_content-with-value="πr²">'
+            '</oppia-noninteractive-math>'
+        )
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        translated = protected.replace('Find the area', 'Finde die Fläche')
+        result = html_translation_services.postprocess_translated_html(
+            translated
+        )
+        self.assertIn('Finde die Fläche', result)
+        self.assertIn('math_content-with-value="πr²"', result)
+        self.assertNotIn('translate="no"', result)
+        self.assertNotIn('data-oi-id', result)

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -24,221 +24,194 @@ from core.domain import html_translation_services
 from core.tests import test_utils
 
 
-class ProtectHtmlForTranslationTests(test_utils.GenericTestBase):
-    """Tests for protect_html_for_translation."""
+class HtmlTranslationServicesTests(test_utils.GenericTestBase):
+    """Tests for HTML translation services."""
 
-    def test_returns_empty_string_unchanged(self) -> None:
+    def test_empty_and_whitespace_strings(self) -> None:
         self.assertEqual(
             html_translation_services.protect_html_for_translation(''), ''
         )
-
-    def test_plain_text_is_unchanged(self) -> None:
-        source = '<p>Hello world</p>'
         self.assertEqual(
-            html_translation_services.protect_html_for_translation(source),
-            source,
+            html_translation_services.protect_html_for_translation('   '), '   '
+        )
+        self.assertEqual(
+            html_translation_services.postprocess_translated_html(''), ''
         )
 
-    def test_math_component_gets_translate_no(self) -> None:
+    def test_skip_components_receive_translate_no(self) -> None:
         source = (
-            '<p>Find the area: '
             '<oppia-noninteractive-math math_content-with-value="x²">'
-            '</oppia-noninteractive-math></p>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('translate="no"', result)
-        self.assertIn('math_content-with-value', result)
-
-    def test_video_component_gets_translate_no(self) -> None:
-        source = (
+            '</oppia-noninteractive-math>'
             '<oppia-noninteractive-video video_id-with-value="abc123">'
             '</oppia-noninteractive-video>'
-        )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('translate="no"', result)
-
-    def test_skillreview_component_gets_translate_no(self) -> None:
-        source = (
-            '<oppia-noninteractive-skillreview skill_id-with-value="abc"'
-            ' text-with-value="Fractions">'
+            '<oppia-noninteractive-skillreview skill_id-with-value="abc">'
             '</oppia-noninteractive-skillreview>'
+            '<oppia-noninteractive-math translate="no"></oppia-noninteractive-math>'
         )
         result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('translate="no"', result)
-        # Text-with-value should NOT be extracted for skillreview.
-        self.assertNotIn('data-oi-attr', result)
+        self.assertEqual(result.count('translate="no"'), 4)
 
-    def test_link_text_extracted_url_preserved(self) -> None:
+    def test_translatable_text_attrs_extracted_and_restored(self) -> None:
         source = (
-            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
-            ' text-with-value="Learn more">'
-            '</oppia-noninteractive-link>'
+            '<oppia-noninteractive-link url-with-value="https://oppia.org" '
+            'text-with-value="Learn more"></oppia-noninteractive-link>'
         )
-        result = html_translation_services.protect_html_for_translation(source)
-        # Text-with-value extracted into a span.
-        self.assertIn('data-oi-attr="text-with-value"', result)
-        self.assertIn('Learn more', result)
-        # Url-with-value preserved on the component.
-        self.assertIn('url-with-value="https://oppia.org"', result)
-        # Text-with-value removed from component.
-        self.assertNotIn('oppia-noninteractive-link text-with-value', result)
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        self.assertIn('data-oi-attr="text-with-value"', protected)
 
-    def test_image_alt_and_caption_extracted(self) -> None:
+        restored = html_translation_services.postprocess_translated_html(
+            protected
+        )
+        self.assertIn('text-with-value="Learn more"', restored)
+        self.assertNotIn('data-oi-id', restored)
+
+    def test_image_alt_and_caption_extracted_and_restored(self) -> None:
         source = (
-            '<oppia-noninteractive-image filepath-with-value="img.png"'
-            ' alt-with-value="A red car"'
-            ' caption-with-value="Figure 1">'
+            '<oppia-noninteractive-image filepath-with-value="img.png" '
+            'alt-with-value="A red car" caption-with-value="Figure 1">'
             '</oppia-noninteractive-image>'
         )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="alt-with-value"', result)
-        self.assertIn('data-oi-attr="caption-with-value"', result)
-        self.assertIn('A red car', result)
-        self.assertIn('Figure 1', result)
-        # Filepath must be preserved on the component.
-        self.assertIn('filepath-with-value="img.png"', result)
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        restored = html_translation_services.postprocess_translated_html(
+            protected
+        )
+        self.assertIn('alt-with-value="A red car"', restored)
+        self.assertIn('caption-with-value="Figure 1"', restored)
 
-    def test_collapsible_heading_extracted_content_protected(self) -> None:
+    def test_encoded_html_attrs_extracted_and_restored(self) -> None:
         source = (
-            '<oppia-noninteractive-collapsible'
-            ' heading-with-value="Show solution"'
-            ' content-with-value="&lt;p&gt;Step 1&lt;/p&gt;">'
+            '<oppia-noninteractive-collapsible heading-with-value="Show" '
+            'content-with-value="&lt;p&gt;Step 1&lt;/p&gt;">'
             '</oppia-noninteractive-collapsible>'
         )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="heading-with-value"', result)
-        self.assertIn('Show solution', result)
-        self.assertIn('data-oi-attr="content-with-value"', result)
-        self.assertIn('Step 1', result)
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        self.assertIn('data-oi-encoded="true"', protected)
 
-    def test_workedexample_question_extracted_answer_protected(self) -> None:
+        restored = html_translation_services.postprocess_translated_html(
+            protected
+        )
+        self.assertIn(
+            'content-with-value="&lt;p&gt;Step 1&lt;/p&gt;"', restored
+        )
+
+    def test_workedexample_extracted_and_restored(self) -> None:
         source = (
-            '<oppia-noninteractive-workedexample'
-            ' question-with-value="Solve for x"'
-            ' answer-with-value="&lt;p&gt;x=5&lt;/p&gt;">'
+            '<oppia-noninteractive-workedexample question-with-value="Q1" '
+            'answer-with-value="&lt;p&gt;A1&lt;/p&gt;">'
             '</oppia-noninteractive-workedexample>'
         )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="question-with-value"', result)
-        self.assertIn('Solve for x', result)
-        self.assertIn('data-oi-attr="answer-with-value"', result)
-        self.assertIn('x=5', result)
+        protected = html_translation_services.protect_html_for_translation(
+            source
+        )
+        restored = html_translation_services.postprocess_translated_html(
+            protected
+        )
+        self.assertIn('question-with-value="Q1"', restored)
+        self.assertIn('answer-with-value="&lt;p&gt;A1&lt;/p&gt;"', restored)
 
-    def test_tabs_json_unpacked_into_temp_elements(self) -> None:
+    def test_tabs_json_extracted_and_restored(self) -> None:
         tabs = json.dumps(
-            [{'title': 'Hint', 'content': '&lt;p&gt;Try again&lt;/p&gt;'}]
+            [
+                {'title': 'Hint', 'content': '&lt;p&gt;Try&lt;/p&gt;'},
+                {'title': 'Hint 2'},
+            ]
         )
         source = (
             '<oppia-noninteractive-tabs tab_contents-with-value=\'%s\'>'
             '</oppia-noninteractive-tabs>' % tabs
         )
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertIn('data-oi-attr="tab-title-0"', result)
-        self.assertIn('Hint', result)
-        self.assertIn('data-oi-attr="tab-content-0"', result)
-        self.assertIn('Try again', result)
-
-    def test_anchor_tag_is_not_protected(self) -> None:
-        source = '<a href="https://example.com">Click here</a>'
-        result = html_translation_services.protect_html_for_translation(source)
-        self.assertNotIn('translate="no"', result)
-        self.assertIn('href="https://example.com"', result)
-
-    def test_function_is_idempotent(self) -> None:
-        source = (
-            '<oppia-noninteractive-math math_content-with-value="x²">'
-            '</oppia-noninteractive-math>'
-        )
-        once = html_translation_services.protect_html_for_translation(source)
-        twice = html_translation_services.protect_html_for_translation(once)
-        self.assertEqual(once.count('translate="no"'), 1)
-        self.assertEqual(twice.count('translate="no"'), 1)
-
-
-class PostprocessTranslatedHtmlTests(test_utils.GenericTestBase):
-    """Tests for postprocess_translated_html."""
-
-    def test_empty_string_returns_empty_string(self) -> None:
-        self.assertEqual(
-            html_translation_services.postprocess_translated_html(''), ''
-        )
-
-    def test_strips_translate_no(self) -> None:
-        source = (
-            '<oppia-noninteractive-math translate="no"'
-            ' math_content-with-value="x²">'
-            '</oppia-noninteractive-math>'
-        )
-        result = html_translation_services.postprocess_translated_html(source)
-        self.assertNotIn('translate="no"', result)
-
-    def test_link_text_restored_url_preserved(self) -> None:
-        source = (
-            '<oppia-noninteractive-link url-with-value="https://oppia.org"'
-            ' text-with-value="Learn more">'
-            '</oppia-noninteractive-link>'
-        )
         protected = html_translation_services.protect_html_for_translation(
             source
         )
-        # Simulate Azure translating the span text.
-        translated = protected.replace('Learn more', 'यहाँ और जानें')
-        result = html_translation_services.postprocess_translated_html(
-            translated
-        )
-        self.assertIn('text-with-value="यहाँ और जानें"', result)
-        self.assertIn('url-with-value="https://oppia.org"', result)
-        self.assertNotIn('data-oi-id', result)
-        self.assertNotIn('translate="no"', result)
+        self.assertIn('tab-title-0', protected)
+        self.assertIn('tab-content-0', protected)
+        self.assertIn('tab-title-1', protected)
 
-    def test_image_alt_and_caption_restored(self) -> None:
-        source = (
-            '<oppia-noninteractive-image filepath-with-value="img.png"'
-            ' alt-with-value="A red car"'
-            ' caption-with-value="Figure 1">'
-            '</oppia-noninteractive-image>'
-        )
-        protected = html_translation_services.protect_html_for_translation(
-            source
-        )
-        translated = protected.replace('A red car', 'एक लाल कार').replace(
-            'Figure 1', 'चित्र 1'
-        )
-        result = html_translation_services.postprocess_translated_html(
-            translated
-        )
-        self.assertIn('alt-with-value="एक लाल कार"', result)
-        self.assertIn('caption-with-value="चित्र 1"', result)
-        self.assertIn('filepath-with-value="img.png"', result)
-
-    def test_math_component_preserved_unchanged(self) -> None:
-        source = (
-            '<oppia-noninteractive-math math_content-with-value="πr²">'
-            '</oppia-noninteractive-math>'
-        )
-        protected = html_translation_services.protect_html_for_translation(
-            source
-        )
-        result = html_translation_services.postprocess_translated_html(
+        restored = html_translation_services.postprocess_translated_html(
             protected
         )
-        self.assertIn('math_content-with-value="πr²"', result)
-        self.assertNotIn('translate="no"', result)
+        self.assertIn('Hint', restored)
+        self.assertIn('&lt;p&gt;Try&lt;/p&gt;', restored)
+        self.assertIn('Hint 2', restored)
 
-    def test_full_roundtrip_with_plain_text(self) -> None:
+    def test_tabs_with_invalid_json_is_skipped(self) -> None:
         source = (
-            '<p>Find the area</p>'
-            '<oppia-noninteractive-math math_content-with-value="πr²">'
-            '</oppia-noninteractive-math>'
+            '<oppia-noninteractive-tabs tab_contents-with-value="invalid">'
+            '</oppia-noninteractive-tabs>'
         )
         protected = html_translation_services.protect_html_for_translation(
             source
         )
-        translated = protected.replace('Find the area', 'Finde die Fläche')
-        result = html_translation_services.postprocess_translated_html(
-            translated
+        self.assertIn('translate="no"', protected)
+
+        source_with_no = (
+            '<oppia-noninteractive-tabs tab_contents-with-value="invalid" '
+            'translate="no"></oppia-noninteractive-tabs>'
         )
-        self.assertIn('Finde die Fläche', result)
-        self.assertIn('math_content-with-value="πr²"', result)
-        self.assertNotIn('translate="no"', result)
+        protected2 = html_translation_services.protect_html_for_translation(
+            source_with_no
+        )
+        self.assertIn('translate="no"', protected2)
+
+    def test_tabs_json_null_value_protects_whole_component(self) -> None:
+        # JSON null parses fine but raises TypeError when iterated over,
+        # hitting the TypeError branch of the except clause.
+        source = (
+            '<oppia-noninteractive-tabs tab_contents-with-value="null">'
+            '</oppia-noninteractive-tabs>'
+        )
+        result = html_translation_services.protect_html_for_translation(source)
+        self.assertIn('translate="no"', result)
+        self.assertNotIn('data-oi-attr', result)
+
+    def test_tabs_zero_count_produces_empty_json_array(self) -> None:
+        # The tab-title-0 span populates tabs_data["0"], entering the
+        # reconstruction block. data-oi-tab-count="0" makes range(0) run
+        # zero iterations, producing an empty JSON array.
+        source = (
+            '<span data-oi-id="0" data-oi-attr="tab-title-0">T</span>'
+            '<oppia-noninteractive-tabs data-oi-id="0" '
+            'data-oi-tab-count="0" translate="no">'
+            '</oppia-noninteractive-tabs>'
+        )
+        result = html_translation_services.postprocess_translated_html(source)
+        self.assertIn('tab_contents-with-value="[]"', result)
+        self.assertNotIn('data-oi-tab-count', result)
+
+    def test_orphaned_temp_tags_are_removed(self) -> None:
+        source = (
+            '<span data-oi-id="99" data-oi-attr="text-with-value">'
+            'Orphan</span>'
+        )
+        restored = html_translation_services.postprocess_translated_html(source)
+        self.assertEqual(restored, '')
+
+    def test_non_oppia_tag_with_data_oi_id_skipped_in_comp_map(self) -> None:
+        # The <p> has BOTH data-oi-id and data-oi-attr, so it appears in
+        # the temp-tag loop. At line 249-250 the comp_id_to_tag build
+        # skips it (not an oppia- tag), so component_tag resolves to None
+        # and the element is decomposed via the orphan branch.
+        source = '<p data-oi-id="0" data-oi-attr="text-with-value">Orphan</p>'
+        result = html_translation_services.postprocess_translated_html(source)
         self.assertNotIn('data-oi-id', result)
+        self.assertNotIn('Orphan', result)
+
+    def test_missing_component_tag_for_tabs_data_skips_gracefully(self) -> None:
+        source = (
+            '<span data-oi-id="100" data-oi-attr="tab-title-0">Title</span>'
+            '<div data-oi-id="100" data-oi-attr="tab-content-0" '
+            'data-oi-encoded="true">&lt;p&gt;Content&lt;/p&gt;</div>'
+        )
+        restored = html_translation_services.postprocess_translated_html(source)
+        self.assertEqual(restored, '')
+
+    def test_encode_attr_html(self) -> None:
+        source = '<p>&">\'</p>'
+        encoded = html_translation_services._encode_attr_html(source)
+        self.assertEqual(encoded, '&lt;p&gt;&amp;&quot;&gt;\'&lt;/p&gt;')

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -65,7 +65,7 @@ class ProtectHtmlForTranslationTests(test_utils.GenericTestBase):
         )
         result = html_translation_services.protect_html_for_translation(source)
         self.assertIn('translate="no"', result)
-        # text-with-value should NOT be extracted for skillreview.
+        # Text-with-value should NOT be extracted for skillreview.
         self.assertNotIn('data-oi-attr', result)
 
     def test_link_text_extracted_url_preserved(self) -> None:
@@ -75,12 +75,12 @@ class ProtectHtmlForTranslationTests(test_utils.GenericTestBase):
             '</oppia-noninteractive-link>'
         )
         result = html_translation_services.protect_html_for_translation(source)
-        # text-with-value extracted into a span.
+        # Text-with-value extracted into a span.
         self.assertIn('data-oi-attr="text-with-value"', result)
         self.assertIn('Learn more', result)
-        # url-with-value preserved on the component.
+        # Url-with-value preserved on the component.
         self.assertIn('url-with-value="https://oppia.org"', result)
-        # text-with-value removed from component.
+        # Text-with-value removed from component.
         self.assertNotIn('oppia-noninteractive-link text-with-value', result)
 
     def test_image_alt_and_caption_extracted(self) -> None:
@@ -95,7 +95,7 @@ class ProtectHtmlForTranslationTests(test_utils.GenericTestBase):
         self.assertIn('data-oi-attr="caption-with-value"', result)
         self.assertIn('A red car', result)
         self.assertIn('Figure 1', result)
-        # filepath must be preserved on the component.
+        # Filepath must be preserved on the component.
         self.assertIn('filepath-with-value="img.png"', result)
 
     def test_collapsible_heading_extracted_content_protected(self) -> None:

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -213,5 +213,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
 
     def test_encode_attr_html(self) -> None:
         source = '<p>&">\'</p>'
-        encoded = html_translation_services._encode_attr_html(source)
+        encoded = html_translation_services._encode_attr_html(
+            source
+        )  # pylint: disable=protected-access
         self.assertEqual(encoded, '&lt;p&gt;&amp;&quot;&gt;\'&lt;/p&gt;')

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -210,10 +210,3 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         )
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
-
-    def test_encode_attr_html(self) -> None:
-        source = '<p>&">\'</p>'
-        encoded = html_translation_services._encode_attr_html(
-            source
-        )  # pylint: disable=protected-access
-        self.assertEqual(encoded, '&lt;p&gt;&amp;&quot;&gt;\'&lt;/p&gt;')

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -61,13 +61,13 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         protected = html_translation_services.protect_html_for_translation(
             source
         )
-        self.assertIn('data-oi-attr="text-with-value"', protected)
+        self.assertIn('data-temp-attr-name="text-with-value"', protected)
 
         restored = html_translation_services.postprocess_translated_html(
             protected
         )
         self.assertIn('text-with-value="Learn more"', restored)
-        self.assertNotIn('data-oi-id', restored)
+        self.assertNotIn('data-temp-comp-id', restored)
 
     def test_image_alt_and_caption_extracted_and_restored(self) -> None:
         source = (
@@ -93,7 +93,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         protected = html_translation_services.protect_html_for_translation(
             source
         )
-        self.assertIn('data-oi-encoded="true"', protected)
+        self.assertIn('data-temp-is-encoded="true"', protected)
 
         restored = html_translation_services.postprocess_translated_html(
             protected
@@ -170,38 +170,45 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         )
         result = html_translation_services.protect_html_for_translation(source)
         self.assertIn('translate="no"', result)
-        self.assertNotIn('data-oi-attr', result)
+        self.assertNotIn('data-temp-attr-name', result)
 
     def test_tabs_zero_count_produces_empty_json_array(self) -> None:
         # The tab-title-0 span populates tabs_data["0"], entering the
-        # reconstruction block. data-oi-tab-count="0" makes range(0) run
+        # reconstruction block. data-temp-tab-count="0" makes range(0) run
         # zero iterations, producing an empty JSON array.
         source = (
-            '<span data-oi-id="0" data-oi-attr="tab-title-0">T</span>'
-            '<oppia-noninteractive-tabs data-oi-id="0" '
-            'data-oi-tab-count="0" translate="no">'
+            '<span data-temp-comp-id="0" data-temp-attr-name="tab-title-0">'
+            'T</span>'
+            '<oppia-noninteractive-tabs data-temp-comp-id="0" '
+            'data-temp-tab-count="0" translate="no">'
             '</oppia-noninteractive-tabs>'
         )
         result = html_translation_services.postprocess_translated_html(source)
         self.assertIn('tab_contents-with-value="[]"', result)
-        self.assertNotIn('data-oi-tab-count', result)
+        self.assertNotIn('data-temp-tab-count', result)
 
     def test_orphaned_temp_tags_are_removed(self) -> None:
         source = (
-            '<span data-oi-id="99" data-oi-attr="text-with-value">'
+            '<span data-temp-comp-id="99" '
+            'data-temp-attr-name="text-with-value">'
             'Orphan</span>'
         )
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
 
-    def test_non_oppia_tag_with_data_oi_id_skipped_in_comp_map(self) -> None:
-        # The <p> has BOTH data-oi-id and data-oi-attr, so it appears in
-        # the temp-tag loop. At line 249-250 the comp_id_to_tag build
-        # skips it (not an oppia- tag), so component_tag resolves to None
-        # and the element is decomposed via the orphan branch.
-        source = '<p data-oi-id="0" data-oi-attr="text-with-value">Orphan</p>'
+    def test_non_oppia_tag_with_data_temp_comp_id_skipped_in_comp_map(
+        self,
+    ) -> None:
+        # The <p> has BOTH data-temp-comp-id and data-temp-attr-name, so it
+        # appears in the temp-tag loop. The comp_id_to_tag build skips it
+        # (not an oppia- tag), so component_tag resolves to None and the
+        # element is decomposed via the orphan branch.
+        source = (
+            '<p data-temp-comp-id="0" '
+            'data-temp-attr-name="text-with-value">Orphan</p>'
+        )
         result = html_translation_services.postprocess_translated_html(source)
-        self.assertNotIn('data-oi-id', result)
+        self.assertNotIn('data-temp-comp-id', result)
         self.assertNotIn('Orphan', result)
 
     def test_translatable_text_attr_with_none_value_is_skipped(self) -> None:
@@ -215,14 +222,17 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         protected = html_translation_services.protect_html_for_translation(
             source
         )
-        self.assertNotIn('data-oi-attr', protected)
+        self.assertNotIn('data-temp-attr-name', protected)
 
     def test_encoded_html_attr_with_none_value_is_skipped(self) -> None:
-        source = '<oppia-noninteractive-collapsible></oppia-noninteractive-collapsible>'
+        source = (
+            '<oppia-noninteractive-collapsible>'
+            '</oppia-noninteractive-collapsible>'
+        )
         protected = html_translation_services.protect_html_for_translation(
             source
         )
-        self.assertNotIn('data-oi-attr', protected)
+        self.assertNotIn('data-temp-attr-name', protected)
 
     def test_tabs_json_with_missing_title_or_content_is_handled(self) -> None:
         tabs = json.dumps(
@@ -253,14 +263,18 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self,
     ) -> None:
         source = (
-            '<div data-oi-id="99" data-oi-attr="content-with-value" '
-            'data-oi-encoded="true">&lt;p&gt;Orphan&lt;/p&gt;</div>'
+            '<div data-temp-comp-id="99" '
+            'data-temp-attr-name="content-with-value" '
+            'data-temp-is-encoded="true">&lt;p&gt;Orphan&lt;/p&gt;</div>'
         )
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
 
     def test_postprocess_tabs_with_none_tag_skips_gracefully(self) -> None:
-        source = '<span data-oi-id="99" data-oi-attr="tab-title-0">Title</span>'
+        source = (
+            '<span data-temp-comp-id="99" '
+            'data-temp-attr-name="tab-title-0">Title</span>'
+        )
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
 

--- a/core/domain/html_translation_services_test.py
+++ b/core/domain/html_translation_services_test.py
@@ -29,7 +29,7 @@ import bs4
 class HtmlTranslationServicesTests(test_utils.GenericTestBase):
     """Tests for HTML translation services."""
 
-    def test_empty_and_whitespace_strings(self) -> None:
+    def test_protect_html_with_empty_string_returns_empty_string(self) -> None:
         self.assertEqual(
             html_translation_services.protect_html_for_translation(''), ''
         )
@@ -40,7 +40,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             html_translation_services.postprocess_translated_html(''), ''
         )
 
-    def test_skip_components_receive_translate_no(self) -> None:
+    def test_protect_html_with_skip_components_adds_translate_no_attribute(
+        self,
+    ) -> None:
         source = (
             '<oppia-noninteractive-math math_content-with-value="x²">'
             '</oppia-noninteractive-math>'
@@ -53,7 +55,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         result = html_translation_services.protect_html_for_translation(source)
         self.assertEqual(result.count('translate="no"'), 4)
 
-    def test_translatable_text_attrs_extracted_and_restored(self) -> None:
+    def test_process_html_with_translatable_text_attributes_extracts_and_restores_values(
+        self,
+    ) -> None:
         source = (
             '<oppia-noninteractive-link url-with-value="https://oppia.org" '
             'text-with-value="Learn more"></oppia-noninteractive-link>'
@@ -69,7 +73,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertIn('text-with-value="Learn more"', restored)
         self.assertNotIn('data-temp-comp-id', restored)
 
-    def test_image_alt_and_caption_extracted_and_restored(self) -> None:
+    def test_process_html_with_image_alt_and_caption_extracts_and_restores_values(
+        self,
+    ) -> None:
         source = (
             '<oppia-noninteractive-image filepath-with-value="img.png" '
             'alt-with-value="A red car" caption-with-value="Figure 1">'
@@ -84,7 +90,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertIn('alt-with-value="A red car"', restored)
         self.assertIn('caption-with-value="Figure 1"', restored)
 
-    def test_encoded_html_attrs_extracted_and_restored(self) -> None:
+    def test_process_html_with_encoded_html_attributes_extracts_and_restores_values(
+        self,
+    ) -> None:
         source = (
             '<oppia-noninteractive-collapsible heading-with-value="Show" '
             'content-with-value="&lt;p&gt;Step 1&lt;/p&gt;">'
@@ -102,7 +110,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
             'content-with-value="&lt;p&gt;Step 1&lt;/p&gt;"', restored
         )
 
-    def test_workedexample_extracted_and_restored(self) -> None:
+    def test_process_html_with_workedexample_extracts_and_restores_values(
+        self,
+    ) -> None:
         source = (
             '<oppia-noninteractive-workedexample question-with-value="Q1" '
             'answer-with-value="&lt;p&gt;A1&lt;/p&gt;">'
@@ -117,7 +127,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertIn('question-with-value="Q1"', restored)
         self.assertIn('answer-with-value="&lt;p&gt;A1&lt;/p&gt;"', restored)
 
-    def test_tabs_json_extracted_and_restored(self) -> None:
+    def test_process_html_with_tabs_json_extracts_and_restores_values(
+        self,
+    ) -> None:
         tabs = json.dumps(
             [
                 {'title': 'Hint', 'content': '&lt;p&gt;Try&lt;/p&gt;'},
@@ -142,7 +154,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertIn('&lt;p&gt;Try&lt;/p&gt;', restored)
         self.assertIn('Hint 2', restored)
 
-    def test_tabs_with_invalid_json_is_skipped(self) -> None:
+    def test_protect_html_with_invalid_tabs_json_skips_processing(self) -> None:
         source = (
             '<oppia-noninteractive-tabs tab_contents-with-value="invalid">'
             '</oppia-noninteractive-tabs>'
@@ -161,7 +173,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         )
         self.assertIn('translate="no"', protected2)
 
-    def test_tabs_json_null_value_protects_whole_component(self) -> None:
+    def test_protect_html_with_tabs_json_null_value_adds_translate_no_attribute(
+        self,
+    ) -> None:
         # JSON null parses fine but raises TypeError when iterated over,
         # hitting the TypeError branch of the except clause.
         source = (
@@ -172,7 +186,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertIn('translate="no"', result)
         self.assertNotIn('data-temp-attr-name', result)
 
-    def test_tabs_zero_count_produces_empty_json_array(self) -> None:
+    def test_postprocess_html_with_zero_tab_count_produces_empty_json_array(
+        self,
+    ) -> None:
         # The tab-title-0 span populates tabs_data["0"], entering the
         # reconstruction block. data-temp-tab-count="0" makes range(0) run
         # zero iterations, producing an empty JSON array.
@@ -187,7 +203,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertIn('tab_contents-with-value="[]"', result)
         self.assertNotIn('data-temp-tab-count', result)
 
-    def test_orphaned_temp_tags_are_removed(self) -> None:
+    def test_postprocess_html_with_orphaned_temp_tags_removes_them(
+        self,
+    ) -> None:
         source = (
             '<span data-temp-comp-id="99" '
             'data-temp-attr-name="text-with-value">'
@@ -196,7 +214,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
 
-    def test_non_oppia_tag_with_data_temp_comp_id_skipped_in_comp_map(
+    def test_postprocess_html_with_non_oppia_tag_skips_processing(
         self,
     ) -> None:
         # The <p> has BOTH data-temp-comp-id and data-temp-attr-name, so it
@@ -211,7 +229,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertNotIn('data-temp-comp-id', result)
         self.assertNotIn('Orphan', result)
 
-    def test_translatable_text_attr_with_none_value_is_skipped(self) -> None:
+    def test_protect_html_with_none_value_translatable_text_attr_skips_processing(
+        self,
+    ) -> None:
         soup = bs4.BeautifulSoup(
             '<oppia-noninteractive-link></oppia-noninteractive-link>',
             'html.parser',
@@ -224,7 +244,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         )
         self.assertNotIn('data-temp-attr-name', protected)
 
-    def test_encoded_html_attr_with_none_value_is_skipped(self) -> None:
+    def test_protect_html_with_none_value_encoded_html_attr_skips_processing(
+        self,
+    ) -> None:
         source = (
             '<oppia-noninteractive-collapsible>'
             '</oppia-noninteractive-collapsible>'
@@ -234,7 +256,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         )
         self.assertNotIn('data-temp-attr-name', protected)
 
-    def test_tabs_json_with_missing_title_or_content_is_handled(self) -> None:
+    def test_process_html_with_missing_tab_title_or_content_handles_gracefully(
+        self,
+    ) -> None:
         tabs = json.dumps(
             [
                 {'content': '&lt;p&gt;No Title&lt;/p&gt;'},
@@ -259,7 +283,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         self.assertIn('No Title', restored)
         self.assertIn('No Content', restored)
 
-    def test_postprocess_encoded_attr_with_none_tag_skips_gracefully(
+    def test_postprocess_html_with_none_tag_encoded_attr_skips_gracefully(
         self,
     ) -> None:
         source = (
@@ -270,7 +294,7 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
 
-    def test_postprocess_tabs_with_none_tag_skips_gracefully(self) -> None:
+    def test_postprocess_html_with_none_tag_tabs_skips_gracefully(self) -> None:
         source = (
             '<span data-temp-comp-id="99" '
             'data-temp-attr-name="tab-title-0">Title</span>'
@@ -278,7 +302,9 @@ class HtmlTranslationServicesTests(test_utils.GenericTestBase):
         restored = html_translation_services.postprocess_translated_html(source)
         self.assertEqual(restored, '')
 
-    def test_tabs_with_json_type_error_is_skipped(self) -> None:
+    def test_protect_html_with_tabs_json_type_error_skips_processing(
+        self,
+    ) -> None:
         source = (
             '<oppia-noninteractive-tabs tab_contents-with-value="123">'
             '</oppia-noninteractive-tabs>'

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -238,6 +238,7 @@
         "scripts.run_mypy_checks_test",
         "scripts.linters.pylint_extensions_test",
         "core.domain.html_cleaner_test",
+        "core.domain.html_translation_services_test",
         "core.platform.taskqueue.dev_mode_taskqueue_services_test",
         "core.storage.suggestion.gae_models_test",
         "core.storage.auth.gae_models_test",


### PR DESCRIPTION
## Overview


1. This PR fixes part of #https://github.com/oppia/oppia/issues/24714.
2. This PR does the following  Protects Components: Automatically injects translate="no" into all oppia-noninteractive- tags.
Extracts Translatable Text: Safely pulls learner-visible text from component attributes (e.g., links, image alt text) into temporary <span>tags so the API can translate them.
Handles Nested/Encoded HTML: Unescapes, recursively processes, and re-encodes hidden HTML content (e.g., inside Collapsible or Worked Example components).
Unpacks Tabs: Parses the JSON tab_contents-with-value, translates individual titles and contents, and safely reconstructs the JSON afterward.
Skips Technical Elements: Components like Math and Video are strictly ignored to prevent breaking LaTeX or video IDs. 
Skill Review Exclusion: Explicitly excludes oppia-noninteractive-skillreview (with a TODO) as its values are tied to backend mappings, aligning with  ongoing Exploration metadata translation project (#24933).
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ x I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct
Passing Units Tests are proof

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
