### PR TITLE
Fix #18495: Display the title and the current tab of the exploration being edited.

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navbar-breadcrumb.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navbar-breadcrumb.component.html
@@ -1,11 +1,11 @@
-<ul class="nav navbar-nav d-none d-md-block oppia-navbar-breadcrumb ng-cloak">
+<ul class="nav navbar-nav d-none d-md-block oppia-navbar-breadcrumb">
   <li>
     <span class="oppia-navbar-breadcrumb-separator"></span>
     <span *ngIf="navbarTitle">
-      <[navbarTitle]>
+      {{navbarTitle}}
       <span class="oppia-navbar-breadcrumb-separator oppia-navbar-breadcrumb-separator-icon"></span>
       <span>
-        <[getCurrentTabName()]>
+        {{ getCurrentTabName() }}
       </span>
     </span>
     <span *ngIf="navbarTitle === ''" (click)="editTitle()" class="oppia-untitled-exploration-text">

--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navbar-breadcrumb.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navbar-breadcrumb.component.spec.ts
@@ -87,7 +87,13 @@ describe('Editor Navbar Breadcrumb component', () => {
   });
 
   it('should initialize component properties after controller is initialized', () => {
-    expect(component.navbarTitle).toBeUndefined();
+    expect(component.navbarTitle).toBe('Exploration Title...');
+  });
+
+  it('should set navbarTitle to null when exploration title is not yet initialized', () => {
+    explorationTitleService.savedMemento = null;
+    component.setNavbarTitle();
+    expect(component.navbarTitle).toBeNull();
   });
 
   it(

--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navbar-breadcrumb.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navbar-breadcrumb.component.ts
@@ -33,7 +33,7 @@ export class EditorNavbarBreadcrumbComponent implements OnInit, OnDestroy {
   // This property is initialized using Angular lifecycle hooks
   // and we need to do non-null assertion. For more information, see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
-  navbarTitle!: string;
+  navbarTitle: string | null = null;
   _TAB_NAMES_TO_HUMAN_READABLE_NAMES: object = {
     main: 'Edit',
     translation: 'Translation',
@@ -72,18 +72,30 @@ export class EditorNavbarBreadcrumbComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.setNavbarTitle();
     this.directiveSubscriptions.add(
       this.explorationTitleService.onExplorationPropertyChanged.subscribe(
-        propertyName => {
-          const _MAX_TITLE_LENGTH = 20;
-          this.navbarTitle = String(this.explorationTitleService.savedMemento);
-          if (this.navbarTitle.length > _MAX_TITLE_LENGTH) {
-            this.navbarTitle =
-              this.navbarTitle.substring(0, _MAX_TITLE_LENGTH - 3) + '...';
-          }
+        () => {
+          this.setNavbarTitle();
         }
       )
     );
+  }
+
+  setNavbarTitle(): void {
+    if (
+      this.explorationTitleService.savedMemento === undefined ||
+      this.explorationTitleService.savedMemento === null
+    ) {
+      this.navbarTitle = null;
+      return;
+    }
+    const _MAX_TITLE_LENGTH = 20;
+    this.navbarTitle = String(this.explorationTitleService.savedMemento);
+    if (this.navbarTitle.length > _MAX_TITLE_LENGTH) {
+      this.navbarTitle =
+        this.navbarTitle.substring(0, _MAX_TITLE_LENGTH - 3) + '...';
+    }
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Overview

1. This PR fixes #18495 .
2. This PR does the following: Displays the title of the exploration that is being edited and the name of the current tab as well.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

before:

https://github.com/user-attachments/assets/12eda302-5f69-4cdf-8213-59053dfa97e8

after:

https://github.com/user-attachments/assets/7c6c90ca-59e2-453c-aa32-5453ec0938f0


#### Proof of changes on desktop with slow/throttled network


https://github.com/user-attachments/assets/763e332c-f196-4e10-9eb1-58e69c8b8a3f


#### Proof of changes on mobile phone


https://github.com/user-attachments/assets/43f49cd2-ddde-4477-84d3-a21ee8826fbb



