### PR TITLE
Fix part of #20564: Replace oppia-thumbnail-uploader with oppia-image-uploader

### DIFF
--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.html
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.html
@@ -134,18 +134,10 @@
               </span>
             </div>
             <label class="form-heading">Thumbnail</label>
-            <oppia-thumbnail-uploader [disabled]="!topicRights.canEditTopic()"
-                                      [useLocalStorage]="false"
-                                      [filename]="topic.getThumbnailFilename()"
-                                      (updateFilename)="updateTopicThumbnailFilename($event)"
-                                      [bgColor]="topic.getThumbnailBgColor()"
-                                      (updateBgColor)="updateTopicThumbnailBgColor($event)"
-                                      [allowedBgColors]="allowedBgColors"
-                                      [aspectRatio]="'4:3'"
-                                      [previewTitle]="editableName"
-                                      previewDescriptionBgColor="#2F6687"
-                                      [previewFooter]="topic.getCanonicalStoryIds().length + ' Lessons'">
-            </oppia-thumbnail-uploader>
+            <oppia-image-uploader
+              [imageUploaderParameters]="imageUploaderParameters"
+              (imageSave)="onImageSave($event)">
+            </oppia-image-uploader>
             <div class="topic-classroom-container">
               <label>Classroom</label>
               <span *ngIf="isAssignedToAClassroom()">

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.spec.ts
@@ -1100,4 +1100,57 @@ describe('Topic editor tab directive', () => {
       topicEditorStateService.updateExistenceOfTopicUrlFragment
     ).not.toHaveBeenCalled();
   });
+
+  it('should return early from onImageSave when entityType is null', () => {
+    const mockPageContextService = TestBed.inject(PageContextService);
+    spyOn(mockPageContextService, 'getEntityType').and.returnValue(undefined);
+    const postThumbnailSpy = spyOn(
+      assetsBackendApiService,
+      'postThumbnailFile'
+    );
+
+    component.onImageSave({
+      filename: 'img.svg',
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    expect(postThumbnailSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not splice availableSkillSummariesForDiagnosticTest when skillSummary is not found', () => {
+    component.skillForDiagnosticTestFormControl.setValue(skillSummary);
+    component.availableSkillSummariesForDiagnosticTest = [];
+    let updateSpy = spyOn(topicUpdateService, 'updateDiagnosticTestSkills');
+    component.addSkillForDiagnosticTest();
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it('should not set topicDataHasLoaded when hasLoadedTopic return false', () => {
+    spyOn(topicEditorStateService, 'hasLoadedTopic').and.returnValue(false);
+    component.topicDataHasLoaded = false;
+    component.initEditor();
+    expect(component.topicDataHasLoaded).toBe(false);
+  });
+
+  it('should use default bgColor and undefined filename when topic thumbnail is not set', () => {
+    spyOn(component.topic, 'getThumbnailBgColor').and.returnValue(
+      null as unknown as string
+    );
+    spyOn(component.topic, 'getThumbnailFilename').and.returnValue(
+      null as unknown as string
+    );
+    component.initEditor();
+    expect(component.imageUploaderParameters.bgColor).toEqual(
+      component.allowedBgColors[0]
+    );
+    expect(component.imageUploaderParameters.filename).toBeUndefined();
+  });
+
+  it('should toggle main topic card when called without arguments', () => {
+    spyOn(windowDimensionsService, 'isWindowNarrow').and.returnValue(true);
+    expect(component.mainTopicCardIsShown).toEqual(true);
+    component.togglePreviewListCards();
+    expect(component.mainTopicCardIsShown).toEqual(false);
+  });
 });

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.spec.ts
@@ -52,6 +52,9 @@ import {TopicsAndSkillsDashboardBackendApiService} from 'domain/topics_and_skill
 import {CdkDragDrop} from '@angular/cdk/drag-drop';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
+import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
+import {of} from 'rxjs';
+import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 
 class MockNgbModal {
   open() {
@@ -87,6 +90,7 @@ class MockImageUploadHelperService {
 
 describe('Topic editor tab directive', () => {
   let component: TopicEditorTabComponent;
+  let assetsBackendApiService: AssetsBackendApiService;
   let fixture: ComponentFixture<TopicEditorTabComponent>;
   let ngbModal: NgbModal;
   let urlInterpolationService: UrlInterpolationService;
@@ -134,6 +138,7 @@ describe('Topic editor tab directive', () => {
         EntityCreationService,
         TopicEditorRoutingService,
         QuestionBackendApiService,
+        AssetsBackendApiService,
         {
           provide: TopicsAndSkillsDashboardBackendApiService,
           useValue: MockTopicsAndSkillsDashboardBackendApiService,
@@ -172,6 +177,7 @@ describe('Topic editor tab directive', () => {
     undoRedoService = TestBed.inject(UndoRedoService);
     entityCreationService = TestBed.inject(EntityCreationService);
     topicEditorRoutingService = TestBed.inject(TopicEditorRoutingService);
+    assetsBackendApiService = TestBed.inject(AssetsBackendApiService);
 
     spyOnProperty(topicEditorStateService, 'onTopicInitialized').and.callFake(
       () => {
@@ -510,24 +516,55 @@ describe('Topic editor tab directive', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('should call the TopicUpdateService if thumbnail is updated', () => {
+  it('should call the TopicUpdateService if thumbnail is updated', fakeAsync(() => {
     let topicThumbnailSpy = spyOn(
       topicUpdateService,
       'setTopicThumbnailFilename'
     );
-    component.updateTopicThumbnailFilename('img2.svg');
-    expect(topicThumbnailSpy).toHaveBeenCalled();
-  });
 
-  it('should call the TopicUpdateService if thumbnail is updated', () => {
-    component.updateTopicThumbnailFilename('img2.svg');
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img2.svg'})
+    );
+
+    component.onImageSave({
+      filename: 'img2.svg',
+      bg_color: component.topic.getThumbnailBgColor(),
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
+    expect(topicThumbnailSpy).toHaveBeenCalled();
+  }));
+
+  it('should not call the TopicUpdateService if thumbnail is same', fakeAsync(() => {
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img2.svg'})
+    );
+
+    component.onImageSave({
+      filename: 'img2.svg',
+      bg_color: component.topic.getThumbnailBgColor(),
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
     let topicThumbnailSpy = spyOn(
       topicUpdateService,
       'setTopicThumbnailFilename'
     );
-    component.updateTopicThumbnailFilename('img2.svg');
+
+    component.onImageSave({
+      filename: 'img2.svg',
+      bg_color: component.topic.getThumbnailBgColor(),
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
     expect(topicThumbnailSpy).not.toHaveBeenCalled();
-  });
+  }));
 
   it('should call the TopicUpdateService if topic description is updated', () => {
     let topicDescriptionSpy = spyOn(topicUpdateService, 'setTopicDescription');
@@ -597,14 +634,25 @@ describe('Topic editor tab directive', () => {
     expect(topicDeleteSpy).toHaveBeenCalled();
   });
 
-  it('should call the TopicUpdateService if thumbnail bg color is updated', () => {
+  it('should call the TopicUpdateService if thumbnail bg color is updated', fakeAsync(() => {
     let topicThumbnailBGSpy = spyOn(
       topicUpdateService,
       'setTopicThumbnailBgColor'
     );
-    component.updateTopicThumbnailBgColor('#FFFFFF');
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img2.svg'})
+    );
+
+    component.onImageSave({
+      filename: component.topic.getThumbnailFilename(),
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
     expect(topicThumbnailBGSpy).toHaveBeenCalled();
-  });
+  }));
 
   it('should call TopicEditorRoutingService to navigate to skill', () => {
     let topicThumbnailBGSpy = spyOn(
@@ -622,15 +670,34 @@ describe('Topic editor tab directive', () => {
     );
   });
 
-  it('should not call the TopicUpdateService if thumbnail bg color is same', () => {
-    component.updateTopicThumbnailBgColor('#FFFFFF');
+  it('should not call the TopicUpdateService if thumbnail bg color is same', fakeAsync(() => {
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img2.svg'})
+    );
+
+    component.onImageSave({
+      filename: component.topic.getThumbnailFilename(),
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
     let topicThumbnailBGSpy = spyOn(
       topicUpdateService,
       'setTopicThumbnailBgColor'
     );
-    component.updateTopicThumbnailBgColor('#FFFFFF');
+
+    component.onImageSave({
+      filename: component.topic.getThumbnailFilename(),
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
     expect(topicThumbnailBGSpy).not.toHaveBeenCalled();
-  });
+  }));
 
   it('should toggle topic preview', () => {
     expect(component.topicPreviewCardIsShown).toEqual(false);

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.component.ts
@@ -45,6 +45,13 @@ import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 import {Topic} from 'domain/topic/topic-object.model';
 import {TopicRights} from 'domain/topic/topic-rights.model';
 import {RearrangeSkillsInSubtopicsModalComponent} from '../modal-templates/rearrange-skills-in-subtopics-modal.component';
+import {
+  ImageUploaderData,
+  ImageUploaderParameters,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
+
+import {AssetsBackendApiService} from 'services/assets-backend-api.service';
+import {AlertsService} from 'services/alerts.service';
 
 @Component({
   selector: 'oppia-topic-editor-tab',
@@ -88,6 +95,7 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
   subtopicQuestionCountDict!: Record<number, number>;
   uncategorizedSkillSummaries!: ShortSkillSummary[];
   editableThumbnailDataUrl!: string;
+  imageUploaderParameters!: ImageUploaderParameters;
   canonicalStorySummaries!: StorySummary[];
   mainTopicCardIsShown!: boolean;
   storiesListIsShown!: boolean;
@@ -108,6 +116,8 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
 
   constructor(
     private pageContextService: PageContextService,
+    private assetsBackendApiService: AssetsBackendApiService,
+    private alertsService: AlertsService,
     private entityCreationService: EntityCreationService,
     private focusManagerService: FocusManagerService,
     private imageUploadHelperService: ImageUploadHelperService,
@@ -163,6 +173,22 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
     this.editableTopicUrlFragment = this.topic.getUrlFragment();
     this.editableDescription = this.topic.getDescription();
     this.allowedBgColors = AppConstants.ALLOWED_THUMBNAIL_BG_COLORS.topic;
+    this.imageUploaderParameters = {
+      disabled: !this.topicRights.canEditTopic(),
+      maxImageSizeInKB: 100,
+      imageName: 'Thumbnail',
+      orientation: 'landscape',
+      bgColor:
+        this.topic.getThumbnailBgColor() ??
+        (this.allowedBgColors as string[])[0],
+      allowedBgColors: this.allowedBgColors as string[],
+      allowedImageFormats: ['svg'],
+      aspectRatio: '4:3',
+      filename: this.topic.getThumbnailFilename() ?? undefined,
+      previewTitle: this.editableName,
+      previewDescriptionBgColor: '#2F6687',
+      previewFooter: `${this.topic.getCanonicalStoryIds().length} Lessons`,
+    };
     this.topicNameExists = false;
     this.topicUrlFragmentExists = false;
     this.hostname = this.windowRef.nativeWindow.location.hostname;
@@ -410,24 +436,48 @@ export class TopicEditorTabComponent implements OnInit, OnDestroy {
     this.updateTopicUrlFragment(urlFragment);
   }
 
-  updateTopicThumbnailFilename(newThumbnailFilename: string): void {
-    if (newThumbnailFilename === this.topic.getThumbnailFilename()) {
-      return;
-    }
-    this.topicUpdateService.setTopicThumbnailFilename(
-      this.topic,
-      newThumbnailFilename
-    );
-  }
+  onImageSave(imageData: ImageUploaderData): void {
+    const entityType = this.pageContextService.getEntityType();
+    const entityId = this.pageContextService.getEntityId();
 
-  updateTopicThumbnailBgColor(newThumbnailBgColor: string): void {
-    if (newThumbnailBgColor === this.topic.getThumbnailBgColor()) {
+    if (!entityType || !entityId) {
       return;
     }
-    this.topicUpdateService.setTopicThumbnailBgColor(
-      this.topic,
-      newThumbnailBgColor
-    );
+
+    this.assetsBackendApiService
+      .postThumbnailFile(
+        imageData.image_data,
+        imageData.filename,
+        entityType,
+        entityId
+      )
+      .toPromise()
+      .then(() => {
+        if (imageData.filename !== this.topic.getThumbnailFilename()) {
+          this.topicUpdateService.setTopicThumbnailFilename(
+            this.topic,
+            imageData.filename
+          );
+        }
+
+        if (imageData.bg_color !== this.topic.getThumbnailBgColor()) {
+          this.topicUpdateService.setTopicThumbnailBgColor(
+            this.topic,
+            imageData.bg_color
+          );
+        }
+
+        this.imageUploaderParameters = {
+          ...this.imageUploaderParameters,
+          filename: imageData.filename,
+          bgColor: imageData.bg_color,
+        };
+      })
+      .catch(() => {
+        this.alertsService.addWarning(
+          'There was an error while saving the thumbnail.'
+        );
+      });
   }
 
   updateTopicDescription(newDescription: string): void {

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.html
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.html
@@ -89,15 +89,10 @@
 
       <div class="thumbnail-editor e2e-test-subtopic-thumbnail e2e-test-photo-button create-new-subtopic-input-field">
         <strong>Thumbnail Image*</strong>
-        <oppia-thumbnail-uploader (updateFilename)="updateSubtopicThumbnailFilename($event)"
-                                  [useLocalStorage]="false"
-                                  [bgColor]="editableThumbnailBgColor"
-                                  (updateBgColor)="updateSubtopicThumbnailBgColor($event)"
-                                  [allowedBgColors]="allowedBgColors"
-                                  [aspectRatio]="'4:3'"
-                                  [previewTitle]="subtopicTitle"
-                                  previewDescriptionBgColor="#BE563C">
-        </oppia-thumbnail-uploader>
+        <oppia-image-uploader
+          [imageUploaderParameters]="imageUploaderParameters"
+          (imageSave)="onImageSave($event)">
+        </oppia-image-uploader>
       </div>
     </div>
   </div>

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
@@ -41,14 +41,6 @@ import {By} from '@angular/platform-browser';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
-import {
-  ComponentFixture,
-  TestBed,
-  waitForAsync,
-  fakeAsync,
-  tick,
-} from '@angular/core/testing';
-import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 class MockWindowRef {
   nativeWindow = {

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
@@ -38,11 +38,20 @@ import {SubtopicPage} from 'domain/topic/subtopic-page.model';
 import {StudyGuide} from 'domain/topic/study-guide.model';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {ImageLocalStorageService} from 'services/image-local-storage.service';
+import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 class MockWindowRef {
   nativeWindow = {
     location: {
       hostname: 'local',
+    },
+    sessionStorage: {
+      setItem: (key: string, value: string) => {},
+      getItem: (key: string) => null,
+      removeItem: (key: string) => {},
+      clear: () => {},
     },
   };
 }
@@ -137,6 +146,7 @@ describe('create new subtopic modal', function () {
     htmlLengthService = new MockHtmlLengthService();
 
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       declarations: [
         CreateNewSubtopicModalComponent,
         UrlFragmentEditorComponent,
@@ -164,6 +174,7 @@ describe('create new subtopic modal', function () {
         },
         TopicUpdateService,
         SubtopicValidationService,
+        ImageLocalStorageService,
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -270,26 +281,29 @@ describe('create new subtopic modal', function () {
   );
 
   it(
-    'should update editableThumbnailFilename when ' +
-      'filename updated in "Thumbnail Image" modal',
+    'should update editableThumbnailFilename when ' + 'onImageSave is called',
     () => {
-      let newFileName = 'shivamOppiaFile';
-      component.updateSubtopicThumbnailFilename(newFileName);
+      const imageData: ImageUploaderData = {
+        filename: 'shivamOppiaFile',
+        bg_color: '#C6DCDA',
+        image_data: new Blob(),
+      };
+      component.onImageSave(imageData);
 
-      expect(component.editableThumbnailFilename).toBe(newFileName);
+      expect(component.editableThumbnailFilename).toBe('shivamOppiaFile');
     }
   );
 
-  it(
-    'should update ThumbnailBgColor when ' +
-      'user select new color in "Thumbnail Image" modal',
-    () => {
-      let newThumbnailBgColor = 'red';
-      component.updateSubtopicThumbnailBgColor(newThumbnailBgColor);
+  it('should update ThumbnailBgColor when ' + 'onImageSave is called', () => {
+    const imageData: ImageUploaderData = {
+      filename: 'test.svg',
+      bg_color: 'red',
+      image_data: new Blob(),
+    };
+    component.onImageSave(imageData);
 
-      expect(component.editableThumbnailBgColor).toBe(newThumbnailBgColor);
-    }
-  );
+    expect(component.editableThumbnailBgColor).toBe('red');
+  });
 
   it(
     'should reset errorMsg when user' + ' enter data in "Title" input area',

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.spec.ts
@@ -41,6 +41,14 @@ import {By} from '@angular/platform-browser';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 class MockWindowRef {
   nativeWindow = {

--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.component.ts
@@ -33,6 +33,11 @@ import {
   CALCULATION_TYPE_CHARACTER,
   HtmlLengthService,
 } from 'services/html-length.service';
+import {ImageLocalStorageService} from 'services/image-local-storage.service';
+import {
+  ImageUploaderData,
+  ImageUploaderParameters,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 @Component({
   selector: 'oppia-create-new-subtopic-modal',
@@ -68,6 +73,7 @@ export class CreateNewSubtopicModalComponent
   MAX_CHARS_IN_SUBTOPIC_TITLE!: number;
   MAX_CHARS_IN_STUDY_GUIDE_SECTION_HEADING!: number;
   generatedUrlPrefix!: string;
+  imageUploaderParameters!: ImageUploaderParameters;
   studyGuideSectionCharacterLimit: number =
     AppConstants.STUDY_GUIDE_SECTION_CHARACTER_LIMIT;
 
@@ -78,6 +84,7 @@ export class CreateNewSubtopicModalComponent
     private topicEditorStateService: TopicEditorStateService,
     private platformFeatureService: PlatformFeatureService,
     private htmlLengthService: HtmlLengthService,
+    private imageLocalStorageService: ImageLocalStorageService,
     private windowRef: WindowRef
   ) {
     super(ngbActiveModal);
@@ -113,6 +120,32 @@ export class CreateNewSubtopicModalComponent
     this.errorMsg = null;
     this.subtopicUrlFragmentExists = false;
     this.generatedUrlPrefix = `${this.hostname}/learn/${this.classroomUrlFragment} /${this.topic.getUrlFragment()}/studyguide`;
+    this.imageUploaderParameters = {
+      disabled: false,
+      maxImageSizeInKB: 100,
+      imageName: 'Thumbnail',
+      orientation: 'landscape',
+      bgColor: (this.allowedBgColors as string[])[0],
+      allowedBgColors: this.allowedBgColors as string[],
+      allowedImageFormats: ['svg'],
+      aspectRatio: '4:3',
+      previewTitle: this.subtopicTitle,
+      previewDescriptionBgColor: '#BE563C',
+    };
+  }
+
+  onImageSave(imageData: ImageUploaderData): void {
+    this.editableThumbnailFilename = imageData.filename;
+    this.editableThumbnailBgColor = imageData.bg_color;
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.imageLocalStorageService.saveImage(
+        imageData.filename,
+        reader.result as string
+      );
+    };
+    reader.readAsDataURL(imageData.image_data);
+    this.imageLocalStorageService.setThumbnailBgColor(imageData.bg_color);
   }
 
   getSchema(): object {
@@ -141,14 +174,6 @@ export class CreateNewSubtopicModalComponent
       this.subtopicId,
       this.editableThumbnailBgColor
     );
-  }
-
-  updateSubtopicThumbnailFilename(newThumbnailFilename: string): void {
-    this.editableThumbnailFilename = newThumbnailFilename;
-  }
-
-  updateSubtopicThumbnailBgColor(newThumbnailBgColor: string): void {
-    this.editableThumbnailBgColor = newThumbnailBgColor;
   }
 
   resetErrorMsg(): void {

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.html
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.html
@@ -116,16 +116,10 @@
             <p>
               <strong>Thumbnail Image*</strong>
             </p>
-            <oppia-thumbnail-uploader [filename]="subtopic?.getThumbnailFilename()"
-                                      [useLocalStorage]="false"
-                                      (updateFilename)="updateSubtopicThumbnailFilename($event)"
-                                      [bgColor]="subtopic?.getThumbnailBgColor()"
-                                      (updateBgColor)="updateSubtopicThumbnailBgColor($event)"
-                                      [allowedBgColors]="allowedBgColors"
-                                      [aspectRatio]="'4:3'"
-                                      [previewTitle]="editableTitle"
-                                      previewDescriptionBgColor="#BE563C">
-            </oppia-thumbnail-uploader>
+            <oppia-image-uploader
+              [imageUploaderParameters]="imageUploaderParameters"
+              (imageSave)="onImageSave($event)">
+            </oppia-image-uploader>
           </div>
         </div>
         <div *ngIf="editableThumbnailFilename && subtopicEditorCardIsShown">

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.spec.ts
@@ -328,6 +328,7 @@ describe('Subtopic editor tab', () => {
     tick();
 
     expect(thumbnailSpy).toHaveBeenCalled();
+    expect(component.editableThumbnailFilename).toBe('img.svg');
   }));
 
   it('should not call topicUpdateService when onImageSave is called with same filename', fakeAsync(() => {
@@ -377,6 +378,7 @@ describe('Subtopic editor tab', () => {
     tick();
 
     expect(thumbnailBgSpy).toHaveBeenCalled();
+    expect(component.editableThumbnailBgColor).toBe('#FFFFFF');
   }));
 
   it('should not call topicUpdateService when onImageSave is called with same bg color', fakeAsync(() => {
@@ -841,5 +843,22 @@ describe('Subtopic editor tab', () => {
     component.initEditor();
 
     expect(topicEditorStateService.loadSubtopicPage).not.toHaveBeenCalled();
+  });
+
+  it('should return early from onImageSave when entityType is null', () => {
+    const mockPageContextService = TestBed.inject(PageContextService);
+    spyOn(mockPageContextService, 'getEntityType').and.returnValue(undefined);
+    const postThumbnailSpy = spyOn(
+      assetsBackendApiService,
+      'postThumbnailFile'
+    );
+
+    component.onImageSave({
+      filename: 'img.svg',
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    expect(postThumbnailSpy).not.toHaveBeenCalled();
   });
 });

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.spec.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.spec.ts
@@ -43,6 +43,10 @@ import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {CdkDragDrop} from '@angular/cdk/drag-drop';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
+import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
+import {of} from 'rxjs';
+import {AssetsBackendApiService} from 'services/assets-backend-api.service';
+import {PageContextService} from 'services/page-context.service';
 
 class MockQuestionBackendApiService {
   async fetchTotalQuestionCountForSkillIdsAsync() {
@@ -86,6 +90,15 @@ class MockNgbModalRef {
   componentInstance = {};
 }
 
+class MockPageContextService {
+  getEntityType() {
+    return 'topic';
+  }
+  getEntityId() {
+    return 'sndsjfn42';
+  }
+}
+
 describe('Subtopic editor tab', () => {
   let component: SubtopicEditorTabComponent;
   let fixture: ComponentFixture<SubtopicEditorTabComponent>;
@@ -102,6 +115,7 @@ describe('Subtopic editor tab', () => {
   let topicReinitializedEventEmitter = new EventEmitter();
   let subtopicPageLoadedEventEmitter = new EventEmitter();
   let studyGuideLoadedEventEmitter = new EventEmitter();
+  let assetsBackendApiService: AssetsBackendApiService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -126,6 +140,10 @@ describe('Subtopic editor tab', () => {
           provide: PlatformFeatureService,
           useClass: MockPlatformFeatureService,
         },
+        {
+          provide: PageContextService,
+          useClass: MockPageContextService,
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -141,6 +159,7 @@ describe('Subtopic editor tab', () => {
     topicEditorRoutingService = TestBed.inject(TopicEditorRoutingService);
     platformFeatureService = TestBed.inject(PlatformFeatureService);
     wds = TestBed.inject(WindowDimensionsService);
+    assetsBackendApiService = TestBed.inject(AssetsBackendApiService);
 
     let topic = new Topic(
       'id',
@@ -290,47 +309,104 @@ describe('Subtopic editor tab', () => {
     expect(urlFragmentSpy).not.toHaveBeenCalled();
   });
 
-  it('should call topicUpdateService if subtopic thumbnail updates', () => {
+  it('should call topicUpdateService when onImageSave is called with new filename', fakeAsync(() => {
     let thumbnailSpy = spyOn(
       topicUpdateService,
       'setSubtopicThumbnailFilename'
     );
-    component.updateSubtopicThumbnailFilename('img.svg');
+
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img.svg'})
+    );
+
+    component.onImageSave({
+      filename: 'img.svg',
+      bg_color: component.editableThumbnailBgColor,
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
     expect(thumbnailSpy).toHaveBeenCalled();
-  });
+  }));
 
-  it('should not call topicUpdateService if subtopic thumbnail is not updated', () => {
-    component.updateSubtopicThumbnailFilename('img.svg');
+  it('should not call topicUpdateService when onImageSave is called with same filename', fakeAsync(() => {
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img.svg'})
+    );
+
+    component.onImageSave({
+      filename: 'img.svg',
+      bg_color: component.editableThumbnailBgColor,
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
     let thumbnailSpy = spyOn(
       topicUpdateService,
       'setSubtopicThumbnailFilename'
     );
-    component.updateSubtopicThumbnailFilename('img.svg');
-    expect(thumbnailSpy).not.toHaveBeenCalled();
-  });
+    component.onImageSave({
+      filename: 'img.svg',
+      bg_color: component.editableThumbnailBgColor,
+      image_data: new Blob(),
+    } as ImageUploaderData);
 
-  it('should call topicUpdateService if subtopic thumbnail bg color updates', () => {
+    tick();
+
+    expect(thumbnailSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should call topicUpdateService when onImageSave is called with new bg color', fakeAsync(() => {
     let thumbnailBgSpy = spyOn(
       topicUpdateService,
       'setSubtopicThumbnailBgColor'
     );
-    component.updateSubtopicThumbnailBgColor('#FFFFFF');
-    expect(thumbnailBgSpy).toHaveBeenCalled();
-  });
 
-  it(
-    'should not call topicUpdateService if subtopic ' +
-      'thumbnail bg color is not updated',
-    () => {
-      component.updateSubtopicThumbnailBgColor('#FFFFFF');
-      let thumbnailBgSpy = spyOn(
-        topicUpdateService,
-        'setSubtopicThumbnailBgColor'
-      );
-      component.updateSubtopicThumbnailBgColor('#FFFFFF');
-      expect(thumbnailBgSpy).not.toHaveBeenCalled();
-    }
-  );
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img.svg'})
+    );
+
+    component.onImageSave({
+      filename: component.editableThumbnailFilename,
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
+    expect(thumbnailBgSpy).toHaveBeenCalled();
+  }));
+
+  it('should not call topicUpdateService when onImageSave is called with same bg color', fakeAsync(() => {
+    spyOn(assetsBackendApiService, 'postThumbnailFile').and.returnValue(
+      of({filename: 'img.svg'})
+    );
+
+    component.onImageSave({
+      filename: component.editableThumbnailFilename,
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
+    let thumbnailBgSpy = spyOn(
+      topicUpdateService,
+      'setSubtopicThumbnailBgColor'
+    );
+
+    component.onImageSave({
+      filename: component.editableThumbnailFilename,
+      bg_color: '#FFFFFF',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
+    expect(thumbnailBgSpy).not.toHaveBeenCalled();
+  }));
 
   it('should return skill editor URL', () => {
     let skillId = 'asd4242a';

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
@@ -290,6 +290,7 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
             this.subtopic.getId(),
             imageData.filename
           );
+          this.editableThumbnailFilename = imageData.filename;
         }
 
         if (imageData.bg_color !== this.subtopic.getThumbnailBgColor()) {
@@ -298,6 +299,7 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
             this.subtopic.getId(),
             imageData.bg_color
           );
+          this.editableThumbnailBgColor = imageData.bg_color;
         }
 
         this.imageUploaderParameters = {

--- a/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
+++ b/core/templates/pages/topic-editor-page/subtopic-editor/subtopic-editor-tab.component.ts
@@ -39,6 +39,13 @@ import {StudyGuideSection} from 'domain/topic/study-guide-sections.model';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {DeleteStudyGuideSectionComponent} from 'pages/topic-editor-page/subtopic-editor/delete-study-guide-section-modal.component';
 import {AddStudyGuideSectionModalComponent} from 'pages/topic-editor-page/subtopic-editor/add-study-guide-section.component';
+import {
+  ImageUploaderData,
+  ImageUploaderParameters,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
+import {AlertsService} from 'services/alerts.service';
+import {AssetsBackendApiService} from 'services/assets-backend-api.service';
+import {PageContextService} from 'services/page-context.service';
 
 @Component({
   selector: 'oppia-subtopic-editor-tab',
@@ -59,6 +66,7 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
   editableTitle!: string;
   editableThumbnailFilename!: string;
   editableThumbnailBgColor!: string;
+  imageUploaderParameters!: ImageUploaderParameters;
   initialSubtopicUrlFragment!: string;
   editableUrlFragment!: string;
   subtopicPage!: SubtopicPage;
@@ -90,6 +98,9 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
   generatedUrlPrefix!: string;
 
   constructor(
+    private pageContextService: PageContextService,
+    private assetsBackendApiService: AssetsBackendApiService,
+    private alertsService: AlertsService,
     private questionBackendApiService: QuestionBackendApiService,
     private subtopicValidationService: SubtopicValidationService,
     private topicEditorRoutingService: TopicEditorRoutingService,
@@ -162,6 +173,23 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
         this.subtopicPage = this.topicEditorStateService.getSubtopicPage();
       }
       this.allowedBgColors = AppConstants.ALLOWED_THUMBNAIL_BG_COLORS.subtopic;
+      const canEdit =
+        this.topicEditorStateService.getTopicRights()?.canEditTopic() ?? false;
+      this.imageUploaderParameters = {
+        disabled: !canEdit,
+        maxImageSizeInKB: 100,
+        imageName: 'Thumbnail',
+        orientation: 'landscape',
+        bgColor:
+          this.subtopic.getThumbnailBgColor() ??
+          (this.allowedBgColors as string[])[0],
+        allowedBgColors: this.allowedBgColors as string[],
+        allowedImageFormats: ['svg'],
+        aspectRatio: '4:3',
+        filename: this.subtopic.getThumbnailFilename() ?? undefined,
+        previewTitle: this.editableTitle,
+        previewDescriptionBgColor: '#BE563C',
+      };
       if (this.isShowRestructuredStudyGuidesFeatureEnabled()) {
         var sections = this.studyGuide.getSections();
         this.sections = sections;
@@ -239,30 +267,50 @@ export class SubtopicEditorTabComponent implements OnInit, OnDestroy {
     this.editableUrlFragment = urlFragment;
   }
 
-  updateSubtopicThumbnailFilename(newThumbnailFilename: string): void {
-    var oldThumbnailFilename = this.subtopic.getThumbnailFilename();
-    if (newThumbnailFilename === oldThumbnailFilename) {
-      return;
-    }
-    this.topicUpdateService.setSubtopicThumbnailFilename(
-      this.topic,
-      this.subtopic.getId(),
-      newThumbnailFilename
-    );
-    this.editableThumbnailFilename = newThumbnailFilename;
-  }
+  onImageSave(imageData: ImageUploaderData): void {
+    const entityType = this.pageContextService.getEntityType();
+    const entityId = this.pageContextService.getEntityId();
 
-  updateSubtopicThumbnailBgColor(newThumbnailBgColor: string): void {
-    var oldThumbnailBgColor = this.subtopic.getThumbnailBgColor();
-    if (newThumbnailBgColor === oldThumbnailBgColor) {
+    if (!entityType || !entityId) {
       return;
     }
-    this.topicUpdateService.setSubtopicThumbnailBgColor(
-      this.topic,
-      this.subtopic.getId(),
-      newThumbnailBgColor
-    );
-    this.editableThumbnailBgColor = newThumbnailBgColor;
+
+    this.assetsBackendApiService
+      .postThumbnailFile(
+        imageData.image_data,
+        imageData.filename,
+        entityType,
+        entityId
+      )
+      .toPromise()
+      .then(() => {
+        if (imageData.filename !== this.subtopic.getThumbnailFilename()) {
+          this.topicUpdateService.setSubtopicThumbnailFilename(
+            this.topic,
+            this.subtopic.getId(),
+            imageData.filename
+          );
+        }
+
+        if (imageData.bg_color !== this.subtopic.getThumbnailBgColor()) {
+          this.topicUpdateService.setSubtopicThumbnailBgColor(
+            this.topic,
+            this.subtopic.getId(),
+            imageData.bg_color
+          );
+        }
+
+        this.imageUploaderParameters = {
+          ...this.imageUploaderParameters,
+          filename: imageData.filename,
+          bgColor: imageData.bg_color,
+        };
+      })
+      .catch(() => {
+        this.alertsService.addWarning(
+          'There was an error while saving the thumbnail.'
+        );
+      });
   }
 
   resetErrorMsg(): void {

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.html
@@ -67,13 +67,10 @@
     </div>
     <div class="create-new-topic-input-field">
       <label class="create-new-topic-input-label">Topic Thumbnail*</label>
-      <oppia-thumbnail-uploader [previewTitle]="newlyCreatedTopic.name"
-                                [aspectRatio]="'4:3'"
-                                [disabled]="false"
-                                [useLocalStorage]="true"
-                                [allowedBgColors]="allowedBgColors"
-                                previewDescriptionBgColor="#2F6687">
-      </oppia-thumbnail-uploader>
+      <oppia-image-uploader
+        [imageUploaderParameters]="imageUploaderParameters"
+        (imageSave)="onImageSave($event)">
+      </oppia-image-uploader>
     </div>
   </div>
 

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
@@ -28,6 +28,14 @@ import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {CreateNewTopicModalComponent} from './create-new-topic-modal.component';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 describe('Create new topic modal', () => {
   let fixture: ComponentFixture<CreateNewTopicModalComponent>;
@@ -207,4 +215,40 @@ describe('Create new topic modal', () => {
     );
     expect(componentInstance.onTopicUrlFragmentChange).toHaveBeenCalled();
   });
+
+  it('should save image and thumbnail bg color on image save', fakeAsync(() => {
+    const saveImageSpy = spyOn(imageLocalStorageService, 'saveImage');
+    const setBgColorSpy = spyOn(
+      imageLocalStorageService,
+      'setThumbnailBgColor'
+    );
+
+    const mockFileReader = {
+      result: 'data:image/svg+xml;base64,test',
+      onload: null as (() => void) | null,
+      readAsDataURL() {
+        if (this.onload) {
+          this.onload();
+        }
+      },
+    };
+
+    spyOn(window, 'FileReader').and.returnValue(
+      mockFileReader as unknown as FileReader
+    );
+
+    componentInstance.onImageSave({
+      filename: 'test.svg',
+      bg_color: '#C6DCDA',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
+    expect(saveImageSpy).toHaveBeenCalledWith(
+      'test.svg',
+      'data:image/svg+xml;base64,test'
+    );
+    expect(setBgColorSpy).toHaveBeenCalledWith('#C6DCDA');
+  }));
 });

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
@@ -29,9 +29,6 @@ import {CreateNewTopicModalComponent} from './create-new-topic-modal.component';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
 import {
-  ComponentFixture,
-  TestBed,
-  waitForAsync,
   fakeAsync,
   tick,
 } from '@angular/core/testing';

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
@@ -28,10 +28,7 @@ import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {CreateNewTopicModalComponent} from './create-new-topic-modal.component';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
-import {
-  fakeAsync,
-  tick,
-} from '@angular/core/testing';
+import {fakeAsync, tick} from '@angular/core/testing';
 import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 describe('Create new topic modal', () => {

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
@@ -25,6 +25,10 @@ import {TopicEditorStateService} from 'pages/topic-editor-page/services/topic-ed
 import {PageContextService} from 'services/page-context.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {ImageLocalStorageService} from 'services/image-local-storage.service';
+import {
+  ImageUploaderData,
+  ImageUploaderParameters,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 @Component({
   selector: 'oppia-create-new-topic-modal',
@@ -47,6 +51,7 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
   maxWebTitleFrag = AppConstants.MAX_CHARS_IN_PAGE_TITLE_FRAGMENT_FOR_WEB;
   minWebTitleFrag = AppConstants.MIN_CHARS_IN_PAGE_TITLE_FRAGMENT_FOR_WEB;
   generatedUrlPrefix = `${this.hostname}/learn/staging`;
+  imageUploaderParameters!: ImageUploaderParameters;
 
   constructor(
     private pageContextService: PageContextService,
@@ -60,6 +65,30 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
 
   ngOnInit(): void {
     this.pageContextService.setImageSaveDestinationToLocalStorage();
+    this.imageUploaderParameters = {
+      disabled: false,
+      maxImageSizeInKB: 100,
+      imageName: 'Thumbnail',
+      orientation: 'landscape',
+      bgColor: (this.allowedBgColors as string[])[0],
+      allowedBgColors: this.allowedBgColors as string[],
+      allowedImageFormats: ['svg'],
+      aspectRatio: '4:3',
+      previewTitle: this.newlyCreatedTopic.name,
+      previewDescriptionBgColor: '#2F6687',
+    };
+  }
+
+  onImageSave(imageData: ImageUploaderData): void {
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.imageLocalStorageService.saveImage(
+        imageData.filename,
+        reader.result as string
+      );
+    };
+    reader.readAsDataURL(imageData.image_data);
+    this.imageLocalStorageService.setThumbnailBgColor(imageData.bg_color);
   }
 
   save(): void {


### PR DESCRIPTION
## Overview

1. This PR fixes part of #20564.
2. This PR migrates 4 components from the deprecated `oppia-thumbnail-uploader` to the newer `oppia-image-uploader` component as part of the broader effort to consolidate image upload components in Oppia: 
- `create-new-topic-modal.component`
- `topic-editor-tab.component`
- `create-new-subtopic-modal.component`
- `subtopic-editor-tab.component`

Each component now uses a unified `imageUploaderParameters` input and listens to the `(imageSave)` event via a new `onImageSave()` handler, replacing the previous multiple bindings (`useLocalStorage`, `updateFilename`, `updateBgColor`).

For the two editor-tab components (`topic-editor-tab` and `subtopic-editor-tab`), `oppia-image-uploader` only emits image preview data via `(imageSave)` and does not handle backend persistence directly (unlike the previous `oppia-thumbnail-uploader`, which handled persistence internally via `AssetsBackendApiService.postThumbnailFile()`). To preserve existing behavior, an explicit `postThumbnailFile()` call has been added inside `onImageSave()` before updating filename/bg_color via `TopicUpdateService`.

For the two modal components (`create-new-topic-modal` and `create-new-subtopic-modal`), the existing `ImageLocalStorageService.saveImage()` flow is preserved. Uploaded images are converted to base64 via `FileReader` and stored prior to entity creation.

3. (For bug-fixing PRs only) N/A - this is a component migration.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

Demo video 

The following video demonstrates the updated `oppia-image-uploader` working across all 4 migrated locations: 

https://drive.google.com/file/d/1YOtrmxmUpuPzzybm8EYf1S7AtJ1gIBD-/view?usp=drive_link

 
#### Proof of changes on desktop with slow/throttled network

Manually tested locally on desktop. Upload, preview rendering, and save flow work correctly without UI issues.

#### Proof of changes on mobile phone

N/A - this feature is desktop-only and matches previous `oppia-thumbnail-uploader` behavior.

#### Proof of changes in Arabic language

N/A - no new UI strings added. Existing uploader UI is reused from `oppia-image-uploader`.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
