### PR TITLE
[GSoC 2026] M1.9.2 - Add playwright acceptance tests to the merge queue

### DIFF
--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -214,9 +214,7 @@ jobs:
   acceptance_test:
     needs: [check_test_suites_to_run, build, setup_merge_sha]
     runs-on: ubuntu-22.04
-    if: ${{
-        ( fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0 && github.event_name != 'merge_group' ) || ( fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0 && github.event_name == 'merge_group' )
-      }}
+    if: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0 }}
     strategy:
       # Fast fail only if it's a merge queue.
       fail-fast: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/full_stack_tests.yml
+++ b/.github/workflows/full_stack_tests.yml
@@ -215,14 +215,13 @@ jobs:
     needs: [check_test_suites_to_run, build, setup_merge_sha]
     runs-on: ubuntu-22.04
     if: ${{
-        fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0
-        && github.event_name != 'merge_group'
+        ( fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0 && github.event_name != 'merge_group' ) || ( fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.count > 0 && github.event_name == 'merge_group' )
       }}
     strategy:
       # Fast fail only if it's a merge queue.
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        suite: ${{ fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.suites }}
+        suite: ${{ github.event_name == 'merge_group' && fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance_playwright.suites || fromJSON(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance.suites }}
     name: Acceptance (${{ matrix.suite.name }})
     steps:
       - name: Check for broken suites

--- a/scripts/check_ci_test_suites_to_run.py
+++ b/scripts/check_ci_test_suites_to_run.py
@@ -76,6 +76,7 @@ class TestSuitesByTypeDict(TypedDict):
 
     e2e: List[GenericTestSuiteDict]
     acceptance: List[GenericTestSuiteDict]
+    acceptance_playwright: List[GenericTestSuiteDict]
     lighthouse_performance: List[LighthouseTestSuiteDict]
     lighthouse_accessibility: List[LighthouseTestSuiteDict]
 
@@ -92,6 +93,7 @@ class CITestSuitesToRunDict(TypedDict):
 
     e2e: CITestSuitesDict
     acceptance: CITestSuitesDict
+    acceptance_playwright: CITestSuitesDict
     lighthouse_performance: CITestSuitesDict
     lighthouse_accessibility: CITestSuitesDict
 
@@ -141,6 +143,7 @@ def create_ci_test_suites_dict(
 def create_ci_test_suites_to_run_dict(
     e2e: Optional[CITestSuitesDict] = None,
     acceptance: Optional[CITestSuitesDict] = None,
+    acceptance_playwright: Optional[CITestSuitesDict] = None,
     lighthouse_performance: Optional[CITestSuitesDict] = None,
     lighthouse_accessibility: Optional[CITestSuitesDict] = None,
 ) -> CITestSuitesToRunDict:
@@ -149,6 +152,8 @@ def create_ci_test_suites_to_run_dict(
     Args:
         e2e: dict | None. The e2e test suites to run in the CI.
         acceptance: dict | None. The acceptance test suites to run in the CI.
+        acceptance_playwright: dict | None. The Playwright acceptance test
+            suites to run in the CI.
         lighthouse_performance: dict | None. The lighthouse performance test
             suites to run in the CI.
         lighthouse_accessibility: dict | None. The lighthouse accessibility
@@ -160,6 +165,8 @@ def create_ci_test_suites_to_run_dict(
     return {
         'e2e': e2e or create_ci_test_suites_dict(),
         'acceptance': acceptance or create_ci_test_suites_dict(),
+        'acceptance_playwright': acceptance_playwright
+        or create_ci_test_suites_dict(),
         'lighthouse_performance': lighthouse_performance
         or create_ci_test_suites_dict(),
         'lighthouse_accessibility': lighthouse_accessibility
@@ -257,6 +264,7 @@ def output_test_suites_to_run_to_github_workflow(
     test_suites_to_run_output = {
         'e2e': test_suites_to_run['e2e'],
         'acceptance': test_suites_to_run['acceptance'],
+        'acceptance_playwright': test_suites_to_run['acceptance_playwright'],
         'lighthouse_performance': test_suites_to_run['lighthouse_performance'],
         'lighthouse_accessibility': test_suites_to_run[
             'lighthouse_accessibility'
@@ -352,6 +360,9 @@ def get_all_test_suites_by_type() -> TestSuitesByTypeDict:
     acceptance_test_suites = get_test_suites_from_config(
         os.path.join(CI_TEST_SUITE_CONFIGS_DIRECTORY, 'acceptance.json')
     )
+    acceptance_playwright_suites = [
+        s for s in acceptance_test_suites if s.get('framework') == 'playwright'
+    ]
 
     lighthouse_accessibility_test_suites = (
         partition_lighthouse_pages_into_test_suites(
@@ -367,6 +378,7 @@ def get_all_test_suites_by_type() -> TestSuitesByTypeDict:
     return {
         'e2e': e2e_test_suites,
         'acceptance': acceptance_test_suites,
+        'acceptance_playwright': acceptance_playwright_suites,
         'lighthouse_accessibility': lighthouse_accessibility_test_suites,
         'lighthouse_performance': lighthouse_performance_test_suites,
     }
@@ -379,6 +391,9 @@ def output_all_test_suites_to_run_to_github_workflow() -> None:
         e2e=create_ci_test_suites_dict(all_test_suites_by_type['e2e']),
         acceptance=create_ci_test_suites_dict(
             all_test_suites_by_type['acceptance']
+        ),
+        acceptance_playwright=create_ci_test_suites_dict(
+            all_test_suites_by_type['acceptance_playwright']
         ),
         lighthouse_performance=create_ci_test_suites_dict(
             all_test_suites_by_type['lighthouse_performance']
@@ -618,6 +633,10 @@ def get_ci_test_suites_to_run(
             ),
         )
 
+    acceptance_playwright_test_suites = [
+        s for s in acceptance_test_suites if s.get('framework') == 'playwright'
+    ]
+
     lighthouse_accessibility_test_suites = (
         partition_lighthouse_pages_into_test_suites(
             LIGHTHOUSE_ACCESSIBILITY_MODULE,
@@ -639,6 +658,9 @@ def get_ci_test_suites_to_run(
     return create_ci_test_suites_to_run_dict(
         e2e=create_ci_test_suites_dict(all_test_suites_by_type['e2e']),
         acceptance=create_ci_test_suites_dict(acceptance_test_suites),
+        acceptance_playwright=create_ci_test_suites_dict(
+            acceptance_playwright_test_suites
+        ),
         lighthouse_accessibility=create_ci_test_suites_dict(
             lighthouse_accessibility_test_suites
         ),

--- a/scripts/check_ci_test_suites_to_run_test.py
+++ b/scripts/check_ci_test_suites_to_run_test.py
@@ -212,14 +212,17 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                             {
                                 'name': 'blog-admin/assign-roles',
                                 'module': 'blog-admin/assign-roles.spec.ts',
+                                'framework': 'puppeteer',
                             },
                             {
                                 'name': 'blog-editor/publish',
                                 'module': 'blog-editor/publish.spec.ts',
+                                'framework': 'puppeteer',
                             },
                             {
                                 'name': 'exploration-player/view-exploration',
                                 'module': 'exploration-player/view-exploration.spec.ts',
+                                'framework': 'playwright',
                             },
                         ],
                     }
@@ -362,14 +365,27 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                     {
                         'name': 'blog-admin/assign-roles',
                         'module': 'blog-admin/assign-roles.spec.ts',
+                        'framework': 'puppeteer',
                     },
                     {
                         'name': 'blog-editor/publish',
                         'module': 'blog-editor/publish.spec.ts',
+                        'framework': 'puppeteer',
                     },
                     {
                         'name': 'exploration-player/view-exploration',
                         'module': 'exploration-player/view-exploration.spec.ts',
+                        'framework': 'playwright',
+                    },
+                ],
+            },
+            'acceptance_playwright': {
+                'count': 1,
+                'suites': [
+                    {
+                        'name': 'exploration-player/view-exploration',
+                        'module': 'exploration-player/view-exploration.spec.ts',
+                        'framework': 'playwright',
                     },
                 ],
             },
@@ -745,6 +761,10 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                                     'count': 0,
                                     'suites': [],
                                 },
+                                'acceptance_playwright': {
+                                    'count': 0,
+                                    'suites': [],
+                                },
                                 'lighthouse_accessibility': {
                                     'count': 0,
                                     'suites': [],
@@ -815,6 +835,17 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                                         {
                                             'name': 'exploration-player/view-exploration',  # pylint: disable=line-too-long
                                             'module': 'exploration-player/view-exploration.spec.ts',  # pylint: disable=line-too-long
+                                            'framework': 'playwright',
+                                        }
+                                    ],
+                                },
+                                'acceptance_playwright': {
+                                    'count': 1,
+                                    'suites': [
+                                        {
+                                            'name': 'exploration-player/view-exploration',
+                                            'module': 'exploration-player/view-exploration.spec.ts',
+                                            'framework': 'playwright',
                                         }
                                     ],
                                 },
@@ -884,6 +915,17 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                                         {
                                             'name': 'exploration-player/view-exploration',  # pylint: disable=line-too-long
                                             'module': 'exploration-player/view-exploration.spec.ts',  # pylint: disable=line-too-long
+                                            'framework': 'playwright',
+                                        }
+                                    ],
+                                },
+                                'acceptance_playwright': {
+                                    'count': 1,
+                                    'suites': [
+                                        {
+                                            'name': 'exploration-player/view-exploration',
+                                            'module': 'exploration-player/view-exploration.spec.ts',
+                                            'framework': 'playwright',
                                         }
                                     ],
                                 },
@@ -922,6 +964,10 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                             {
                                 'e2e': self.all_test_suites['e2e'],
                                 'acceptance': {
+                                    'count': 0,
+                                    'suites': [],
+                                },
+                                'acceptance_playwright': {
                                     'count': 0,
                                     'suites': [],
                                 },
@@ -965,6 +1011,7 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                 {
                     'name': 'blog-admin/create-blog-post',
                     'module': 'blog-admin/create-blog-post.spec.ts',
+                    'framework': 'puppeteer',
                 }
             )
 
@@ -997,8 +1044,13 @@ class CheckCITestSuitesToRunTests(test_utils.GenericTestBase):
                                         {
                                             'name': 'blog-admin/create-blog-post',  # pylint: disable=line-too-long
                                             'module': 'blog-admin/create-blog-post.spec.ts',  # pylint: disable=line-too-long
+                                            'framework': 'puppeteer',
                                         }
                                     ],
+                                },
+                                'acceptance_playwright': {
+                                    'count': 0,
+                                    'suites': [],
                                 },
                                 'lighthouse_accessibility': {
                                     'count': 0,


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes part of https://github.com/oppia/oppia/issues/24715
2. This PR does the following: Re-introduces Playwright acceptance tests into the GitHub Actions merge queue, while keeping Puppeteer acceptance tests skipped during merge queue runs.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

I tested on my fork with event `pull_request` instead of event `merge_group` and only playwright tests ran.
https://github.com/Mohak51234/oppia/pull/32

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
