### PR TITLE
fix: wrap long usernames in profile dropdown

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -448,6 +448,14 @@
   padding: 0;
   width: 190px;
 }
+
+.oppia-top-navigation-bar .e2e-test-profile-link strong {
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  word-break: break-word;
+}
 .oppia-top-navigation-bar .oppia-navbar-dropdown-item {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Wrap long usernames in the profile dropdown menu instead of letting them overflow off-screen
- Adds `overflow-wrap`, `word-break`, and `white-space: normal` to the username label in the profile menu

Fixes #25552

## Test plan
- [ ] Log in with a very long username and open the profile dropdown
- [ ] Confirm the full username is visible within the dropdown width
- [ ] Confirm normal-length usernames are unchanged


Made with [Cursor](https://cursor.com)