### PR TITLE
[GSoC 2026] M1.21 - Fix Part of #24717: Added skeleton learner assessment flow with stubbed end-to-end navigation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -705,6 +705,7 @@
 /core/templates/domain/certificate-assessment/ @oppia/contributor-experience-team
 /core/controllers/certificate_assessment*.py @oppia/contributor-experience-team
 /core/templates/pages/certificate-offering-available-page @oppia/lace-frontend-reviewers
+/core/templates/pages/certificate-assessment-player-page @oppia/lace-frontend-reviewers
 
 # Speed Improvement team.
 /core/templates/google-analytics.initializer.ts @oppia/lace-frontend-reviewers

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -6824,6 +6824,24 @@ export default {
         }
       ]
     },
+    "CERTIFICATE_ASSESSMENT_PLAYER": {
+      "ROUTE": "certificate-assessment/:certificate_id",
+      "TITLE": "Certificate Assessment Player | Oppia",
+      "META": [
+        {
+          "PROPERTY_TYPE": "itemprop",
+          "PROPERTY_VALUE": "description",
+          // eslint-disable-next-line max-len
+          "CONTENT": "Take a certificate assessment in Oppia and review what you have learned in your classroom."
+        },
+        {
+          "PROPERTY_TYPE": "itemprop",
+          "PROPERTY_VALUE": "og:description",
+          // eslint-disable-next-line max-len
+          "CONTENT": "Take a certificate assessment in Oppia and review what you have learned in your classroom."
+        }
+      ]
+    },
     "FACILITATOR_DASHBOARD": {
       "ROUTE": "facilitator-dashboard",
       "TITLE": "Facilitator Dashboard - Oppia",

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -6605,13 +6605,13 @@ export default {
           "PROPERTY_TYPE": "itemprop",
           "PROPERTY_VALUE": "description",
           // eslint-disable-next-line max-len
-          "CONTENT": "Take a certificate assessment in Oppia and review what you have learned in your classroom."
+          "CONTENT": "Take a certificate assessment in Oppia and review what you have learned from your classroom."
         },
         {
           "PROPERTY_TYPE": "itemprop",
           "PROPERTY_VALUE": "og:description",
           // eslint-disable-next-line max-len
-          "CONTENT": "Take a certificate assessment in Oppia and review what you have learned in your classroom."
+          "CONTENT": "Take a certificate assessment in Oppia and review what you have learned from your classroom."
         }
       ]
     },

--- a/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.html
@@ -1,0 +1,7 @@
+<div class="assessment-card">
+  <h2>Instructions</h2>
+  <p>This is a generic instruction panel for the certificate assessment.</p>
+  <button class="btn btn-primary" (click)="startAssessment.emit()">
+    Start Assessment
+  </button>
+</div>

--- a/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.html
@@ -1,7 +1,7 @@
 <div class="assessment-card">
   <h2>Instructions</h2>
   <p>This is a generic instruction panel for the certificate assessment.</p>
-  <button class="btn btn-primary" (click)="startAssessment.emit()">
+  <button class="btn btn-primary" (click)="onStartAssessment()">
     Start Assessment
   </button>
 </div>

--- a/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.spec.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for AssessmentInstructionPanelComponent.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {AssessmentInstructionPanelComponent} from './assessment-instruction-panel.component';
+
+describe('AssessmentInstructionPanelComponent', () => {
+  let component: AssessmentInstructionPanelComponent;
+  let fixture: ComponentFixture<AssessmentInstructionPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AssessmentInstructionPanelComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AssessmentInstructionPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should emit startAssessment when onStartAssessment is called', () => {
+    spyOn(component.startAssessment, 'emit');
+
+    component.onStartAssessment();
+
+    expect(component.startAssessment.emit).toHaveBeenCalled();
+  });
+
+  it('should emit startAssessment when the start button is clicked', () => {
+    spyOn(component.startAssessment, 'emit');
+
+    const button = fixture.debugElement.query(By.css('button'));
+    button.triggerEventHandler('click', null);
+
+    expect(component.startAssessment.emit).toHaveBeenCalled();
+  });
+});

--- a/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Component for the assessment instruction panel.
+ */
+
 import {Component, EventEmitter, Output} from '@angular/core';
 
 @Component({

--- a/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.ts
@@ -7,22 +7,17 @@
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an "AS-IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * @fileoverview Certificate offering available page component.
- */
+import {Component, EventEmitter, Output} from '@angular/core';
 
-import {Component, Input} from '@angular/core';
-import './certificate-offering-available-page.component.css';
 @Component({
-  selector: 'oppia-available-certificate-offering-page',
-  templateUrl: './certificate-offering-available-page.component.html',
+  selector: 'oppia-assessment-instruction-panel',
+  templateUrl: './assessment-instruction-panel.component.html',
 })
-export class AvailableCertificateOfferingPageComponent {
-  @Input() classroomUrlFragment: string = '';
-  certificateId: string = 'temporary_certificate_id';
+export class AssessmentInstructionPanelComponent {
+  @Output() startAssessment = new EventEmitter<void>();
 }

--- a/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-instruction-panel.component.ts
@@ -24,4 +24,8 @@ import {Component, EventEmitter, Output} from '@angular/core';
 })
 export class AssessmentInstructionPanelComponent {
   @Output() startAssessment = new EventEmitter<void>();
+
+  onStartAssessment(): void {
+    this.startAssessment.emit();
+  }
 }

--- a/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.html
@@ -1,5 +1,5 @@
 <div class="assessment-card">
   <h2>Certificate Assessment</h2>
   <p>This assessment is linked to certificate id: {{certificateId}}</p>
-  <button class="btn btn-primary" (click)="continue.emit()">Continue</button>
+  <button class="btn btn-primary" (click)="onContinue()">Continue</button>
 </div>

--- a/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.html
@@ -1,0 +1,5 @@
+<div class="assessment-card">
+  <h2>Certificate Assessment</h2>
+  <p>This assessment is linked to certificate id: {{certificateId}}</p>
+  <button class="btn btn-primary" (click)="continue.emit()">Continue</button>
+</div>

--- a/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.spec.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for AssessmentIntroductionCardComponent.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {AssessmentIntroductionCardComponent} from './assessment-introduction-card.component';
+
+describe('AssessmentIntroductionCardComponent', () => {
+  let component: AssessmentIntroductionCardComponent;
+  let fixture: ComponentFixture<AssessmentIntroductionCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AssessmentIntroductionCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AssessmentIntroductionCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should default certificateId to an empty string', () => {
+    expect(component.certificateId).toBe('');
+  });
+
+  it('should display the provided certificateId', () => {
+    component.certificateId = 'cert-123';
+    fixture.detectChanges();
+
+    const paragraph = fixture.debugElement.query(By.css('p')).nativeElement;
+    expect(paragraph.textContent).toContain('cert-123');
+  });
+
+  it('should emit continue when onContinue is called', () => {
+    spyOn(component.continue, 'emit');
+
+    component.onContinue();
+
+    expect(component.continue.emit).toHaveBeenCalled();
+  });
+
+  it('should emit continue when the button is clicked', () => {
+    spyOn(component.continue, 'emit');
+
+    const button = fixture.debugElement.query(By.css('button'));
+    button.triggerEventHandler('click', null);
+
+    expect(component.continue.emit).toHaveBeenCalled();
+  });
+});

--- a/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.ts
@@ -13,6 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Component for the assessment introduction card.
+ */
+
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 @Component({

--- a/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.ts
@@ -3,7 +3,6 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// You may obtain a copy of the License at
 //
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
@@ -26,4 +25,8 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 export class AssessmentIntroductionCardComponent {
   @Input() certificateId = '';
   @Output() continue = new EventEmitter<void>();
+
+  onContinue(): void {
+    this.continue.emit();
+  }
 }

--- a/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/assessment-introduction-card.component.ts
@@ -3,26 +3,23 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
+// You may obtain a copy of the License at
 //
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an "AS-IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * @fileoverview Certificate offering available page component.
- */
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 
-import {Component, Input} from '@angular/core';
-import './certificate-offering-available-page.component.css';
 @Component({
-  selector: 'oppia-available-certificate-offering-page',
-  templateUrl: './certificate-offering-available-page.component.html',
+  selector: 'oppia-assessment-introduction-card',
+  templateUrl: './assessment-introduction-card.component.html',
 })
-export class AvailableCertificateOfferingPageComponent {
-  @Input() classroomUrlFragment: string = '';
-  certificateId: string = 'temporary_certificate_id';
+export class AssessmentIntroductionCardComponent {
+  @Input() certificateId = '';
+  @Output() continue = new EventEmitter<void>();
 }

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.html
@@ -10,16 +10,10 @@
     <ul>
       <li *ngFor="let choice of currentQuestion.choices">{{choice}}</li>
     </ul>
-    <button
-      *ngIf="!isLastQuestion"
-      class="btn btn-primary"
-      (click)="nextQuestion.emit()">
+    <button *ngIf="!isLastQuestion" class="btn btn-primary" (click)="nextQuestion.emit()">
       Next
     </button>
-    <button
-      *ngIf="isLastQuestion"
-      class="btn btn-primary"
-      (click)="submitAssessment.emit()">
+    <button *ngIf="isLastQuestion" class="btn btn-primary" (click)="submitAssessment.emit()">
       Submit
     </button>
   </div>

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.html
@@ -10,10 +10,10 @@
     <ul>
       <li *ngFor="let choice of currentQuestion.choices">{{choice}}</li>
     </ul>
-    <button *ngIf="!isLastQuestion" class="btn btn-primary" (click)="nextQuestion.emit()">
+    <button *ngIf="!isLastQuestion" class="btn btn-primary" (click)="onNextQuestion()">
       Next
     </button>
-    <button *ngIf="isLastQuestion" class="btn btn-primary" (click)="submitAssessment.emit()">
+    <button *ngIf="isLastQuestion" class="btn btn-primary" (click)="onSubmitAssessment()">
       Submit
     </button>
   </div>

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.html
@@ -1,0 +1,26 @@
+<div class="assessment-conversation-skin">
+  <div class="assessment-progress-bar">
+    <div class="assessment-progress-fill" [style.width.%]="progressPercentage"></div>
+  </div>
+  <p class="assessment-progress-text">
+    Question {{currentQuestionIndex + 1}} of {{totalQuestions}}
+  </p>
+  <div class="assessment-question-card">
+    <h3>{{currentQuestion.prompt}}</h3>
+    <ul>
+      <li *ngFor="let choice of currentQuestion.choices">{{choice}}</li>
+    </ul>
+    <button
+      *ngIf="!isLastQuestion"
+      class="btn btn-primary"
+      (click)="nextQuestion.emit()">
+      Next
+    </button>
+    <button
+      *ngIf="isLastQuestion"
+      class="btn btn-primary"
+      (click)="submitAssessment.emit()">
+      Submit
+    </button>
+  </div>
+</div>

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.spec.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for AssessmentIntroductionCardComponent.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {AssessmentIntroductionCardComponent} from './assessment-introduction-card.component';
+
+describe('AssessmentIntroductionCardComponent', () => {
+  let component: AssessmentIntroductionCardComponent;
+  let fixture: ComponentFixture<AssessmentIntroductionCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AssessmentIntroductionCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AssessmentIntroductionCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should default certificateId to an empty string', () => {
+    expect(component.certificateId).toBe('');
+  });
+
+  it('should display the provided certificateId', () => {
+    component.certificateId = 'cert-123';
+    fixture.detectChanges();
+
+    const paragraph = fixture.debugElement.query(By.css('p')).nativeElement;
+    expect(paragraph.textContent).toContain('cert-123');
+  });
+
+  it('should emit continue when onContinue is called', () => {
+    spyOn(component.continue, 'emit');
+
+    component.onContinue();
+
+    expect(component.continue.emit).toHaveBeenCalled();
+  });
+
+  it('should emit continue when the button is clicked', () => {
+    spyOn(component.continue, 'emit');
+
+    const button = fixture.debugElement.query(By.css('button'));
+    button.triggerEventHandler('click', null);
+
+    expect(component.continue.emit).toHaveBeenCalled();
+  });
+});

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.spec.ts
@@ -13,54 +13,84 @@
 // limitations under the License.
 
 /**
- * @fileoverview Unit tests for AssessmentIntroductionCardComponent.
+ * @fileoverview Unit tests for CertificateAssessmentConversationSkinComponent.
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 
-import {AssessmentIntroductionCardComponent} from './assessment-introduction-card.component';
+import {CertificateAssessmentConversationSkinComponent} from './certificate-assessment-conversation-skin.component';
 
-describe('AssessmentIntroductionCardComponent', () => {
-  let component: AssessmentIntroductionCardComponent;
-  let fixture: ComponentFixture<AssessmentIntroductionCardComponent>;
+describe('CertificateAssessmentConversationSkinComponent', () => {
+  let component: CertificateAssessmentConversationSkinComponent;
+  let fixture: ComponentFixture<CertificateAssessmentConversationSkinComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AssessmentIntroductionCardComponent],
+      declarations: [CertificateAssessmentConversationSkinComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(AssessmentIntroductionCardComponent);
+    fixture = TestBed.createComponent(
+      CertificateAssessmentConversationSkinComponent
+    );
     component = fixture.componentInstance;
+    component.currentQuestion = {
+      prompt: 'What is 2 + 2?',
+      choices: ['3', '4', '5'],
+    };
     fixture.detectChanges();
   });
 
-  it('should default certificateId to an empty string', () => {
-    expect(component.certificateId).toBe('');
+  it('should default currentQuestionIndex to 0', () => {
+    expect(component.currentQuestionIndex).toBe(0);
   });
 
-  it('should display the provided certificateId', () => {
-    component.certificateId = 'cert-123';
+  it('should default totalQuestions to 0', () => {
+    expect(component.totalQuestions).toBe(0);
+  });
+
+  it('should default progressPercentage to 0', () => {
+    expect(component.progressPercentage).toBe(0);
+  });
+
+  it('should default isLastQuestion to false', () => {
+    expect(component.isLastQuestion).toBe(false);
+  });
+
+  it('should accept a provided currentQuestion', () => {
+    expect(component.currentQuestion).toEqual({
+      prompt: 'What is 2 + 2?',
+      choices: ['3', '4', '5'],
+    });
+  });
+
+  it('should accept provided currentQuestionIndex, totalQuestions, progressPercentage and isLastQuestion', () => {
+    component.currentQuestionIndex = 2;
+    component.totalQuestions = 5;
+    component.progressPercentage = 40;
+    component.isLastQuestion = true;
     fixture.detectChanges();
 
-    const paragraph = fixture.debugElement.query(By.css('p')).nativeElement;
-    expect(paragraph.textContent).toContain('cert-123');
+    expect(component.currentQuestionIndex).toBe(2);
+    expect(component.totalQuestions).toBe(5);
+    expect(component.progressPercentage).toBe(40);
+    expect(component.isLastQuestion).toBe(true);
   });
 
-  it('should emit continue when onContinue is called', () => {
-    spyOn(component.continue, 'emit');
+  it('should emit nextQuestion when onNextQuestion is called', () => {
+    spyOn(component.nextQuestion, 'emit');
 
-    component.onContinue();
+    component.onNextQuestion();
 
-    expect(component.continue.emit).toHaveBeenCalled();
+    expect(component.nextQuestion.emit).toHaveBeenCalled();
   });
 
-  it('should emit continue when the button is clicked', () => {
-    spyOn(component.continue, 'emit');
+  it('should emit submitAssessment when onSubmitAssessment is called', () => {
+    spyOn(component.submitAssessment, 'emit');
 
-    const button = fixture.debugElement.query(By.css('button'));
-    button.triggerEventHandler('click', null);
+    component.onSubmitAssessment();
 
-    expect(component.continue.emit).toHaveBeenCalled();
+    expect(component.submitAssessment.emit).toHaveBeenCalled();
   });
 });

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.ts
@@ -35,4 +35,12 @@ export class CertificateAssessmentConversationSkinComponent {
   @Input() isLastQuestion = false;
   @Output() nextQuestion = new EventEmitter<void>();
   @Output() submitAssessment = new EventEmitter<void>();
+
+  onNextQuestion(): void {
+    this.nextQuestion.emit();
+  }
+
+  onSubmitAssessment(): void {
+    this.submitAssessment.emit();
+  }
 }

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+
+interface AssessmentQuestion {
+  prompt: string;
+  choices: string[];
+}
+
+@Component({
+  selector: 'oppia-certificate-assessment-conversation-skin',
+  templateUrl: './certificate-assessment-conversation-skin.component.html',
+})
+export class CertificateAssessmentConversationSkinComponent {
+  @Input() currentQuestion!: AssessmentQuestion;
+  @Input() currentQuestionIndex = 0;
+  @Input() totalQuestions = 0;
+  @Input() progressPercentage = 0;
+  @Input() isLastQuestion = false;
+  @Output() nextQuestion = new EventEmitter<void>();
+  @Output() submitAssessment = new EventEmitter<void>();
+}

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-conversation-skin.component.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Component for the assessment conversation skin.
+ */
+
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 interface AssessmentQuestion {

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.spec.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Location} from '@angular/common';
+import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {Router} from '@angular/router';
+import {AppConstants} from 'app.constants';
+import {PlatformFeatureService} from 'services/platform-feature.service';
+import {CertificateAssessmentPlayerPageAuthGuard} from './certificate-assessment-player-page-auth.guard';
+
+describe('CertificateAssessmentPlayerPageAuthGuard', () => {
+  let guard: CertificateAssessmentPlayerPageAuthGuard;
+  let router: jasmine.SpyObj<Router>;
+  let location: jasmine.SpyObj<Location>;
+  let platformFeatureService: PlatformFeatureService;
+
+  beforeEach(() => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    location = jasmine.createSpyObj('Location', ['replaceState']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        CertificateAssessmentPlayerPageAuthGuard,
+        {
+          provide: Router,
+          useValue: router,
+        },
+        {
+          provide: Location,
+          useValue: location,
+        },
+        {
+          provide: PlatformFeatureService,
+          useValue: {
+            status: {
+              EnableCertificateAssessment: {
+                isEnabled: true,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    guard = TestBed.inject(CertificateAssessmentPlayerPageAuthGuard);
+    platformFeatureService = TestBed.inject(
+      PlatformFeatureService
+    ) as PlatformFeatureService;
+  });
+
+  it('should allow access when feature flag is enabled', fakeAsync(() => {
+    platformFeatureService.status.EnableCertificateAssessment.isEnabled = true;
+
+    let result = false;
+    guard
+      .canActivate(
+        {} as never,
+        {url: '/certificate-assessment/cert-1'} as never
+      )
+      .then(value => {
+        result = value;
+      });
+    tick();
+
+    expect(result).toBeTrue();
+    expect(router.navigate).not.toHaveBeenCalled();
+  }));
+
+  it('should redirect to 404 when feature flag is disabled', fakeAsync(() => {
+    platformFeatureService.status.EnableCertificateAssessment.isEnabled = false;
+    router.navigate.and.resolveTo(true);
+
+    let result = true;
+    guard
+      .canActivate(
+        {} as never,
+        {url: '/certificate-assessment/cert-1'} as never
+      )
+      .then(value => {
+        result = value;
+      });
+    tick();
+
+    expect(result).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith([
+      `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
+    ]);
+    expect(location.replaceState).toHaveBeenCalledWith(
+      '/certificate-assessment/cert-1'
+    );
+  }));
+});

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.spec.ts
@@ -104,4 +104,28 @@ describe('CertificateAssessmentPlayerPageAuthGuard', () => {
       '/certificate-assessment/cert-1'
     );
   }));
+
+  it('should replace state via the catch block when router.navigate rejects', fakeAsync(() => {
+    platformFeatureService.status.EnableCertificateAssessment.isEnabled = false;
+    router.navigate.and.rejectWith(new Error('Navigation failed'));
+
+    let result = true;
+    guard
+      .canActivate(
+        {} as never,
+        {url: '/certificate-assessment/cert-1'} as never
+      )
+      .then(value => {
+        result = value;
+      });
+    tick();
+
+    expect(result).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith([
+      `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
+    ]);
+    expect(location.replaceState).toHaveBeenCalledWith(
+      '/certificate-assessment/cert-1'
+    );
+  }));
 });

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.spec.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Guard that redirects to 404 when the certificate assessment feature is disabled.
+ */
+
 import {Location} from '@angular/common';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {Router} from '@angular/router';

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.ts
@@ -39,6 +39,14 @@ export class CertificateAssessmentPlayerPageAuthGuard implements CanActivate {
     private location: Location
   ) {}
 
+  //  Returns true if the EnableCertificateAssessment feature flag is
+  //  enabled, allowing navigation to proceed to the requested route.
+
+  //  Returns false if the feature flag is disabled. In this case the user
+  //  is redirected to the 404 page and the browser URL is replaced with
+  //  the originally requested state.url, so that navigation to the
+  //  disabled route is blocked and does not appear in browser history.
+
   async canActivate(
     _route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-auth.guard.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Guard that redirects to 404 when the certificate assessment
+ * learner page is disabled.
+ */
+
+import {Location} from '@angular/common';
+import {Injectable} from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+} from '@angular/router';
+
+import {AppConstants} from 'app.constants';
+import {PlatformFeatureService} from 'services/platform-feature.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CertificateAssessmentPlayerPageAuthGuard implements CanActivate {
+  constructor(
+    private platformFeatureService: PlatformFeatureService,
+    private router: Router,
+    private location: Location
+  ) {}
+
+  async canActivate(
+    _route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean> {
+    if (
+      this.platformFeatureService.status.EnableCertificateAssessment.isEnabled
+    ) {
+      return true;
+    }
+
+    try {
+      await this.router.navigate([
+        `${AppConstants.PAGES_REGISTERED_WITH_FRONTEND.ERROR.ROUTE}/404`,
+      ]);
+      this.location.replaceState(state.url);
+    } catch {
+      this.location.replaceState(state.url);
+    }
+    return false;
+  }
+}

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.html
@@ -1,0 +1,16 @@
+<oppia-angular-root>
+  <oppia-base-content>
+    <navbar-breadcrumb>
+      <ul class="nav navbar-nav oppia-navbar-breadcrumb">
+        <li>
+          <span class="oppia-navbar-breadcrumb-separator"></span>
+          <span>Certificate Assessment Player</span>
+        </li>
+      </ul>
+    </navbar-breadcrumb>
+    <content>
+      <certificate-assessment-player-page></certificate-assessment-player-page>
+    </content>
+    <page-footer></page-footer>
+  </oppia-base-content>
+</oppia-angular-root>

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.spec.ts
@@ -17,13 +17,18 @@
  */
 
 import {AppConstants} from 'app.constants';
+import {PageHeadService} from 'services/page-head.service';
+import {TranslateService} from '@ngx-translate/core';
 import {CertificateAssessmentPlayerPageRootComponent} from './certificate-assessment-player-page-root.component';
 
 describe('CertificateAssessmentPlayerPageRootComponent', () => {
   let component: CertificateAssessmentPlayerPageRootComponent;
 
   beforeEach(() => {
-    component = new CertificateAssessmentPlayerPageRootComponent();
+    component = new CertificateAssessmentPlayerPageRootComponent(
+      {} as PageHeadService,
+      {} as TranslateService
+    );
   });
 
   it('should set the title from AppConstants', () => {

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.spec.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for CertificateAssessmentPlayerPageRootComponent.
+ */
+
+import {AppConstants} from 'app.constants';
+import {CertificateAssessmentPlayerPageRootComponent} from './certificate-assessment-player-page-root.component';
+
+describe('CertificateAssessmentPlayerPageRootComponent', () => {
+  let component: CertificateAssessmentPlayerPageRootComponent;
+
+  beforeEach(() => {
+    component = new CertificateAssessmentPlayerPageRootComponent();
+  });
+
+  it('should set the title from AppConstants', () => {
+    expect(component.title).toBe(
+      AppConstants.PAGES_REGISTERED_WITH_FRONTEND.CERTIFICATE_ASSESSMENT_PLAYER
+        .TITLE
+    );
+  });
+
+  it('should set the meta tags from AppConstants', () => {
+    expect(component.meta).toBe(
+      AppConstants.PAGES_REGISTERED_WITH_FRONTEND.CERTIFICATE_ASSESSMENT_PLAYER
+        .META as unknown as typeof component.meta
+    );
+  });
+});

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page-root.component.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Root wrapper for the certificate assessment player page.
+ */
+
+import {Component} from '@angular/core';
+import {AppConstants} from 'app.constants';
+import {BaseRootComponent, MetaTagData} from 'pages/base-root.component';
+
+@Component({
+  selector: 'oppia-certificate-assessment-player-page-root',
+  templateUrl: './certificate-assessment-player-page-root.component.html',
+})
+export class CertificateAssessmentPlayerPageRootComponent extends BaseRootComponent {
+  title: string =
+    AppConstants.PAGES_REGISTERED_WITH_FRONTEND.CERTIFICATE_ASSESSMENT_PLAYER
+      .TITLE;
+
+  // TODO(#26274): Make the root-page meta tag contract readonly across BaseRootComponent
+  // and all subclasses, then remove this cast and align AppConstants META values.
+  meta: MetaTagData[] = AppConstants.PAGES_REGISTERED_WITH_FRONTEND
+    .CERTIFICATE_ASSESSMENT_PLAYER.META as unknown as Readonly<MetaTagData>[];
+}

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.html
@@ -1,28 +1,24 @@
 <div class="certificate-assessment-page-container position-relative">
-  <oppia-assessment-introduction-card
-    *ngIf="currentStage === 'intro'"
-    [certificateId]="certificateId"
-    (continue)="showInstructions()">
+  <oppia-assessment-introduction-card *ngIf="currentStage === 'intro'"
+                                      [certificateId]="certificateId"
+                                      (continue)="showInstructions()">
   </oppia-assessment-introduction-card>
 
-  <oppia-assessment-instruction-panel
-    *ngIf="currentStage === 'instructions'"
-    (startAssessment)="startAssessment()">
+  <oppia-assessment-instruction-panel *ngIf="currentStage === 'instructions'"
+                                      (startAssessment)="startAssessment()">
   </oppia-assessment-instruction-panel>
 
-  <oppia-certificate-assessment-conversation-skin
-    *ngIf="currentStage === 'questions'"
-    [currentQuestion]="getCurrentQuestion()"
-    [currentQuestionIndex]="currentQuestionIndex"
-    [totalQuestions]="mockQuestions.length"
-    [progressPercentage]="getProgressPercentage()"
-    [isLastQuestion]="currentQuestionIndex === mockQuestions.length - 1"
-    (nextQuestion)="nextQuestion()"
-    (submitAssessment)="submitAssessment()">
+  <oppia-certificate-assessment-conversation-skin *ngIf="currentStage === 'questions'"
+                                                  [currentQuestion]="getCurrentQuestion()"
+                                                  [currentQuestionIndex]="currentQuestionIndex"
+                                                  [totalQuestions]="mockQuestions.length"
+                                                  [progressPercentage]="getProgressPercentage()"
+                                                  [isLastQuestion]="currentQuestionIndex === mockQuestions.length - 1"
+                                                  (nextQuestion)="nextQuestion()"
+                                                  (submitAssessment)="submitAssessment()">
   </oppia-certificate-assessment-conversation-skin>
 
-  <oppia-certificate-assessment-result-card
-    *ngIf="currentStage === 'result'"
-    [certificateId]="certificateId">
+  <oppia-certificate-assessment-result-card *ngIf="currentStage === 'result'"
+                                            [certificateId]="certificateId">
   </oppia-certificate-assessment-result-card>
 </div>

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.html
@@ -1,0 +1,28 @@
+<div class="certificate-assessment-page-container position-relative">
+  <oppia-assessment-introduction-card
+    *ngIf="currentStage === 'intro'"
+    [certificateId]="certificateId"
+    (continue)="showInstructions()">
+  </oppia-assessment-introduction-card>
+
+  <oppia-assessment-instruction-panel
+    *ngIf="currentStage === 'instructions'"
+    (startAssessment)="startAssessment()">
+  </oppia-assessment-instruction-panel>
+
+  <oppia-certificate-assessment-conversation-skin
+    *ngIf="currentStage === 'questions'"
+    [currentQuestion]="getCurrentQuestion()"
+    [currentQuestionIndex]="currentQuestionIndex"
+    [totalQuestions]="mockQuestions.length"
+    [progressPercentage]="getProgressPercentage()"
+    [isLastQuestion]="currentQuestionIndex === mockQuestions.length - 1"
+    (nextQuestion)="nextQuestion()"
+    (submitAssessment)="submitAssessment()">
+  </oppia-certificate-assessment-conversation-skin>
+
+  <oppia-certificate-assessment-result-card
+    *ngIf="currentStage === 'result'"
+    [certificateId]="certificateId">
+  </oppia-certificate-assessment-result-card>
+</div>

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.spec.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Unit tests for CertificateAssessmentPlayerPageComponent.
+ */
+
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ActivatedRoute, Router} from '@angular/router';

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.spec.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute, Router} from '@angular/router';
+import {CertificateAssessmentPlayerPageComponent} from './certificate-assessment-player-page.component';
+
+describe('CertificateAssessmentPlayerPageComponent', () => {
+  let component: CertificateAssessmentPlayerPageComponent;
+  let fixture: ComponentFixture<CertificateAssessmentPlayerPageComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CertificateAssessmentPlayerPageComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (name: string) => {
+                  if (name === 'certificate_id') {
+                    return 'cert-123';
+                  }
+                  return null;
+                },
+              },
+              url: [],
+            },
+          },
+        },
+        {
+          provide: Router,
+          useValue: {
+            navigate: jasmine.createSpy('navigate'),
+          },
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CertificateAssessmentPlayerPageComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+  });
+
+  it('should initialize intro stage for the base route', () => {
+    fixture.detectChanges();
+
+    expect(component.certificateId).toBe('cert-123');
+    expect(component.currentStage).toBe('intro');
+  });
+
+  it('should navigate to the session route on startAssessment', () => {
+    fixture.detectChanges();
+
+    component.startAssessment();
+
+    expect(router.navigate).toHaveBeenCalledWith(['session'], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+    });
+  });
+
+  it('should navigate to the result route on submitAssessment', () => {
+    spyOn(Date, 'now').and.returnValue(1234);
+    fixture.detectChanges();
+
+    component.submitAssessment();
+
+    expect(router.navigate).toHaveBeenCalledWith([
+      '/certificate-assessment/cert-123/result',
+      'attempt-1234',
+    ]);
+  });
+});

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.spec.ts
@@ -26,25 +26,30 @@ describe('CertificateAssessmentPlayerPageComponent', () => {
   let fixture: ComponentFixture<CertificateAssessmentPlayerPageComponent>;
   let router: Router;
 
-  beforeEach(async () => {
+  const activatedRouteStub = (routePath: string | null) => ({
+    snapshot: {
+      paramMap: {
+        get: (name: string) => {
+          if (name === 'certificate_id') {
+            return 'cert-123';
+          }
+          return null;
+        },
+      },
+      url: routePath ? [{path: routePath}] : [],
+    },
+  });
+
+  const configureComponent = async (
+    routePath: string | null
+  ): Promise<void> => {
+    TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       declarations: [CertificateAssessmentPlayerPageComponent],
       providers: [
         {
           provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              paramMap: {
-                get: (name: string) => {
-                  if (name === 'certificate_id') {
-                    return 'cert-123';
-                  }
-                  return null;
-                },
-              },
-              url: [],
-            },
-          },
+          useValue: activatedRouteStub(routePath),
         },
         {
           provide: Router,
@@ -59,6 +64,10 @@ describe('CertificateAssessmentPlayerPageComponent', () => {
     fixture = TestBed.createComponent(CertificateAssessmentPlayerPageComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
+  };
+
+  beforeEach(async () => {
+    await configureComponent(null);
   });
 
   it('should initialize intro stage for the base route', () => {
@@ -66,6 +75,18 @@ describe('CertificateAssessmentPlayerPageComponent', () => {
 
     expect(component.certificateId).toBe('cert-123');
     expect(component.currentStage).toBe('intro');
+  });
+
+  it('should set current stage to questions when route is session', async () => {
+    await configureComponent('session');
+    fixture.detectChanges();
+    expect(component.currentStage).toBe('questions');
+  });
+
+  it('should set current stage to result when route is result', async () => {
+    await configureComponent('result');
+    fixture.detectChanges();
+    expect(component.currentStage).toBe('result');
   });
 
   it('should navigate to the session route on startAssessment', () => {
@@ -88,5 +109,52 @@ describe('CertificateAssessmentPlayerPageComponent', () => {
       '/certificate-assessment/cert-123/result',
       'attempt-1234',
     ]);
+  });
+
+  it('should switch to the instructions stage on showInstructions', () => {
+    fixture.detectChanges();
+    expect(component.currentStage).toBe('intro');
+
+    component.showInstructions();
+
+    expect(component.currentStage).toBe('instructions');
+  });
+
+  it('should advance to the next question on nextQuestion when not at the last question', () => {
+    fixture.detectChanges();
+    expect(component.currentQuestionIndex).toBe(0);
+
+    component.nextQuestion();
+
+    expect(component.currentQuestionIndex).toBe(1);
+  });
+
+  it('should not advance past the last question on nextQuestion', () => {
+    fixture.detectChanges();
+    component.currentQuestionIndex = component.mockQuestions.length - 1;
+
+    component.nextQuestion();
+
+    expect(component.currentQuestionIndex).toBe(
+      component.mockQuestions.length - 1
+    );
+  });
+
+  it('should compute the progress percentage based on the current question index', () => {
+    fixture.detectChanges();
+    component.currentQuestionIndex = 0;
+    expect(component.getProgressPercentage()).toBe(
+      Math.round((1 / component.mockQuestions.length) * 100)
+    );
+
+    component.currentQuestionIndex = component.mockQuestions.length - 1;
+    expect(component.getProgressPercentage()).toBe(100);
+  });
+
+  it('should return the question at the current question index', () => {
+    fixture.detectChanges();
+    component.currentQuestionIndex = 1;
+
+    expect(component.getCurrentQuestion()).toEqual(component.mockQuestions[1]);
   });
 });

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.component.ts
@@ -1,0 +1,98 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Certificate assessment player page component.
+ */
+
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
+
+interface AssessmentQuestion {
+  prompt: string;
+  choices: string[];
+}
+
+@Component({
+  selector: 'certificate-assessment-player-page',
+  templateUrl: './certificate-assessment-player-page.component.html',
+})
+export class CertificateAssessmentPlayerPageComponent implements OnInit {
+  certificateId = '';
+  currentStage: 'intro' | 'instructions' | 'questions' | 'result' = 'intro';
+  currentQuestionIndex = 0;
+  readonly mockQuestions: AssessmentQuestion[] = [
+    {
+      prompt: 'Mock question 1: What is 2 + 2?',
+      choices: ['3', '4', '5'],
+    },
+    {
+      prompt: 'Mock question 2: Pick the correct answer.',
+      choices: ['Option A', 'Option B', 'Option C'],
+    },
+    {
+      prompt: 'Mock question 3: Final sample question.',
+      choices: ['Yes', 'No', 'Maybe'],
+    },
+  ];
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.certificateId =
+      this.activatedRoute.snapshot.paramMap.get('certificate_id') || '';
+    const currentRoute = this.activatedRoute.snapshot.url[0]?.path || '';
+    if (currentRoute === 'session') {
+      this.currentStage = 'questions';
+    } else if (currentRoute === 'result') {
+      this.currentStage = 'result';
+    }
+  }
+
+  showInstructions(): void {
+    this.currentStage = 'instructions';
+  }
+
+  startAssessment(): void {
+    this.router.navigate(['session'], {relativeTo: this.activatedRoute});
+  }
+
+  nextQuestion(): void {
+    if (this.currentQuestionIndex < this.mockQuestions.length - 1) {
+      this.currentQuestionIndex += 1;
+      return;
+    }
+  }
+
+  submitAssessment(): void {
+    const attemptId = `attempt-${Date.now()}`;
+    this.router.navigate([
+      `/certificate-assessment/${this.certificateId}/result`,
+      attemptId,
+    ]);
+  }
+
+  getProgressPercentage(): number {
+    return Math.round(
+      ((this.currentQuestionIndex + 1) / this.mockQuestions.length) * 100
+    );
+  }
+
+  getCurrentQuestion(): AssessmentQuestion {
+    return this.mockQuestions[this.currentQuestionIndex];
+  }
+}

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.module.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.module.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {SharedComponentsModule} from 'components/shared-component.module';
+import {CertificateAssessmentPlayerPageRootComponent} from './certificate-assessment-player-page-root.component';
+import {CertificateAssessmentPlayerPageComponent} from './certificate-assessment-player-page.component';
+import {AssessmentIntroductionCardComponent} from './assessment-introduction-card.component';
+import {AssessmentInstructionPanelComponent} from './assessment-instruction-panel.component';
+import {CertificateAssessmentConversationSkinComponent} from './certificate-assessment-conversation-skin.component';
+import {CertificateAssessmentResultCardComponent} from './certificate-assessment-result-card.component';
+import {CertificateAssessmentPlayerPageAuthGuard} from './certificate-assessment-player-page-auth.guard';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SharedComponentsModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: CertificateAssessmentPlayerPageRootComponent,
+        canActivate: [CertificateAssessmentPlayerPageAuthGuard],
+      },
+      {
+        path: 'session',
+        component: CertificateAssessmentPlayerPageRootComponent,
+        canActivate: [CertificateAssessmentPlayerPageAuthGuard],
+      },
+      {
+        path: 'result/:attempt_id',
+        component: CertificateAssessmentPlayerPageRootComponent,
+        canActivate: [CertificateAssessmentPlayerPageAuthGuard],
+      },
+    ]),
+  ],
+  declarations: [
+    CertificateAssessmentPlayerPageRootComponent,
+    CertificateAssessmentPlayerPageComponent,
+    AssessmentIntroductionCardComponent,
+    AssessmentInstructionPanelComponent,
+    CertificateAssessmentConversationSkinComponent,
+    CertificateAssessmentResultCardComponent,
+  ],
+  entryComponents: [
+    CertificateAssessmentPlayerPageRootComponent,
+    CertificateAssessmentPlayerPageComponent,
+    AssessmentIntroductionCardComponent,
+    AssessmentInstructionPanelComponent,
+    CertificateAssessmentConversationSkinComponent,
+    CertificateAssessmentResultCardComponent,
+  ],
+})
+export class CertificateAssessmentPlayerPageModule {}

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.module.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-player-page.module.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Module for the assessment player page.
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.html
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.html
@@ -1,0 +1,6 @@
+<div class="assessment-card">
+  <h2>Assessment Result</h2>
+  <p>Result page for certificate id: {{certificateId}}</p>
+  <p>Attempt id: {{attemptId}}</p>
+  <p>This is a stub result card for now.</p>
+</div>

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.spec.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Unit tests for CertificateAssessmentResultCardComponent.
+ */
+
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ActivatedRoute} from '@angular/router';
 import {CertificateAssessmentResultCardComponent} from './certificate-assessment-result-card.component';

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.spec.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.spec.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ActivatedRoute} from '@angular/router';
+import {CertificateAssessmentResultCardComponent} from './certificate-assessment-result-card.component';
+
+describe('CertificateAssessmentResultCardComponent', () => {
+  let component: CertificateAssessmentResultCardComponent;
+  let fixture: ComponentFixture<CertificateAssessmentResultCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CertificateAssessmentResultCardComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (name: string) => {
+                  if (name === 'attempt_id') {
+                    return 'attempt-1';
+                  }
+                  return null;
+                },
+              },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CertificateAssessmentResultCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should read attempt id from the route', () => {
+    fixture.detectChanges();
+
+    expect(component.attemptId).toBe('attempt-1');
+  });
+});

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @fileoverview Component for the certificate assessment result card.
+ */
+
 import {Component, Input} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 

--- a/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.ts
+++ b/core/templates/pages/certificate-assessment-player-page/certificate-assessment-result-card.component.ts
@@ -7,22 +7,24 @@
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an "AS-IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * @fileoverview Certificate offering available page component.
- */
-
 import {Component, Input} from '@angular/core';
-import './certificate-offering-available-page.component.css';
+import {ActivatedRoute} from '@angular/router';
+
 @Component({
-  selector: 'oppia-available-certificate-offering-page',
-  templateUrl: './certificate-offering-available-page.component.html',
+  selector: 'oppia-certificate-assessment-result-card',
+  templateUrl: './certificate-assessment-result-card.component.html',
 })
-export class AvailableCertificateOfferingPageComponent {
-  @Input() classroomUrlFragment: string = '';
-  certificateId: string = 'temporary_certificate_id';
+export class CertificateAssessmentResultCardComponent {
+  @Input() certificateId = '';
+  attemptId = '';
+
+  constructor(private activatedRoute: ActivatedRoute) {
+    this.attemptId =
+      this.activatedRoute.snapshot.paramMap.get('attempt_id') || '';
+  }
 }

--- a/core/templates/pages/certificate-offering-available-page/certificate-offering-available-page.component.html
+++ b/core/templates/pages/certificate-offering-available-page/certificate-offering-available-page.component.html
@@ -31,7 +31,9 @@
         </div>
 
         <div class="oppia-certificate-offering-available-page-actions">
-          <button type="button" class="btn btn-primary">
+          <button type="button"
+                  class="btn btn-primary"
+                  [routerLink]="['/certificate-assessment', certificateId]">
             Continue to assessment
           </button>
         </div>
@@ -54,7 +56,9 @@
           <button type="button" class="btn btn-secondary">
             Check score
           </button>
-          <button type="button" class="btn btn-primary">
+          <button type="button"
+                  class="btn btn-primary"
+                  [routerLink]="['/certificate-assessment', certificateId]">
             Retry assessment
           </button>
         </div>

--- a/core/templates/pages/certificate-offering-available-page/certificate-offering-available-page.component.spec.ts
+++ b/core/templates/pages/certificate-offering-available-page/certificate-offering-available-page.component.spec.ts
@@ -53,4 +53,18 @@ describe('AvailableCertificateOfferingPageComponent', () => {
       fixture.nativeElement.querySelector('h1[tabindex="0"]').textContent.trim()
     ).toBe('Available certificate offering');
   });
+
+  it('should link assessment buttons to the certificate assessment page', () => {
+    fixture.detectChanges();
+
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button')
+    ) as HTMLButtonElement[];
+    expect(buttons[1].getAttribute('ng-reflect-router-link')).toContain(
+      '/certificate-assessment'
+    );
+    expect(buttons[2].getAttribute('ng-reflect-router-link')).toContain(
+      '/certificate-assessment'
+    );
+  });
 });

--- a/core/templates/pages/certificate-offering-available-page/certificate-offering-available-page.component.spec.ts
+++ b/core/templates/pages/certificate-offering-available-page/certificate-offering-available-page.component.spec.ts
@@ -60,11 +60,18 @@ describe('AvailableCertificateOfferingPageComponent', () => {
     const buttons = Array.from(
       fixture.nativeElement.querySelectorAll('button')
     ) as HTMLButtonElement[];
-    expect(buttons[1].getAttribute('ng-reflect-router-link')).toContain(
-      '/certificate-assessment'
+
+    const assessmentButtons = buttons.filter(b =>
+      ['Continue to assessment', 'Retry assessment'].includes(
+        b.textContent?.trim() || ''
+      )
     );
-    expect(buttons[2].getAttribute('ng-reflect-router-link')).toContain(
-      '/certificate-assessment'
-    );
+
+    expect(assessmentButtons.length).toBe(2);
+    assessmentButtons.forEach(button => {
+      expect(button.getAttribute('ng-reflect-router-link')).toContain(
+        '/certificate-assessment'
+      );
+    });
   });
 });

--- a/core/templates/pages/oppia-root/routing/app.routing.module.ts
+++ b/core/templates/pages/oppia-root/routing/app.routing.module.ts
@@ -153,6 +153,14 @@ const routes: Route[] = [
       ).then(m => m.DiagnosticTestPlayerPageModule),
   },
   {
+    path: AppConstants.PAGES_REGISTERED_WITH_FRONTEND
+      .CERTIFICATE_ASSESSMENT_PLAYER.ROUTE,
+    loadChildren: () =>
+      import(
+        'pages/certificate-assessment-player-page/certificate-assessment-player-page.module'
+      ).then(m => m.CertificateAssessmentPlayerPageModule),
+  },
+  {
     path: AppConstants.PAGES_REGISTERED_WITH_FRONTEND.CLASSROOM.ROUTE,
     pathMatch: 'full',
     loadChildren: () =>


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes part of #24717 .
2. This PR does the following: 
- Added the following learner assessment components for skeleton flow of assessment :

   - CertificateAssessmentPlayerPageRootComponent/ CertificateAssessmentPlayerPageComponent Acts as the parent container for the learner flow. Handles view transitions between introduction, instructions, player, and result screens.
   - AssessmentIntroductionCardComponent
Displays placeholder introduction content. Emits continueClicked when the learner proceeds.
   - AssessmentInstructionPanelComponent Displays placeholder assessment instructions. Emits startAssessment when the learner begins the assessment.
   - CertificateAssessmentPlayerPageComponent Displays placeholder assessment content. Includes Next and Submit controls.
   - CertificateAssessmentResultCardComponent Displays placeholder assessment results.
-  Created the skeleton learner assessment flow, wiring the journey from available certificate offerings through the introduction, instructions, assessment player, and result pages.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

[Screencast from 2026-07-13 02-33-58.webm](https://github.com/user-attachments/assets/139bc587-c976-4739-872b-d7d1d1f90465)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
