### PR TITLE
fix(blog): parse backend UTC timestamps in local timezone

### DIFF
--- a/core/templates/pages/blog-dashboard-page/blog-card/blog-card.component.ts
+++ b/core/templates/pages/blog-dashboard-page/blog-card/blog-card.component.ts
@@ -25,6 +25,9 @@ import {BlogPostPageConstants} from 'pages/blog-post-page/blog-post-page.constan
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {PageContextService} from 'services/page-context.service';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 import {UserService} from 'services/user.service';
 
 @Component({
@@ -74,7 +77,10 @@ export class BlogCardComponent implements OnInit {
   }
 
   getDateStringInWords(naiveDate: string): string {
-    return dayjs(naiveDate.split(',')[0], 'MM-DD-YYYY').format('MMMM D, YYYY');
+    return dayjs
+      .utc(naiveDate.split(',')[0], 'MM/DD/YYYY')
+      .local()
+      .format('MMMM D, YYYY');
   }
 
   navigateToBlogPostPage(): void {

--- a/core/templates/pages/blog-dashboard-page/blog-dashboard-tile/blog-dashboard-tile.component.ts
+++ b/core/templates/pages/blog-dashboard-page/blog-dashboard-tile/blog-dashboard-tile.component.ts
@@ -19,6 +19,9 @@
 import {Component, Input, OnInit, Output, EventEmitter} from '@angular/core';
 import {BlogPostSummary} from 'domain/blog/blog-post-summary.model';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 import {BlogDashboardPageService} from '../services/blog-dashboard-page.service';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {BlogPostActionConfirmationModalComponent} from 'pages/blog-dashboard-page/blog-post-action-confirmation/blog-post-action-confirmation.component';
@@ -64,7 +67,10 @@ export class BlogDashboardTileComponent implements OnInit {
   }
 
   getDateStringInWords(naiveDate: string): string {
-    return dayjs(naiveDate.split(',')[0], 'MM-DD-YYYY').format('MMM D, YYYY');
+    return dayjs
+      .utc(naiveDate.split(',')[0], 'MM/DD/YYYY')
+      .local()
+      .format('MMM D, YYYY');
   }
 
   editBlogPost(): void {

--- a/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
+++ b/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
@@ -45,6 +45,9 @@ import {UploadBlogPostThumbnailModalComponent} from 'pages/blog-dashboard-page/m
 import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 import {WindowDimensionsService} from 'services/contextual/window-dimensions.service';
 import {BlogCardPreviewModalComponent} from 'pages/blog-dashboard-page/modal-templates/blog-card-preview-modal.component';
 import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
@@ -209,10 +212,11 @@ export class BlogPostEditorComponent implements OnInit {
   }
 
   getDateStringInWords(naiveDateTime: string): string {
-    let datestring = naiveDateTime.substring(0, naiveDateTime.length - 7);
-    return dayjs(datestring, 'MM-DD-YYYY, HH:mm:ss').format(
-      'MMMM D, YYYY [at] hh:mm A'
-    );
+    const datestring = naiveDateTime.substring(0, naiveDateTime.length - 7);
+    return dayjs
+      .utc(datestring, 'MM/DD/YYYY, HH:mm:ss')
+      .local()
+      .format('MMMM D, YYYY [at] hh:mm A');
   }
 
   updateLocalTitleValue(): void {

--- a/core/templates/pages/blog-post-page/blog-post-page.component.ts
+++ b/core/templates/pages/blog-post-page/blog-post-page.component.ts
@@ -28,6 +28,9 @@ import {WindowRef} from 'services/contextual/window-ref.service';
 import {BlogPostPageService} from './services/blog-post-page.service';
 import {UserService} from 'services/user.service';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 
 import './blog-post-page.component.css';
 
@@ -96,7 +99,10 @@ export class BlogPostPageComponent implements OnInit {
   }
 
   getDateStringInWords(naiveDate: string): string {
-    return dayjs(naiveDate.split(',')[0], 'MM-DD-YYYY').format('MMMM D, YYYY');
+    return dayjs
+      .utc(naiveDate.split(',')[0], 'MM/DD/YYYY')
+      .local()
+      .format('MMMM D, YYYY');
   }
 
   isSmallScreenViewActive(): boolean {


### PR DESCRIPTION
## Summary
- Parse naive UTC blog timestamps from the backend as UTC and display them in the user's local timezone
- Fix date format tokens to `MM/DD/YYYY`, matching `core/utils.DATETIME_FORMAT`
- Applies to blog dashboard editor, cards, tiles, and the public blog post page

## Context
Fixes #24787. After publishing, the blog dashboard showed timestamps that did not match the actual publication time because UTC values were parsed as local time.

## Test plan
- [ ] Publish a blog post and confirm the dashboard timestamp matches local time
- [ ] Verify blog card/tile and blog post page dates remain correct
- [ ] Run affected frontend unit tests for blog components

Made with [Cursor](https://cursor.com)