### PR TITLE
Fix #25022: Add missing Turkish translation for I18N_EXPLORE_OPPIA_CLASSROOM

### DIFF
--- a/assets/i18n/tr.json
+++ b/assets/i18n/tr.json
@@ -299,6 +299,7 @@
   "I18N_EXPLORATION_aqJ07xrTFNLF_TITLE": "Sorunaları Kutu Modelleri ile Çözme",
   "I18N_EXPLORATION_fRXacq7caMoO_TITLE": "Şekillerin Karşılaştırılması",
   "I18N_EXPLORATION_ksezbx9FUWFh_TITLE": "Vergiler ve İndirimler",
+  "I18N_EXPLORE_OPPIA_CLASSROOM": "Oppia Sınıflarını Keşfedin",
   "I18N_FEEDBACK_MESSAGE_ANONYMOUS_AUTHOR": "Anonim",
   "I18N_FEEDBACK_UPDATES_FEEDBACK_THREAD_WARNING": "Herhangi bir kişisel bilgiyi paylaşmaktan kaçının çünkü bu tartışma halka açıktır.",
   "I18N_FEEDBACK_UPDATES_RETURN_TO_FEEDBACK_THREADS_MESSAGE": "Mesaj listesine dön",


### PR DESCRIPTION
## Overview

1. This PR fixes #25022.
2. This PR adds the missing `I18N_EXPLORE_OPPIA_CLASSROOM` translation key to `assets/i18n/tr.json`. As a result, the **Explore Oppia Classrooms** button on the homepage now correctly displays in Turkish (**Oppia Sınıflarını Keşfedin**) instead of falling back to English.
3. The original bug occurred because the `I18N_EXPLORE_OPPIA_CLASSROOM` key existed in `en.json` and was correctly referenced via the `translate` pipe in `splash-page.component.html`, but the corresponding entry was missing from `tr.json`. The key was introduced in PR #25083, and the Turkish translation was never added.
  During investigation, I also found that this key is missing from several other language files. Per @arkia09's guidance in the issue discussion, this PR is intentionally scoped to the Turkish translation only.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

### Desktop Verification

The attached video demonstrates:

## Before: 
- With the site language set to Turkish, the homepage button displayed **Explore Oppia Classrooms** in English because the translation key was missing from `tr.json`.

## After:
- The homepage correctly displays (**Oppia Sınıflarını Keşfedin**) after adding the missing translation.

- Verification across multiple languages to confirm no unintended regressions.
- Browser DevTools console showing no errors during verification.


**Video:**

https://drive.google.com/file/d/1As2RrC9rxHXQbPQjqqn0Qg-b5W5F-aK8/view?usp=drive_link


#### Proof of changes on mobile phone

Not applicable. This change only adds a missing translation string and does not modify any layout, styling, or responsive behavior. 


#### Proof of changes in Arabic language

Verified in the attached video that the Arabic translation remains unchanged and is unaffected by this change.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
