### PR TITLE
Fix #20442: Implement MusicNotesInput customization args validations.

### DIFF
--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.spec.ts
@@ -24,7 +24,10 @@ import {Outcome} from 'domain/exploration/outcome.model';
 
 import {AppConstants} from 'app.constants';
 import {Rule} from 'domain/exploration/rule.model';
-import {MusicNotesInputCustomizationArgs} from 'extensions/interactions/customization-args-defs';
+import {
+  MusicNotesInputCustomizationArgs,
+  ReadableMusicNote,
+} from 'extensions/interactions/customization-args-defs';
 import cloneDeep from 'lodash/cloneDeep';
 
 describe('MusicNotesInputValidationService', () => {
@@ -36,12 +39,35 @@ describe('MusicNotesInputValidationService', () => {
     goodAnswerGroups: AnswerGroup[],
     goodDefaultOutcome: Outcome;
 
+  const createNotes = function (
+    numNotes: number,
+    readableNoteName: string = 'C4'
+  ): ReadableMusicNote[] {
+    const notes: ReadableMusicNote[] = [];
+    for (let i = 0; i < numNotes; i++) {
+      notes.push({
+        readableNoteName: readableNoteName,
+        noteDuration: {num: 1, den: 1},
+      });
+    }
+    return notes;
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [MusicNotesInputValidationService],
     });
 
     validatorService = TestBed.inject(MusicNotesInputValidationService);
+
+    customizationArgs = {
+      sequenceToGuess: {
+        value: [],
+      },
+      initialSequence: {
+        value: [],
+      },
+    };
 
     currentState = 'First State';
     goodDefaultOutcome = Outcome.createFromBackendDict({
@@ -62,18 +88,84 @@ describe('MusicNotesInputValidationService', () => {
   it('should be able to perform basic validation', () => {
     var warnings = validatorService.getAllWarnings(
       currentState,
-      {
-        sequenceToGuess: {
-          value: [],
-        },
-        initialSequence: {
-          value: [],
-        },
-      },
+      customizationArgs,
       goodAnswerGroups,
       goodDefaultOutcome
     );
     expect(warnings).toEqual([]);
+  });
+
+  it('should not raise warnings for valid customization arguments', () => {
+    customizationArgs.sequenceToGuess.value = createNotes(8);
+    customizationArgs.initialSequence.value = createNotes(8, 'A5');
+
+    var warnings =
+      validatorService.getCustomizationArgsWarnings(customizationArgs);
+    expect(warnings).toEqual([]);
+  });
+
+  it('should raise a warning when the sequence to guess is too long', () => {
+    customizationArgs.sequenceToGuess.value = createNotes(9);
+
+    var warnings =
+      validatorService.getCustomizationArgsWarnings(customizationArgs);
+    expect(warnings).toEqual([
+      {
+        type: AppConstants.WARNING_TYPES.CRITICAL,
+        message:
+          'Please make sure that the sequence of notes to guess has at ' +
+          'most 8 notes.',
+      },
+    ]);
+  });
+
+  it('should raise a warning when the initial sequence is too long', () => {
+    customizationArgs.initialSequence.value = createNotes(9);
+
+    var warnings =
+      validatorService.getCustomizationArgsWarnings(customizationArgs);
+    expect(warnings).toEqual([
+      {
+        type: AppConstants.WARNING_TYPES.CRITICAL,
+        message:
+          'Please make sure that the initial sequence of notes has at ' +
+          'most 8 notes.',
+      },
+    ]);
+  });
+
+  it('should raise a warning when a sequence has an invalid note', () => {
+    customizationArgs.sequenceToGuess.value = createNotes(1, 'B5');
+
+    var warnings =
+      validatorService.getCustomizationArgsWarnings(customizationArgs);
+    expect(warnings).toEqual([
+      {
+        type: AppConstants.WARNING_TYPES.CRITICAL,
+        message:
+          'Please make sure that all notes in the sequence of notes to ' +
+          'guess are notes that can be placed on the staff (C4 through A5).',
+      },
+    ]);
+  });
+
+  it('should raise a warning when a note duration is not positive', () => {
+    customizationArgs.initialSequence.value = createNotes(1);
+    customizationArgs.initialSequence.value[0].noteDuration = {
+      num: 0,
+      den: 1,
+    };
+
+    var warnings =
+      validatorService.getCustomizationArgsWarnings(customizationArgs);
+    expect(warnings).toEqual([
+      {
+        type: AppConstants.WARNING_TYPES.CRITICAL,
+        message:
+          'Please make sure that all note durations in the initial ' +
+          'sequence of notes are positive.',
+      },
+    ]);
   });
 
   it('should throw error when rule HasLengthInclusivelyBetween is invalid', () => {

--- a/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
+++ b/extensions/interactions/MusicNotesInput/directives/music-notes-input-validation.service.ts
@@ -23,7 +23,11 @@ import {
   Warning,
   BaseInteractionValidationService,
 } from 'interactions/base-interaction-validation.service';
-import {MusicNotesInputCustomizationArgs} from 'extensions/interactions/customization-args-defs';
+import {
+  MusicNotesInputCustomizationArgs,
+  ReadableMusicNote,
+} from 'extensions/interactions/customization-args-defs';
+import {InteractionsExtensionsConstants} from 'interactions/interactions-extension.constants';
 import {Outcome} from 'domain/exploration/outcome.model';
 import {AppConstants} from 'app.constants';
 
@@ -31,6 +35,13 @@ import {AppConstants} from 'app.constants';
   providedIn: 'root',
 })
 export class MusicNotesInputValidationService {
+  // The music staff can display at most this many notes, so longer
+  // sequences can neither be rendered nor entered by the learner. This
+  // must be kept in sync with MAXIMUM_NOTES_POSSIBLE in
+  // oppia-interactive-music-notes-input.component.ts and with
+  // MusicPhrase._MAX_NOTES_IN_PHRASE in extensions/objects/models/objects.py.
+  static readonly MAX_NOTES_IN_PHRASE = 8;
+
   constructor(
     private baseInteractionValidationServiceInstance: BaseInteractionValidationService
   ) {}
@@ -38,8 +49,53 @@ export class MusicNotesInputValidationService {
   getCustomizationArgsWarnings(
     customizationArgs: MusicNotesInputCustomizationArgs
   ): Warning[] {
-    // TODO(#20442): Implement customization args validations.
-    return [];
+    var warningsList: Warning[] = [];
+
+    this.baseInteractionValidationServiceInstance.requireCustomizationArguments(
+      customizationArgs,
+      ['sequenceToGuess', 'initialSequence']
+    );
+
+    const validNoteNames: string[] = Object.keys(
+      InteractionsExtensionsConstants.NOTE_NAMES_TO_MIDI_VALUES
+    );
+    const sequences: [string, ReadableMusicNote[]][] = [
+      ['sequence of notes to guess', customizationArgs.sequenceToGuess.value],
+      ['initial sequence of notes', customizationArgs.initialSequence.value],
+    ];
+
+    for (const [sequenceLabel, notes] of sequences) {
+      if (notes.length > MusicNotesInputValidationService.MAX_NOTES_IN_PHRASE) {
+        warningsList.push({
+          type: AppConstants.WARNING_TYPES.CRITICAL,
+          message:
+            `Please make sure that the ${sequenceLabel} has at most ` +
+            `${MusicNotesInputValidationService.MAX_NOTES_IN_PHRASE} notes.`,
+        });
+      }
+      if (notes.some(note => !validNoteNames.includes(note.readableNoteName))) {
+        warningsList.push({
+          type: AppConstants.WARNING_TYPES.CRITICAL,
+          message:
+            `Please make sure that all notes in the ${sequenceLabel} are ` +
+            'notes that can be placed on the staff (C4 through A5).',
+        });
+      }
+      if (
+        notes.some(
+          note => note.noteDuration.num < 1 || note.noteDuration.den < 1
+        )
+      ) {
+        warningsList.push({
+          type: AppConstants.WARNING_TYPES.CRITICAL,
+          message:
+            'Please make sure that all note durations in the ' +
+            `${sequenceLabel} are positive.`,
+        });
+      }
+    }
+
+    return warningsList;
   }
 
   getAllWarnings(


### PR DESCRIPTION
## Overview

1. This PR fixes #20442.
2. This PR does the following: Implements `getCustomizationArgsWarnings` in `MusicNotesInputValidationService`, which previously returned an empty array with a `TODO(#20442)` comment, so invalid customization arguments for the Music Notes Input interaction were never surfaced to lesson creators in the exploration editor's warnings panel. The new validation mirrors the backend `MusicPhrase` schema (`extensions/objects/models/objects.py`) and follows the pattern used by sibling validators such as `InteractiveMapValidationService`:
   - requires that both `sequenceToGuess` and `initialSequence` are present (via `requireCustomizationArguments`);
   - warns if either sequence has more than 8 notes — the maximum the music staff can render (`MAXIMUM_NOTES_POSSIBLE` in the interaction component) and the limit enforced by the backend schema's `has_length_at_most` validator;
   - warns if any note is outside the supported staff range (C4 through A5, per `NOTE_NAMES_TO_MIDI_VALUES`);
   - warns if any note duration has a numerator or denominator less than 1.

   All new warnings use `WARNING_TYPES.CRITICAL`, consistent with how other interactions report customization-argument problems.

   The PR also fixes a latent problem in the existing spec: the `HasLengthInclusivelyBetween` test passed an uninitialized `customizationArgs` variable (i.e. `undefined`), which only worked because the old implementation ignored the argument. The spec now initializes valid customization args in `beforeEach`, and new test cases cover every warning branch plus the no-warning case.

3. (For bug-fixing PRs only) The original bug occurred because: the validation was never implemented when the validation service was created — the method has carried a `TODO` comment since its introduction (this is a long-standing gap rather than a regression from a specific PR; see the discussion in #20442).

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

The change is covered by unit tests that exercise every new branch (over-long sequences for each argument, invalid note names, non-positive durations, valid arguments producing no warnings, and the pre-existing rule validation still passing).

I am still setting up the local Docker development server on my machine; I will add before/after screenshots of the exploration editor's warnings panel (Music Notes Input with a >8-note / invalid-note sequence configured) as soon as it is running. In the meantime, the frontend unit tests in CI verify the new behavior.

## PR Pointers

- Never force push! If you do, your PR will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
