### PR TITLE
Fix #26457: Error message at topic editor page while updating subtopic arrangement

### DIFF
--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
@@ -129,7 +129,7 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
 
   drop(event: CdkDragDrop<Subtopic[]>): void {
     moveItemInArray(this.subtopics, event.previousIndex, event.currentIndex);
-    if (event.previousIndex == event.currentIndex) return;
+    if (event.previousIndex === event.currentIndex) return;
     this.topicUpdateService.rearrangeSubtopic(
       this.topic,
       event.previousIndex,

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
@@ -129,7 +129,7 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
 
   drop(event: CdkDragDrop<Subtopic[]>): void {
     moveItemInArray(this.subtopics, event.previousIndex, event.currentIndex);
-
+    if (event.previousIndex == event.currentIndex) return;
     this.topicUpdateService.rearrangeSubtopic(
       this.topic,
       event.previousIndex,

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
@@ -129,7 +129,9 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
 
   drop(event: CdkDragDrop<Subtopic[]>): void {
     moveItemInArray(this.subtopics, event.previousIndex, event.currentIndex);
-    if (event.previousIndex === event.currentIndex) return;
+    if (event.previousIndex === event.currentIndex) {
+      return;
+    }
     this.topicUpdateService.rearrangeSubtopic(
       this.topic,
       event.previousIndex,

--- a/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
+++ b/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
@@ -787,9 +787,9 @@ export class TopicEditorStateService {
           }
         },
         error => {
-          const errorMessage = typeof error == 'string' ? error : error?.error;
+          const errorMessage = typeof error === 'string' ? error : error?.error;
           this.alertsService.addWarning(
-            errorMessage || 'There was an error when saving the topic.'
+            errorMessage ?? 'There was an error when saving the topic.'
           );
           this._topicIsBeingSaved = false;
         }

--- a/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
+++ b/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
@@ -787,8 +787,9 @@ export class TopicEditorStateService {
           }
         },
         error => {
+          const errorMessage = typeof error == 'string' ? error : error?.error;
           this.alertsService.addWarning(
-            error || 'There was an error when saving the topic.'
+            errorMessage || 'There was an error when saving the topic.'
           );
           this._topicIsBeingSaved = false;
         }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #26457
2. This PR does the following: It checks for subtopic rearragement index if previous and current is same than skip updating also fixes error message while updating the topic.
3. (For bug-fixing PRs only) The original bug occurred because: error object was passed into alerts service and there is no check if current and previous ids are same in frontend side itself.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct
Fixed `[object] [object]` issue mentioned
also improvement skipping change if indexes are same

https://github.com/user-attachments/assets/df20ec9a-49be-480d-8558-5edf5a71db55


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
