### PR TITLE
Fix #26476: Correct cast lint message to match validation pattern

### DIFF
--- a/scripts/linters/pylint_extensions.py
+++ b/scripts/linters/pylint_extensions.py
@@ -2252,8 +2252,8 @@ class ExceptionalTypesCommentChecker(checkers.BaseChecker):  # type: ignore[misc
         'C0048': (
             'cast function is used. If the cast is really needed, then please'
             ' add a proper comment with clear justification why cast function'
-            ' is needed. The format of the comment should be -> Here use cast'
-            ' because ...',
+            ' is needed. The format of the comment should be -> Here we use'
+            ' cast because ...',
             'cast-func-used',
             'Casting of any value should be done with a proper explanation in'
             ' the code comment.',


### PR DESCRIPTION
Fixes #26476

The C0048 pylint rule tells developers to write cast comments as \`Here use cast because ...\`, but validation at line 2530 only accepts \`Here we use cast because ...\`. Following the error message literally still fails the lint check.

Update the error message to match the validator.