### PR TITLE
Fix #20766: Restore entity context after successfully closing concept card

### DIFF
--- a/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.spec.ts
+++ b/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.spec.ts
@@ -103,31 +103,47 @@ describe('NoninteractiveSkillreview', () => {
     expect(component.linkText).toBeUndefined();
   });
 
-  it('should open concept card when user clicks the link', () => {
-    spyOn(pageContextService, 'removeCustomEntityContext');
-    let e = {
-      currentTarget: {
-        offsetParent: {
-          dataset: {
-            ckeWidgetId: false,
+  it(
+    'should restore the entity context when user closes the concept ' +
+      'card after successfully viewing it',
+    fakeAsync(() => {
+      spyOn(pageContextService, 'setCustomEntityContext');
+      spyOn(pageContextService, 'getEntityId').and.callFake(function () {
+        return 'InitialEntityId';
+      });
+      spyOn(pageContextService, 'getEntityType').and.callFake(function () {
+        return 'InitialEntityType';
+      });
+      spyOn(pageContextService, 'removeCustomEntityContext');
+      let e = {
+        currentTarget: {
+          offsetParent: {
+            dataset: {
+              ckeWidgetId: false,
+            },
           },
         },
-      },
-    } as unknown as MouseEvent;
+      } as unknown as MouseEvent;
 
-    ckEditorCopyContentService.copyModeActive = false;
-    const modalSpy = spyOn(ngbModal, 'open').and.callFake((dlg, opt) => {
-      return {
-        componentInstance: MockNgbModalRef,
-        result: Promise.resolve(),
-      } as NgbModalRef;
-    });
+      ckEditorCopyContentService.copyModeActive = false;
+      const modalSpy = spyOn(ngbModal, 'open').and.callFake((dlg, opt) => {
+        return {
+          componentInstance: MockNgbModalRef,
+          result: Promise.resolve(),
+        } as NgbModalRef;
+      });
 
-    component.openConceptCard(e);
+      component.openConceptCard(e);
+      flush();
 
-    expect(modalSpy).toHaveBeenCalled();
-    expect(pageContextService.removeCustomEntityContext).not.toHaveBeenCalled();
-  });
+      expect(modalSpy).toHaveBeenCalled();
+      expect(pageContextService.removeCustomEntityContext).toHaveBeenCalled();
+      expect(pageContextService.setCustomEntityContext).toHaveBeenCalledWith(
+        'InitialEntityType',
+        'InitialEntityId'
+      );
+    })
+  );
 
   it('should close concept card when user clicks the link', fakeAsync(() => {
     spyOn(pageContextService, 'setCustomEntityContext');

--- a/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.ts
+++ b/extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.ts
@@ -104,6 +104,19 @@ export class NoninteractiveSkillreview implements OnInit, OnChanges {
     );
   }
 
+  // Restore the entity context to that of the state before the concept card
+  // editor was initialized. This prevents change of context issues in
+  // calling components once the editor is closed.
+  private _restoreEntityContext(): void {
+    this.pageContextService.removeCustomEntityContext();
+    if (this.entityId && this.entityType) {
+      this.pageContextService.setCustomEntityContext(
+        this.entityType,
+        this.entityId
+      );
+    }
+  }
+
   openConceptCard(event: MouseEvent): void {
     if (this._shouldOpenRTEModal(event)) {
       return;
@@ -122,18 +135,11 @@ export class NoninteractiveSkillreview implements OnInit, OnChanges {
     );
     modalRef.componentInstance.skillId = this.skillId;
     modalRef.result.then(
-      () => {},
+      () => {
+        this._restoreEntityContext();
+      },
       res => {
-        this.pageContextService.removeCustomEntityContext();
-        // Restore the entity context to that of the state before the concept card
-        // editor was initialized. This prevents change of context issues in
-        // calling components once the editor is closed.
-        if (this.entityId && this.entityType) {
-          this.pageContextService.setCustomEntityContext(
-            this.entityType,
-            this.entityId
-          );
-        }
+        this._restoreEntityContext();
         const allowedDismissActions = [
           'cancel',
           'escape key press',


### PR DESCRIPTION
## Overview

1. This PR fixes #20766.
2. This PR does the following: When a user opens a concept card link from a question (or exploration) and then closes it, the entity context used for resolving images needs to be restored to what it was before the concept card modal was opened. That restoration only happened when the modal was dismissed (e.g. cancel, escape key, backdrop click), not when it was closed successfully. This left the entity context pointed at the skill from the concept card, so images on the original page (which are resolved relative to the entity context) stopped loading and showed the replacement text instead. This PR extracts the context-restoration logic into a private `_restoreEntityContext()` helper on `NoninteractiveSkillreview` and calls it from both the resolve and the reject branches of the modal's result promise, so the context is restored regardless of how the concept card modal is closed.
3. (For bug-fixing PRs only) The original bug occurred because: `openConceptCard()` in `extensions/rich_text_components/Skillreview/directives/oppia-noninteractive-skillreview.component.ts` only restored the original entity context inside the rejection callback of `modalRef.result.then(...)`. The resolve callback was a no-op (`() => {}`), so successfully closing the concept card modal (as opposed to dismissing it) left the custom skill entity context in place, breaking image resolution on the page underneath.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code. I updated the existing test `'should open concept card when user clicks the link'` (renamed to `'should restore the entity context when user closes the concept card after successfully viewing it'`) to use `fakeAsync`/`flush()` so the resolved modal promise executes, and assert that `removeCustomEntityContext` and `setCustomEntityContext` (with the original entity type/id) are both called after a successful close. This test fails against the old code and passes with the fix.
- [x] The **PR title** starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this fix does not change any markup or UI — it only fixes internal entity-context restoration in a promise callback, mirroring the exact restoration logic that already existed (and was already tested) on the dismissal branch. The added unit test exercises the precise regression scenario from the issue (open concept card, close it successfully, confirm the original entity context is restored) and fails on the unfixed code, so it serves as the proof of correctness here. Happy to add a screen recording if a reviewer would still like to see it live.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
