### PR TITLE
Fix #20921: Fix Continue button missing on initial interaction load

### DIFF
--- a/core/templates/services/page-context.service.spec.ts
+++ b/core/templates/services/page-context.service.spec.ts
@@ -587,6 +587,19 @@ describe('PageContext service', () => {
       expect(ecs.getEditorTabContext()).toBe('preview');
     });
 
+    it('should detect editor tab context is editor', () => {
+      let urlServiceGetHash = spyOn(urlService, 'getHash');
+
+      urlServiceGetHash.and.returnValue('#/gui');
+      expect(ecs.getEditorTabContext()).toBe('editor');
+
+      urlServiceGetHash.and.returnValue('');
+      expect(ecs.getEditorTabContext()).toBe('editor');
+
+      urlServiceGetHash.and.returnValue('#/');
+      expect(ecs.getEditorTabContext()).toBe('editor');
+    });
+
     it('should set and get custom entity id and type', () => {
       expect(ecs.getEntityId()).toBe('undefined');
       expect(ecs.getEntityType()).toBeUndefined();

--- a/core/templates/services/page-context.service.ts
+++ b/core/templates/services/page-context.service.ts
@@ -80,9 +80,9 @@ export class PageContextService {
   // or the current page is not the editor.
   getEditorTabContext(): string | null {
     let hash = this.urlService.getHash();
-    if (hash.indexOf('#/gui') === 0 || hash === '' || hash === '#/') {
+    if (hash.startsWith('#/gui') || hash === '' || hash === '#/') {
       return ServicesConstants.EXPLORATION_EDITOR_TAB_CONTEXT.EDITOR;
-    } else if (hash.indexOf('#/preview') === 0) {
+    } else if (hash.startsWith('#/preview')) {
       return ServicesConstants.EXPLORATION_EDITOR_TAB_CONTEXT.PREVIEW;
     } else {
       return null;

--- a/core/templates/services/page-context.service.ts
+++ b/core/templates/services/page-context.service.ts
@@ -80,7 +80,7 @@ export class PageContextService {
   // or the current page is not the editor.
   getEditorTabContext(): string | null {
     let hash = this.urlService.getHash();
-    if (hash.indexOf('#/gui') === 0) {
+    if (hash.indexOf('#/gui') === 0 || hash === '' || hash === '#/') {
       return ServicesConstants.EXPLORATION_EDITOR_TAB_CONTEXT.EDITOR;
     } else if (hash.indexOf('#/preview') === 0) {
       return ServicesConstants.EXPLORATION_EDITOR_TAB_CONTEXT.PREVIEW;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #20921.
2. This PR does the following: Fixes an issue where the Continue Button interaction (and other interactions sharing the same lifecycle checks) was completely missing from the Interaction preview box on the initial load of the Exploration Editor.
3. (For bug-fixing PRs only) The original bug occurred because: The code only recognized the editor tab if the URL hash explicitly started with "#/gui". However, on a fresh exploration, the URL hash is just "#/" or empty, so it incorrectly assumed it wasn't in the editor and hid the button. We fixed this by allowing "" and "#/" to be recognized as the editor tab.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
Before_fix:
<img width="1920" height="1080" alt="Screenshot (6525)" src="https://github.com/user-attachments/assets/1c567e26-cd32-4430-b189-c8d519162c68" />

After_fix:

https://github.com/user-attachments/assets/e9a15374-c0a7-4aca-84f8-c89db4aefeab

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
