### PR TITLE
Fix #22398: Add admin action to generate dummy state answers

### DIFF
--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -1648,7 +1648,7 @@ class AdminHandler(
                 )
 
             story_node_index = 0
-            if story.story_contents is not None:
+            if story.story_contents is not None:  # pragma: no branch
                 story_node_index = (
                     int(story.story_contents.next_node_id[5:]) - 1
                 )

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -55,6 +55,7 @@ from core.domain import (
     skill_fetchers,
     skill_services,
     state_domain,
+    stats_domain,
     stats_services,
     story_domain,
     story_fetchers,
@@ -238,6 +239,7 @@ class AdminHandlerNormalizePayloadDict(TypedDict):
     num_dummy_question_suggestions_generate: Optional[int]
     skill_id: Optional[str]
     num_dummy_translation_opportunities_to_generate: Optional[int]
+    num_dummy_state_answers_to_generate: Optional[int]
     data: Optional[str]
     num_dummy_stories_to_generate: Optional[int]
     num_dummy_chapters_to_generate: Optional[int]
@@ -269,6 +271,7 @@ class AdminHandler(
                         'reload_collection',
                         'generate_dummy_explorations',
                         'generate_dummy_translation_opportunities',
+                        'generate_dummy_state_answers',
                         'clear_search_index',
                         'generate_dummy_new_structures_data',
                         'generate_dummy_new_skill_data',
@@ -317,6 +320,10 @@ class AdminHandler(
                 'default_value': None,
             },
             'num_dummy_translation_opportunities_to_generate': {
+                'schema': {'type': 'int'},
+                'default_value': None,
+            },
+            'num_dummy_state_answers_to_generate': {
                 'schema': {'type': 'int'},
                 'default_value': None,
             },
@@ -447,6 +454,10 @@ class AdminHandler(
             Exception. The num_dummy_translation_opportunities_to_generate
                 must be provided when the action is
                 generate_dummy_translation_opportunities.
+            Exception. The exploration_id must be provided when the action
+                is generate_dummy_state_answers.
+            Exception. The num_dummy_state_answers_to_generate must be
+                provided when the action is generate_dummy_state_answers.
             InvalidInputException. Generate count cannot be less than publish
                 count.
             Exception. The data must be provided when the action is
@@ -538,6 +549,27 @@ class AdminHandler(
 
                 self._generate_dummy_translation_opportunities(
                     num_dummy_translation_opportunities_to_generate
+                )
+            elif action == 'generate_dummy_state_answers':
+                exploration_id = self.normalized_payload.get('exploration_id')
+                if exploration_id is None:
+                    raise Exception(
+                        'The \'exploration_id\' must be provided when the '
+                        'action is generate_dummy_state_answers.'
+                    )
+                num_dummy_state_answers_to_generate = (
+                    self.normalized_payload.get(
+                        'num_dummy_state_answers_to_generate'
+                    )
+                )
+                if num_dummy_state_answers_to_generate is None:
+                    raise Exception(
+                        'The \'num_dummy_state_answers_to_generate\' must be '
+                        'provided when the action is '
+                        'generate_dummy_state_answers.'
+                    )
+                self._generate_dummy_state_answers(
+                    exploration_id, num_dummy_state_answers_to_generate
                 )
             elif action == 'generate_dummy_blog_post':
                 blog_post_title = self.normalized_payload.get('blog_post_title')
@@ -1303,6 +1335,70 @@ class AdminHandler(
             )
         else:
             raise Exception('Cannot generate dummy explorations in production.')
+
+    def _generate_dummy_state_answers(
+        self, exploration_id: str, num_dummy_state_answers_to_generate: int
+    ) -> None:
+        """Generates dummy submitted answers for the initial exploration state.
+
+        Args:
+            exploration_id: str. The exploration ID.
+            num_dummy_state_answers_to_generate: int. Count of dummy answers to
+                generate.
+
+        Raises:
+            Exception. Environment is not DEVMODE.
+            Exception. Exploration does not exist.
+            Exception. Initial state has no interaction.
+            Exception. Initial state interaction is not supported.
+        """
+        if not constants.DEV_MODE:
+            raise Exception('Cannot generate dummy answers in production.')
+
+        exploration = exp_fetchers.get_exploration_by_id(
+            exploration_id, strict=False
+        )
+        if exploration is None:
+            raise Exception(
+                'Exploration with id %s does not exist.' % exploration_id
+            )
+
+        state_name = exploration.init_state_name
+        initial_state = exploration.states[state_name]
+        interaction_id = initial_state.interaction.id
+        if interaction_id is None:
+            raise Exception(
+                'Initial state of exploration %s has no interaction.'
+                % exploration_id
+            )
+        if interaction_id != 'TextInput':
+            raise Exception(
+                'Unsupported interaction id %s. Currently only TextInput '
+                'is supported.' % interaction_id
+            )
+
+        submitted_answer_list: List[stats_domain.SubmittedAnswer] = []
+        for i in range(num_dummy_state_answers_to_generate):
+            submitted_answer_list.append(
+                stats_domain.SubmittedAnswer(
+                    'dummy answer %s' % i,
+                    interaction_id,
+                    0,
+                    0,
+                    exp_domain.EXPLICIT_CLASSIFICATION,
+                    {},
+                    'dummy_session_%s' % i,
+                    1.0,
+                )
+            )
+
+        stats_services.record_answers(
+            exploration.id,
+            exploration.version,
+            state_name,
+            interaction_id,
+            submitted_answer_list,
+        )
 
     def _generate_dummy_translation_opportunities(
         self, num_dummy_translation_opportunities_to_generate: int

--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -28,6 +28,7 @@ from core.domain import (
     classroom_config_services,
     collection_services,
     exp_domain,
+    exp_fetchers,
     exp_services,
     fs_services,
     opportunity_services,
@@ -2247,6 +2248,47 @@ class GenerateDummyChaptersTest(test_utils.GenericTestBase):
         self.assertEqual(node_5.destination_node_ids, [])
         self.logout()
 
+    def test_generate_single_dummy_chapter_without_graph_changes(self) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+
+        topic = topic_domain.Topic.create_default_topic(
+            'topic', 'topic_name', 'topicurl', 'description', 'fragm'
+        )
+        topic_services.save_new_topic(
+            self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL), topic
+        )
+
+        story = story_domain.Story.create_default_story(
+            'story_id', 'story_title', 'description', 'topic', 'storyurl'
+        )
+        story_services.save_new_story(
+            self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL), story
+        )
+
+        topic_services.add_canonical_story(
+            self.get_user_id_from_email(self.CURRICULUM_ADMIN_EMAIL),
+            'topic',
+            'story_id',
+        )
+
+        self.post_json(
+            '/adminhandler',
+            {
+                'action': 'generate_dummy_chapters',
+                'story_id': 'story_id',
+                'num_dummy_chapters_to_generate': 1,
+            },
+            csrf_token=csrf_token,
+        )
+
+        updated_story = story_fetchers.get_story_by_id('story_id')
+        self.assertEqual(len(updated_story.story_contents.nodes), 1)
+        self.assertEqual(
+            updated_story.story_contents.nodes[0].destination_node_ids, []
+        )
+        self.logout()
+
     def test_raises_error_if_not_curriculum_admin(  # pylint: disable=line-too-long
         self,
     ) -> None:
@@ -2500,6 +2542,124 @@ class GenerateDummyTranslationOpportunitiesTest(test_utils.GenericTestBase):
                     'action': 'generate_dummy_state_answers',
                     'exploration_id': '0',
                     'num_dummy_state_answers_to_generate': None,
+                },
+                csrf_token=csrf_token,
+            )
+
+        self.logout()
+
+    def test_generate_dummy_state_answers_fails_in_production_mode(
+        self,
+    ) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+
+        assert_raises_regexp_context_manager = self.assertRaisesRegex(
+            Exception, 'Cannot generate dummy answers in production.'
+        )
+        with assert_raises_regexp_context_manager, self.prod_mode_swap:
+            self.post_json(
+                '/adminhandler',
+                {
+                    'action': 'generate_dummy_state_answers',
+                    'exploration_id': '0',
+                    'num_dummy_state_answers_to_generate': 2,
+                },
+                csrf_token=csrf_token,
+            )
+
+        self.logout()
+
+    def test_generate_dummy_state_answers_fails_for_invalid_exploration_id(
+        self,
+    ) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+
+        assert_raises_regexp_context_manager = self.assertRaisesRegex(
+            Exception, 'Exploration with id invalid_exp_id does not exist.'
+        )
+        with assert_raises_regexp_context_manager:
+            self.post_json(
+                '/adminhandler',
+                {
+                    'action': 'generate_dummy_state_answers',
+                    'exploration_id': 'invalid_exp_id',
+                    'num_dummy_state_answers_to_generate': 2,
+                },
+                csrf_token=csrf_token,
+            )
+
+        self.logout()
+
+    def test_generate_dummy_state_answers_fails_with_no_interaction(
+        self,
+    ) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+        exploration_id = 'exp_with_no_interaction'
+        curriculum_admin_id = self.get_user_id_from_email(
+            self.CURRICULUM_ADMIN_EMAIL
+        )
+        exploration = self.save_new_valid_exploration(
+            exploration_id, curriculum_admin_id, end_state_name='End'
+        )
+        exploration.states[exploration.init_state_name].interaction.id = None
+
+        assert_raises_regexp_context_manager = self.assertRaisesRegex(
+            Exception,
+            'Initial state of exploration %s has no interaction.'
+            % exploration_id,
+        )
+        with assert_raises_regexp_context_manager, self.swap(
+            exp_fetchers,
+            'get_exploration_by_id',
+            lambda unused_exp_id, strict: exploration,
+        ):
+            self.post_json(
+                '/adminhandler',
+                {
+                    'action': 'generate_dummy_state_answers',
+                    'exploration_id': exploration_id,
+                    'num_dummy_state_answers_to_generate': 2,
+                },
+                csrf_token=csrf_token,
+            )
+
+        self.logout()
+
+    def test_generate_dummy_state_answers_fails_for_unsupported_interaction(
+        self,
+    ) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+        exploration_id = 'exp_with_unsupported_interaction'
+        curriculum_admin_id = self.get_user_id_from_email(
+            self.CURRICULUM_ADMIN_EMAIL
+        )
+        exploration = self.save_new_valid_exploration(
+            exploration_id, curriculum_admin_id, end_state_name='End'
+        )
+        exploration.states[exploration.init_state_name].interaction.id = (
+            'Continue'
+        )
+
+        assert_raises_regexp_context_manager = self.assertRaisesRegex(
+            Exception,
+            'Unsupported interaction id Continue. Currently only TextInput '
+            'is supported.',
+        )
+        with assert_raises_regexp_context_manager, self.swap(
+            exp_fetchers,
+            'get_exploration_by_id',
+            lambda unused_exp_id, strict: exploration,
+        ):
+            self.post_json(
+                '/adminhandler',
+                {
+                    'action': 'generate_dummy_state_answers',
+                    'exploration_id': exploration_id,
+                    'num_dummy_state_answers_to_generate': 2,
                 },
                 csrf_token=csrf_token,
             )

--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -2458,6 +2458,85 @@ class GenerateDummyTranslationOpportunitiesTest(test_utils.GenericTestBase):
 
         self.logout()
 
+    def test_without_exploration_id_generate_dummy_state_answers_fails(
+        self,
+    ) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+
+        assert_raises_regexp_context_manager = self.assertRaisesRegex(
+            Exception,
+            'The \'exploration_id\' must be provided when the action is '
+            'generate_dummy_state_answers.',
+        )
+        with assert_raises_regexp_context_manager:
+            self.post_json(
+                '/adminhandler',
+                {
+                    'action': 'generate_dummy_state_answers',
+                    'exploration_id': None,
+                    'num_dummy_state_answers_to_generate': 2,
+                },
+                csrf_token=csrf_token,
+            )
+
+        self.logout()
+
+    def test_without_num_dummy_state_answers_to_generate_fails(
+        self,
+    ) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+
+        assert_raises_regexp_context_manager = self.assertRaisesRegex(
+            Exception,
+            'The \'num_dummy_state_answers_to_generate\' must be provided '
+            'when the action is generate_dummy_state_answers.',
+        )
+        with assert_raises_regexp_context_manager:
+            self.post_json(
+                '/adminhandler',
+                {
+                    'action': 'generate_dummy_state_answers',
+                    'exploration_id': '0',
+                    'num_dummy_state_answers_to_generate': None,
+                },
+                csrf_token=csrf_token,
+            )
+
+        self.logout()
+
+    def test_admins_can_generate_dummy_state_answers(self) -> None:
+        self.login(self.CURRICULUM_ADMIN_EMAIL, is_super_admin=True)
+        csrf_token = self.get_new_csrf_token()
+        exploration_id = 'dummy_state_answers_exp'
+        curriculum_admin_id = self.get_user_id_from_email(
+            self.CURRICULUM_ADMIN_EMAIL
+        )
+        exploration = self.save_new_valid_exploration(
+            exploration_id, curriculum_admin_id, end_state_name='End'
+        )
+
+        self.post_json(
+            '/adminhandler',
+            {
+                'action': 'generate_dummy_state_answers',
+                'exploration_id': exploration_id,
+                'num_dummy_state_answers_to_generate': 3,
+            },
+            csrf_token=csrf_token,
+        )
+        state_answers = stats_services.get_state_answers(
+            exploration_id, exploration.version, exploration.init_state_name
+        )
+        assert state_answers is not None
+        self.assertEqual(
+            len(state_answers.get_submitted_answer_dict_list()),
+            3,
+        )
+
+        self.logout()
+
     def test_generator_works_when_skill_with_same_description_but_different_id_exists(
         self,
     ) -> None:

--- a/core/templates/domain/admin/admin-backend-api.service.ts
+++ b/core/templates/domain/admin/admin-backend-api.service.ts
@@ -664,6 +664,17 @@ export class AdminBackendApiService {
     });
   }
 
+  async generateDummyStateAnswersAsync(
+    explorationId: string,
+    numDummyStateAnswersToGenerate: number
+  ): Promise<void> {
+    return this._postRequestAsync(AdminPageConstants.ADMIN_HANDLER_URL, {
+      action: 'generate_dummy_state_answers',
+      exploration_id: explorationId,
+      num_dummy_state_answers_to_generate: numDummyStateAnswersToGenerate,
+    });
+  }
+
   async reloadExplorationAsync(explorationId: string): Promise<void> {
     return this._postRequestAsync(AdminPageConstants.ADMIN_HANDLER_URL, {
       action: 'reload_exploration',

--- a/core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.html
+++ b/core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.html
@@ -79,6 +79,34 @@
   </mat-card>
 
   <mat-card class="oppia-page-card oppia-long-text oppia-long-text-card">
+    <div class="container">
+      <h3>Generate dummy state answers</h3>
+      <p>
+        Use this form to generate submitted answers for the initial state of an
+        exploration (TextInput interactions only).
+      </p>
+      <span class="row">
+        <label for="label-target-exploration-id-for-dummy-answers" class="form-label">Exploration ID</label>
+        <input class="form-control d-inline-flex align-items-center oppia-form-inline"
+               [(ngModel)]="targetExplorationIdForDummyAnswers"
+               placeholder="Exploration ID" type="text"
+               id="label-target-exploration-id-for-dummy-answers">
+        <label for="label-target-state-answers-to-generate" class="form-label">Number of answers to generate</label>
+        <input class="form-control d-inline-flex align-items-center oppia-form-inline"
+               [(ngModel)]="numDummyStateAnswersToGenerate"
+               placeholder="Answers to generate" type="number" min="0"
+               id="label-target-state-answers-to-generate">
+        <button type="button"
+                class="btn btn-primary oppia-generate-exploration-text"
+                (click)="generateDummyStateAnswers()"
+                [disabled]="!targetExplorationIdForDummyAnswers || !numDummyStateAnswersToGenerate">
+          Generate Dummy Answers
+        </button>
+      </span>
+    </div>
+  </mat-card>
+
+  <mat-card class="oppia-page-card oppia-long-text oppia-long-text-card">
     <div class="container ms-0">
       <h3>Reload a single collection</h3>
       <div *ngFor="let collection of DEMO_COLLECTIONS"

--- a/core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.ts
+++ b/core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.ts
@@ -47,6 +47,8 @@ export class AdminDevModeActivitiesTabComponent implements OnInit {
   selectedTopicForStory: string = '';
   selectedStoryForChapter: string = '';
   numDummyTranslationOpportunitiesToGenerate: number = 0;
+  numDummyStateAnswersToGenerate: number = 0;
+  targetExplorationIdForDummyAnswers: string = '';
   DEMO_COLLECTIONS: string[][] = [[]];
   DEMO_EXPLORATIONS: string[][] = [[]];
   DUMMY_BLOG_POST_TITLES = [
@@ -194,6 +196,31 @@ export class AdminDevModeActivitiesTabComponent implements OnInit {
         },
         errorResponse => {
           this.setStatusMessage.emit(`Server error: ${errorResponse}`);
+        }
+      );
+    this.adminTaskManagerService.finishTask();
+  }
+
+  generateDummyStateAnswers(): void {
+    if (!this.targetExplorationIdForDummyAnswers) {
+      this.setStatusMessage.emit('Please provide an exploration ID.');
+      return;
+    }
+    this.adminTaskManagerService.startTask();
+    this.setStatusMessage.emit('Processing...');
+    this.adminBackendApiService
+      .generateDummyStateAnswersAsync(
+        this.targetExplorationIdForDummyAnswers,
+        this.numDummyStateAnswersToGenerate
+      )
+      .then(
+        () => {
+          this.setStatusMessage.emit(
+            'Dummy state answers generated successfully.'
+          );
+        },
+        errorResponse => {
+          this.setStatusMessage.emit('Server error: ' + errorResponse);
         }
       );
     this.adminTaskManagerService.finishTask();


### PR DESCRIPTION
## Overview

1. This PR fixes #22398.
2. This PR adds a dev-mode Admin Panel feature for generating dummy submitted answers for an existing exploration.

Specifically:
- Adds a new Admin Panel card for generating dummy state answers.
- Adds a backend admin action: `generate_dummy_state_answers`.
- Validates that the exploration exists and that its initial state has an interaction.
- Currently supports `TextInput` interactions.
- Creates dummy `SubmittedAnswer` objects and records them through `stats_services.record_answers()`.
- Adds backend tests for the new admin action.

3. (For bug-fixing PRs only) N/A. This is a feature request.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

I recorded a demo video showing the feature working locally.

The video shows:
- opening the Admin Panel,
- using an existing exploration with a `TextInput` interaction,
- entering the exploration ID,
- entering the number of dummy answers to generate,
- clicking **Generate Dummy Answers**,
- confirming the success message: `Dummy state answers generated successfully.`

Note: This feature does not add visible content to the exploration editor. It creates backend demo/statistics data by recording dummy learner answers through Oppia’s stats service.

## Validation

I ran the following focused checks locally:

- `python -m scripts.run_backend_tests --test_target core.controllers.admin_test --skip_install`
- `python -m scripts.linters.run_lint_checks --files core/controllers/admin.py core/controllers/admin_test.py core/templates/domain/admin/admin-backend-api.service.ts core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.html core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.ts`
- `python -m scripts.run_frontend_tests --specs_to_run=core/templates/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.component.spec.ts --allow_no_spec`
- `python -m scripts.run_frontend_tests --specs_to_run=core/templates/domain/admin/admin-backend-api.service.spec.ts --allow_no_spec`

All passed locally.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

https://github.com/user-attachments/assets/da3343c3-0d52-4079-84a2-52ffe875b6a0

