### PR TITLE
Fix #26457: Display user readable error message when subtopic save faliure

### DIFF
--- a/core/templates/domain/topic/editable-topic-backend-api.service.spec.ts
+++ b/core/templates/domain/topic/editable-topic-backend-api.service.spec.ts
@@ -325,10 +325,13 @@ describe('Editable topic backend API service', () => {
       .then(successHandler, failHandler);
     let req = httpTestingController.expectOne('/topic_editor_handler/data/1');
     expect(req.request.method).toEqual('PUT');
-    req.flush("Topic with given id doesn't exist.", {
-      status: 404,
-      statusText: "Topic with given id doesn't exist.",
-    });
+    req.flush(
+      {error: "Topic with given id doesn't exist."},
+      {
+        status: 404,
+        statusText: "Topic with given id doesn't exist.",
+      }
+    );
 
     flushMicrotasks();
 

--- a/core/templates/domain/topic/editable-topic-backend-api.service.ts
+++ b/core/templates/domain/topic/editable-topic-backend-api.service.ts
@@ -317,7 +317,7 @@ export class EditableTopicBackendApiService {
           }
         },
         errorResponse => {
-          errorCallback(errorResponse.error);
+          errorCallback(errorResponse.error.error);
         }
       );
   }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #26457 .
2. This PR does the following: Instead of passing the http response to the alert service now we extract annd pass the error message which is a string that alert service expects.
3. (For bug-fixing PRs only) The original bug occurred because: introduced by #10997 .  Alert service expects a string, but the response has been passed to the alert service.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
before

https://github.com/user-attachments/assets/f0e9ba42-4213-4e77-b221-a88ca24711b6

after

https://github.com/user-attachments/assets/88574caa-7fbb-41d9-8074-ad4a324a4b51


#### Proof of changes on desktop with slow/throttled network

https://github.com/user-attachments/assets/6ee18f73-149f-4266-a353-7be68740fa64




#### Proof of changes on mobile phone


https://github.com/user-attachments/assets/117cc602-4f4c-4437-9373-c30ed12c9cdd




#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when updating a topic so callers now receive the underlying error details instead of a wrapped response object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->