### PR TITLE
[GSoC 2026] M1.12 - Fix part of #24716: Add configurable dismiss button support for toast messages

### DIFF
--- a/core/templates/base-components/feedback-modal.component.ts
+++ b/core/templates/base-components/feedback-modal.component.ts
@@ -64,6 +64,7 @@ interface TurnstileWindow extends Window {
 @Component({
   selector: 'oppia-feedback-modal',
   templateUrl: './feedback-modal.component.html',
+  styleUrls: ['feedback-modal.component.css'],
 })
 export class FeedbackModalComponent implements OnInit {
   @Input() feedbackModalType!: FeedbackModalType;

--- a/core/templates/base-components/feedback-modal.component.ts
+++ b/core/templates/base-components/feedback-modal.component.ts
@@ -341,7 +341,7 @@ export class FeedbackModalComponent implements OnInit {
           ? 'I18N_REPORT_WEBSITE_ISSUE_SUBMITTED_SUCCESS'
           : 'I18N_LESSON_FEEDBACK_SUBMITTED_SUCCESS'
       );
-      this.alertsService.addSuccessMessage(successMessage, 7000);
+      this.alertsService.addSuccessMessage(successMessage, 7000, true);
     } catch (error) {
       const errorMessage = this.translateService.instant(
         'I18N_FEEDBACK_SUBMITTED_ERROR'
@@ -375,7 +375,7 @@ export class FeedbackModalComponent implements OnInit {
       const successMessage = this.translateService.instant(
         'I18N_FEEDBACK_SUBMITTED_SUCCESS'
       );
-      this.alertsService.addSuccessMessage(successMessage, 7000);
+      this.alertsService.addSuccessMessage(successMessage, 7000, true);
     } catch (error) {
       const errorMessage = this.translateService.instant(
         'I18N_FEEDBACK_SUBMITTED_ERROR'
@@ -412,7 +412,7 @@ export class FeedbackModalComponent implements OnInit {
       const successMessage = this.translateService.instant(
         'I18N_REPORT_WEBSITE_ISSUE_SUBMITTED_SUCCESS'
       );
-      this.alertsService.addSuccessMessage(successMessage, 7000);
+      this.alertsService.addSuccessMessage(successMessage, 7000, true);
     } catch (error) {
       const errorMessage = this.translateService.instant(
         'I18N_FEEDBACK_SUBMITTED_ERROR'

--- a/core/templates/components/common-layout-directives/common-elements/alert-message.component.ts
+++ b/core/templates/components/common-layout-directives/common-elements/alert-message.component.ts
@@ -25,6 +25,7 @@ export interface MessageObject {
   type: string;
   content: string;
   timeout: number;
+  closeButton?: boolean;
 }
 
 @Component({
@@ -48,6 +49,7 @@ export class AlertMessageComponent {
       this.toastrService
         .info(this.messageObject.content, '', {
           timeOut: this.messageObject.timeout,
+          closeButton: this.messageObject.closeButton,
         })
         .onHidden.toPromise()
         .then(() => {
@@ -57,6 +59,7 @@ export class AlertMessageComponent {
       this.toastrService
         .success(this.messageObject.content, '', {
           timeOut: this.messageObject.timeout,
+          closeButton: this.messageObject.closeButton,
         })
         .onHidden.toPromise()
         .then(() => {

--- a/core/templates/services/alerts.service.ts
+++ b/core/templates/services/alerts.service.ts
@@ -29,6 +29,7 @@ export interface Message {
   type: string;
   content: string;
   timeout: number;
+  closeButton?: boolean;
 }
 
 @Injectable({
@@ -106,7 +107,12 @@ export class AlertsService {
    * @param {string} message - Message content
    * @param {number|undefined} timeoutMilliseconds - Timeout for the toast.
    */
-  addMessage(type: string, message: string, timeoutMilliseconds: number): void {
+  addMessage(
+    type: string,
+    message: string,
+    timeoutMilliseconds: number,
+    closeButton: boolean = false
+  ): void {
     if (this._messages.length >= this.MAX_TOTAL_MESSAGES) {
       return;
     }
@@ -114,6 +120,7 @@ export class AlertsService {
       type: type,
       content: message,
       timeout: timeoutMilliseconds,
+      closeButton: closeButton,
     });
   }
   /**
@@ -144,11 +151,15 @@ export class AlertsService {
    * @param {string} message - Success message to display
    * @param {number|undefined} timeoutMilliseconds - Timeout for the toast.
    */
-  addSuccessMessage(message: string, timeoutMilliseconds?: number): void {
+  addSuccessMessage(
+    message: string,
+    timeoutMilliseconds?: number,
+    closeButton: boolean = false
+  ): void {
     if (timeoutMilliseconds === undefined) {
       timeoutMilliseconds = 3000;
     }
-    this.addMessage('success', message, timeoutMilliseconds);
+    this.addMessage('success', message, timeoutMilliseconds, closeButton);
   }
 
   /**


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes part of https://github.com/oppia/oppia/issues/24716
2. This PR does the following: 
- Adds a configurable `dismissible`/`closeButton` option for toast messages.
- Extends the alerts infrastructure to support per-toast dismiss button configuration.
- Keeps the existing behavior unchanged for all current toasts unless the dismiss option is explicitly enabled.
- Enables the dismiss button for the learner feedback submission success toast.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


https://github.com/user-attachments/assets/fc664405-6996-4b17-940e-1bf4341fddc4



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Success notifications now include a close button where applicable.
  * Alerts can display an optional close button for easier dismissal.

* **Bug Fixes**
  * Improved feedback and issue-report submission confirmations by making success messages easier to close manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->