### PR TITLE
fix: review tests trigger on every 3rd chapter, not wrong ones

### DIFF
--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -334,8 +334,13 @@ class StoryProgressHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         )
 
         learner_completed_story = len(completed_node_ids) == len(ordered_nodes)
-        learner_at_review_point_in_story = len(exp_summaries) != 0 and (
-            len(completed_node_ids) & constants.NUM_EXPLORATIONS_PER_REVIEW_TEST
+        # Every N completed chapters should trigger a review test, not a
+        # bitwise check (3 & 3 == 3, so chapter 3 never matched).
+        learner_at_review_point_in_story = (
+            len(exp_summaries) != 0
+            and len(completed_node_ids) > 0
+            and len(completed_node_ids)
+            % constants.NUM_EXPLORATIONS_PER_REVIEW_TEST
             == 0
         )
 


### PR DESCRIPTION
Ready-for-review tests should pop up after every 3 completed chapters. The check used bitwise `&` instead of `%`, so chapter 3 never matched (3 & 3 = 3) and chapter 4 incorrectly did (4 & 3 = 0).

Switched to modulo so review points land at 3, 6, 9, etc.


Made with [Cursor](https://cursor.com)