### PR TITLE
Fix #26406: Update translation certificate wording, signee, and layout

### DIFF
--- a/core/feconf.py
+++ b/core/feconf.py
@@ -1699,7 +1699,7 @@ CONTRIBUTION_SUBTYPE_COORDINATE: Final = 'coordinate'
 CONTRIBUTION_SUBTYPE_EDIT: Final = 'edit'
 CONTRIBUTION_SUBTYPE_SUBMISSION: Final = 'submission'
 
-TRANSLATION_TEAM_LEAD = 'Anubhuti Varshney'
+TRANSLATION_TEAM_LEAD = 'Aanuoluwapo Adeoti'
 QUESTION_TEAM_LEAD = 'Ryan Hsiao'
 
 # Suggestion fields that can be queried.

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.spec.ts
@@ -496,6 +496,8 @@ describe('Contributor Certificate Download Modal Component', () => {
         moveTo: () => {},
         lineTo: () => {},
         stroke: () => {},
+        save: () => {},
+        restore: () => {},
       }),
       toBlob: (cb: (blob: Blob | null) => void) => cb(mockBlob),
       toDataURL: () => '',
@@ -520,6 +522,295 @@ describe('Contributor Certificate Download Modal Component', () => {
 
     const image = new Image();
     image.dispatchEvent(new Event('load'));
+  });
+
+  it('should draw updated three-line text for translation certificates', () => {
+    const fillTextCalls: {text: string; x: number; y: number}[] = [];
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({
+        fillStyle: '',
+        fillRect: () => {},
+        drawImage: () => {},
+        font: '',
+        textAlign: '',
+        fillText: (text: string, x: number, y: number) => {
+          fillTextCalls.push({text, x, y});
+        },
+        moveTo: () => {},
+        lineTo: () => {},
+        stroke: () => {},
+        save: () => {},
+        restore: () => {},
+      }),
+      toBlob: () => {},
+      toDataURL: () => 'data:image/png;base64,',
+    };
+
+    // Mock Image so that assigning onload synchronously triggers the
+    // callback. This is needed because the source code sets image.src
+    // before image.onload, so the callback must fire on assignment.
+    const mockImage = {
+      set onload(fn: () => void) {
+        fn();
+      },
+      src: '',
+      width: 0,
+      height: 0,
+    };
+
+    spyOn(document, 'createElement').and.callFake((tag: string) => {
+      if (tag === 'canvas') {
+        return mockCanvas as unknown as HTMLCanvasElement;
+      }
+      if (tag === 'a') {
+        return {
+          download: '',
+          href: '',
+          click: () => {},
+        } as unknown as HTMLAnchorElement;
+      }
+      return document.createElement(tag);
+    });
+
+    // Override the global Image constructor.
+    const originalImage = window.Image;
+    (window as unknown as {Image: () => void}).Image = function () {
+      return mockImage;
+    };
+
+    component.suggestionType = 'translate_content';
+    component.createCertificate(certificateData);
+
+    // Restore the original Image constructor.
+    window.Image = originalImage;
+
+    const drawnTexts = fillTextCalls.map(call => call.text);
+
+    // Verify the inverted-pyramid text split for the updated certificate.
+    expect(drawnTexts).toContain(
+      "for their dedication and time in translating Oppia's " +
+        'basic maths, science,'
+    );
+    expect(drawnTexts).toContain(
+      'and financial literacy lessons to Hindi which will help our ' +
+        'Hindi-speaking'
+    );
+    expect(drawnTexts).toContain('learners better understand the lessons.');
+  });
+
+  it('should draw Translations Coordinator title below the signature', () => {
+    const fillTextCalls: {text: string; x: number; y: number}[] = [];
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({
+        fillStyle: '',
+        fillRect: () => {},
+        drawImage: () => {},
+        font: '',
+        textAlign: '',
+        fillText: (text: string, x: number, y: number) => {
+          fillTextCalls.push({text, x, y});
+        },
+        moveTo: () => {},
+        lineTo: () => {},
+        stroke: () => {},
+        save: () => {},
+        restore: () => {},
+      }),
+      toBlob: () => {},
+      toDataURL: () => 'data:image/png;base64,',
+    };
+
+    const mockImage = {
+      set onload(fn: () => void) {
+        fn();
+      },
+      src: '',
+      width: 0,
+      height: 0,
+    };
+
+    spyOn(document, 'createElement').and.callFake((tag: string) => {
+      if (tag === 'canvas') {
+        return mockCanvas as unknown as HTMLCanvasElement;
+      }
+      if (tag === 'a') {
+        return {
+          download: '',
+          href: '',
+          click: () => {},
+        } as unknown as HTMLAnchorElement;
+      }
+      return document.createElement(tag);
+    });
+
+    const originalImage = window.Image;
+    (window as unknown as {Image: () => void}).Image = function () {
+      return mockImage;
+    };
+
+    component.suggestionType = 'translate_content';
+    component.createCertificate(certificateData);
+
+    window.Image = originalImage;
+
+    // Find the signature name and title calls.
+    const signatureCall = fillTextCalls.find(
+      call => call.text === certificateData.team_lead
+    );
+    const titleCall = fillTextCalls.find(
+      call => call.text === 'Translations Coordinator'
+    );
+
+    expect(signatureCall).toBeDefined();
+    expect(titleCall).toBeDefined();
+
+    if (signatureCall && titleCall) {
+      // The title should be drawn 20px below the signature name
+      // (name is at linePosition - 25, title is at linePosition - 5).
+      expect(titleCall.y).toBe(signatureCall.y + 20);
+      // Both should share the same X coordinate (SIGNATURE_BASE_COORDINATE).
+      expect(titleCall.x).toBe(signatureCall.x);
+    }
+  });
+
+  it('should display singular minute for exactly 1 minute of contribution', () => {
+    const fillTextCalls: {text: string; x: number; y: number}[] = [];
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({
+        fillStyle: '',
+        fillRect: () => {},
+        drawImage: () => {},
+        font: '',
+        textAlign: '',
+        fillText: (text: string, x: number, y: number) => {
+          fillTextCalls.push({text, x, y});
+        },
+        moveTo: () => {},
+        lineTo: () => {},
+        stroke: () => {},
+        save: () => {},
+        restore: () => {},
+      }),
+      toBlob: () => {},
+      toDataURL: () => 'data:image/png;base64,',
+    };
+
+    const mockImage = {
+      set onload(fn: () => void) {
+        fn();
+      },
+      src: '',
+      width: 0,
+      height: 0,
+    };
+
+    spyOn(document, 'createElement').and.callFake((tag: string) => {
+      if (tag === 'canvas') {
+        return mockCanvas as unknown as HTMLCanvasElement;
+      }
+      if (tag === 'a') {
+        return {
+          download: '',
+          href: '',
+          click: () => {},
+        } as unknown as HTMLAnchorElement;
+      }
+      return document.createElement(tag);
+    });
+
+    const originalImage = window.Image;
+    (window as unknown as {Image: () => void}).Image = function () {
+      return mockImage;
+    };
+
+    // 1/60 hours = exactly 1 minute.
+    const oneMinuteData: ContributorCertificateInfo = {
+      ...certificateData,
+      contribution_hours: 1 / 60,
+    };
+    component.suggestionType = 'translate_content';
+    component.createCertificate(oneMinuteData);
+
+    window.Image = originalImage;
+
+    const drawnTexts = fillTextCalls.map(call => call.text);
+    const timeText = drawnTexts.find(text => text.includes('1 minute'));
+
+    expect(timeText).toBeDefined();
+    // Should say "1 minute" not "1 minutes".
+    expect(timeText).toContain('1 minute of service');
+  });
+
+  it('should not draw Translations Coordinator title on question certificates', () => {
+    const fillTextCalls: {text: string; x: number; y: number}[] = [];
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({
+        fillStyle: '',
+        fillRect: () => {},
+        drawImage: () => {},
+        font: '',
+        textAlign: '',
+        fillText: (text: string, x: number, y: number) => {
+          fillTextCalls.push({text, x, y});
+        },
+        moveTo: () => {},
+        lineTo: () => {},
+        stroke: () => {},
+        save: () => {},
+        restore: () => {},
+      }),
+      toBlob: () => {},
+      toDataURL: () => 'data:image/png;base64,',
+    };
+
+    const mockImage = {
+      set onload(fn: () => void) {
+        fn();
+      },
+      src: '',
+      width: 0,
+      height: 0,
+    };
+
+    spyOn(document, 'createElement').and.callFake((tag: string) => {
+      if (tag === 'canvas') {
+        return mockCanvas as unknown as HTMLCanvasElement;
+      }
+      if (tag === 'a') {
+        return {
+          download: '',
+          href: '',
+          click: () => {},
+        } as unknown as HTMLAnchorElement;
+      }
+      return document.createElement(tag);
+    });
+
+    const originalImage = window.Image;
+    (window as unknown as {Image: () => void}).Image = function () {
+      return mockImage;
+    };
+
+    component.suggestionType = 'add_question';
+    component.createCertificate(certificateData);
+
+    window.Image = originalImage;
+
+    const drawnTexts = fillTextCalls.map(call => call.text);
+
+    // The title should NOT appear on question certificates.
+    expect(drawnTexts).not.toContain('Translations Coordinator');
+
+    // The signature name should still be drawn.
+    expect(drawnTexts).toContain(certificateData.team_lead);
   });
 
   afterEach(() => {

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/certificate-download-modal.component.ts
@@ -280,16 +280,20 @@ export class CertificateDownloadModalComponent {
           {
             text:
               "for their dedication and time in translating Oppia's " +
-              'basic maths lessons to ' +
-              info.language,
+              'basic maths, science,',
             linePosition: linePosition,
           },
           {
             text:
-              'which will help our ' +
+              'and financial literacy lessons to ' +
               info.language +
-              '-speaking ' +
-              'learners better understand the lessons.',
+              ' which will help our ' +
+              info.language +
+              '-speaking',
+            linePosition: (linePosition += 40),
+          },
+          {
+            text: 'learners better understand the lessons.',
             linePosition: (linePosition += 40),
           },
           {
@@ -350,11 +354,32 @@ export class CertificateDownloadModalComponent {
       ctx.font = '24px Brush Script MT';
       ctx.fillStyle = '#000000';
       linePosition += 100;
-      ctx.fillText(
-        info.team_lead,
-        this.SIGNATURE_BASE_COORDINATE,
-        linePosition
-      );
+
+      // For translation certificates, shift the cursive name UP by 25
+      // pixels to make room for the title between the name and divider line.
+      // For question certificates, draw the name at the standard position.
+      const signatureY =
+        this.suggestionType === 'translate_content'
+          ? linePosition - 25
+          : linePosition;
+      ctx.fillText(info.team_lead, this.SIGNATURE_BASE_COORDINATE, signatureY);
+
+      // Only show the coordinator title on translation certificates.
+      if (this.suggestionType === 'translate_content') {
+        // Save the canvas state so the smaller grey font doesn't leak
+        // into the Date text and divider lines that follow.
+        ctx.save();
+
+        ctx.font = '16px Roboto';
+        ctx.fillStyle = '#8F9899';
+        ctx.fillText(
+          'Translations Coordinator',
+          this.SIGNATURE_BASE_COORDINATE,
+          linePosition - 5
+        );
+
+        ctx.restore();
+      }
 
       ctx.font = '24px Roboto';
       ctx.fillText(


### PR DESCRIPTION
## Overview

1. This PR fixes #26406.
2. This PR does the following: 
   - **Updates the backend constant:** Changes `TRANSLATION_TEAM_LEAD` in `feconf.py` to 'Aanuoluwapo Adeoti'.
   - **Updates certificate text:** Modifies the canvas drawing array in `certificate-download-modal.component.ts` to include "science, and financial literacy lessons" while re-balancing the string lengths to maintain an aesthetically pleasing centered paragraph without bleeding off the canvas edge.
   - **Adds Team Lead Title:** Renders the "Translations Coordinator" title beneath the signature block. 
   - **Prevents Canvas State Leakage:** Wraps the new title logic in `ctx.save()` and `ctx.restore()` so the smaller, grey font configuration doesn't accidentally apply to the horizontal divider lines or the Date text.
   - **Prevents Feature Bleed:** Wraps the new title drawing logic and signature Y-axis offset in a strict `this.suggestionType === 'translate_content'` check. This ensures that Question or Edit contributors do not receive a certificate with the "Translations Coordinator" title.
   - **Adds automated tests:** Includes four new canvas-spy unit tests to explicitly verify text generation, Y-coordinate alignment, negative cases for question certificates, and minute-grammar edge cases.
3. The original bug occurred because: The hardcoded backend constant and frontend canvas drawing logic contained outdated translation team lead information, an incomplete list of translated subjects, and lacked the newly requested organizational title.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #26406 : ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

**Before:**

<img width="2216" height="1920" alt="before changes" src="https://github.com/user-attachments/assets/e966cb9c-9059-41ca-85b1-34cea0bf6865" />

**After:**

<img width="1500" height="1300" alt="after changes" src="https://github.com/user-attachments/assets/f9320cca-55b5-4ca7-8f96-80d622472228" />

#### Proof of changes on desktop with slow/throttled network
*(Note: As this PR modifies the internal output of a generated Canvas Blob, network throttling does not affect the visual rendering of the certificate).*

#### Proof of changes on mobile phone
*N/A - This PR only modifies the internal `ctx.fillText` coordinates and text wrapping logic of a generated Canvas image. It does not alter DOM responsiveness, HTML layouts, or CSS media queries.*

#### Proof of changes in Arabic language
*N/A - The changes do not alter HTML/CSS layouts where RTL (Right-to-Left) text flow would break the DOM structure. The Canvas API generates the text strings independently of the page's directional layout.*

## PR Pointers
- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
