### PR TITLE
[GSoC 2026] M1.9.1 - Add workflow for updating all playwright acceptance tests snapshots

### DIFF
--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -1,5 +1,10 @@
 name: Generate build files
 description: 'Generate build files'
+inputs:
+  prod-env:
+    description: "Whether to build in prod mode."
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -7,7 +12,7 @@ runs:
       id: restore_build_files_cache
       uses: actions/cache@v4
       with:
-        key: ${{ runner.os }}-build-files-${{ github.sha }}
+        key: ${{ runner.os }}-build-files-${{ inputs.prod-env != 'false' && 'prod' || 'dev' }}-${{ github.sha }}
         path: |
           /home/runner/work/oppia/oppia/build
           /home/runner/work/oppia/oppia/webpack_bundles
@@ -16,7 +21,11 @@ runs:
           /home/runner/work/oppia/oppia/backend_prod_files
           /home/runner/work/oppia/oppia/dist
           /home/runner/work/oppia/oppia/third_party/generated
-    - name: Build Webpack
-      if: steps.restore_build_files_cache.outputs.cache-hit != 'true'
+    - name: Build (prod)
+      if: steps.restore_build_files_cache.outputs.cache-hit != 'true' && inputs.prod-env != 'false'
       run: python -m scripts.build --prod_env
+      shell: bash
+    - name: Build (dev)
+      if: steps.restore_build_files_cache.outputs.cache-hit != 'true' && inputs.prod-env == 'false'
+      run: python -c "from scripts import build; build.build_js_files(dev_mode=True)"
       shell: bash

--- a/.github/actions/generate-build-files/action.yml
+++ b/.github/actions/generate-build-files/action.yml
@@ -21,11 +21,11 @@ runs:
           /home/runner/work/oppia/oppia/backend_prod_files
           /home/runner/work/oppia/oppia/dist
           /home/runner/work/oppia/oppia/third_party/generated
-    - name: Build (prod)
+    - name: Build Webpack (prod)
       if: steps.restore_build_files_cache.outputs.cache-hit != 'true' && inputs.prod-env != 'false'
       run: python -m scripts.build --prod_env
       shell: bash
-    - name: Build (dev)
+    - name: Build Webpack (dev)
       if: steps.restore_build_files_cache.outputs.cache-hit != 'true' && inputs.prod-env == 'false'
       run: python -c "from scripts import build; build.build_js_files(dev_mode=True)"
       shell: bash

--- a/.github/actions/run-a-specific-acceptance-test/action.yml
+++ b/.github/actions/run-a-specific-acceptance-test/action.yml
@@ -12,6 +12,10 @@ inputs:
     options:
       - mobile
       - desktop
+  prod-env:
+    description: "Whether to run in prod mode (adds --prod_env)."
+    required: false
+    default: "true"
   update-snapshots:
     description: Whether to update the snapshots instead of comparing them.
     required: false
@@ -47,7 +51,7 @@ runs:
         --skip_build
         --suite=${{ inputs.test-suite }}
         ${{ inputs.viewport-type == 'mobile' && '--mobile' || '' }}
-        --prod_env
+        ${{ inputs.prod-env != 'false' && '--prod_env' || '' }}
         ${{ inputs.update-snapshots && '--update_snapshots' || '' }}
         --server_log_level=info
         | tee acceptance_test_${{ inputs.modified-suite-name-for-uploads || '' }}.log

--- a/.github/workflows/stress_test_acceptance_test.yml
+++ b/.github/workflows/stress_test_acceptance_test.yml
@@ -29,10 +29,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   setup_merge_sha:
     name: Capture develop SHA

--- a/.github/workflows/stress_test_acceptance_test.yml
+++ b/.github/workflows/stress_test_acceptance_test.yml
@@ -1,11 +1,7 @@
 # This workflow is used to run the acceptance tests multiple times.
 # It's not used in the CI, but is used to test the flakiness of an acceptance test.
-#
-# When update_snapshots is true, the suite is run with --update_snapshots for
-# both viewports and the regenerated prod-{viewport}-screenshots folders are
-# uploaded as artifacts for review.
 
-name: Stress Test / Update Snapshots (Acceptance Test)
+name: Stress Test (Acceptance Test)
 
 permissions: read-all
 on:
@@ -15,7 +11,7 @@ on:
         # Maximum 256 jobs can be generated using matrix. We also use matrix from mobile and desktop
         # viewport. So, maximum number of times a test-suite can be run is 128.
         # Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrix
-        description: 'Number of times to run the acceptance tests (Max: 128). Ignored when update_snapshots is true.'
+        description: 'Number of times to run the acceptance tests (Max: 128).'
         required: true
         default: '10'
         type: choice
@@ -32,14 +28,6 @@ on:
         description: 'Name of acceptance test suite to run (e.g. "interested-donor/make-a-donation").'
         required: true
         type: string
-      update_snapshots:
-        description: >
-          Regenerate Playwright screenshot baselines instead of stress-testing.
-          Forces num_runs to 1 and uploads prod-{viewport}-screenshots for both
-          viewports as artifacts for review.
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -63,7 +51,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      NUM_RUNS: ${{ inputs.update_snapshots && '1' || inputs.num_runs }}
+      NUM_RUNS: ${{ inputs.num_runs }}
     steps:
       - name: Generate Matrix
         id: set-matrix
@@ -120,23 +108,10 @@ jobs:
         run: |
           SUITE_NAME=$TEST_SUITE-${{ matrix.run }}-${{ matrix.viewport-type }}
           echo "MODIFIED_SUITE_NAME=${SUITE_NAME//\//_}" >> $GITHUB_OUTPUT
-          # The screenshots folder lives at the spec-file-directory level
-          # (e.g. specs/logged-in-learner/prod-desktop-screenshots/), not
-          # nested under the full suite name. Strip everything after the first
-          # "/" to get just the directory component.
-          echo "SPEC_DIR=${TEST_SUITE%%/*}" >> $GITHUB_OUTPUT
       - name: Run ${{ matrix.viewport-type == 'mobile' && 'Mobile' || 'Desktop' }} Acceptance Test
         uses: ./.github/actions/run-a-specific-acceptance-test
         with:
           test-suite: ${{ inputs.test_suite }}
           viewport-type: ${{ matrix.viewport-type }}
-          update-snapshots: ${{ inputs.update_snapshots }}
-          enable-screen-recording: ${{ !inputs.update_snapshots }}
+          enable-screen-recording: true
           modified-suite-name-for-uploads: ${{ steps.generate_suite_name_for_artifacts.outputs.MODIFIED_SUITE_NAME }}
-      - name: Upload all snapshots in the prod-${{ matrix.viewport-type }}-screenshots folder for review
-        if: ${{ !cancelled() && inputs.update_snapshots}}
-        uses: actions/upload-artifact@v4
-        with:
-          name: updated-snapshots_${{ steps.generate_suite_name_for_artifacts.outputs.MODIFIED_SUITE_NAME }}
-          path: /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/prod-${{ matrix.viewport-type }}-screenshots/
-          if-no-files-found: warn

--- a/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
+++ b/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
@@ -112,6 +112,7 @@ jobs:
           BASE_NAME=$TEST_SUITE-${{ github.event.inputs.env-mode }}
           echo "DESKTOP_SUITE_NAME=${BASE_NAME//\//_}-desktop" >> $GITHUB_OUTPUT
           echo "MOBILE_SUITE_NAME=${BASE_NAME//\//_}-mobile" >> $GITHUB_OUTPUT
+          echo "MODIFIED_SUITE_NAME=${BASE_NAME//\//_}" >> $GITHUB_OUTPUT
           # The screenshots folder lives at the spec-file-directory level
           # (e.g. specs/logged-in-learner/prod-desktop-screenshots/), not
           # nested under the full suite name. Strip everything after the
@@ -126,13 +127,6 @@ jobs:
           update-snapshots: true
           enable-screen-recording: false
           modified-suite-name-for-uploads: ${{ steps.generate_suite_name_for_artifacts.outputs.DESKTOP_SUITE_NAME }}
-      - name: Upload desktop snapshots for review
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: updated-snapshots_${{ steps.generate_suite_name_for_artifacts.outputs.DESKTOP_SUITE_NAME }}
-          path: /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-desktop-screenshots/
-          if-no-files-found: warn
 
       - name: Run Mobile Acceptance Test (${{ github.event.inputs.env-mode }})
         uses: ./.github/actions/run-a-specific-acceptance-test
@@ -143,10 +137,13 @@ jobs:
           update-snapshots: true
           enable-screen-recording: false
           modified-suite-name-for-uploads: ${{ steps.generate_suite_name_for_artifacts.outputs.MOBILE_SUITE_NAME }}
-      - name: Upload mobile snapshots for review
+
+      - name: Upload snapshots for review
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: updated-snapshots_${{ steps.generate_suite_name_for_artifacts.outputs.MOBILE_SUITE_NAME }}
-          path: /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-mobile-screenshots/
+          name: updated-snapshots_${{ steps.generate_suite_name_for_artifacts.outputs.MODIFIED_SUITE_NAME }}
+          path: |
+            /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-desktop-screenshots/
+            /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-mobile-screenshots/
           if-no-files-found: warn

--- a/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
+++ b/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
@@ -27,10 +27,6 @@ on:
         required: false
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   setup_merge_sha:
     name: Capture develop SHA
@@ -148,15 +144,13 @@ jobs:
 
           SPECS_PREFIX="core/tests/playwright-acceptance-tests/specs/"
 
+          git add -A -- "$SPECS_PREFIX"
+
           # -z for NUL-separated output (safe with any filename), and we
           # match both modified/renamed tracked files and new untracked
           # files (update-snapshots can create brand-new baseline images).
           CHANGED_COUNT=0
           while IFS= read -r -d '' filepath; do
-            echo "Raw filepath: '$filepath'"
-            # git status --porcelain -z prefixes each entry with a 2-char
-            # status code and a space; strip that to get the bare path.
-            filepath="${filepath:3}"
             case "$filepath" in
               *-screenshots/*)
                 # Strip the leading specs/ prefix so the artifact zip is rooted
@@ -168,7 +162,7 @@ jobs:
                 CHANGED_COUNT=$((CHANGED_COUNT + 1))
                 ;;
             esac
-          done < <(git status --porcelain -z --untracked-files=all -- 'core/tests/playwright-acceptance-tests/specs/')
+          done < <(git diff --cached --name-only -z -- "$SPECS_PREFIX")
 
           echo "Staged $CHANGED_COUNT changed/new snapshot file(s)."
           echo "STAGING_DIR=$STAGING_DIR" >> "$GITHUB_OUTPUT"
@@ -200,31 +194,3 @@ jobs:
           name: updated-snapshots-all-${{ github.event.inputs.env-mode }}
           path: merged-snapshots
           if-no-files-found: warn
-
-  delete_individual_snapshot_artifacts:
-    name: Delete individual per-suite snapshot artifacts
-    needs: consolidate_snapshots
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-22.04
-    permissions:
-      actions: write
-    steps:
-      - name: Delete per-suite artifacts (keep consolidated one)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # List all artifacts for this run, filter to the per-suite ones
-          # (updated-snapshots_<suite>), and delete each by ID. The
-          # consolidated artifact is named updated-snapshots-all-<env-mode>,
-          # so it won't match this prefix and is left intact.
-          gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
-            --paginate \
-            --jq '.artifacts[] | select(.name | startswith("updated-snapshots_")) | .id' \
-          | while read -r artifact_id; do
-              echo "Deleting artifact ID $artifact_id"
-              gh api \
-                --method DELETE \
-                "repos/${{ github.repository }}/actions/artifacts/$artifact_id" \
-                || echo "Failed to delete artifact $artifact_id (may already be gone)."
-            done

--- a/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
+++ b/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
@@ -1,0 +1,152 @@
+# This workflow regenerates Playwright acceptance-test screenshot baselines.
+#
+# On dispatch, choose:
+#   - env-mode: dev or prod
+#   - run-mode: 'all' (every acceptance_playwright suite) or 'single' (one
+#     suite, given via test-suite)
+#
+# Each selected suite runs once for desktop and once for mobile, and the
+# regenerated {env-mode}-{viewport}-screenshots folders are uploaded as
+# workflow artifacts for review.
+
+name: Update Snapshots (Playwright Acceptance Tests)
+
+permissions: read-all
+on:
+  workflow_dispatch:
+    inputs:
+      env-mode:
+        required: true
+        type: choice
+        options: [dev, prod]
+      run-mode:
+        required: true
+        type: choice
+        options: [all, single]
+      test-suite:
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  setup_merge_sha:
+    name: Capture develop SHA
+    runs-on: ubuntu-22.04
+    outputs:
+      develop_sha: ${{ steps.get_sha.outputs.sha }}
+    steps:
+      - name: Get latest develop SHA
+        id: get_sha
+        run: |
+          SHA=$(git ls-remote https://github.com/oppia/oppia.git refs/heads/develop | awk '{print $1}')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build the app (${{ github.event.inputs.env-mode }}), and store build files as an artifact
+    needs: setup_merge_sha
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository so that local actions can be used
+        uses: actions/checkout@v4
+      - name: Merge develop and set up dependencies
+        uses: ./.github/actions/merge-develop-and-set-up-dependencies
+        with:
+          merge_sha: ${{ needs.setup_merge_sha.outputs.develop_sha }}
+      - name: Generate build files
+        uses: ./.github/actions/generate-build-files
+        with:
+          prod-env: ${{ github.event.inputs.env-mode == 'prod' }}
+
+  check_test_suites_to_run:
+    name: Compute which tests to run
+    needs: setup_merge_sha
+    runs-on: ubuntu-22.04
+    outputs:
+      TEST_SUITES_TO_RUN: ${{ steps.compute_test_suites.outputs.TEST_SUITES_TO_RUN }}
+    steps:
+      - name: Checkout repository so that local actions can be used
+        uses: actions/checkout@v4
+      - name: Merge develop and set up dependencies
+        uses: ./.github/actions/merge-develop-and-set-up-dependencies
+        with:
+          merge_sha: ${{ needs.setup_merge_sha.outputs.develop_sha }}
+      - id: compute_test_suites
+        name: Check test suites to run
+        # Note that the script also writes the output to $GITHUB_OUTPUT.
+        run: python -m scripts.check_ci_test_suites_to_run --github_head_ref="HEAD" --github_base_ref="HEAD" --output_all_test_suites
+
+  update_snapshots_playwright_acceptance_tests:
+    needs: [build, check_test_suites_to_run, setup_merge_sha]
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        suite: ${{ github.event.inputs.run-mode == 'single' && fromJson(format('[{{"name":"{0}"}}]', github.event.inputs.test-suite)) || fromJson(needs.check_test_suites_to_run.outputs.TEST_SUITES_TO_RUN).acceptance_playwright.suites }}
+    name: "[${{ github.event.inputs.env-mode == 'prod' && 'Prod' || 'Dev' }}] ${{ matrix.suite.name }}"
+    env:
+      TEST_SUITE: ${{ matrix.suite.name }}
+    steps:
+      - name: Sanitize test_suite input
+        run: |
+          if [[ "$TEST_SUITE" =~ [^a-zA-Z/-] ]]; then
+            echo "TEST_SUITE contains invalid characters (only letters, slashes, and dashes allowed)."
+            exit 1
+          else
+            echo "TEST_SUITE is valid."
+          fi
+      - name: Checkout repository so that local actions can be used
+        uses: actions/checkout@v4
+      - name: Merge develop and set up dependencies
+        uses: ./.github/actions/merge-develop-and-set-up-dependencies
+        with:
+          merge_sha: ${{ needs.setup_merge_sha.outputs.develop_sha }}
+      - name: Generate build files
+        uses: ./.github/actions/generate-build-files
+        with:
+          prod-env: ${{ github.event.inputs.env-mode == 'prod' }}
+      - name: Generate modified suite names for artifacts
+        id: generate_suite_name_for_artifacts
+        run: |
+          BASE_NAME=$TEST_SUITE-${{ github.event.inputs.env-mode }}
+          echo "DESKTOP_SUITE_NAME=${BASE_NAME//\//_}-desktop" >> $GITHUB_OUTPUT
+          echo "MOBILE_SUITE_NAME=${BASE_NAME//\//_}-mobile" >> $GITHUB_OUTPUT
+          # The screenshots folder lives at the spec-file-directory level
+          # (e.g. specs/logged-in-learner/prod-desktop-screenshots/), not
+          # nested under the full suite name. Strip everything after the
+          # first "/" to get just the directory component.
+          echo "SPEC_DIR=${TEST_SUITE%%/*}" >> $GITHUB_OUTPUT
+      - name: Run Desktop Acceptance Test (${{ github.event.inputs.env-mode }})
+        uses: ./.github/actions/run-a-specific-acceptance-test
+        with:
+          test-suite: ${{ matrix.suite.name }}
+          viewport-type: 'desktop'
+          prod-env: ${{ github.event.inputs.env-mode == 'prod' }}
+          update-snapshots: true
+          enable-screen-recording: false
+          modified-suite-name-for-uploads: ${{ steps.generate_suite_name_for_artifacts.outputs.DESKTOP_SUITE_NAME }}
+      - name: Upload desktop snapshots for review
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-snapshots_${{ steps.generate_suite_name_for_artifacts.outputs.DESKTOP_SUITE_NAME }}
+          path: /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-desktop-screenshots/
+          if-no-files-found: warn
+
+      - name: Run Mobile Acceptance Test (${{ github.event.inputs.env-mode }})
+        uses: ./.github/actions/run-a-specific-acceptance-test
+        with:
+          test-suite: ${{ matrix.suite.name }}
+          viewport-type: 'mobile'
+          prod-env: ${{ github.event.inputs.env-mode == 'prod' }}
+          update-snapshots: true
+          enable-screen-recording: false
+          modified-suite-name-for-uploads: ${{ steps.generate_suite_name_for_artifacts.outputs.MOBILE_SUITE_NAME }}
+      - name: Upload mobile snapshots for review
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-snapshots_${{ steps.generate_suite_name_for_artifacts.outputs.MOBILE_SUITE_NAME }}
+          path: /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-mobile-screenshots/
+          if-no-files-found: warn

--- a/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
+++ b/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
@@ -138,14 +138,48 @@ jobs:
           enable-screen-recording: false
           modified-suite-name-for-uploads: ${{ steps.generate_suite_name_for_artifacts.outputs.MOBILE_SUITE_NAME }}
 
-      - name: Upload snapshots for review
+      - name: Stage only changed/new snapshot files
         if: ${{ !cancelled() }}
+        id: stage_changed_snapshots
+        run: |
+          STAGING_DIR="$GITHUB_WORKSPACE/staged-snapshots"
+          rm -rf "$STAGING_DIR"
+          mkdir -p "$STAGING_DIR"
+
+          SPECS_PREFIX="core/tests/playwright-acceptance-tests/specs/"
+
+          # -z for NUL-separated output (safe with any filename), and we
+          # match both modified/renamed tracked files and new untracked
+          # files (update-snapshots can create brand-new baseline images).
+          CHANGED_COUNT=0
+          while IFS= read -r -d '' filepath; do
+            echo "Raw filepath: '$filepath'"
+            # git status --porcelain -z prefixes each entry with a 2-char
+            # status code and a space; strip that to get the bare path.
+            filepath="${filepath:3}"
+            case "$filepath" in
+              *-screenshots/*)
+                # Strip the leading specs/ prefix so the artifact zip is rooted
+                # at the suite directory (e.g. logged-in-learner/...) instead of
+                # the full repo path.
+                relative_path="${filepath#$SPECS_PREFIX}"
+                mkdir -p "$STAGING_DIR/$(dirname "$relative_path")"
+                cp "$filepath" "$STAGING_DIR/$relative_path"
+                CHANGED_COUNT=$((CHANGED_COUNT + 1))
+                ;;
+            esac
+          done < <(git status --porcelain -z --untracked-files=all -- 'core/tests/playwright-acceptance-tests/specs/')
+
+          echo "Staged $CHANGED_COUNT changed/new snapshot file(s)."
+          echo "STAGING_DIR=$STAGING_DIR" >> "$GITHUB_OUTPUT"
+          echo "HAS_CHANGES=$([[ $CHANGED_COUNT -gt 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload changed snapshots for review
+        if: ${{ !cancelled() && steps.stage_changed_snapshots.outputs.HAS_CHANGES == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: updated-snapshots_${{ steps.generate_suite_name_for_artifacts.outputs.MODIFIED_SUITE_NAME }}
-          path: |
-            /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-desktop-screenshots/
-            /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-mobile-screenshots/
+          path: ${{ steps.stage_changed_snapshots.outputs.STAGING_DIR }}
           if-no-files-found: warn
 
   consolidate_snapshots:
@@ -166,3 +200,31 @@ jobs:
           name: updated-snapshots-all-${{ github.event.inputs.env-mode }}
           path: merged-snapshots
           if-no-files-found: warn
+
+  delete_individual_snapshot_artifacts:
+    name: Delete individual per-suite snapshot artifacts
+    needs: consolidate_snapshots
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: write
+    steps:
+      - name: Delete per-suite artifacts (keep consolidated one)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # List all artifacts for this run, filter to the per-suite ones
+          # (updated-snapshots_<suite>), and delete each by ID. The
+          # consolidated artifact is named updated-snapshots-all-<env-mode>,
+          # so it won't match this prefix and is left intact.
+          gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
+            --paginate \
+            --jq '.artifacts[] | select(.name | startswith("updated-snapshots_")) | .id' \
+          | while read -r artifact_id; do
+              echo "Deleting artifact ID $artifact_id"
+              gh api \
+                --method DELETE \
+                "repos/${{ github.repository }}/actions/artifacts/$artifact_id" \
+                || echo "Failed to delete artifact $artifact_id (may already be gone)."
+            done

--- a/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
+++ b/.github/workflows/update_snapshots_playwright_acceptance_tests.yml
@@ -147,3 +147,22 @@ jobs:
             /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-desktop-screenshots/
             /home/runner/work/oppia/oppia/core/tests/playwright-acceptance-tests/specs/${{ steps.generate_suite_name_for_artifacts.outputs.SPEC_DIR }}/${{ github.event.inputs.env-mode }}-mobile-screenshots/
           if-no-files-found: warn
+
+  consolidate_snapshots:
+    name: Consolidate all snapshots into a single artifact
+    needs: update_snapshots_playwright_acceptance_tests
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download all per-suite snapshot artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: updated-snapshots_*
+          path: merged-snapshots
+          merge-multiple: true
+      - name: Upload consolidated snapshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-snapshots-all-${{ github.event.inputs.env-mode }}
+          path: merged-snapshots
+          if-no-files-found: warn


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes part of https://github.com/oppia/oppia/issues/24715
2. This PR adds dev-mode support to the Playwright acceptance test CI infrastructure, which previously only supported prod-mode builds and runs. Specifically:

- Adds a prod-env input to the generate-build-files composite action, so it can build either a dev bundle (via scripts.build.build_js_files(dev_mode=True)) or a prod bundle (existing python -m scripts.build --prod_env path), with the cache key namespaced by env-mode ({prod|dev}-{sha}) so dev and prod builds no longer collide on the same cache entry.
- Adds a prod-env input to the run-a-specific-acceptance-test composite action, making the existing --prod_env flag conditional instead of hardcoded, defaulting to true for backward compatibility with existing callers.
- Restructures the Update Snapshots (Playwright Acceptance Tests) workflow:
    - Adds workflow_dispatch inputs env-mode (dev/prod) and run-mode (all/single, with an optional test-suite name for the single case), so contributors can regenerate baselines for either environment and for one suite or all of them.
    - Regenerated screenshot baselines are uploaded per suite/viewport combination to {env-mode}-{viewport}-screenshots artifact folders.

- Reverted the changes that I made in stress_test_acceptance_test.yml in the PR https://github.com/oppia/oppia/pull/26469 since now we have this separate workflow.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Workflow runs with different inputs - 
1) All acceptance tests with dev mode - https://github.com/Mohak51234/oppia/actions/runs/28704809152
2) Single acceptance test with dev mode - https://github.com/Mohak51234/oppia/actions/runs/28704845837
3) All acceptance tests with prod mode - https://github.com/Mohak51234/oppia/actions/runs/28704850779
4) Single acceptance test with prod mode - https://github.com/Mohak51234/oppia/actions/runs/28704855584

Latest run with single upload job -
https://github.com/Mohak51234/oppia/actions/runs/28794747328

Latest Changes with a consolidating job and a delete artifact job - https://github.com/Mohak51234/oppia/actions/runs/28894207141

Latest Changes with delete job removed - https://github.com/Mohak51234/oppia/actions/runs/28931393940

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
