### PR TITLE
Fix #18372: return 404 when state missing from version history

### DIFF
--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -2478,6 +2478,9 @@ class StateVersionHistoryHandler(
         if version_history is None:
             raise self.NotFoundException
 
+        if state_name not in version_history.state_version_history:
+            raise self.NotFoundException
+
         state_version_history = version_history.state_version_history[
             state_name
         ]


### PR DESCRIPTION
## Overview

1. This PR fixes #18372.
2. `StateVersionHistoryHandler.get` now returns 404 when the requested state name is not in `state_version_history` for that exploration version, instead of raising `KeyError` (HTTP 500).

## Root cause

After a state is renamed, clients can still request the old name via `/version_history_handler/state/<exp_id>/<state_name>/<version>`. The handler did a direct dict lookup, which crashed when the name was absent.

## Why this fix is correct

A missing state in the version-history map means there is no history to return for that name at that version — the same case already handled when the whole version history record is missing (`NotFoundException`).


Made with [Cursor](https://cursor.com)