### PR TITLE
Fix #23342: Added collapsible accordion to study guide page

### DIFF
--- a/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.html
+++ b/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.html
@@ -37,11 +37,16 @@
   <p *ngIf="isHackySubtopicTitleTranslationDisplayed()" class="content-title">{{ subtopicTitleTranslationKey | translate }}</p>
   <div class="content-box">
     <div class="content">
-      <div class="card" *ngFor="let section of sections">
-        <div class="card-header">
+      <div class="card" *ngFor="let section of sections; let i = index">
+        <div class="card-header"
+             [class.card-header-highlighted]="isSectionHighlighted(i)"
+             (click)="toggleSection(i)"
+             (keydown.enter)="toggleSection(i)"
+             tabindex="0">
           <h3 class="card-title">{{ section.heading.unicode }}</h3>
+          <i class="material-icons card-chevron" [class.expanded]="isSectionExpanded(i)">expand_more</i>
         </div>
-        <div class="card-content">
+        <div class="card-content" *ngIf="isSectionExpanded(i)">
           <oppia-rte-output-display [rteString]="section.content.html">
           </oppia-rte-output-display>
         </div>
@@ -130,12 +135,22 @@
   .card {
     background-color: #fff;
     border: none !important;
+    margin-bottom: 12px;
     overflow: hidden;
   }
 
   .card-header {
+    align-items: center;
     background-color: #003b36;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
     padding: 10px 10px;
+    user-select: none;
+  }
+
+  .card-header-highlighted {
+    background-color: #00645c;
   }
 
   .card-title {
@@ -144,7 +159,16 @@
     font-size: 18px;
     font-weight: 700;
     margin: 0;
-    text-align: center;
+  }
+
+  .card-chevron {
+    color: #fff;
+    flex-shrink: 0;
+    transition: transform 0.3s ease;
+  }
+
+  .card-chevron.expanded {
+    transform: rotate(180deg);
   }
 
   .card-content {
@@ -279,11 +303,11 @@
     }
 
     .card-header {
-      padding: 15px 15px;
+      padding: 15px;
     }
 
     .card-title {
-      font-size: 18px;
+      font-size: 16px;
     }
 
     .card-content {

--- a/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.spec.ts
+++ b/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.spec.ts
@@ -356,6 +356,7 @@ describe('Subtopic viewer page', function () {
       'subtopic-url'
     );
     spyOn(loaderService, 'showLoadingScreen');
+    spyOn(urlService, 'getUrlParams').and.returnValue({});
 
     spyOn(
       subtopicViewerBackendApiService,
@@ -370,7 +371,151 @@ describe('Subtopic viewer page', function () {
 
     expect(component.sections).toEqual(subtopicDataObject.getSections());
     expect(component.pageContents).toBeNull();
+    expect(component.expandedSectionIndices).toEqual(new Set([0]));
+    expect(component.highlightedSectionIndex).toBe(-1);
   }));
+
+  it('should expand first section by default when sections are loaded', fakeAsync(() => {
+    platformFeatureService.status.ShowRestructuredStudyGuides.isEnabled = true;
+    spyOn(urlService, 'getTopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'topic-url'
+    );
+    spyOn(urlService, 'getClassroomUrlFragmentFromLearnerUrl').and.returnValue(
+      'classroom-url'
+    );
+    spyOn(urlService, 'getSubtopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'subtopic-url'
+    );
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(urlService, 'getUrlParams').and.returnValue({});
+    spyOn(
+      subtopicViewerBackendApiService,
+      'fetchSubtopicDataAsync'
+    ).and.returnValue(Promise.resolve(subtopicDataObject));
+    spyOn(topicViewerBackendApiService, 'fetchTopicDataAsync').and.returnValue(
+      Promise.resolve(topicDataObject)
+    );
+
+    component.ngOnInit();
+    tick();
+
+    expect(component.expandedSectionIndices).toEqual(new Set([0]));
+    expect(component.isSectionExpanded(0)).toBeTrue();
+    expect(component.isSectionExpanded(1)).toBeFalse();
+    expect(component.highlightedSectionIndex).toBe(-1);
+    expect(component.isSectionHighlighted(0)).toBeFalse();
+  }));
+
+  it('should pre-expand and highlight a section when section query param is provided', fakeAsync(() => {
+    platformFeatureService.status.ShowRestructuredStudyGuides.isEnabled = true;
+    spyOn(urlService, 'getTopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'topic-url'
+    );
+    spyOn(urlService, 'getClassroomUrlFragmentFromLearnerUrl').and.returnValue(
+      'classroom-url'
+    );
+    spyOn(urlService, 'getSubtopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'subtopic-url'
+    );
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(urlService, 'getUrlParams').and.returnValue({section: '0'});
+    spyOn(
+      subtopicViewerBackendApiService,
+      'fetchSubtopicDataAsync'
+    ).and.returnValue(Promise.resolve(subtopicDataObject));
+    spyOn(topicViewerBackendApiService, 'fetchTopicDataAsync').and.returnValue(
+      Promise.resolve(topicDataObject)
+    );
+
+    component.ngOnInit();
+    tick();
+
+    expect(component.expandedSectionIndices).toEqual(new Set([0]));
+    expect(component.highlightedSectionIndex).toBe(0);
+    expect(component.isSectionExpanded(0)).toBeTrue();
+    expect(component.isSectionHighlighted(0)).toBeTrue();
+  }));
+
+  it('should fall back to first section when section query param is out of range', fakeAsync(() => {
+    platformFeatureService.status.ShowRestructuredStudyGuides.isEnabled = true;
+    spyOn(urlService, 'getTopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'topic-url'
+    );
+    spyOn(urlService, 'getClassroomUrlFragmentFromLearnerUrl').and.returnValue(
+      'classroom-url'
+    );
+    spyOn(urlService, 'getSubtopicUrlFragmentFromLearnerUrl').and.returnValue(
+      'subtopic-url'
+    );
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(urlService, 'getUrlParams').and.returnValue({section: '99'});
+    spyOn(
+      subtopicViewerBackendApiService,
+      'fetchSubtopicDataAsync'
+    ).and.returnValue(Promise.resolve(subtopicDataObject));
+    spyOn(topicViewerBackendApiService, 'fetchTopicDataAsync').and.returnValue(
+      Promise.resolve(topicDataObject)
+    );
+
+    component.ngOnInit();
+    tick();
+
+    expect(component.expandedSectionIndices).toEqual(new Set([0]));
+    expect(component.highlightedSectionIndex).toBe(-1);
+  }));
+
+  it('should toggle a section open then closed', () => {
+    component.expandedSectionIndices = new Set([0]);
+
+    component.toggleSection(1);
+    expect(component.expandedSectionIndices.has(1)).toBeTrue();
+
+    component.toggleSection(1);
+    expect(component.expandedSectionIndices.has(1)).toBeFalse();
+  });
+
+  it('should collapse current section when toggling it while expanded', () => {
+    component.expandedSectionIndices = new Set([2]);
+
+    component.toggleSection(2);
+
+    expect(component.expandedSectionIndices.has(2)).toBeFalse();
+    expect(component.isSectionExpanded(2)).toBeFalse();
+  });
+
+  it('should allow multiple sections to be open simultaneously', () => {
+    component.expandedSectionIndices = new Set([0]);
+
+    component.toggleSection(1);
+    component.toggleSection(2);
+
+    expect(component.isSectionExpanded(0)).toBeTrue();
+    expect(component.isSectionExpanded(1)).toBeTrue();
+    expect(component.isSectionExpanded(2)).toBeTrue();
+  });
+
+  it('should report correct isSectionExpanded values', () => {
+    component.expandedSectionIndices = new Set([1]);
+
+    expect(component.isSectionExpanded(0)).toBeFalse();
+    expect(component.isSectionExpanded(1)).toBeTrue();
+    expect(component.isSectionExpanded(2)).toBeFalse();
+  });
+
+  it('should report correct isSectionHighlighted values', () => {
+    component.highlightedSectionIndex = 2;
+
+    expect(component.isSectionHighlighted(0)).toBeFalse();
+    expect(component.isSectionHighlighted(1)).toBeFalse();
+    expect(component.isSectionHighlighted(2)).toBeTrue();
+  });
+
+  it('should not highlight any section when highlightedSectionIndex is -1', () => {
+    component.highlightedSectionIndex = -1;
+
+    expect(component.isSectionHighlighted(0)).toBeFalse();
+    expect(component.isSectionHighlighted(1)).toBeFalse();
+  });
 
   it(
     'should obtain translated title and set it whenever the ' +

--- a/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.ts
+++ b/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.ts
@@ -73,6 +73,8 @@ export class SubtopicViewerPageComponent implements OnInit, OnDestroy {
   subtopicSummaryIsShown: boolean = false;
   isPracticeTabDisplayed: boolean = false;
   currentSubtopicId!: number;
+  expandedSectionIndices: Set<number> = new Set([0]);
+  highlightedSectionIndex: number = -1;
 
   constructor(
     private alertsService: AlertsService,
@@ -146,6 +148,7 @@ export class SubtopicViewerPageComponent implements OnInit, OnDestroy {
       ([subtopicDataObject, topicDataObject]) => {
         if (this.isShowRestructuredStudyGuidesFeatureEnabled()) {
           this.sections = subtopicDataObject.getSections();
+          this.initializeSectionExpansion();
         } else {
           this.pageContents = subtopicDataObject.getPageContents();
         }
@@ -225,6 +228,40 @@ export class SubtopicViewerPageComponent implements OnInit, OnDestroy {
         this.parentTopicTitleTranslationKey
       ) && !this.i18nLanguageCodeService.isCurrentLanguageEnglish()
     );
+  }
+
+  initializeSectionExpansion(): void {
+    const params = this.urlService.getUrlParams();
+    if (Object.prototype.hasOwnProperty.call(params, 'section')) {
+      const sectionIndex = parseInt(params.section, 10);
+      if (
+        !isNaN(sectionIndex) &&
+        this.sections !== null &&
+        sectionIndex >= 0 &&
+        sectionIndex < this.sections.length
+      ) {
+        this.expandedSectionIndices = new Set([sectionIndex]);
+        this.highlightedSectionIndex = sectionIndex;
+        return;
+      }
+    }
+    this.expandedSectionIndices = new Set([0]);
+  }
+
+  isSectionExpanded(index: number): boolean {
+    return this.expandedSectionIndices.has(index);
+  }
+
+  isSectionHighlighted(index: number): boolean {
+    return this.highlightedSectionIndex === index;
+  }
+
+  toggleSection(index: number): void {
+    if (this.expandedSectionIndices.has(index)) {
+      this.expandedSectionIndices.delete(index);
+    } else {
+      this.expandedSectionIndices.add(index);
+    }
   }
 
   openStudyGuide(event?: MouseEvent): void {


### PR DESCRIPTION
## Overview
1. This PR fixes #23342.
2. This PR adds a collapsible accordion to the study guide page so learners aren't shown a wall of content all at once. Sections are collapsed by default, except the first one, which is expanded on load. Clicking a section toggles it open or closed without affecting other open sections, so multiple sections can stay open at the same time. The chevron rotates to show expanded or collapsed state.

Deep linking with a `?section=N` param pre-expands and highlights that section, so a learner coming from a practice session lands right where they need to.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes on line 1 above.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #23342: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

N/A

#### Proof of changes on mobile phone

<img width="300" height="674" alt="Mobile view — iPhone 12 Pro" src="https://github.com/user-attachments/assets/d29fe5cc-985c-492c-9517-e3f3c27c8286" />

#### Proof of changes in Arabic language

<img width="300" height="674" alt="Arabic RTL view — iPhone 12 Pro" src="https://github.com/user-attachments/assets/78a320f7-7242-4038-a9b7-198a49d0bb6f" />