### PR TITLE
fix: hide empty blog pagination placeholders

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page.component.css
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.css
@@ -163,6 +163,16 @@ ngb-pagination .page-item.active .page-link {
   color: #333;
 }
 
+ngb-pagination .page-item.disabled:not(:first-child):not(:last-child) {
+  display: none;
+}
+
+ngb-pagination .page-item.disabled:first-child .page-link,
+ngb-pagination .page-item.disabled:last-child .page-link {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 ngb-pagination ul li:last-child.page-item {
   margin-left: 4px;
 }


### PR DESCRIPTION
## Summary
- Hide disabled pagination page placeholders that render as empty circles on the blog homepage
- Grey out prev/next arrows when navigation in that direction is unavailable

Fixes #24807

## Test plan
- [ ] Open the blog homepage with pagination visible
- [ ] Verify no empty circles appear before page 1 or after the last page number
- [ ] On the first page, confirm the previous arrow is greyed out
- [ ] On the last page, confirm the next arrow is greyed out


Made with [Cursor](https://cursor.com)