### PR TITLE
Fix #26736: Migrate add-remove-and-edit-subtopics test from Puppeteer to Playwright

### DIFF
--- a/core/tests/playwright-acceptance-tests/specs/topic-manager/add-remove-and-edit-subtopics.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/topic-manager/add-remove-and-edit-subtopics.spec.ts
@@ -1,0 +1,150 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Acceptance test from CUJv3 Doc
+ * https://docs.google.com/document/d/1D7kkFTzg3rxUe3QJ_iPlnxUzBFNElmRkmAWss00nFno/
+ *
+ * TM.TE Add, remove, and edit the subtopics of a topic.
+ */
+
+import {test} from '@playwright/test';
+import testConstants from '../../utilities/common/test-constants';
+import {UserFactory} from '../../utilities/common/user-factory';
+import {CurriculumAdmin} from '../../utilities/user/curriculum-admin';
+import {ExplorationEditor} from '../../utilities/user/exploration-editor';
+import {TopicManager} from '../../utilities/user/topic-manager';
+
+const ROLES = testConstants.Roles;
+
+test.describe.configure({mode: 'serial'});
+
+test.describe('Topic Manager', function () {
+  let topicManager: TopicManager & ExplorationEditor & CurriculumAdmin;
+  let curriculumAdmin: CurriculumAdmin & ExplorationEditor;
+
+  test.beforeAll(async function ({browser}) {
+    test.setTimeout(600000);
+    curriculumAdmin = await UserFactory.createNewUser(
+      'curriculumAdm',
+      'curriculum_adm@example.com',
+      browser,
+      [ROLES.CURRICULUM_ADMIN]
+    );
+
+    const explorationId =
+      await curriculumAdmin.createAndPublishExplorationWithCards(
+        'Solving problems without a calculator',
+        'Mathematics'
+      );
+    await curriculumAdmin.createTopic(
+      'Arithmetic Operations',
+      'arithmetic-operation'
+    );
+    await curriculumAdmin.createSubtopicForTopic(
+      'Addition',
+      'addition',
+      'Arithmetic Operations'
+    );
+    await curriculumAdmin.addStoryToTopic(
+      'The Broken Calculator',
+      'the-broken-calculator',
+      'Arithmetic Operations'
+    );
+    await curriculumAdmin.addChapter(
+      'Solving problems without a calculator',
+      explorationId
+    );
+    await curriculumAdmin.createAndPublishClassroom(
+      'Maths',
+      'maths',
+      'Arithmetic Operations'
+    );
+
+    // Create more topics and skills.
+    await curriculumAdmin.createTopic('Whole Numbers', 'whole-numbers');
+    await curriculumAdmin.createSkillFromSkillsDashboard(
+      'Subtraction',
+      'Review Material for Subtraction'
+    );
+    await curriculumAdmin.createSkillFromSkillsDashboard(
+      'Word Problems',
+      'Review Material for Word Problems'
+    );
+
+    // Create topic manager user.
+    topicManager = await UserFactory.createNewUser(
+      'topicManager',
+      'topic_manager@example.com',
+      browser,
+      [ROLES.TOPIC_MANAGER],
+      'Arithmetic Operations'
+    );
+  });
+
+  test('should be able to add and delete a subtopic in a topic', async function () {
+    await topicManager.openTopicEditor('Arithmetic Operations');
+    await topicManager.createSubtopicForTopic(
+      'Subtraction',
+      'subtraction',
+      'Arithmetic Operations'
+    );
+    await topicManager.openTopicEditor('Arithmetic Operations');
+    await topicManager.verifySubtopicPresenceInTopic('Subtraction');
+
+    // Delete the subtopic.
+    await topicManager.deleteSubtopicFromTopic(
+      'Subtraction',
+      'Arithmetic Operations'
+    );
+    await topicManager.saveTopicDraft('Arithmetic Operations', 'Updated topic');
+    await topicManager.openTopicEditor('Arithmetic Operations');
+    await topicManager.verifySubtopicPresenceInTopic('Addition');
+    await topicManager.verifySubtopicPresenceInTopic(
+      'Subtraction', // Subtopic Name.
+      null, // Check in the same topic.
+      false // Should not exist.
+    );
+  });
+
+  test('should be able to edit and preview subtopic', async function () {
+    await topicManager.openSubtopicEditor('Addition');
+    await topicManager.editSubTopicDetails(
+      'Intro to Addition and Subtraction',
+      'intro-add-subtract',
+      'This is introduction to Addition and Subtraction.',
+      testConstants.data.profilePicture
+    );
+    await topicManager.expectScreenshotToMatch(
+      'updatedAdditionSubtopic',
+      __dirname
+    );
+
+    await topicManager.saveTopicDraft('Arithmetic Operations', 'Updated topic');
+    await topicManager.expectToastMessageToBe('Changes Saved.');
+
+    await topicManager.navigateToSubtopicPreviewTab(
+      'Intro to Addition and Subtraction',
+      'Arithmetic Operations'
+    );
+    await topicManager.expectSubtopicPreviewToHave(
+      'Intro to Addition and Subtraction',
+      'This is introduction to Addition and Subtraction.'
+    );
+  });
+
+  test.afterAll(async function () {
+    await UserFactory.closeAllBrowsers();
+  });
+});


### PR DESCRIPTION
## Overview
This PR migrates the  acceptance test from Puppeteer to Playwright as part of issue #26736.

## Changes
- Replace  with  (Playwright API)
- Add  fixture to  calls
- Add  for sequential test execution
- Add  in  for long-running tests
- Replace  with  (Playwright API)
- All test logic and assertions remain identical

## Verification
- [ ] Local Playwright test execution passes
- [ ] Screen recording and trace file uploaded as per contributing guide

Closes #26736