### PR TITLE
fix

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/common/puppeteer-utils.ts
@@ -1141,6 +1141,37 @@ export class BaseUser {
   }
 
   /**
+   * Waits until the list of elements matching the given selector stops
+   * changing (by count or text content) for at least 200 ms. Some lists
+   * (e.g. contributor dashboard opportunities) refresh shortly after their
+   * initial load, which can otherwise cause a stale read.
+   * TODO(#23395): This is a workaround for the list refreshing after it has
+   * already loaded. Once the underlying issue is fixed, remove this method.
+   * @param {string} selector - The selector matching the list of elements.
+   */
+  async waitForElementListToStabilize(selector: string): Promise<void> {
+    let previousItems: string[] = [];
+    let itemsChanged = true;
+
+    do {
+      await this.page.waitForTimeout(200);
+
+      const currentItems = await this.page.evaluate((sel: string) => {
+        const elements = document.querySelectorAll(sel);
+        return Array.from(elements).map((el, index) => {
+          return el.textContent?.trim() || `element-${index}`;
+        });
+      }, selector);
+
+      itemsChanged =
+        previousItems.length !== currentItems.length ||
+        !previousItems.every((item, index) => item === currentItems[index]);
+
+      previousItems = currentItems;
+    } while (itemsChanged);
+  }
+
+  /**
    * Waits for the static assets on the page to load.
    */
   async waitForStaticAssetsToLoad(): Promise<void> {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -119,31 +119,7 @@ export class Contributor extends ExplorationEditor {
     // This causes problem that older node gets detached from the DOM.
     // So, we are ensuring that the opportunity list hasn't been changed
     // for 200 ms.
-    let previousElementIds: string[] = [];
-    let opportunityItemListChanged = true;
-
-    // TODO(#23395): Currently, the opportunity list is refreshed after the
-    // page is loaded. This causes the test to fail. We are using a workaround
-    // for now, by waiting for the opportunity list to be loaded.
-    // Once the issue is fixed, remove the following do-while loop.
-    do {
-      await this.page.waitForTimeout(200);
-
-      const currentElementIds = await this.page.evaluate((selector: string) => {
-        const elements = document.querySelectorAll(selector);
-        return Array.from(elements).map((el, index) => {
-          return el.textContent?.trim() || `element-${index}`;
-        });
-      }, opportunityItemSelector);
-
-      opportunityItemListChanged =
-        previousElementIds.length !== currentElementIds.length ||
-        !previousElementIds.every(
-          (id, index) => id === currentElementIds[index]
-        );
-
-      previousElementIds = currentElementIds;
-    } while (opportunityItemListChanged);
+    await this.waitForElementListToStabilize(opportunityItemSelector);
 
     // Handle the case where no translation opportunity is present.
     if (!translationOpportunitiesPreset) {

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/translation-submitter.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/translation-submitter.ts
@@ -420,9 +420,17 @@ export class TranslationSubmitter extends BaseUser {
     subheading: string,
     visible: boolean = true
   ): Promise<ElementHandle | null> {
+    await this.page.waitForNetworkIdle();
+
     const translationOpportunitiesPreset = await this.isElementVisible(
       opportunityItemSelector
     );
+
+    // Sometimes, the opportunities refreshes after they have been loaded.
+    // This causes problem that older node gets detached from the DOM.
+    // So, we are ensuring that the opportunity list hasn't been changed
+    // for 200 ms.
+    await this.waitForElementListToStabilize(opportunityItemSelector);
 
     // Handle the case where the translation opportunity is not present.
     if (!translationOpportunitiesPreset) {


### PR DESCRIPTION
Fixes #26664

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #[fill_in_number_here] or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [ ] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

---

TranslationSubmitter.expectTranslationOpportunityToBePresentInTranslateTextTab (the exact call site in the issue's stack trace) read the opportunity list right after selectLanguageFilter without waiting for the async refetch to settle, causing a stale-list race identical to the already-fixed issue #23395 in Contributor.expectOpportunityToBePresent. On self-review, my first pass fixed this by copy-pasting the 24-line wait/stabilize block, compounding the duplication the file's own TODO(#22539) already flags. Fixed properly by extracting that logic into a single shared BaseUser.waitForElementListToStabilize() helper in puppeteer-utils.ts, and having both Contributor and TranslationSubmitter call it — net code reduction with the same runtime behavior.

**How this was tested:** `scripts/`