### PR TITLE
 Fix #20030: Validate exploration ID in auth guards before making backend requests

### DIFF
--- a/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.spec.ts
@@ -273,4 +273,20 @@ describe('ExplorationPlayerPageAuthGuard', () => {
       done();
     });
   });
+
+  it('should reject if router.navigate fails for invalid exploration ID', done => {
+    spyOn(router, 'navigate').and.returnValue(Promise.reject('nav error'));
+
+    const route = {
+      paramMap: convertToParamMap({exploration_id: 'learning!&url'}),
+      queryParams: {},
+    } as ActivatedRouteSnapshot;
+
+    const state = createMockState('/explore/learning!&url');
+
+    guard.canActivate(route, state).catch(err => {
+      expect(err).toBe('nav error');
+      done();
+    });
+  });
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.spec.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.spec.ts
@@ -222,4 +222,55 @@ describe('ExplorationPlayerPageAuthGuard', () => {
       done();
     });
   });
+  it('should redirect to error/400 for invalid exploration ID without calling backend', done => {
+    const validateSpy = spyOn(
+      accessValidationBackendApiService,
+      'validateAccessToExplorationPlayerPage'
+    );
+
+    const navigateSpy = spyOn(router, 'navigate').and.callThrough();
+
+    const route = {
+      paramMap: convertToParamMap({exploration_id: 'learning!&url'}),
+      queryParams: {},
+    } as ActivatedRouteSnapshot;
+
+    const state = createMockState('/explore/learning!&url');
+
+    guard.canActivate(route, state).then(result => {
+      expect(result).toBeFalse();
+      expect(validateSpy).not.toHaveBeenCalled();
+      expect(navigateSpy).toHaveBeenCalledWith([
+        `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/400`,
+      ]);
+      expect(location.replaceState).toHaveBeenCalledWith(state.url);
+      done();
+    });
+  });
+
+  it('should redirect to embed error page for invalid exploration ID in embed URL without calling backend', done => {
+    const validateSpy = spyOn(
+      accessValidationBackendApiService,
+      'validateAccessToExplorationPlayerPage'
+    );
+
+    const navigateSpy = spyOn(router, 'navigate').and.callThrough();
+
+    const route = {
+      paramMap: convertToParamMap({exploration_id: 'learning!&url'}),
+      queryParams: {},
+    } as ActivatedRouteSnapshot;
+
+    const state = createMockState('/embed/explore/learning!&url');
+
+    guard.canActivate(route, state).then(result => {
+      expect(result).toBeFalse();
+      expect(validateSpy).not.toHaveBeenCalled();
+      expect(navigateSpy).toHaveBeenCalledWith([
+        `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR_IFRAMED.ROUTE}`,
+      ]);
+      expect(location.replaceState).toHaveBeenCalledWith(state.url);
+      done();
+    });
+  });
 });

--- a/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.ts
@@ -47,6 +47,29 @@ export class ExplorationPlayerPageAuthGuard implements CanActivate {
     return new Promise<boolean>(resolve => {
       const version = route.queryParams.v || null;
       let explorationId = route.paramMap.get('exploration_id') || '';
+      const entityIdRegex = new RegExp(AppConstants.ENTITY_ID_REGEX);
+      if (!entityIdRegex.test(explorationId)) {
+        if (state.url.includes('embed')) {
+          this.router
+            .navigate([
+              `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR_IFRAMED.ROUTE}`,
+            ])
+            .then(() => {
+              this.location.replaceState(state.url);
+              resolve(false);
+            });
+        } else {
+          this.router
+            .navigate([
+              `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/400`,
+            ])
+            .then(() => {
+              this.location.replaceState(state.url);
+              resolve(false);
+            });
+        }
+        return;
+      }
       this.accessValidationBackendApiService
         .validateAccessToExplorationPlayerPage(explorationId, version)
         .then(() => {

--- a/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.ts
+++ b/core/templates/pages/exploration-player-page/current-lesson-player/exploration-player-page-auth.guard.ts
@@ -44,7 +44,7 @@ export class ExplorationPlayerPageAuthGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Promise<boolean> {
-    return new Promise<boolean>(resolve => {
+    return new Promise<boolean>((resolve, reject) => {
       const version = route.queryParams.v || null;
       let explorationId = route.paramMap.get('exploration_id') || '';
       const entityIdRegex = new RegExp(AppConstants.ENTITY_ID_REGEX);
@@ -57,7 +57,7 @@ export class ExplorationPlayerPageAuthGuard implements CanActivate {
             .then(() => {
               this.location.replaceState(state.url);
               resolve(false);
-            });
+            }, reject);
         } else {
           this.router
             .navigate([
@@ -66,7 +66,7 @@ export class ExplorationPlayerPageAuthGuard implements CanActivate {
             .then(() => {
               this.location.replaceState(state.url);
               resolve(false);
-            });
+            }, reject);
         }
         return;
       }
@@ -112,7 +112,7 @@ export class ExplorationPlayerPageAuthGuard implements CanActivate {
               .then(() => {
                 this.location.replaceState(state.url);
                 resolve(false);
-              });
+              }, reject);
           }
         });
     });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.spec.ts
@@ -238,4 +238,19 @@ describe('LessonPlayerPageAuthGuard', () => {
       done();
     });
   });
+
+  it('should reject if router.navigate fails for invalid exploration ID', done => {
+    spyOn(router, 'navigate').and.returnValue(Promise.reject('nav error'));
+
+    const route = createMockRoute('learning!&url');
+    const state: RouterStateSnapshot = {
+      url: '/lesson/learning!&url',
+      root: new ActivatedRouteSnapshot(),
+    };
+
+    guard.canActivate(route, state).catch(err => {
+      expect(err).toBe('nav error');
+      done();
+    });
+  });
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.spec.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.spec.ts
@@ -186,4 +186,56 @@ describe('LessonPlayerPageAuthGuard', () => {
       done();
     });
   });
+
+  it('should redirect to error/400 for invalid exploration ID without calling backend', done => {
+    const validateSpy = spyOn(
+      backendApiService,
+      'validateAccessToExplorationPlayerPage'
+    );
+
+    const navigateSpy = spyOn(router, 'navigate').and.callThrough();
+    const replaceStateSpy = spyOn(location, 'replaceState');
+
+    const route = createMockRoute('learning!&url');
+    const state: RouterStateSnapshot = {
+      url: '/lesson/learning!&url',
+      root: new ActivatedRouteSnapshot(),
+    };
+
+    guard.canActivate(route, state).then(result => {
+      expect(result).toBeFalse();
+      expect(validateSpy).not.toHaveBeenCalled();
+      expect(navigateSpy).toHaveBeenCalledWith([
+        `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/400`,
+      ]);
+      expect(replaceStateSpy).toHaveBeenCalledWith(state.url);
+      done();
+    });
+  });
+
+  it('should redirect to embed error page for invalid exploration ID in embed URL without calling backend', done => {
+    const validateSpy = spyOn(
+      backendApiService,
+      'validateAccessToExplorationPlayerPage'
+    );
+
+    const navigateSpy = spyOn(router, 'navigate').and.callThrough();
+    const replaceStateSpy = spyOn(location, 'replaceState');
+
+    const route = createMockRoute('learning!&url');
+    const state: RouterStateSnapshot = {
+      url: '/embed/lesson/learning!&url',
+      root: new ActivatedRouteSnapshot(),
+    };
+
+    guard.canActivate(route, state).then(result => {
+      expect(result).toBeFalse();
+      expect(validateSpy).not.toHaveBeenCalled();
+      expect(navigateSpy).toHaveBeenCalledWith([
+        `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR_IFRAMED.ROUTE}`,
+      ]);
+      expect(replaceStateSpy).toHaveBeenCalledWith(state.url);
+      done();
+    });
+  });
 });

--- a/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.ts
@@ -47,6 +47,32 @@ export class LessonPlayerPageAuthGuard implements CanActivate {
     return new Promise<boolean>(resolve => {
       const version = route.queryParams.v || null;
       let explorationId = route.paramMap.get('exploration_id') || '';
+      // Validate the exploration ID before making any backend requests.
+      // Invalid IDs (e.g. containing special characters) should be rejected
+      // on the frontend to avoid unnecessary backend calls and server errors.
+      const entityIdRegex = new RegExp(AppConstants.ENTITY_ID_REGEX);
+      if (!entityIdRegex.test(explorationId)) {
+        if (state.url.includes('embed')) {
+          this.router
+            .navigate([
+              `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR_IFRAMED.ROUTE}`,
+            ])
+            .then(() => {
+              this.location.replaceState(state.url);
+              resolve(false);
+            });
+        } else {
+          this.router
+            .navigate([
+              `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/400`,
+            ])
+            .then(() => {
+              this.location.replaceState(state.url);
+              resolve(false);
+            });
+        }
+        return;
+      }
       if (this.platformFeatureService.status.NewLessonPlayer.isEnabled) {
         this.accessValidationBackendApiService
           .validateAccessToExplorationPlayerPage(explorationId, version)

--- a/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.ts
+++ b/core/templates/pages/exploration-player-page/new-lesson-player/lesson-player-auth.guard.ts
@@ -44,7 +44,7 @@ export class LessonPlayerPageAuthGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Promise<boolean> {
-    return new Promise<boolean>(resolve => {
+    return new Promise<boolean>((resolve, reject) => {
       const version = route.queryParams.v || null;
       let explorationId = route.paramMap.get('exploration_id') || '';
       // Validate the exploration ID before making any backend requests.
@@ -60,7 +60,7 @@ export class LessonPlayerPageAuthGuard implements CanActivate {
             .then(() => {
               this.location.replaceState(state.url);
               resolve(false);
-            });
+            }, reject);
         } else {
           this.router
             .navigate([
@@ -69,7 +69,7 @@ export class LessonPlayerPageAuthGuard implements CanActivate {
             .then(() => {
               this.location.replaceState(state.url);
               resolve(false);
-            });
+            }, reject);
         }
         return;
       }


### PR DESCRIPTION
## Overview

1. This PR fixes #20030 .

2. This PR adds an early exploration ID validation check in both
`ExplorationPlayerPageAuthGuard` and `LessonPlayerPageAuthGuard`, before
any backend request is made. When a user navigates to a URL like
`/explore/learning!&url`, the frontend now validates the exploration ID
against `AppConstants.ENTITY_ID_REGEX` (`^[a-zA-Z0-9-_]{1,12}$`) and
routes directly to the error page without hitting the backend at all.
Both embed and non-embed cases are handled — invalid IDs in embed URLs
route to `ERROR_IFRAMED`, and non-embed URLs route to `ERROR/400`,
consistent with the existing catch block behavior in both guards.

3. The original bug occurred because the frontend never validated the
exploration ID from the route params before calling
`/access_validation_handler/can_access_exploration_player_page/<exploration_id>`.
Any malformed URL like `/explore/learning!&url` would cause the frontend
to send the invalid ID to the backend, which correctly rejected it with a
schema validation error and logged a full `InvalidInputException` stack
trace on every occurrence. Both auth guards needed fixing because all 4
routes that accept `:exploration_id` are split across them —
`explore/:exploration_id` and `embed/exploration/:exploration_id` go
through `ExplorationPlayerPageAuthGuard`, while `lesson/:exploration_id`
and `embed/lesson/:exploration_id` go through `LessonPlayerPageAuthGuard`.

## Essential Checklist

Please follow the
[instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of
      on line 1 above. Once I open the PR, I will check that any issues
      this PR fully fixes are listed in the "Development" section of the
      sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the
      changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or
      "Fix part of #bugnum: ...", followed by a short, clear summary of
      the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a
      comment with the phrase "@{{reviewer_username}} PTAL" if I can't
      assign them directly).

## Proof that changes are correct

<img width="1920" height="1020" alt="Screenshot 2026-06-28 170042" src="https://github.com/user-attachments/assets/c22589c9-fb70-4c33-95f2-bd0e70ff4871" />


#### Proof of changes on desktop with slow/throttled network

#### Before:

https://github.com/user-attachments/assets/cfb9afe9-50f2-4073-a922-1b1d373d23ec

#### After:

https://github.com/user-attachments/assets/2314c7e4-ded4-4068-920e-ba283d03aa84

#### Proof of changes on mobile phone

N/A — this PR changes route-guard validation logic only and does not introduce any mobile-specific UI changes. The invalid URL handling was verified in the web browser, and the same guard logic is used regardless of viewport size.

#### Proof of changes in Arabic language

N/A — this PR makes no UI changes.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
