### PR TITLE
Fix part of #26623: Rename time millisec utility for UTC clarity

### DIFF
--- a/core/controllers/creator_dashboard.py
+++ b/core/controllers/creator_dashboard.py
@@ -221,10 +221,10 @@ class CreatorDashboardHandler(
                         'category': collection_summary.category,
                         'objective': collection_summary.objective,
                         'language_code': collection_summary.language_code,
-                        'last_updated_msec': utils.get_time_in_millisecs(
+                        'last_updated_msec': utils.get_utc_time_in_millisecs(
                             collection_summary.collection_model_last_updated
                         ),
-                        'created_on': utils.get_time_in_millisecs(
+                        'created_on': utils.get_utc_time_in_millisecs(
                             collection_summary.collection_model_created_on
                         ),
                         'status': collection_summary.status,

--- a/core/controllers/feedback_updates.py
+++ b/core/controllers/feedback_updates.py
@@ -182,7 +182,7 @@ class FeedbackThreadHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
                 'current_content_html': current_content_html,
                 'description': suggestion_thread.subject,
                 'author_username': suggestion_author_setting.username,
-                'created_on_msecs': utils.get_time_in_millisecs(
+                'created_on_msecs': utils.get_utc_time_in_millisecs(
                     messages[0].created_on
                 ),
             }
@@ -202,7 +202,9 @@ class FeedbackThreadHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
                 'text': m.text,
                 'updated_status': m.updated_status,
                 'author_username': author_username,
-                'created_on_msecs': utils.get_time_in_millisecs(m.created_on),
+                'created_on_msecs': utils.get_utc_time_in_millisecs(
+                    m.created_on
+                ),
             }
             message_summary_list.append(message_summary)
 

--- a/core/controllers/feedback_updates_test.py
+++ b/core/controllers/feedback_updates_test.py
@@ -377,7 +377,7 @@ class FeedbackThreadHandlerTests(test_utils.GenericTestBase):
             messages_summary['author_username'], self.EDITOR_USERNAME
         )
         self.assertEqual(
-            utils.get_time_in_millisecs(first_suggestion.created_on),
+            utils.get_utc_time_in_millisecs(first_suggestion.created_on),
             messages_summary['created_on_msecs'],
         )
         self.assertEqual(

--- a/core/controllers/improvements_test.py
+++ b/core/controllers/improvements_test.py
@@ -635,7 +635,7 @@ class ExplorationImprovementsHandlerTests(ImprovementsTestBase):
                 'issue_description': 'issue description',
                 'status': 'resolved',
                 'resolver_username': None,
-                'resolved_on_msecs': utils.get_time_in_millisecs(
+                'resolved_on_msecs': utils.get_utc_time_in_millisecs(
                     self.MOCK_DATE
                 ),
             },

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -1614,7 +1614,7 @@ class DeleteAccountHandlerTests(test_utils.GenericTestBase):
 
 class ExportAccountHandlerTests(test_utils.GenericTestBase):
     GENERIC_DATE: Final = datetime.datetime(2021, 5, 20)
-    GENERIC_EPOCH: Final = utils.get_time_in_millisecs(GENERIC_DATE)
+    GENERIC_EPOCH: Final = utils.get_utc_time_in_millisecs(GENERIC_DATE)
 
     def setUp(self) -> None:
         super().setUp()

--- a/core/controllers/topic_editor.py
+++ b/core/controllers/topic_editor.py
@@ -178,7 +178,7 @@ class TopicEditorStoryHandler(
                 if node.planned_publication_date is not None:
                     current_time_msecs = utils.get_current_time_in_millisecs()
                     planned_publication_date_msecs = (
-                        utils.get_time_in_millisecs(
+                        utils.get_utc_time_in_millisecs(
                             node.planned_publication_date
                         )
                     )

--- a/core/domain/app_feedback_report_domain.py
+++ b/core/domain/app_feedback_report_domain.py
@@ -134,7 +134,7 @@ class AppFeedbackReport:
             'schema_version': self.schema_version,
             'platform': self.platform,
             'submitted_on_timestamp': utils.get_human_readable_time_string(
-                utils.get_time_in_millisecs(self.submitted_on_timestamp)
+                utils.get_utc_time_in_millisecs(self.submitted_on_timestamp)
             ),
             'local_timezone_offset_hrs': self.local_timezone_offset_hrs,
             'ticket_id': self.ticket_id,

--- a/core/domain/app_feedback_report_domain_test.py
+++ b/core/domain/app_feedback_report_domain_test.py
@@ -47,7 +47,7 @@ USER_1_USERNAME = 'username1'
 REPORT_SUBMITTED_TIMESTAMP = datetime.datetime.fromtimestamp(1615151836)
 # The timestamp in sec since epoch for Mar 19 2021 17:10:36 UTC.
 TICKET_CREATION_TIMESTAMP = datetime.datetime.fromtimestamp(1616173836)
-TICKET_CREATION_TIMESTAMP_MSEC = utils.get_time_in_millisecs(
+TICKET_CREATION_TIMESTAMP_MSEC = utils.get_utc_time_in_millisecs(
     TICKET_CREATION_TIMESTAMP
 )
 
@@ -249,7 +249,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
             'schema_version': ANDROID_REPORT_INFO_SCHEMA_VERSION,
             'platform': PLATFORM_ANDROID,
             'submitted_on_timestamp': utils.get_human_readable_time_string(
-                utils.get_time_in_millisecs(REPORT_SUBMITTED_TIMESTAMP)
+                utils.get_utc_time_in_millisecs(REPORT_SUBMITTED_TIMESTAMP)
             ),
             'local_timezone_offset_hrs': 0,
             'ticket_id': TICKET_ID,

--- a/core/domain/app_feedback_report_services_test.py
+++ b/core/domain/app_feedback_report_services_test.py
@@ -58,7 +58,7 @@ class AppFeedbackReportServicesUnitTests(test_utils.GenericTestBase):
         feconf.APP_FEEDBACK_REPORT_MAXIMUM_LIFESPAN + datetime.timedelta(days=2)
     )
     TICKET_CREATION_TIMESTAMP = datetime.datetime.fromtimestamp(1616173836)
-    TICKET_CREATION_TIMESTAMP_MSEC = utils.get_time_in_millisecs(
+    TICKET_CREATION_TIMESTAMP_MSEC = utils.get_utc_time_in_millisecs(
         TICKET_CREATION_TIMESTAMP
     )
     TICKET_NAME = 'a ticket name'

--- a/core/domain/beam_job_domain.py
+++ b/core/domain/beam_job_domain.py
@@ -142,10 +142,10 @@ class BeamJobRun:
             'job_name': self.job_name,
             'job_state': self.job_state,
             'job_started_on_msecs': (
-                utils.get_time_in_millisecs(self.job_started_on)
+                utils.get_utc_time_in_millisecs(self.job_started_on)
             ),
             'job_updated_on_msecs': (
-                utils.get_time_in_millisecs(self.job_updated_on)
+                utils.get_utc_time_in_millisecs(self.job_updated_on)
             ),
             'job_is_synchronous': self.job_is_synchronous,
             'dataflow_job_id': self.dataflow_job_id,

--- a/core/domain/beam_job_domain_test.py
+++ b/core/domain/beam_job_domain_test.py
@@ -84,8 +84,12 @@ class BeamJobRunTests(test_utils.TestBase):
                 'job_id': '123',
                 'job_name': 'FooJob',
                 'job_state': 'RUNNING',
-                'job_started_on_msecs': utils.get_time_in_millisecs(self.NOW),
-                'job_updated_on_msecs': utils.get_time_in_millisecs(self.NOW),
+                'job_started_on_msecs': utils.get_utc_time_in_millisecs(
+                    self.NOW
+                ),
+                'job_updated_on_msecs': utils.get_utc_time_in_millisecs(
+                    self.NOW
+                ),
                 'job_is_synchronous': True,
                 'dataflow_job_id': None,
             },

--- a/core/domain/blog_services_test.py
+++ b/core/domain/blog_services_test.py
@@ -841,7 +841,7 @@ class BlogServicesUnitTests(test_utils.GenericTestBase):
             )
             if old_blog_post_summary.published_on:
                 rank = math.floor(
-                    utils.get_time_in_millisecs(
+                    utils.get_utc_time_in_millisecs(
                         old_blog_post_summary.published_on
                     )
                 )
@@ -868,7 +868,7 @@ class BlogServicesUnitTests(test_utils.GenericTestBase):
             )
             if new_blog_post_summary.published_on:
                 rank = math.floor(
-                    utils.get_time_in_millisecs(
+                    utils.get_utc_time_in_millisecs(
                         new_blog_post_summary.published_on
                     )
                 )

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1225,7 +1225,7 @@ class ExplorationCommitLogEntry:
             adding username (derived from user_id).
         """
         return {
-            'last_updated': utils.get_time_in_millisecs(self.last_updated),
+            'last_updated': utils.get_utc_time_in_millisecs(self.last_updated),
             'exploration_id': self.exploration_id,
             'commit_type': self.commit_type,
             'commit_message': self.commit_message,

--- a/core/domain/feedback_domain.py
+++ b/core/domain/feedback_domain.py
@@ -140,7 +140,7 @@ class FeedbackThread:
         """
         return {
             'last_updated_msecs': (
-                utils.get_time_in_millisecs(self.last_updated)
+                utils.get_utc_time_in_millisecs(self.last_updated)
             ),
             'original_author_id': self.original_author_id,
             'state_name': self.state_name,
@@ -252,7 +252,9 @@ class FeedbackMessage:
         """
         return {
             'author_id': self.author_id,
-            'created_on_msecs': utils.get_time_in_millisecs(self.created_on),
+            'created_on_msecs': utils.get_utc_time_in_millisecs(
+                self.created_on
+            ),
             'entity_type': self.entity_type,
             'entity_id': self.entity_id,
             'message_id': self.message_id,
@@ -417,7 +419,7 @@ class FeedbackThreadSummary:
             'status': self.status,
             'original_author_id': self.original_author_id,
             'last_updated_msecs': (
-                utils.get_time_in_millisecs(self.last_updated)
+                utils.get_utc_time_in_millisecs(self.last_updated)
             ),
             'last_message_text': self.last_message_text,
             'total_message_count': self.total_message_count,

--- a/core/domain/feedback_domain_test.py
+++ b/core/domain/feedback_domain_test.py
@@ -43,7 +43,7 @@ class FeedbackThreadDomainUnitTests(test_utils.GenericTestBase):
             'original_author_id': self.viewer_id,
             'message_count': 1,
             'subject': 'a subject',
-            'last_updated_msecs': utils.get_time_in_millisecs(fake_date),
+            'last_updated_msecs': utils.get_utc_time_in_millisecs(fake_date),
             'last_nonempty_message_text': 'last message',
             'last_nonempty_message_author_id': self.viewer_id,
         }
@@ -134,7 +134,7 @@ class FeedbackMessageDomainUnitTests(test_utils.GenericTestBase):
         fake_date = datetime.datetime(2016, 4, 10, 0, 0, 0, 0)
         expected_message_dict: feedback_domain.FeedbackMessageDict = {
             'author_id': self.owner_id,
-            'created_on_msecs': utils.get_time_in_millisecs(fake_date),
+            'created_on_msecs': utils.get_utc_time_in_millisecs(fake_date),
             'entity_type': feconf.ENTITY_TYPE_EXPLORATION,
             'entity_id': self.EXP_ID,
             'message_id': self.MESSAGE_ID,

--- a/core/domain/general_feedback_services.py
+++ b/core/domain/general_feedback_services.py
@@ -80,7 +80,7 @@ def _lesson_feedback_model_to_domain(
         parent_feedback_id=model.parent_feedback_id,
         response_list=sanitized_responses,
         unread_response_count=model.unread_response_count,
-        created_on_msecs=utils.get_time_in_millisecs(model.created_on),
+        created_on_msecs=utils.get_utc_time_in_millisecs(model.created_on),
     )
 
 
@@ -119,7 +119,7 @@ def _platform_feedback_model_to_domain(
         include_technical_logs=model.include_technical_logs,
         screenshot_filename=model.screenshot_filename,
         screenshot_entity_id=model.screenshot_entity_id,
-        created_on_msecs=utils.get_time_in_millisecs(model.created_on),
+        created_on_msecs=utils.get_utc_time_in_millisecs(model.created_on),
     )
 
 

--- a/core/domain/improvements_domain.py
+++ b/core/domain/improvements_domain.py
@@ -187,6 +187,6 @@ class TaskEntry:
             'resolved_on_msecs': (
                 None
                 if not self.resolved_on
-                else utils.get_time_in_millisecs(self.resolved_on)
+                else utils.get_utc_time_in_millisecs(self.resolved_on)
             ),
         }

--- a/core/domain/improvements_domain_test.py
+++ b/core/domain/improvements_domain_test.py
@@ -99,7 +99,7 @@ class TaskEntryTests(test_utils.GenericTestBase):
                 'issue_description': 'issue description',
                 'status': 'resolved',
                 'resolver_username': None,
-                'resolved_on_msecs': utils.get_time_in_millisecs(
+                'resolved_on_msecs': utils.get_utc_time_in_millisecs(
                     self.MOCK_DATE
                 ),
             },

--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -2034,10 +2034,10 @@ def get_collection_summary_dicts(
                 'category': collection_summary.category,
                 'objective': collection_summary.objective,
                 'language_code': collection_summary.language_code,
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     collection_summary.collection_model_last_updated
                 ),
-                'created_on': utils.get_time_in_millisecs(
+                'created_on': utils.get_utc_time_in_millisecs(
                     collection_summary.collection_model_created_on
                 ),
                 'status': collection_summary.status,

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -2370,8 +2370,10 @@ class QuestionSummary:
             'id': self.id,
             'question_content': self.question_content,
             'interaction_id': self.interaction_id,
-            'last_updated_msec': utils.get_time_in_millisecs(self.last_updated),
-            'created_on_msec': utils.get_time_in_millisecs(self.created_on),
+            'last_updated_msec': utils.get_utc_time_in_millisecs(
+                self.last_updated
+            ),
+            'created_on_msec': utils.get_utc_time_in_millisecs(self.created_on),
             'misconception_ids': self.misconception_ids,
             'version': self.version,
         }

--- a/core/domain/question_domain_test.py
+++ b/core/domain/question_domain_test.py
@@ -2382,10 +2382,10 @@ class QuestionSummaryTest(test_utils.GenericTestBase):
             'id': 'question_1',
             'question_content': '<p>question content</p>',
             'interaction_id': 'TextInput',
-            'last_updated_msec': utils.get_time_in_millisecs(
+            'last_updated_msec': utils.get_utc_time_in_millisecs(
                 self.fake_date_updated
             ),
-            'created_on_msec': utils.get_time_in_millisecs(
+            'created_on_msec': utils.get_utc_time_in_millisecs(
                 self.fake_date_created
             ),
             'misconception_ids': ['skill1-1', 'skill2-2'],

--- a/core/domain/search_services.py
+++ b/core/domain/search_services.py
@@ -405,7 +405,7 @@ def _blog_post_summary_to_search_dict(
             'tags': blog_post_summary.tags,
             'summary': blog_post_summary.summary,
             'rank': math.floor(
-                utils.get_time_in_millisecs(blog_post_summary.published_on)
+                utils.get_utc_time_in_millisecs(blog_post_summary.published_on)
             ),
         }
         return doc

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -2040,10 +2040,10 @@ class SkillSummary:
             'language_code': self.language_code,
             'version': self.version,
             'misconception_count': self.misconception_count,
-            'skill_model_created_on': utils.get_time_in_millisecs(
+            'skill_model_created_on': utils.get_utc_time_in_millisecs(
                 self.skill_model_created_on
             ),
-            'skill_model_last_updated': utils.get_time_in_millisecs(
+            'skill_model_last_updated': utils.get_utc_time_in_millisecs(
                 self.skill_model_last_updated
             ),
         }
@@ -2123,10 +2123,10 @@ class AugmentedSkillSummary:
             'misconception_count': self.misconception_count,
             'topic_names': self.topic_names,
             'classroom_names': self.classroom_names,
-            'skill_model_created_on': utils.get_time_in_millisecs(
+            'skill_model_created_on': utils.get_utc_time_in_millisecs(
                 self.skill_model_created_on
             ),
-            'skill_model_last_updated': utils.get_time_in_millisecs(
+            'skill_model_last_updated': utils.get_utc_time_in_millisecs(
                 self.skill_model_last_updated
             ),
         }

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -1236,7 +1236,7 @@ class SkillSummaryTests(test_utils.GenericTestBase):
     def setUp(self) -> None:
         super().setUp()
         current_time = datetime.datetime.utcnow()
-        time_in_millisecs = utils.get_time_in_millisecs(current_time)
+        time_in_millisecs = utils.get_utc_time_in_millisecs(current_time)
         self.skill_summary_dict = {
             'id': 'skill_id',
             'description': 'description',
@@ -1320,7 +1320,7 @@ class AugmentedSkillSummaryTests(test_utils.GenericTestBase):
     def setUp(self) -> None:
         super().setUp()
         current_time = datetime.datetime.utcnow()
-        self.time_in_millisecs = utils.get_time_in_millisecs(current_time)
+        self.time_in_millisecs = utils.get_utc_time_in_millisecs(current_time)
 
         self.augmented_skill_summary = skill_domain.AugmentedSkillSummary(
             'skill_id',

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -832,17 +832,17 @@ class StoryNode:
             'exploration_id': self.exploration_id,
             'status': self.status,
             'planned_publication_date_msecs': (
-                utils.get_time_in_millisecs(self.planned_publication_date)
+                utils.get_utc_time_in_millisecs(self.planned_publication_date)
                 if self.planned_publication_date
                 else None
             ),
             'last_modified_msecs': (
-                utils.get_time_in_millisecs(self.last_modified)
+                utils.get_utc_time_in_millisecs(self.last_modified)
                 if self.last_modified
                 else None
             ),
             'first_publication_date_msecs': (
-                utils.get_time_in_millisecs(self.first_publication_date)
+                utils.get_utc_time_in_millisecs(self.first_publication_date)
                 if self.first_publication_date
                 else None
             ),
@@ -1153,7 +1153,7 @@ class StoryNode:
         """
         current_time_msecs = utils.get_current_time_in_millisecs()
         planned_publication_date_msecs = (
-            utils.get_time_in_millisecs(self.planned_publication_date)
+            utils.get_utc_time_in_millisecs(self.planned_publication_date)
             if self.planned_publication_date
             else None
         )
@@ -1180,7 +1180,7 @@ class StoryNode:
         """
         current_time_msecs = utils.get_current_time_in_millisecs()
         planned_publication_date_msecs = (
-            utils.get_time_in_millisecs(self.planned_publication_date)
+            utils.get_utc_time_in_millisecs(self.planned_publication_date)
             if self.planned_publication_date
             else None
         )
@@ -3054,10 +3054,10 @@ class StorySummary:
             'thumbnail_filename': self.thumbnail_filename,
             'thumbnail_bg_color': self.thumbnail_bg_color,
             'url_fragment': self.url_fragment,
-            'story_model_created_on': utils.get_time_in_millisecs(
+            'story_model_created_on': utils.get_utc_time_in_millisecs(
                 self.story_model_created_on
             ),
-            'story_model_last_updated': utils.get_time_in_millisecs(
+            'story_model_last_updated': utils.get_utc_time_in_millisecs(
                 self.story_model_last_updated
             ),
         }

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -841,7 +841,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
     def test_story_node_update_planned_publication_date(self) -> None:
         self.story.story_contents.nodes[0].planned_publication_date = None
         current_time = datetime.datetime.now(datetime.timezone.utc)
-        current_time_msecs = utils.get_time_in_millisecs(current_time)
+        current_time_msecs = utils.get_utc_time_in_millisecs(current_time)
         self.story.update_node_planned_publication_date(
             'node_1', current_time_msecs
         )
@@ -853,7 +853,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
     def test_story_node_update_last_modified(self) -> None:
         self.story.story_contents.nodes[0].last_modified = None
         current_time = datetime.datetime.now(datetime.timezone.utc)
-        current_time_msecs = utils.get_time_in_millisecs(current_time)
+        current_time_msecs = utils.get_utc_time_in_millisecs(current_time)
         self.story.update_node_last_modified('node_1', current_time_msecs)
         self.assertEqual(
             self.story.story_contents.nodes[0].last_modified, current_time
@@ -862,7 +862,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
     def test_story_node_update_first_publication_date(self) -> None:
         self.story.story_contents.nodes[0].first_publication_date = None
         current_time = datetime.datetime.now(datetime.timezone.utc)
-        current_time_msecs = utils.get_time_in_millisecs(current_time)
+        current_time_msecs = utils.get_utc_time_in_millisecs(current_time)
         self.story.update_node_first_publication_date(
             'node_1', current_time_msecs
         )
@@ -2910,8 +2910,12 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             'thumbnail_bg_color': '#F8BF74',
             'thumbnail_filename': 'image.svg',
             'url_fragment': 'story-frag-two',
-            'story_model_created_on': utils.get_time_in_millisecs(curr_time),
-            'story_model_last_updated': utils.get_time_in_millisecs(curr_time),
+            'story_model_created_on': utils.get_utc_time_in_millisecs(
+                curr_time
+            ),
+            'story_model_last_updated': utils.get_utc_time_in_millisecs(
+                curr_time
+            ),
         }
 
         self.assertEqual(story_summary.to_dict(), expected_dict)
@@ -2996,7 +3000,7 @@ class StorySummaryTests(test_utils.GenericTestBase):
     def setUp(self) -> None:
         super().setUp()
         current_time = datetime.datetime.utcnow()
-        time_in_millisecs = utils.get_time_in_millisecs(current_time)
+        time_in_millisecs = utils.get_utc_time_in_millisecs(current_time)
         self.story_summary_dict = {
             'story_model_created_on': time_in_millisecs,
             'version': 1,

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -156,8 +156,8 @@ class BaseSuggestion:
             'change_cmd': self.change_cmd.to_dict(),
             'score_category': self.score_category,
             'language_code': self.language_code,
-            'last_updated': utils.get_time_in_millisecs(self.last_updated),
-            'created_on': utils.get_time_in_millisecs(self.created_on),
+            'last_updated': utils.get_utc_time_in_millisecs(self.last_updated),
+            'created_on': utils.get_utc_time_in_millisecs(self.created_on),
             'edited_by_reviewer': self.edited_by_reviewer,
         }
 

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -202,8 +202,8 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             },
             'score_category': 'content.Algebra',
             'language_code': None,
-            'last_updated': utils.get_time_in_millisecs(self.fake_date),
-            'created_on': utils.get_time_in_millisecs(self.fake_date),
+            'last_updated': utils.get_utc_time_in_millisecs(self.fake_date),
+            'created_on': utils.get_utc_time_in_millisecs(self.fake_date),
             'edited_by_reviewer': False,
         }
 
@@ -1135,8 +1135,8 @@ class SuggestionTranslateContentUnitTests(test_utils.GenericTestBase):
             },
             'score_category': 'translation.Algebra',
             'language_code': 'hi',
-            'last_updated': utils.get_time_in_millisecs(self.fake_date),
-            'created_on': utils.get_time_in_millisecs(self.fake_date),
+            'last_updated': utils.get_utc_time_in_millisecs(self.fake_date),
+            'created_on': utils.get_utc_time_in_millisecs(self.fake_date),
             'edited_by_reviewer': False,
         }
 
@@ -2279,8 +2279,8 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
             },
             'score_category': 'question.topic_1',
             'language_code': 'en',
-            'last_updated': utils.get_time_in_millisecs(self.fake_date),
-            'created_on': utils.get_time_in_millisecs(self.fake_date),
+            'last_updated': utils.get_utc_time_in_millisecs(self.fake_date),
+            'created_on': utils.get_utc_time_in_millisecs(self.fake_date),
             'edited_by_reviewer': False,
         }
 
@@ -3288,8 +3288,8 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
             },
             'score_category': 'question.skill1',
             'language_code': 'en',
-            'last_updated': utils.get_time_in_millisecs(self.fake_date),
-            'created_on': utils.get_time_in_millisecs(self.fake_date),
+            'last_updated': utils.get_utc_time_in_millisecs(self.fake_date),
+            'created_on': utils.get_utc_time_in_millisecs(self.fake_date),
             'edited_by_reviewer': False,
         }
         suggestion = suggestion_registry.SuggestionAddQuestion(
@@ -3371,8 +3371,8 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
             },
             'score_category': 'question.skill1',
             'language_code': 'en',
-            'last_updated': utils.get_time_in_millisecs(self.fake_date),
-            'created_on': utils.get_time_in_millisecs(self.fake_date),
+            'last_updated': utils.get_utc_time_in_millisecs(self.fake_date),
+            'created_on': utils.get_utc_time_in_millisecs(self.fake_date),
             'edited_by_reviewer': False,
         }
         suggestion = suggestion_registry.SuggestionAddQuestion(
@@ -3513,8 +3513,8 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
             },
             'score_category': 'question.skill1',
             'language_code': 'en',
-            'last_updated': utils.get_time_in_millisecs(self.fake_date),
-            'created_on': utils.get_time_in_millisecs(self.fake_date),
+            'last_updated': utils.get_utc_time_in_millisecs(self.fake_date),
+            'created_on': utils.get_utc_time_in_millisecs(self.fake_date),
             'edited_by_reviewer': False,
         }
         self.save_new_skill('skill1', self.author_id, description='description')

--- a/core/domain/summary_services.py
+++ b/core/domain/summary_services.py
@@ -587,12 +587,12 @@ def get_displayable_exp_summary_dicts(
                 'title': exploration_summary.title,
                 'activity_type': constants.ACTIVITY_TYPE_EXPLORATION,
                 'category': exploration_summary.category,
-                'created_on_msec': utils.get_time_in_millisecs(
+                'created_on_msec': utils.get_utc_time_in_millisecs(
                     exploration_summary.exploration_model_created_on
                 ),
                 'objective': exploration_summary.objective,
                 'language_code': exploration_summary.language_code,
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     exploration_summary.exploration_model_last_updated
                 ),
                 'human_readable_contributors_summary': (
@@ -667,7 +667,7 @@ def _get_displayable_collection_summary_dicts(
                     'language_code': collection_summary.language_code,
                     'tags': collection_summary.tags,
                     'node_count': collection_summary.node_count,
-                    'last_updated_msec': utils.get_time_in_millisecs(
+                    'last_updated_msec': utils.get_utc_time_in_millisecs(
                         collection_summary.collection_model_last_updated
                     ),
                     'thumbnail_icon_url': (

--- a/core/domain/takeout_service_test.py
+++ b/core/domain/takeout_service_test.py
@@ -121,7 +121,7 @@ class TakeoutServiceProfileUserUnitTests(test_utils.GenericTestBase):
     USER_1_EMAIL: Final = 'user1@example.com'
     GENERIC_USERNAME: Final = 'user'
     GENERIC_DATE: Final = datetime.datetime(2019, 5, 20)
-    GENERIC_EPOCH: Final = utils.get_time_in_millisecs(GENERIC_DATE)
+    GENERIC_EPOCH: Final = utils.get_utc_time_in_millisecs(GENERIC_DATE)
     GENERIC_IMAGE_URL: Final = 'www.example.com/example.png'
     GENERIC_USER_BIO: Final = 'I am a user of Oppia!'
     GENERIC_SUBJECT_INTERESTS: Final = ['Math', 'Science']
@@ -332,7 +332,7 @@ class TakeoutServiceFullUserUnitTests(test_utils.GenericTestBase):
     GENERIC_USERNAME: Final = 'user'
     GENERIC_PIN: Final = '12345'
     GENERIC_DATE: Final = datetime.datetime(2019, 5, 20)
-    GENERIC_EPOCH: Final = utils.get_time_in_millisecs(GENERIC_DATE)
+    GENERIC_EPOCH: Final = utils.get_utc_time_in_millisecs(GENERIC_DATE)
     GENERIC_IMAGE_URL: Final = 'www.example.com/example.png'
     GENERIC_USER_BIO: Final = 'I am a user of Oppia!'
     GENERIC_SUBJECT_INTERESTS: Final = ['Math', 'Science']
@@ -1815,7 +1815,7 @@ class TakeoutServiceFullUserUnitTests(test_utils.GenericTestBase):
                 'has_suggestion': self.THREAD_HAS_SUGGESTION,
                 'summary': self.THREAD_SUMMARY,
                 'message_count': self.THREAD_MESSAGE_COUNT,
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     feedback_thread_model.last_updated
                 ),
             },
@@ -1827,7 +1827,7 @@ class TakeoutServiceFullUserUnitTests(test_utils.GenericTestBase):
                 'has_suggestion': False,
                 'summary': None,
                 'message_count': 2,
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     feedback_models.GeneralFeedbackThreadModel.get_by_id(
                         thread_id
                     ).last_updated
@@ -2037,7 +2037,7 @@ class TakeoutServiceFullUserUnitTests(test_utils.GenericTestBase):
         expected_blog_post_data = {
             'content': 'content sample',
             'title': 'sample title',
-            'published_on': utils.get_time_in_millisecs(
+            'published_on': utils.get_utc_time_in_millisecs(
                 blog_post_model.published_on
             ),
             'url_fragment': 'sample-url-fragment',
@@ -2078,10 +2078,10 @@ class TakeoutServiceFullUserUnitTests(test_utils.GenericTestBase):
                 'parent_feedback_id': self.PARENT_FEEDBACK_ID_1,
                 'response_list': self.LESSON_FEEDBACK_RESPONSE_LIST,
                 'unread_response_count': self.LESSON_FEEDBACK_UNREAD_RESPONSE_COUNT,
-                'created_on_msec': utils.get_time_in_millisecs(
+                'created_on_msec': utils.get_utc_time_in_millisecs(
                     lesson_feedback_model.created_on
                 ),
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     lesson_feedback_model.last_updated
                 ),
             }

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -2652,10 +2652,10 @@ class TopicSummary:
             'published_story_exploration_mapping': (
                 self.published_story_exploration_mapping
             ),
-            'topic_model_created_on': utils.get_time_in_millisecs(
+            'topic_model_created_on': utils.get_utc_time_in_millisecs(
                 self.topic_model_created_on
             ),
-            'topic_model_last_updated': utils.get_time_in_millisecs(
+            'topic_model_last_updated': utils.get_utc_time_in_millisecs(
                 self.topic_model_last_updated
             ),
         }

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -1995,7 +1995,7 @@ class TopicSummaryTests(test_utils.GenericTestBase):
     def setUp(self) -> None:
         super().setUp()
         current_time = datetime.datetime.utcnow()
-        time_in_millisecs = utils.get_time_in_millisecs(current_time)
+        time_in_millisecs = utils.get_utc_time_in_millisecs(current_time)
         self.topic_summary_dict = {
             'url_fragment': 'url-frag',
             'id': 'topic_id',

--- a/core/jobs/batch_jobs/blog_post_search_indexing_jobs_test.py
+++ b/core/jobs/batch_jobs/blog_post_search_indexing_jobs_test.py
@@ -83,7 +83,7 @@ class IndexBlogPostSummariesInSearchJobTests(job_test_utils.JobTestBase):
                             'tags': ['tag1', 'tag2'],
                             'summary': 'blog_post_summary',
                             'rank': math.floor(
-                                utils.get_time_in_millisecs(
+                                utils.get_utc_time_in_millisecs(
                                     blog_summary.published_on
                                 )
                             ),
@@ -130,7 +130,7 @@ class IndexBlogPostSummariesInSearchJobTests(job_test_utils.JobTestBase):
                             'tags': ['tag1', 'tag2'],
                             'summary': 'blog_post_summary',
                             'rank': math.floor(
-                                utils.get_time_in_millisecs(
+                                utils.get_utc_time_in_millisecs(
                                     blog_summary.published_on
                                 )
                             ),
@@ -188,7 +188,7 @@ class IndexBlogPostSummariesInSearchJobTests(job_test_utils.JobTestBase):
                             'tags': ['tag1', 'tag2'],
                             'summary': 'blog_post_summary',
                             'rank': math.floor(
-                                utils.get_time_in_millisecs(
+                                utils.get_utc_time_in_millisecs(
                                     blog_summary.published_on
                                 )
                             ),

--- a/core/jobs/batch_jobs/story_node_jobs.py
+++ b/core/jobs/batch_jobs/story_node_jobs.py
@@ -107,7 +107,7 @@ class PopulateStoryNodeJob(base_jobs.JobBase):
                                     and cmd['story_id'] == story_model.id
                                 ):
                                     story_published_on = (
-                                        utils.get_time_in_millisecs(
+                                        utils.get_utc_time_in_millisecs(
                                             topic_metadata.created_on
                                         )
                                     )
@@ -133,7 +133,7 @@ class PopulateStoryNodeJob(base_jobs.JobBase):
                                     and node.get('last_modified_msecs') is None
                                 ):
                                     node['last_modified_msecs'] = (
-                                        utils.get_time_in_millisecs(
+                                        utils.get_utc_time_in_millisecs(
                                             story_metadata.created_on
                                         )
                                     )
@@ -143,7 +143,7 @@ class PopulateStoryNodeJob(base_jobs.JobBase):
                                     and cmd['node_id'] == node['id']
                                 ):
                                     node_created_on = (
-                                        utils.get_time_in_millisecs(
+                                        utils.get_utc_time_in_millisecs(
                                             story_metadata.created_on
                                         )
                                     )

--- a/core/jobs/batch_jobs/story_node_jobs_test.py
+++ b/core/jobs/batch_jobs/story_node_jobs_test.py
@@ -237,30 +237,30 @@ class PopulateStoryNodeJobTests(job_test_utils.JobTestBase):
         self.assertEqual(story_1_nodes[0]['unpublishing_reason'], None)
         self.assertEqual(
             story_1_nodes[0]['first_publication_date_msecs'],
-            (utils.get_time_in_millisecs(self.TOPIC_SNAPSHOT_2_DATE)),
+            (utils.get_utc_time_in_millisecs(self.TOPIC_SNAPSHOT_2_DATE)),
         )
         self.assertEqual(
             story_1_nodes[0]['planned_publication_date_msecs'],
-            (utils.get_time_in_millisecs(self.TOPIC_SNAPSHOT_2_DATE)),
+            (utils.get_utc_time_in_millisecs(self.TOPIC_SNAPSHOT_2_DATE)),
         )
         self.assertEqual(
             story_1_nodes[0]['last_modified_msecs'],
-            (utils.get_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
+            (utils.get_utc_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
         )
 
         self.assertEqual(story_1_nodes[1]['status'], 'Published')
         self.assertEqual(story_1_nodes[1]['unpublishing_reason'], None)
         self.assertEqual(
             story_1_nodes[1]['first_publication_date_msecs'],
-            (utils.get_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
+            (utils.get_utc_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
         )
         self.assertEqual(
             story_1_nodes[1]['planned_publication_date_msecs'],
-            (utils.get_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
+            (utils.get_utc_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
         )
         self.assertEqual(
             story_1_nodes[1]['last_modified_msecs'],
-            (utils.get_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
+            (utils.get_utc_time_in_millisecs(self.STORY_1_SHAPSHOT_2_DATE)),
         )
 
         updated_story_model_2 = story_models.StoryModel.get(self.STORY_2_ID)
@@ -276,7 +276,7 @@ class PopulateStoryNodeJobTests(job_test_utils.JobTestBase):
         )
         self.assertEqual(
             story_2_nodes[0]['last_modified_msecs'],
-            (utils.get_time_in_millisecs(self.STORY_2_SHAPSHOT_1_DATE)),
+            (utils.get_utc_time_in_millisecs(self.STORY_2_SHAPSHOT_1_DATE)),
         )
 
     def test_topic_with_no_story_reference_raises_error(self) -> None:

--- a/core/storage/app_feedback_report/gae_models.py
+++ b/core/storage/app_feedback_report/gae_models.py
@@ -336,7 +336,7 @@ class AppFeedbackReportModel(base_models.BaseModel):
         Raises:
             Exception. If the id generator is producing too many collisions.
         """
-        submitted_datetime_in_msec = utils.get_time_in_millisecs(
+        submitted_datetime_in_msec = utils.get_utc_time_in_millisecs(
             submitted_on_datetime
         )
         for _ in range(base_models.MAX_RETRIES):
@@ -486,7 +486,7 @@ class AppFeedbackReportModel(base_models.BaseModel):
             cls.get_all().filter(cls.scrubbed_by == user_id).fetch()
         )
         for report_model in report_models:
-            submitted_on_msec = utils.get_time_in_millisecs(
+            submitted_on_msec = utils.get_utc_time_in_millisecs(
                 report_model.submitted_on
             )
             if utils.is_user_id_valid(report_model.scrubbed_by):
@@ -643,7 +643,7 @@ class AppFeedbackReportTicketModel(base_models.BaseModel):
         Raises:
             Exception. If the id generator is producing too many collisions.
         """
-        current_datetime_in_msec = utils.get_time_in_millisecs(
+        current_datetime_in_msec = utils.get_utc_time_in_millisecs(
             datetime.datetime.utcnow()
         )
         for _ in range(base_models.MAX_RETRIES):

--- a/core/storage/app_feedback_report/gae_models_test.py
+++ b/core/storage/app_feedback_report/gae_models_test.py
@@ -44,21 +44,21 @@ class AppFeedbackReportModelTests(test_utils.GenericTestBase):
     REPORT_SUBMITTED_TIMESTAMP_1: Final = datetime.datetime.fromtimestamp(
         1615151836
     )
-    REPORT_SUBMITTED_TIMESTAMP_1_MSEC: Final = utils.get_time_in_millisecs(
+    REPORT_SUBMITTED_TIMESTAMP_1_MSEC: Final = utils.get_utc_time_in_millisecs(
         REPORT_SUBMITTED_TIMESTAMP_1
     )
     # Timestamp in sec since epoch for Mar 12 2021 3:22:17 UTC.
     REPORT_SUBMITTED_TIMESTAMP_2: Final = datetime.datetime.fromtimestamp(
         1615519337
     )
-    REPORT_SUBMITTED_TIMESTAMP_2_MSEC: Final = utils.get_time_in_millisecs(
+    REPORT_SUBMITTED_TIMESTAMP_2_MSEC: Final = utils.get_utc_time_in_millisecs(
         REPORT_SUBMITTED_TIMESTAMP_2
     )
     # Timestamp in sec since epoch for Mar 19 2021 17:10:36 UTC.
     TICKET_CREATION_TIMESTAMP: Final = datetime.datetime.fromtimestamp(
         1616173836
     )
-    TICKET_CREATION_TIMESTAMP_MSEC: Final = utils.get_time_in_millisecs(
+    TICKET_CREATION_TIMESTAMP_MSEC: Final = utils.get_utc_time_in_millisecs(
         TICKET_CREATION_TIMESTAMP
     )
     TICKET_ID: Final = '%s.%s.%s' % (
@@ -357,7 +357,7 @@ class AppFeedbackReportModelTests(test_utils.GenericTestBase):
             id='%s.%s.%s'
             % (
                 self.PLATFORM_ANDROID,
-                int(utils.get_time_in_millisecs(expired_timestamp)),
+                int(utils.get_utc_time_in_millisecs(expired_timestamp)),
                 'randomInteger123',
             ),
             platform=self.PLATFORM_ANDROID,
@@ -568,7 +568,7 @@ class AppFeedbackReportTicketModelTests(test_utils.GenericTestBase):
     REPORT_SUBMITTED_TIMESTAMP: Final = datetime.datetime.fromtimestamp(
         1615151836
     )
-    REPORT_SUBMITTED_TIMESTAMP_MSEC: Final = utils.get_time_in_millisecs(
+    REPORT_SUBMITTED_TIMESTAMP_MSEC: Final = utils.get_utc_time_in_millisecs(
         REPORT_SUBMITTED_TIMESTAMP
     )
     # Timestamp in sec since epoch for Mar 7 2021 21:17:16 UTC.
@@ -577,7 +577,7 @@ class AppFeedbackReportTicketModelTests(test_utils.GenericTestBase):
     TICKET_CREATION_TIMESTAMP: Final = datetime.datetime.fromtimestamp(
         1616173836
     )
-    TICKET_CREATION_TIMESTAMP_MSEC: Final = utils.get_time_in_millisecs(
+    TICKET_CREATION_TIMESTAMP_MSEC: Final = utils.get_utc_time_in_millisecs(
         TICKET_CREATION_TIMESTAMP
     )
 
@@ -693,7 +693,7 @@ class AppFeedbackReportStatsModelTests(test_utils.GenericTestBase):
     TICKET_CREATION_TIMESTAMP: Final = datetime.datetime.fromtimestamp(
         1616173836
     )
-    TICKET_CREATION_TIMESTAMP_MSEC: Final = utils.get_time_in_millisecs(
+    TICKET_CREATION_TIMESTAMP_MSEC: Final = utils.get_utc_time_in_millisecs(
         TICKET_CREATION_TIMESTAMP
     )
     TICKET_ID: Final = '%s.%s.%s' % (

--- a/core/storage/base_model/gae_models.py
+++ b/core/storage/base_model/gae_models.py
@@ -1800,7 +1800,9 @@ class VersionedModel(BaseModel):
                 'commit_cmds': model.commit_cmds,
                 'commit_type': model.commit_type,
                 'version_number': version_numbers[ind],
-                'created_on_ms': utils.get_time_in_millisecs(model.created_on),
+                'created_on_ms': utils.get_utc_time_in_millisecs(
+                    model.created_on
+                ),
             }
             for (ind, model) in enumerate(returned_models_without_none)
         ]

--- a/core/storage/blog/gae_models.py
+++ b/core/storage/blog/gae_models.py
@@ -229,7 +229,7 @@ class BlogPostModel(base_models.BaseModel):
         )
         for blog_post_model in blog_post_models:
             published_on = (
-                utils.get_time_in_millisecs(blog_post_model.published_on)
+                utils.get_utc_time_in_millisecs(blog_post_model.published_on)
                 if blog_post_model.published_on is not None
                 else None
             )

--- a/core/storage/blog/gae_models_test.py
+++ b/core/storage/blog/gae_models_test.py
@@ -170,7 +170,7 @@ class BlogPostModelTest(test_utils.GenericTestBase):
                 'url_fragment': 'sample-url-fragment',
                 'tags': self.TAGS,
                 'thumbnail_filename': self.THUMBNAIL,
-                'published_on': utils.get_time_in_millisecs(
+                'published_on': utils.get_utc_time_in_millisecs(
                     self.blog_post_model.published_on
                 ),
             }
@@ -220,7 +220,7 @@ class BlogPostModelTest(test_utils.GenericTestBase):
         blog_post_model.update_timestamps()
         blog_post_model.put()
         user_data = blog_models.BlogPostModel.export_data(user_id)
-        expected_millis = utils.get_time_in_millisecs(fake_date)
+        expected_millis = utils.get_utc_time_in_millisecs(fake_date)
         test_data = {
             'blog_one': {
                 'title': self.TITLE,
@@ -620,7 +620,7 @@ class BlogAuthorDetailsModelTest(test_utils.GenericTestBase):
     USER_2_ROLE: Final = feconf.ROLE_ID_BLOG_POST_EDITOR
     USER_2_NAME: Final = 'user two'
     GENERIC_DATE: Final = datetime.datetime(2019, 5, 20)
-    GENERIC_EPOCH: Final = utils.get_time_in_millisecs(
+    GENERIC_EPOCH: Final = utils.get_utc_time_in_millisecs(
         datetime.datetime(2019, 5, 20)
     )
     GENERIC_IMAGE_URL: Final = 'www.example.com/example.png'

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -212,7 +212,7 @@ class GeneralFeedbackThreadModel(base_models.BaseModel):
                 'has_suggestion': feedback_model.has_suggestion,
                 'summary': feedback_model.summary,
                 'message_count': feedback_model.message_count,
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     feedback_model.last_updated
                 ),
             }

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -151,7 +151,7 @@ class FeedbackThreadModelTest(test_utils.GenericTestBase):
                 'has_suggestion': self.HAS_SUGGESTION,
                 'summary': self.SUMMARY,
                 'message_count': self.MESSAGE_COUNT,
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     self.feedback_thread_model.last_updated
                 ),
             }

--- a/core/storage/general_feedback/gae_models.py
+++ b/core/storage/general_feedback/gae_models.py
@@ -186,10 +186,10 @@ class LessonFeedbackModel(base_models.BaseFeedbackModel):
                 'parent_feedback_id': feedback_model.parent_feedback_id,
                 'response_list': sanitized_response_list,
                 'unread_response_count': feedback_model.unread_response_count,
-                'created_on_msec': utils.get_time_in_millisecs(
+                'created_on_msec': utils.get_utc_time_in_millisecs(
                     feedback_model.created_on
                 ),
-                'last_updated_msec': utils.get_time_in_millisecs(
+                'last_updated_msec': utils.get_utc_time_in_millisecs(
                     feedback_model.last_updated
                 ),
             }

--- a/core/storage/general_feedback/gae_models_test.py
+++ b/core/storage/general_feedback/gae_models_test.py
@@ -167,10 +167,10 @@ class LessonFeedbackModelTests(test_utils.GenericTestBase):
             'parent_feedback_id': None,
             'response_list': [],
             'unread_response_count': 0,
-            'created_on_msec': utils.get_time_in_millisecs(
+            'created_on_msec': utils.get_utc_time_in_millisecs(
                 feedback_model.created_on
             ),
-            'last_updated_msec': utils.get_time_in_millisecs(
+            'last_updated_msec': utils.get_utc_time_in_millisecs(
                 feedback_model.last_updated
             ),
         }
@@ -193,7 +193,7 @@ class LessonFeedbackModelTests(test_utils.GenericTestBase):
         )
         self.assertEqual(
             export_data[self.feedback_id2]['created_on_msec'],
-            utils.get_time_in_millisecs(feedback_model.created_on),
+            utils.get_utc_time_in_millisecs(feedback_model.created_on),
         )
 
     def test_export_data_returns_empty_dict_for_nonexistent_user(

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -189,7 +189,7 @@ class AnswerSubmittedEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     @classmethod
@@ -272,7 +272,7 @@ class ExplorationActualStartEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     @classmethod
@@ -344,7 +344,7 @@ class SolutionHitEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     @classmethod
@@ -456,7 +456,7 @@ class StartExplorationEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     # In the type annotation below, Dict[str, str] is used for 'params'.
@@ -615,7 +615,7 @@ class MaybeLeaveExplorationEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     # In the type annotation below, Dict[str, str] is used for 'params'.
@@ -769,7 +769,7 @@ class CompleteExplorationEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     # In the type annotation below, Dict[str, str] is used for 'params'.
@@ -891,7 +891,7 @@ class RateExplorationEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, user_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, user_id)
         )
 
     @classmethod
@@ -1005,7 +1005,7 @@ class StateHitEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     # In the type annotation below, Dict[str, str] is used for 'params'.
@@ -1111,7 +1111,7 @@ class StateCompleteEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     @classmethod
@@ -1192,7 +1192,7 @@ class LeaveForRefresherExplorationEventLogEntryModel(base_models.BaseModel):
         timestamp = datetime.datetime.utcnow()
         return cls.get_new_id(
             '%s:%s:%s'
-            % (utils.get_time_in_millisecs(timestamp), exp_id, session_id)
+            % (utils.get_utc_time_in_millisecs(timestamp), exp_id, session_id)
         )
 
     @classmethod

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -273,36 +273,38 @@ class UserSettingsModel(base_models.BaseModel):
             'username': user.username,
             'normalized_username': user.normalized_username,
             'last_agreed_to_terms_msec': (
-                utils.get_time_in_millisecs(user.last_agreed_to_terms)
+                utils.get_utc_time_in_millisecs(user.last_agreed_to_terms)
                 if user.last_agreed_to_terms
                 else None
             ),
             'last_started_state_editor_tutorial_msec': (
-                utils.get_time_in_millisecs(
+                utils.get_utc_time_in_millisecs(
                     user.last_started_state_editor_tutorial
                 )
                 if user.last_started_state_editor_tutorial
                 else None
             ),
             'last_started_state_translation_tutorial_msec': (
-                utils.get_time_in_millisecs(
+                utils.get_utc_time_in_millisecs(
                     user.last_started_state_translation_tutorial
                 )
                 if user.last_started_state_translation_tutorial
                 else None
             ),
             'last_logged_in_msec': (
-                utils.get_time_in_millisecs(user.last_logged_in)
+                utils.get_utc_time_in_millisecs(user.last_logged_in)
                 if user.last_logged_in
                 else None
             ),
             'last_edited_an_exploration_msec': (
-                utils.get_time_in_millisecs(user.last_edited_an_exploration)
+                utils.get_utc_time_in_millisecs(user.last_edited_an_exploration)
                 if user.last_edited_an_exploration
                 else None
             ),
             'last_created_an_exploration_msec': (
-                utils.get_time_in_millisecs(user.last_created_an_exploration)
+                utils.get_utc_time_in_millisecs(
+                    user.last_created_an_exploration
+                )
                 if user.last_created_an_exploration
                 else None
             ),
@@ -1272,7 +1274,7 @@ class UserSubscriptionsModel(base_models.BaseModel):
             'last_checked_msec': (
                 None
                 if user_model.last_checked is None
-                else utils.get_time_in_millisecs(user_model.last_checked)
+                else utils.get_utc_time_in_millisecs(user_model.last_checked)
             ),
         }
 
@@ -1802,13 +1804,13 @@ class ExplorationUserDataModel(base_models.BaseModel):
             user_data[user_model.exploration_id] = {
                 'rating': user_model.rating,
                 'rated_on_msec': (
-                    utils.get_time_in_millisecs(user_model.rated_on)
+                    utils.get_utc_time_in_millisecs(user_model.rated_on)
                     if user_model.rated_on
                     else None
                 ),
                 'draft_change_list': user_model.draft_change_list,
                 'draft_change_list_last_updated_msec': (
-                    utils.get_time_in_millisecs(
+                    utils.get_utc_time_in_millisecs(
                         user_model.draft_change_list_last_updated
                     )
                     if user_model.draft_change_list_last_updated

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -55,7 +55,7 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
     PROFILE_1_ROLE: Final = feconf.ROLE_ID_MOBILE_LEARNER
     GENERIC_USERNAME: Final = 'user'
     GENERIC_DATE: Final = datetime.datetime(2019, 5, 20)
-    GENERIC_EPOCH: Final = utils.get_time_in_millisecs(
+    GENERIC_EPOCH: Final = utils.get_utc_time_in_millisecs(
         datetime.datetime(2019, 5, 20)
     )
     GENERIC_IMAGE_URL: Final = 'www.example.com/example.png'
@@ -1443,7 +1443,7 @@ class UserSubscriptionsModelTests(test_utils.GenericTestBase):
             'collection_ids': self.COLLECTION_IDS,
             'exploration_ids': self.EXPLORATION_IDS,
             'general_feedback_thread_ids': self.GENERAL_FEEDBACK_THREAD_IDS,
-            'last_checked_msec': utils.get_time_in_millisecs(
+            'last_checked_msec': utils.get_utc_time_in_millisecs(
                 self.GENERIC_DATETIME
             ),
         }
@@ -1789,7 +1789,7 @@ class ExplorationUserDataModelTest(test_utils.GenericTestBase):
     DATETIME_OBJECT: Final = datetime.datetime.strptime(
         '2016-02-16', '%Y-%m-%d'
     )
-    DATETIME_EPOCH: Final = utils.get_time_in_millisecs(DATETIME_OBJECT)
+    DATETIME_EPOCH: Final = utils.get_utc_time_in_millisecs(DATETIME_OBJECT)
     USER_1_ID: Final = 'id_1'
     USER_2_ID: Final = 'id_2'
     EXP_ID_ONE: Final = 'exp_id_one'

--- a/core/utils.py
+++ b/core/utils.py
@@ -582,7 +582,7 @@ def base64_from_int(value: int) -> str:
     return base64.b64encode(byte_value).decode('utf-8')
 
 
-def get_time_in_millisecs(datetime_obj: datetime.datetime) -> float:
+def get_utc_time_in_millisecs(datetime_obj: datetime.datetime) -> float:
     """Returns time in milliseconds since the Epoch.
 
     Args:
@@ -655,7 +655,9 @@ def get_current_time_in_millisecs() -> float:
     Returns:
         float. The time in milliseconds since the Epoch.
     """
-    return get_time_in_millisecs(datetime.datetime.now(datetime.timezone.utc))
+    return get_utc_time_in_millisecs(
+        datetime.datetime.now(datetime.timezone.utc)
+    )
 
 
 def get_human_readable_time_string(time_msec: float) -> str:

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -769,7 +769,7 @@ class UtilsTests(test_utils.GenericTestBase):
 
     def test_get_time_in_millisecs(self) -> None:
         dt = datetime.datetime(2020, 6, 15)
-        msecs = utils.get_time_in_millisecs(dt)
+        msecs = utils.get_utc_time_in_millisecs(dt)
         self.assertEqual(
             dt,
             datetime.datetime.fromtimestamp(
@@ -779,7 +779,7 @@ class UtilsTests(test_utils.GenericTestBase):
 
     def test_get_time_in_millisecs_with_complicated_time(self) -> None:
         dt = datetime.datetime(2020, 6, 15, 5, 18, 23, microsecond=123456)
-        msecs = utils.get_time_in_millisecs(dt)
+        msecs = utils.get_utc_time_in_millisecs(dt)
         self.assertEqual(
             dt,
             datetime.datetime.fromtimestamp(
@@ -789,7 +789,7 @@ class UtilsTests(test_utils.GenericTestBase):
 
     def test_get_time_in_millisecs_with_utc_aware_datetime(self) -> None:
         dt = datetime.datetime(2020, 6, 15, tzinfo=datetime.timezone.utc)
-        msecs = utils.get_time_in_millisecs(dt)
+        msecs = utils.get_utc_time_in_millisecs(dt)
         self.assertEqual(
             dt,
             datetime.datetime.fromtimestamp(
@@ -805,7 +805,7 @@ class UtilsTests(test_utils.GenericTestBase):
         dt_utc = datetime.datetime(
             2020, 6, 15, 0, 0, 0, tzinfo=datetime.timezone.utc
         )
-        msecs = utils.get_time_in_millisecs(dt_ist)
+        msecs = utils.get_utc_time_in_millisecs(dt_ist)
         self.assertEqual(
             dt_utc,
             datetime.datetime.fromtimestamp(


### PR DESCRIPTION
## Overview

1. This PR fixes #26622 .
2. This pr fixes part of https://github.com/oppia/oppia/issues/26624 and https://github.com/oppia/oppia/pull/26358
3. This PR renames the datetime utility function from `get_time_in_millisecs()` to `get_utc_time_in_millisecs()`.

This is the first step in the datetime standardization work. The rename makes the utility’s behavior clearer by explicitly showing that datetime values are normalized relative to UTC before converting them to milliseconds since the Epoch.

This PR keeps the behavior unchanged. It only improves the function name and updates the affected call sites and tests to use the new name. The broader migration of application-layer current-time calls to shared utilities will be handled separately.

4. N/A. This is a datetime standardization/refactoring PR, not a user-facing bug fix caused by a specific prior PR.

## Essential Checklist

Please follow the [[instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request)](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

* [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [x] I have written tests for my code.
* [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
* [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A. This PR does not add or modify any Beam job that changes production server data. It only renames a datetime utility function and updates its usages.

* [ ] A testing doc has been written: N/A.
* [ ] *(To be confirmed by the server admin)* All jobs in this PR have been verified on a live server, and the PR is safe to merge. N/A.

## Proof that changes are correct

No UI proof of changes is needed because this is a backend-only utility rename. The behavior is verified through backend tests and lint checks.

Verification performed:

```bash
python -m scripts.run_backend_tests --test_target=core.utils_test
```

```bash
python -m scripts.linters.run_lint_checks --files core/utils.py core/utils_test.py
```

I also checked the updated call sites to confirm that the old `get_time_in_millisecs()` name has been replaced by `get_utc_time_in_millisecs()` where applicable.

#### Proof of changes on desktop with slow/throttled network

N/A. This is a backend-only utility rename and does not change any user-facing UI.

#### Proof of changes on mobile phone

N/A. This is a backend-only utility rename and does not change any mobile UI.

#### Proof of changes in Arabic language

N/A. This PR does not change UI strings, layout, or translations.

## PR Pointers

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
* Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the [["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR)](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
* See the [[Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers)](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.