### PR TITLE
Fix #16089: Add Hinglish translation tips to Contributor Dashboard

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -6015,6 +6015,19 @@ export default {
       // eslint-disable-next-line max-len
       "Refer to Glossary - https://docs.google.com/spreadsheets/d/13NMEnYqLZuMbeX1Z6XXG-femHkKNAN8KwjhaC67EkxI/edit#gid=0"
     ],
+    // Hinglish.
+    "hi-en": [
+      // eslint-disable-next-line max-len
+      "For mathematical terms in Hinglish, use the English words (e.g. numerator, denominator) instead of their Hindi equivalents (e.g. Bhinn, Ansh).",
+      // eslint-disable-next-line max-len
+      "Use respectful pronouns (like “Aap” instead of “Tum/Tu”) and a corresponding respectful tone like “kariye, karenge”.",
+      // eslint-disable-next-line max-len
+      "Feel free to change the voice and sequence of phrases to make the sentence more readable.",
+      // eslint-disable-next-line max-len
+      "Preserve punctuation and bolding. If the original content has bold text, make sure it is bold in Hinglish as well. If there are bullet points, double quotes, etc., make sure that the translated content also has bullet points and double quotes.",
+      // eslint-disable-next-line max-len
+      "If the original card has “components” (such as pictures, links, and equations), these need to be added to the translated content. You can use the “Copy tool” for this -- click on the Copy tool and then click on the component you want to carry over. Also, double-click on the image and translate the alt text (and caption, if any)."
+    ],
     // Spanish.
     "es": [
       "Include proper punctuation, ¡blank!, ¿question? and accent marks.",


### PR DESCRIPTION
## Overview

1. This PR fixes #16089.
2. This PR does the following: Adds a `"hi-en"` (Hinglish) entry to the `TRANSLATION_TIPS` constant in `assets/constants.ts`, so that translators working on Hinglish content in the Contributor Dashboard see language-specific translation guidelines, the same way translators for Hindi, Arabic, Bangla, Chinese, Spanish, and Portuguese already do. The tips added are the ones requested in the issue: use English words for mathematical terms instead of their Hindi equivalents, use respectful pronouns and tone, allow rephrasing for readability, preserve punctuation/bolding, and carry over components (images, links, equations) using the Copy tool.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code. (N/A: this is a static data addition to the `TRANSLATION_TIPS` lookup table, mirroring the existing `"hi"`, `"ar"`, `"bn"`, etc. entries, none of which have per-language unit tests. The consuming template (`translation-modal.component.html`) already iterates `TRANSLATION_TIPS[activeLanguageCode]` generically and is unchanged.)
- [x] The **PR title** starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a data-only change to a static translation-tips lookup table (`TRANSLATION_TIPS["hi-en"]`) that already has an existing, tested UI consumer (`translation-modal.component.html`, which iterates `TRANSLATION_TIPS[activeLanguageCode]` for every language). The same list is already rendered correctly for the `"hi"` entry that this PR's `"hi-en"` entry mirrors, so no new UI logic is introduced.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
