### PR TITLE
Fix part of #20564: Migrate create-new-topic-modal to use oppia-image-uploader

### DIFF
--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.html
@@ -67,13 +67,10 @@
     </div>
     <div class="create-new-topic-input-field">
       <label class="create-new-topic-input-label">Topic Thumbnail*</label>
-      <oppia-thumbnail-uploader [previewTitle]="newlyCreatedTopic.name"
-                                [aspectRatio]="'4:3'"
-                                [disabled]="false"
-                                [useLocalStorage]="true"
-                                [allowedBgColors]="allowedBgColors"
-                                previewDescriptionBgColor="#2F6687">
-      </oppia-thumbnail-uploader>
+      <oppia-image-uploader
+        [imageUploaderParameters]="imageUploaderParameters"
+        (imageSave)="onImageSave($event)">
+      </oppia-image-uploader>
     </div>
   </div>
 

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.spec.ts
@@ -28,6 +28,8 @@ import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {CreateNewTopicModalComponent} from './create-new-topic-modal.component';
 import {UrlFragmentEditorComponent} from '../../../components/url-fragment-editor/url-fragment-editor.component';
 import {By} from '@angular/platform-browser';
+import {fakeAsync, tick} from '@angular/core/testing';
+import {ImageUploaderData} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 describe('Create new topic modal', () => {
   let fixture: ComponentFixture<CreateNewTopicModalComponent>;
@@ -207,4 +209,40 @@ describe('Create new topic modal', () => {
     );
     expect(componentInstance.onTopicUrlFragmentChange).toHaveBeenCalled();
   });
+
+  it('should save image and thumbnail bg color on image save', fakeAsync(() => {
+    const saveImageSpy = spyOn(imageLocalStorageService, 'saveImage');
+    const setBgColorSpy = spyOn(
+      imageLocalStorageService,
+      'setThumbnailBgColor'
+    );
+
+    const mockFileReader = {
+      result: 'data:image/svg+xml;base64,test',
+      onload: null as (() => void) | null,
+      readAsDataURL() {
+        if (this.onload) {
+          this.onload();
+        }
+      },
+    };
+
+    spyOn(window, 'FileReader').and.returnValue(
+      mockFileReader as unknown as FileReader
+    );
+
+    componentInstance.onImageSave({
+      filename: 'test.svg',
+      bg_color: '#C6DCDA',
+      image_data: new Blob(),
+    } as ImageUploaderData);
+
+    tick();
+
+    expect(saveImageSpy).toHaveBeenCalledWith(
+      'test.svg',
+      'data:image/svg+xml;base64,test'
+    );
+    expect(setBgColorSpy).toHaveBeenCalledWith('#C6DCDA');
+  }));
 });

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
@@ -25,6 +25,10 @@ import {TopicEditorStateService} from 'pages/topic-editor-page/services/topic-ed
 import {PageContextService} from 'services/page-context.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {ImageLocalStorageService} from 'services/image-local-storage.service';
+import {
+  ImageUploaderData,
+  ImageUploaderParameters,
+} from 'components/forms/custom-forms-directives/image-uploader.component';
 
 @Component({
   selector: 'oppia-create-new-topic-modal',
@@ -47,6 +51,7 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
   maxWebTitleFrag = AppConstants.MAX_CHARS_IN_PAGE_TITLE_FRAGMENT_FOR_WEB;
   minWebTitleFrag = AppConstants.MIN_CHARS_IN_PAGE_TITLE_FRAGMENT_FOR_WEB;
   generatedUrlPrefix = `${this.hostname}/learn/staging`;
+  imageUploaderParameters!: ImageUploaderParameters;
 
   constructor(
     private pageContextService: PageContextService,
@@ -60,6 +65,30 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
 
   ngOnInit(): void {
     this.pageContextService.setImageSaveDestinationToLocalStorage();
+    this.imageUploaderParameters = {
+      disabled: false,
+      maxImageSizeInKB: 100,
+      imageName: 'Thumbnail',
+      orientation: 'landscape',
+      bgColor: (this.allowedBgColors as string[])[0],
+      allowedBgColors: this.allowedBgColors as string[],
+      allowedImageFormats: ['svg'],
+      aspectRatio: '4:3',
+      previewTitle: this.newlyCreatedTopic.name,
+      previewDescriptionBgColor: '#2F6687',
+    };
+  }
+
+  onImageSave(imageData: ImageUploaderData): void {
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.imageLocalStorageService.saveImage(
+        imageData.filename,
+        reader.result as string
+      );
+    };
+    reader.readAsDataURL(imageData.image_data);
+    this.imageLocalStorageService.setThumbnailBgColor(imageData.bg_color);
   }
 
   save(): void {

--- a/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/modals/create-new-topic-modal.component.ts
@@ -142,5 +142,9 @@ export class CreateNewTopicModalComponent extends ConfirmOrCancelModal {
           this.topicEditorStateService.getTopicWithNameExists();
       }
     );
+    this.imageUploaderParameters = {
+      ...this.imageUploaderParameters,
+      previewTitle: this.newlyCreatedTopic.name,
+    };
   }
 }

--- a/core/tests/playwright-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -38,7 +38,7 @@ const photoBoxButton = 'div.e2e-test-photo-button';
 const subtopicPhotoBoxButton =
   '.e2e-test-subtopic-thumbnail .e2e-test-photo-button';
 const uploadPhotoButton = 'button.e2e-test-photo-upload-submit';
-const photoUploadModal = 'edit-thumbnail-modal';
+const photoUploadModal = 'edit-thumbnail-modal, oppia-image-uploader-modal';
 
 const topicsTab = 'a.e2e-test-topics-tab';
 const desktopTopicSelector = 'a.e2e-test-topic-name';

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -42,7 +42,7 @@ const photoBoxButton = 'div.e2e-test-photo-button';
 const subtopicPhotoBoxButton =
   '.e2e-test-subtopic-thumbnail .e2e-test-photo-button';
 const uploadPhotoButton = 'button.e2e-test-photo-upload-submit';
-const photoUploadModal = 'edit-thumbnail-modal';
+const photoUploadModal = 'edit-thumbnail-modal, oppia-image-uploader-modal';
 const removeQuestionConfirmationButton =
   '.e2e-test-remove-question-confirmation-button';
 

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
@@ -32,7 +32,7 @@ const saveChangesMessageInput = 'textarea.e2e-test-commit-message-input';
 // Photo Upload Modal.
 const chapterPhotoBoxButton = '.e2e-test-photo-button';
 const uploadPhotoButton = 'button.e2e-test-photo-upload-submit';
-const photoUploadModal = 'edit-thumbnail-modal';
+const photoUploadModal = 'edit-thumbnail-modal, oppia-image-uploader-modal';
 
 // Topic and Skills Dashboard Page.
 const topicsTab = 'a.e2e-test-topics-tab';


### PR DESCRIPTION
## Overview

1. This PR fixes part of #20564.
2. This PR migrates `create-new-topic-modal.component` from the legacy `oppia-thumbnail-uploader` to the newer `oppia-image-uploader`.

   The component now uses a unified `imageUploaderParameters` input object and listens to the `imageSave` event via a new `onImageSave()` handler. Since `oppia-image-uploader` emits image data but does not persist it to local storage internally, the handler converts the uploaded `Blob` to a base64 string using `FileReader` and stores it via `imageLocalStorageService.saveImage()`, preserving the existing image upload flow before topic creation.

3. N/A - this is a component migration, not a bug fix.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

Demo video:

https://drive.google.com/file/d/1YOtrmxmUpuPzzybm8EYf1S7AtJ1gIBD-/view?usp=drive_link

#### Proof of changes on desktop with slow/throttled network

Tested locally. Verified that thumbnail upload, preview rendering, and local storage persistence work correctly.


#### Proof of changes on mobile phone

N/A - this is a desktop-only editor feature.

#### Proof of changes in Arabic language

N/A - no user-facing strings were added or modified.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
