### PR TITLE
[GSoC 2026] M2.2 - Fix part of #19614: Add Android-compatible story handler to prevent arc field breakage

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -94,6 +94,7 @@ export default {
   "ACTIVITY_TYPE_EXPLORATION_VOICEOVERS": "exp_voiceovers",
   "ACTIVITY_TYPE_COLLECTION": "collection",
   "ACTIVITY_TYPE_STORY": "story",
+  "ACTIVITY_TYPE_STORY_MIGRATION": "story_migration",
   "ACTIVITY_TYPE_SKILL": "skill",
   "ACTIVITY_TYPE_SUBTOPIC": "subtopic",
   "ACTIVITY_TYPE_SUBTOPIC_WITH_STUDY_GUIDE_MIGRATION": "subtopic_with_study_guide_migration",

--- a/core/controllers/android.py
+++ b/core/controllers/android.py
@@ -510,16 +510,21 @@ class AndroidActivityHandler(
             for activity_data, entity in zip(activities_data, fetched_entities):
                 if (
                     activity_type == constants.ACTIVITY_TYPE_STORY_MIGRATION
-                    and entity is not None
+                    and isinstance(entity, story_domain.Story)
                 ):
-                    payload = entity.to_dict_for_android()
+                    response_dict: ActivityDataResponseDict = {
+                        'id': activity_data['id'],
+                        'version': activity_data.get('version'),
+                        'payload': entity.to_dict_for_android(),
+                    }
                 else:
-                    payload = entity.to_dict() if entity is not None else None
-                response_dict: ActivityDataResponseDict = {
-                    'id': activity_data['id'],
-                    'version': activity_data.get('version'),
-                    'payload': payload,
-                }
+                    response_dict = {
+                        'id': activity_data['id'],
+                        'version': activity_data.get('version'),
+                        'payload': (
+                            entity.to_dict() if entity is not None else None
+                        ),
+                    }
                 activities.append(response_dict)
 
         self.render_json(activities)

--- a/core/controllers/android.py
+++ b/core/controllers/android.py
@@ -108,6 +108,7 @@ class _ActivityDataResponseDictRequiredFields(TypedDict):
     payload: Union[
         exp_domain.ExplorationDictForAndroid,
         story_domain.StoryDict,
+        story_domain.StoryDictForAndroid,
         skill_domain.SkillDict,
         subtopic_page_domain.SubtopicPageDict,
         study_guide_domain.StudyGuideAndroidDict,
@@ -162,6 +163,7 @@ class AndroidActivityHandler(
                         constants.ACTIVITY_TYPE_EXPLORATION_TRANSLATIONS,
                         constants.ACTIVITY_TYPE_EXPLORATION_VOICEOVERS,
                         constants.ACTIVITY_TYPE_STORY,
+                        constants.ACTIVITY_TYPE_STORY_MIGRATION,
                         constants.ACTIVITY_TYPE_SKILL,
                         constants.ACTIVITY_TYPE_SUBTOPIC,
                         constants.ACTIVITY_TYPE_SUBTOPIC_WITH_STUDY_GUIDE_MIGRATION,
@@ -486,6 +488,12 @@ class AndroidActivityHandler(
                         ids_and_versions
                     )
                 )
+            elif activity_type == constants.ACTIVITY_TYPE_STORY_MIGRATION:
+                fetched_entities = (
+                    story_fetchers.get_multiple_stories_by_ids_and_version(
+                        ids_and_versions
+                    )
+                )
             elif activity_type == constants.ACTIVITY_TYPE_SKILL:
                 fetched_entities = (
                     skill_fetchers.get_multiple_skills_by_ids_and_version(
@@ -500,10 +508,17 @@ class AndroidActivityHandler(
                 )
 
             for activity_data, entity in zip(activities_data, fetched_entities):
+                if (
+                    activity_type == constants.ACTIVITY_TYPE_STORY_MIGRATION
+                    and entity is not None
+                ):
+                    payload = entity.to_dict_for_android()
+                else:
+                    payload = entity.to_dict() if entity is not None else None
                 response_dict: ActivityDataResponseDict = {
                     'id': activity_data['id'],
                     'version': activity_data.get('version'),
-                    'payload': entity.to_dict() if entity is not None else None,
+                    'payload': payload,
                 }
                 activities.append(response_dict)
 

--- a/core/controllers/android_test.py
+++ b/core/controllers/android_test.py
@@ -375,6 +375,25 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                 [{'id': 'story_id', 'version': 1, 'payload': story.to_dict()}],
             )
 
+    def test_get_story_migration_returns_correct_json(self) -> None:
+        story = self.save_new_story('story_id', 'user_id', 'Title')
+        with self.secrets_swap:
+            self.assertEqual(
+                self.get_json(
+                    '/android_data?activity_type=story_migration&'
+                    'activities_data=[{"id": "story_id", "version": 1}]',
+                    headers={'X-ApiKey': 'secret'},
+                    expected_status_int=200,
+                ),
+                [
+                    {
+                        'id': 'story_id',
+                        'version': 1,
+                        'payload': story.to_dict_for_android(),
+                    }
+                ],
+            )
+
     def test_get_skill_returns_correct_json(self) -> None:
         skill = self.save_new_skill('skill_id', 'user_id', 'Description')
         with self.secrets_swap:

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -1296,6 +1296,16 @@ class StoryContentsDict(TypedDict, total=False):
     arcs: List[ArcDict]
 
 
+class StoryContentsDictForAndroid(TypedDict):
+    """Dictionary representing the StoryContents object for Android
+    (without the arcs field for backward compatibility).
+    """
+
+    nodes: List[StoryNodeDict]
+    initial_node_id: Optional[str]
+    next_node_id: str
+
+
 class StoryContents:
     """Domain object representing the story_contents dict."""
 
@@ -1653,6 +1663,20 @@ class StoryContents:
             'arcs': [arc.to_dict() for arc in self.arcs],
         }
 
+    def to_dict_for_android(self) -> StoryContentsDictForAndroid:
+        """Returns a dict representing this StoryContents domain object for
+        Android, without the arcs field for backward compatibility.
+
+        Returns:
+            dict. A dict, mapping all fields of StoryContents instance except
+            arcs.
+        """
+        return {
+            'nodes': [node.to_dict() for node in self.nodes],
+            'initial_node_id': self.initial_node_id,
+            'next_node_id': self.next_node_id,
+        }
+
     @classmethod
     def from_dict(cls, story_contents_dict: StoryContentsDict) -> StoryContents:
         """Return a StoryContents domain object from a dict.
@@ -1691,6 +1715,27 @@ class StoryDict(TypedDict):
     description: str
     notes: str
     story_contents: StoryContentsDict
+    story_contents_schema_version: int
+    language_code: str
+    corresponding_topic_id: str
+    version: int
+    url_fragment: str
+    meta_tag_content: str
+
+
+class StoryDictForAndroid(TypedDict):
+    """Dictionary representing the Story object for Android (without the arcs
+    field for backward compatibility).
+    """
+
+    id: str
+    title: str
+    thumbnail_filename: Optional[str]
+    thumbnail_bg_color: Optional[str]
+    thumbnail_size_in_bytes: Optional[int]
+    description: str
+    notes: str
+    story_contents: StoryContentsDictForAndroid
     story_contents_schema_version: int
     language_code: str
     corresponding_topic_id: str
@@ -2016,6 +2061,30 @@ class Story:
             'corresponding_topic_id': self.corresponding_topic_id,
             'version': self.version,
             'story_contents': self.story_contents.to_dict(),
+            'thumbnail_filename': self.thumbnail_filename,
+            'thumbnail_bg_color': self.thumbnail_bg_color,
+            'thumbnail_size_in_bytes': self.thumbnail_size_in_bytes,
+            'url_fragment': self.url_fragment,
+            'meta_tag_content': self.meta_tag_content,
+        }
+
+    def to_dict_for_android(self) -> StoryDictForAndroid:
+        """Returns a dict representing this Story domain object for Android,
+        without the arcs field for backward compatibility.
+
+        Returns:
+            dict. A dict, mapping all fields of Story instance except arcs.
+        """
+        return {
+            'id': self.id,
+            'title': self.title,
+            'description': self.description,
+            'notes': self.notes,
+            'language_code': self.language_code,
+            'story_contents_schema_version': self.story_contents_schema_version,
+            'corresponding_topic_id': self.corresponding_topic_id,
+            'version': self.version,
+            'story_contents': self.story_contents.to_dict_for_android(),
             'thumbnail_filename': self.thumbnail_filename,
             'thumbnail_bg_color': self.thumbnail_bg_color,
             'thumbnail_size_in_bytes': self.thumbnail_size_in_bytes,

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -538,6 +538,42 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         }
         self.assertEqual(story.to_dict(), expected_story_dict)
 
+    def test_to_dict_for_android(self) -> None:
+        """Test that to_dict_for_android returns a dict without arcs."""
+        topic_id = utils.generate_random_string(12)
+        story = story_domain.Story.create_default_story(
+            self.STORY_ID,
+            'Title',
+            'Description',
+            topic_id,
+            'story-frag-default',
+        )
+        expected_story_dict: story_domain.StoryDictForAndroid = {
+            'id': self.STORY_ID,
+            'title': 'Title',
+            'thumbnail_filename': None,
+            'thumbnail_bg_color': None,
+            'thumbnail_size_in_bytes': None,
+            'description': 'Description',
+            'notes': feconf.DEFAULT_STORY_NOTES,
+            'story_contents': {
+                'nodes': [],
+                'initial_node_id': None,
+                'next_node_id': self.NODE_ID_1,
+            },
+            'story_contents_schema_version': (
+                feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION
+            ),
+            'language_code': constants.DEFAULT_LANGUAGE_CODE,
+            'corresponding_topic_id': topic_id,
+            'version': 0,
+            'url_fragment': 'story-frag-default',
+            'meta_tag_content': '',
+        }
+        self.assertEqual(story.to_dict_for_android(), expected_story_dict)
+        # Verify arcs field is not present in the Android dict.
+        self.assertNotIn('arcs', story.to_dict_for_android()['story_contents'])
+
     def test_get_acquired_skill_ids_for_node_ids(self) -> None:
         self.story.story_contents.nodes[0].acquired_skill_ids = ['skill_1']
         self.story.story_contents.nodes[1].acquired_skill_ids = ['skill_2']
@@ -2515,6 +2551,23 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             story_contents_from_dict.to_dict(), story_contents_dict
         )
+
+    def test_story_contents_to_dict_for_android(self) -> None:
+        """Test that StoryContents.to_dict_for_android returns a dict
+        without arcs.
+        """
+        story_node = story_domain.StoryNode.create_default_story_node(
+            self.NODE_ID_1,
+            'Node title',
+        )
+        story_contents = story_domain.StoryContents(
+            [story_node], self.NODE_ID_1, '2'
+        )
+        story_contents_dict = story_contents.to_dict_for_android()
+        self.assertNotIn('arcs', story_contents_dict)
+        self.assertIn('nodes', story_contents_dict)
+        self.assertIn('initial_node_id', story_contents_dict)
+        self.assertIn('next_node_id', story_contents_dict)
 
     # TODO(#13059): Here we use MyPy ignore because after we fully type the
     # codebase we plan to get rid of the tests that intentionally test wrong


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes part of #19614.
2. This PR does the following:

The arc-based chapter groupings feature (PR #26393) added a new `arcs` field to `StoryContents`, upgrading the schema from v6 to v7. The `AndroidActivityHandler` at `/android_data` returns `entity.to_dict()` for story requests, which now includes the `arcs` field. This will break Android clients that parse story data with a fixed schema that doesn't expect this new field.

This PR adds Android backward compatibility following the exact pattern Mohit used for study guides (commit 1306efac):
- Added `ACTIVITY_TYPE_STORY_MIGRATION` constant to `assets/constants.ts`.
- Added `StoryContentsDictForAndroid` and `StoryDictForAndroid` TypedDicts to `core/domain/story_domain.py` that mirror the existing dicts but without the `arcs` field.
- Added `to_dict_for_android()` methods on `StoryContents` and `Story` that serialize without `arcs`.
- Added a new `story_migration` activity type handler in `core/controllers/android.py` that calls `to_dict_for_android()` instead of `to_dict()`.
- Added `StoryDictForAndroid` to the response payload Union type in `_ActivityDataResponseDictRequiredFields`.
- Added tests: `test_get_story_migration_returns_correct_json` in `android_test.py`, and `test_to_dict_for_android` / `test_story_contents_to_dict_for_android` in `story_domain_test.py`.

Android workflow:
1. Android temporarily switches from `story` to `story_migration` activity type.
2. Server returns story data without `arcs` (backward compatible).
3. When Android is ready to parse arcs, they switch back to `story` activity type.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

N/A

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
