### PR TITLE
Fix #26510: Make BlogAdmin role removal error message more user-friendly

### DIFF
--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1707,6 +1707,9 @@ def remove_user_role(user_id: str, role: str) -> None:
     if role in feconf.ALLOWED_DEFAULT_USER_ROLES_ON_REGISTRATION:
         raise Exception('Removing a default role is not allowed.')
 
+    if role not in user_settings.roles:
+        raise Exception('User does not have this role.')
+
     user_settings.roles.remove(role)
 
     role_services.log_role_query(

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -1241,6 +1241,16 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         ):
             user_services.remove_user_role(user_id, feconf.ROLE_ID_FULL_USER)
 
+    def test_remove_user_role_if_user_does_not_have_role_raises_error(self) -> None:
+        user_id = user_services.create_new_user(
+            'someUser', 'user@example.com'
+        ).user_id
+
+        with self.assertRaisesRegex(
+            Exception, 'User does not have this role.'
+        ):
+            user_services.remove_user_role(user_id, feconf.ROLE_ID_BLOG_POST_EDITOR)
+
     def test_add_user_role(self) -> None:
         auth_id = 'test_id'
         username = 'testname'


### PR DESCRIPTION
## Overview

1. This PR fixes #26510.
2. This PR does the following: It modifies the `remove_user_role` function in the backend `user_services` to verify that a user possesses a role before attempting to remove it. If the user does not have the role, it now throws a clean `Exception('User does not have this role.')` instead of a raw Python crash. A unit test was also added to explicitly assert this new error behavior.
3. The original bug occurred because: The backend code attempts to execute `user_settings.roles.remove(role)` without first checking if the role existed in the list. This resulted in an unhandled Python `ValueError` (`list.remove(x): x not in list`), which is displayed to the end-user.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop
BEFORE:
<img width="1909" height="909" alt="image" src="https://github.com/user-attachments/assets/9c61723e-e0b7-4b5e-8491-6169bf27b4ac" />

AFTER:
<img width="1913" height="901" alt="image" src="https://github.com/user-attachments/assets/1f524286-a4c4-48a5-8aa7-13690600b850" />