### PR TITLE
Fix #26656: Reset image save destination after translation modal

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.spec.ts
@@ -440,6 +440,19 @@ describe('Translation Modal Component', () => {
     expect(handler(event)).toBeUndefined();
   });
 
+  it('should reset the image save destination when the modal is destroyed', () => {
+    pageContextService.setImageSaveDestinationToLocalStorage();
+    expect(pageContextService.getImageSaveDestination()).toBe(
+      AppConstants.IMAGE_SAVE_DESTINATION_LOCAL_STORAGE
+    );
+
+    component.ngOnDestroy();
+
+    expect(pageContextService.getImageSaveDestination()).toBe(
+      AppConstants.IMAGE_SAVE_DESTINATION_SERVER
+    );
+  });
+
   describe('when initialized', () => {
     describe('with an rtl language', () => {
       beforeEach(fakeAsync(() => {
@@ -1315,6 +1328,7 @@ describe('Translation Modal Component', () => {
               useValue: {
                 setImageSaveDestinationToLocalStorage: () => {},
                 setCustomEntityContext: () => {},
+                resetImageSaveDestination: () => {},
                 getEntityType: () => 'exploration',
                 getEntityId: () => '1',
                 getImageSaveDestination: () => 'localStorage',

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-modal.component.ts
@@ -620,6 +620,7 @@ export class TranslationModalComponent {
   }
 
   ngOnDestroy(): void {
+    this.pageContextService.resetImageSaveDestination();
     this.windowRef.nativeWindow.removeEventListener(
       'beforeunload',
       this.beforeUnloadHandler


### PR DESCRIPTION
## Overview

1. This PR fixes #26656.
2. This PR does the following: This PR resets the image save destination when the translation modal is destroyed. The translation modal sets the image save destination to local storage while translations are being edited. However, after the modal is closed, the image save destination should be reset back to the default server destination so that later image uploads from the exploration editor are saved to the server/datastore. This PR adds that cleanup in `ngOnDestroy()`, adds a unit test to verify that the image save destination is reset correctly, and updates the mock `PageContextService` in an existing spec suite to include the newly called `resetImageSaveDestination` method.
3. The original bug occurred because: `TranslationModalComponent` sets the image save destination to local storage in `ngOnInit()` for translation editing, but never reset it on any close path (the reset only ran inside certain submit branches). Since the exploration editor's "Modify existing translations" flow reuses this component, closing the translation modal left the whole editor session with local storage as the image save destination. Images uploaded afterwards through the RTE were saved only to the browser's local storage — no upload request was sent to the server — while the saved content still referenced the generated filename. The image rendered correctly for the creator (served from local storage) but returned a 404 for everyone else and after a page reload, showing a broken image with only the alt text/caption. This also explains why uploading the same image a second time (after a page reload) fixed it. I have not yet identified the exact PR that introduced this regression; it was likely exposed when the modify-translations flow in the exploration editor began reusing `TranslationModalComponent`, and I can trace the specific PR if needed.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A. This PR does not add or modify any Beam jobs, and it does not modify production server data.

- [x] A testing doc is not needed because this PR does not include Beam jobs or production data migrations.
- [x] _(To be confirmed by the server admin)_ N/A. There are no jobs in this PR that need to be verified on a live server.

## Proof that changes are correct

**Unit test.** This PR adds a unit test for the cleanup behavior in `TranslationModalComponent`. The test verifies that:

1. The image save destination can be set to local storage while the translation modal is active.
2. Calling `ngOnDestroy()` resets the image save destination back to the server destination.

Test added: `should reset the image save destination when the modal is destroyed`

All frontend tests in the spec file

<img width="1920" height="1020" alt="Screenshot 2026-07-10 013336" src="https://github.com/user-attachments/assets/1b38a6f2-4672-437c-aeff-1dc5540ac9bf" />

**Before the fix** 
In an exploration with an accepted translation and the `exploration_editor_can_modify_translations` feature flag enabled: edit the translated content → Save Content → "Modify existing translations" → open a language's translation editor → close it → upload an SVG in any card's content. No POST to `/createhandler/imageupload/...` is sent, and after a page reload the image is broken (asset GET returns 404, server logs `OSError: File image/<filename> not found`).


https://github.com/user-attachments/assets/3180162d-433c-4369-89bd-353708094b48


**After the fix** Repeating the exact same steps with this PR applied: the POST to `/createhandler/imageupload/exploration/<id>` fires on "Use This Image", and the image renders correctly after a hard reload.


https://github.com/user-attachments/assets/1a91c5b4-2e53-4a5b-b305-8fb936149767

#### Proof of changes on desktop with slow/throttled network

N/A All the proves already attached.

#### Proof of changes on mobile phone

N/A. This PR does not change any UI; it only adds state cleanup in a component's `ngOnDestroy()`. The affected flow (exploration editor translation modal) is a creator-facing desktop flow.

#### Proof of changes in Arabic language

N/A. This PR does not make any UI changes, so there are no visual differences to verify in a right-to-left language.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing the translation modal now restores image saving to the default server destination.
  * Added test coverage to confirm the reset happens during modal teardown, helping prevent images from being saved in the wrong place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->