### PR TITLE
Fix N/A: Fix flaky hint button click blocked by invisible .hint-container overlay on mobile

### DIFF
--- a/core/templates/components/button-directives/hint-and-solution-buttons.component.css
+++ b/core/templates/components/button-directives/hint-and-solution-buttons.component.css
@@ -131,9 +131,11 @@ oppia-hint-and-solution-buttons .hint-box::before {
     bottom: 80px;
     font-size: 15px;
     left: 5px;
+    pointer-events: auto;
   }
 
   oppia-hint-and-solution-buttons .hint-container {
+    pointer-events: none;
     width: 100%;
   }
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes N/A
2. This PR does the following: 
Fixes a flaky failure (~64/100 runs) in `changes-site-language-to-rtl.spec.ts` (`Logged-In Learner > should be able to play an exploration and interact with pop-ups, modals and buttons`), where clicking the hint button (`.e2e-test-view-hint`) times out with:
TimeoutError: Element <button...e2e-test-view-hint...> took too long to be clickable.
Detected reasons:
Element is blocked by <div.hint-container.ng-star-inserted>

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Debugging doc - https://docs.google.com/document/d/1cnRxNgI_n2FkTbVK2yOteRDYvuZ5jGFjvv5UXdyipDw/edit

Stress Test (Before) - https://github.com/Mohak51234/oppia/actions/runs/29208330443 
Stress Test (After) -  https://github.com/Mohak51234/oppia/actions/runs/29229563639 and https://github.com/Mohak51234/oppia/actions/runs/29235455949


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction behavior for responsive hint and solution controls.
  * Ensured hint content remains interactive while preventing unintended interactions with its surrounding container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->