### PR TITLE
Fix N/A: Reassign extension frontend templates to lace-frontend-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -371,9 +371,11 @@
 /extensions/domain*.py @oppia/lace-frontend-reviewers
 /extensions/interactions/ @oppia/lace-frontend-reviewers
 /extensions/objects/ @oppia/lace-backend-reviewers
-/extensions/objects/templates/filepath-editor.component*.ts @oppia/lace-frontend-reviewers
-/extensions/objects/templates/filepath-editor.component.html @oppia/lace-frontend-reviewers
+/extensions/objects/templates/*.ts @oppia/lace-frontend-reviewers
+/extensions/objects/templates/*.html @oppia/lace-frontend-reviewers
 /extensions/value_generators/ @oppia/lace-backend-reviewers
+/extensions/value_generators/templates/*.ts @oppia/lace-frontend-reviewers
+/extensions/value_generators/templates/*.html @oppia/lace-frontend-reviewers
 /extensions/__init__.py @oppia/lace-frontend-reviewers
 
 
@@ -409,6 +411,8 @@
 /extensions/answer_summarizers/ @oppia/lace-backend-reviewers
 /extensions/issues/ @oppia/lace-backend-reviewers
 /extensions/visualizations/ @oppia/lace-backend-reviewers
+/extensions/visualizations/*.ts @oppia/lace-frontend-reviewers
+/extensions/visualizations/*.html @oppia/lace-frontend-reviewers
 
 
 # Library page.


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes N/A
2. This PR fixes incorrect ownership assignments in `.github/CODEOWNERS`.
3. Currently, `/extensions/objects/`, `/extensions/value_generators/`, and`/extensions/visualizations/` are owned entirely by `@oppia/lace-backend-reviewers`, including the `.ts`/`.html` editor template files inside them. These are Angular components (object editors, value generator UIs, visualization components) and should be reviewed by `@oppia/lace-frontend-reviewers`.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

No proof required.



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
