### PR TITLE
Fix #25624: Prevent navbar overlap for long language names

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -618,6 +618,51 @@
     }
   }
 }
+
+@media screen and (min-width: 769px) and (max-width: 1500px) {
+  .oppia-top-navigation-bar .oppia-language-dropdown-button {
+    max-width: 45px;
+    overflow: hidden;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+  .oppia-top-navigation-bar .oppia-language-dropdown-button .desktop-view-language-code {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 950px) {
+  .oppia-top-navigation-bar .oppia-navbar-tab-content {
+    display: inline-block;
+    max-width: 60px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+}
+
+@media screen and (min-width: 951px) and (max-width: 1150px) {
+  .oppia-top-navigation-bar .oppia-navbar-tab-content {
+    display: inline-block;
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+}
+
+@media screen and (min-width: 1151px) and (max-width: 1500px) {
+  .oppia-top-navigation-bar .oppia-navbar-tab-content {
+    display: inline-block;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+}
 .dropdn {
   position: absolute;
   z-index: 500;

--- a/core/templates/services/contextual/window-dimensions.service.ts
+++ b/core/templates/services/contextual/window-dimensions.service.ts
@@ -47,7 +47,7 @@ export class WindowDimensionsService {
   }
 
   isWindowNarrow(): boolean {
-    let NORMAL_NAVBAR_CUTOFF_WIDTH_PX = 768;
+    let NORMAL_NAVBAR_CUTOFF_WIDTH_PX = 1150;
     return this.getWidth() <= NORMAL_NAVBAR_CUTOFF_WIDTH_PX;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #25624

The desktop navbar was shown between 769px and 1150px even when translated labels (for example "Naija (Nigerian Pidgin)") were too long to fit, causing tabs to overlap.

## Changes

- Raise the mobile navbar cutoff to 1150px so the hamburger menu is used at widths where the desktop layout breaks.
- Add responsive truncation for navbar tab labels and hide the long language name in the language dropdown at intermediate desktop widths.

## Test plan

- [ ] Open `/donate`, switch to a language with long navbar labels, and resize between 769px and 1500px
- [ ] Confirm navbar items no longer overlap and the mobile menu still works at <=1150px

Made with [Cursor](https://cursor.com)