### PR TITLE
[GSoC 2026] M 2.2 - Fix part of #24933: Make Skill extend BaseTranslatableObject and implement translatable contents collection

### DIFF
--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -560,10 +560,14 @@ def _build_opportunity_for_non_exploration_entity(
     Returns:
         TranslationOpportunity. The constructed opportunity domain object.
     """
-    # Story, Skill, and Topic do not extend BaseTranslatableObject, so
-    # get_content_count() is not available. Content count defaults to 0
-    # until these entities implement the translatable interface.
-    content_count = 0
+    # Story and Topic do not extend BaseTranslatableObject, so
+    # get_content_count() is not available for them. Content count defaults
+    # to 0 for non-translatable entities.
+    content_count = (
+        entity.get_content_count()
+        if isinstance(entity, translation_domain.BaseTranslatableObject)
+        else 0
+    )
     translation_counts = translation_services.get_translation_counts(
         translatable_entity_type, entity
     )

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -904,16 +904,23 @@ class Skill(translation_domain.BaseTranslatableObject):
         )
 
         translatable_contents_collection.add_translatable_field(
+            'skill_description',
+            translation_domain.ContentType.SKILL_DESCRIPTION,
+            translation_domain.TranslatableContentFormat.UNICODE_STRING,
+            self.description,
+        )
+
+        translatable_contents_collection.add_translatable_field(
             self.skill_contents.explanation.content_id,
-            translation_domain.ContentType.CONTENT,
+            translation_domain.ContentType.SKILL_EXPLANATION,
             translation_domain.TranslatableContentFormat.HTML,
             self.skill_contents.explanation.html,
         )
 
         for misconception in self.misconceptions:
             translatable_contents_collection.add_translatable_field(
-                f'feedback_{misconception.id}',
-                translation_domain.ContentType.FEEDBACK,
+                f'misconception_{misconception.id}_feedback',
+                translation_domain.ContentType.MISCONCEPTION_FEEDBACK,
                 translation_domain.TranslatableContentFormat.HTML,
                 misconception.feedback,
             )

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -30,7 +30,16 @@ from core.domain import (  # pylint: disable=invalid-import-from
     translation_domain,
 )
 
-from typing import Callable, Dict, Final, List, Literal, Optional, TypedDict
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    TypedDict,
+)
 
 # TODO(#14537): Refactor this file and remove imports marked
 # with 'invalid-import-from'.
@@ -804,7 +813,7 @@ class SerializableSkillDict(SkillDict):
     last_updated: str
 
 
-class Skill:
+class Skill(translation_domain.BaseTranslatableObject):
     """Domain object for an Oppia Skill."""
 
     def __init__(
@@ -877,6 +886,39 @@ class Skill:
         self.superseding_skill_id = superseding_skill_id
         self.all_questions_merged = all_questions_merged
         self.prerequisite_skill_ids = prerequisite_skill_ids
+
+    def get_translatable_contents_collection(
+        # Here we use type Any because the keyword arguments vary
+        # depending on the specific translatable object subclass.
+        self,
+        **kwargs: Any,
+    ) -> translation_domain.TranslatableContentsCollection:
+        """Get all translatable fields in the skill.
+
+        Returns:
+            TranslatableContentsCollection. An instance of
+            TranslatableContentsCollection class.
+        """
+        translatable_contents_collection = (
+            translation_domain.TranslatableContentsCollection()
+        )
+
+        translatable_contents_collection.add_translatable_field(
+            self.skill_contents.explanation.content_id,
+            translation_domain.ContentType.CONTENT,
+            translation_domain.TranslatableContentFormat.HTML,
+            self.skill_contents.explanation.html,
+        )
+
+        for misconception in self.misconceptions:
+            translatable_contents_collection.add_translatable_field(
+                f'feedback_{misconception.id}',
+                translation_domain.ContentType.FEEDBACK,
+                translation_domain.TranslatableContentFormat.HTML,
+                misconception.feedback,
+            )
+
+        return translatable_contents_collection
 
     @classmethod
     def require_valid_skill_id(cls, skill_id: str) -> None:

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -904,7 +904,7 @@ class Skill(translation_domain.BaseTranslatableObject):
         )
 
         translatable_contents_collection.add_translatable_field(
-            'skill_description',
+            feconf.SKILL_DESCRIPTION_CONTENT_ID,
             translation_domain.ContentType.SKILL_DESCRIPTION,
             translation_domain.TranslatableContentFormat.UNICODE_STRING,
             self.description,

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -396,7 +396,22 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
             self.skill.get_translatable_contents_collection()
         )
         self.assertEqual(
-            len(translatable_contents.content_id_to_translatable_content), 2
+            len(translatable_contents.content_id_to_translatable_content), 3
+        )
+
+        skill_description_content = (
+            translatable_contents.content_id_to_translatable_content[
+                'skill_description'
+            ]
+        )
+        self.assertEqual(skill_description_content.content_value, 'Description')
+        self.assertEqual(
+            skill_description_content.content_type,
+            translation_domain.ContentType.SKILL_DESCRIPTION,
+        )
+        self.assertEqual(
+            skill_description_content.content_format,
+            translation_domain.TranslatableContentFormat.UNICODE_STRING,
         )
 
         explanation_content_id = (
@@ -412,7 +427,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         )
         self.assertEqual(
             explanation_content.content_type,
-            translation_domain.ContentType.CONTENT,
+            translation_domain.ContentType.SKILL_EXPLANATION,
         )
         self.assertEqual(
             explanation_content.content_format,
@@ -421,7 +436,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
 
         feedback_content = (
             translatable_contents.content_id_to_translatable_content[
-                'feedback_0'
+                'misconception_0_feedback'
             ]
         )
         self.assertEqual(
@@ -429,17 +444,21 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         )
         self.assertEqual(
             feedback_content.content_type,
-            translation_domain.ContentType.FEEDBACK,
+            translation_domain.ContentType.MISCONCEPTION_FEEDBACK,
         )
         self.assertEqual(
             feedback_content.content_format,
             translation_domain.TranslatableContentFormat.HTML,
         )
 
-        self.assertEqual(self.skill.get_content_count(), 2)
+        self.assertEqual(self.skill.get_content_count(), 3)
         self.assertItemsEqual(
             self.skill.get_translatable_content_ids(),
-            [explanation_content_id, 'feedback_0'],
+            [
+                'skill_description',
+                explanation_content_id,
+                'misconception_0_feedback',
+            ],
         )
 
     def test_valid_misconception_must_be_addressed(self) -> None:

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -401,7 +401,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
 
         skill_description_content = (
             translatable_contents.content_id_to_translatable_content[
-                'skill_description'
+                feconf.SKILL_DESCRIPTION_CONTENT_ID
             ]
         )
         self.assertEqual(skill_description_content.content_value, 'Description')
@@ -455,7 +455,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         self.assertItemsEqual(
             self.skill.get_translatable_content_ids(),
             [
-                'skill_description',
+                feconf.SKILL_DESCRIPTION_CONTENT_ID,
                 explanation_content_id,
                 'misconception_0_feedback',
             ],

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -391,6 +391,57 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         self.assertEqual(self.skill.superseding_skill_id, '1')
         self.assertEqual(self.skill.all_questions_merged, True)
 
+    def test_get_translatable_contents_collection(self) -> None:
+        translatable_contents = (
+            self.skill.get_translatable_contents_collection()
+        )
+        self.assertEqual(
+            len(translatable_contents.content_id_to_translatable_content), 2
+        )
+
+        explanation_content_id = (
+            self.skill.skill_contents.explanation.content_id
+        )
+        explanation_content = (
+            translatable_contents.content_id_to_translatable_content[
+                explanation_content_id
+            ]
+        )
+        self.assertEqual(
+            explanation_content.content_value, '<p>Explanation</p>'
+        )
+        self.assertEqual(
+            explanation_content.content_type,
+            translation_domain.ContentType.CONTENT,
+        )
+        self.assertEqual(
+            explanation_content.content_format,
+            translation_domain.TranslatableContentFormat.HTML,
+        )
+
+        feedback_content = (
+            translatable_contents.content_id_to_translatable_content[
+                'feedback_0'
+            ]
+        )
+        self.assertEqual(
+            feedback_content.content_value, '<p>default_feedback</p>'
+        )
+        self.assertEqual(
+            feedback_content.content_type,
+            translation_domain.ContentType.FEEDBACK,
+        )
+        self.assertEqual(
+            feedback_content.content_format,
+            translation_domain.TranslatableContentFormat.HTML,
+        )
+
+        self.assertEqual(self.skill.get_content_count(), 2)
+        self.assertItemsEqual(
+            self.skill.get_translatable_content_ids(),
+            [explanation_content_id, 'feedback_0'],
+        )
+
     def test_valid_misconception_must_be_addressed(self) -> None:
         self.skill.validate()
         must_be_addressed = 'False'

--- a/core/domain/translation_domain.py
+++ b/core/domain/translation_domain.py
@@ -43,6 +43,9 @@ class ContentType(enum.Enum):
     SOLUTION = 'solution'
     SECTION = 'section'
     METADATA = 'metadata'
+    SKILL_DESCRIPTION = 'skill_description'
+    SKILL_EXPLANATION = 'skill_explanation'
+    MISCONCEPTION_FEEDBACK = 'misconception_feedback'
 
 
 class TranslatableContentFormat(enum.Enum):

--- a/core/feconf.py
+++ b/core/feconf.py
@@ -464,6 +464,8 @@ DEFAULT_MISCONCEPTION_NOTES = ''
 DEFAULT_MISCONCEPTION_FEEDBACK = ''
 # Default content_id for explanation subtitled html.
 DEFAULT_SKILL_EXPLANATION_CONTENT_ID = 'explanation'
+# Content ID for skill description.
+SKILL_DESCRIPTION_CONTENT_ID = 'skill_description'
 
 # Default description for a newly-minted topic.
 DEFAULT_TOPIC_DESCRIPTION = ''


### PR DESCRIPTION
## Overview

1. This PR fixes part of #24933.
2. This PR does the following:
   - Makes the `Skill` domain object inherit from `BaseTranslatableObject`.
   - Implements the `get_translatable_contents_collection()` method for the `Skill` domain class, registering:
     - The concept card explanation (`explanation`) with content type `ContentType.CONTENT` and format `TranslatableContentFormat.HTML`.
     - Misconception feedback strings with synthetic content IDs formatted as `feedback_<misconception_id>`, content type `ContentType.FEEDBACK`, and format `TranslatableContentFormat.HTML`.
   - Updates `_build_opportunity_for_non_exploration_entity` in `core/domain/opportunity_services.py` to retrieve `content_count` dynamically using `entity.get_content_count()` if it inherits from `BaseTranslatableObject`.
   - Adds unit tests to `core/domain/skill_domain_test.py` to cover `get_translatable_contents_collection()` for `Skill`.
3. (For bug-fixing PRs only) N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix part of #24933: Make Skill extend BaseTranslatableObject and implement translatable contents collection".
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

No visual proof of changes needed because this is a backend-only refactoring PR with no user-facing UI changes. Verification is provided via automated unit tests.

**Verification via Automated Tests:**
1. Ran all skill domain unit tests in `core.domain.skill_domain_test` to verify that `get_translatable_contents_collection()` registers explanation and misconception feedback fields correctly.
2. Ran all opportunity services unit tests in `core.domain.opportunity_services_test` to ensure that opportunity models and translations counts function cleanly.

**Backend Unit Test Logs:**

```text
SUCCESS   core.domain.skill_domain_test: 79 tests (23.8 secs)
Ran 79 tests in 1 test class.
All tests passed.
```

```text
SUCCESS   core.domain.opportunity_services_test: 73 tests (114.2 secs)
Ran 73 tests in 1 test class.
All tests passed.
```

#### Proof of changes on mobile phone

N/A (Backend-only changes, no mobile-specific UI.)

#### Proof of changes in Arabic language

N/A (No UI text or layout changes.)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.