### PR TITLE
Fix N/A: Fix boolean input handling in run-a-specific-acceptance-test action

### DIFF
--- a/.github/actions/run-a-specific-acceptance-test/action.yml
+++ b/.github/actions/run-a-specific-acceptance-test/action.yml
@@ -8,23 +8,17 @@ inputs:
   viewport-type:
     description: "The viewport type to use for running the tests."
     required: true
-    type: choice
-    options:
-      - mobile
-      - desktop
   prod-env:
     description: "Whether to run in prod mode (adds --prod_env)."
     required: false
-    default: "true"
+    default: 'true'
   update-snapshots:
     description: Whether to update the snapshots instead of comparing them.
     required: false
-    default: false
-    type: boolean
+    default: 'false'
   enable-screen-recording:
     description: Whether to record the screen during the test.
     required: true
-    type: boolean
   modified-suite-name-for-uploads:
     description: A unique suite name without spaces and forward-slashes to use for the artifacts uploads. If not provided, the test data will not be uploaded.
 
@@ -61,16 +55,23 @@ runs:
       shell: bash
       # We use xvfb-run to create a virtual screen to run tests without headless mode.
       # Numbers in 1920x1080x24 represent screen width, height and color depth respectively.
+      #
+      # NOTE: composite action inputs are always strings, even when declared
+      # `type: boolean` in this file (GitHub Actions does not support typed
+      # inputs for composite actions; `type:` here has no runtime effect).
+      # `inputs.foo && x || y` treats ANY non-empty string as truthy - including
+      # the literal string "false" - so these must be compared with `== 'true'`
+      # explicitly instead of relying on truthiness.
       run: >
         set -o pipefail;
-        VIDEO_RECORDING_IS_ENABLED=${{ inputs.enable-screen-recording && '1' || '0' }}
+        VIDEO_RECORDING_IS_ENABLED=${{ inputs.enable-screen-recording == 'true' && '1' || '0' }}
         xvfb-run -a --server-args="-screen 0, 1920x1080x24"
         python -m scripts.run_acceptance_tests
         --skip_build
         --suite=${{ inputs.test-suite }}
         ${{ inputs.viewport-type == 'mobile' && '--mobile' || '' }}
         ${{ inputs.prod-env != 'false' && '--prod_env' || '' }}
-        ${{ inputs.update-snapshots && '--update_snapshots' || '' }}
+        ${{ inputs.update-snapshots == 'true' && '--update_snapshots' || '' }}
         --server_log_level=info
         | tee acceptance_test_${{ inputs.modified-suite-name-for-uploads || '' }}.log
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes N/A
2. This PR does the following: Fixes incorrect boolean handling in the run-a-specific-acceptance-test composite action. The update-snapshots and enable-screen-recording inputs were being evaluated with bare truthiness (${{ inputs.foo && x || y }}), which always resolved to the "true" branch regardless of what value was actually passed in, because composite action inputs are strings and any non-empty string (including "false") is truthy in this context. This PR switches both checks to explicit string comparisons (== 'true'), so the flags now correctly reflect the value passed by the caller. It also removes the type: boolean/type: choice and options fields from update-snapshots, enable-screen-recording, and viewport-type, since composite actions don't support typed inputs and these fields were silently ignored — leaving them in was misleading since they implied validation/coercion that never actually happened.
3. The original bug occurred because: Composite action inputs in GitHub Actions are always strings at runtime, even when the inputs.<name> block in action.yml declares type: boolean — GitHub's schema for composite actions only supports description, required, and default; there is no real type coercion like there is for workflow_call/workflow_dispatch inputs. As a result, inputs.update-snapshots and inputs.enable-screen-recording were the literal strings "true" or "false", not real booleans.

For reference - https://github.com/actions/runner/issues/2238

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Observed wrong behaviour here when the test was passing without prod screenshots and without --update-snapshots flag - https://github.com/Mohak51234/oppia/actions/runs/29693093223/job/88210310650

Reproduced issue again here - https://github.com/Mohak51234/oppia/actions/runs/29698653921

After changes test is failing correctly as it should - https://github.com/Mohak51234/oppia/actions/runs/29698499298

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
