### PR TITLE
Fix #22726: Resolve email footer preferences link before sending

### DIFF
--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -561,6 +561,39 @@ def require_sender_id_is_valid(intent: str, sender_id: str) -> None:
         )
 
 
+def _get_rendered_email_footer() -> str:
+    """Returns the email footer with its preferences-page URL resolved.
+
+    EMAIL_FOOTER may contain
+    feconf.EMAIL_FOOTER_PREFERENCES_LINK_PLACEHOLDER as a placeholder
+    for the preferences-page URL. A footer without the placeholder is
+    returned unchanged.
+
+    Returns:
+        str. The rendered email footer.
+    """
+    email_footer = platform_parameter_services.get_platform_parameter_value(
+        platform_parameter_list.ParamName.EMAIL_FOOTER.value
+    )
+    assert isinstance(email_footer, str)
+
+    if feconf.EMAIL_FOOTER_PREFERENCES_LINK_PLACEHOLDER not in email_footer:
+        return email_footer
+
+    oppia_site_url_for_emails = (
+        platform_parameter_services.get_platform_parameter_value(
+            platform_parameter_list.ParamName.OPPIA_SITE_URL_FOR_EMAILS.value
+        )
+    )
+    assert isinstance(oppia_site_url_for_emails, str)
+
+    preferences_url = oppia_site_url_for_emails + feconf.PREFERENCES_URL
+    return email_footer.replace(
+        feconf.EMAIL_FOOTER_PREFERENCES_LINK_PLACEHOLDER,
+        preferences_url,
+    )
+
+
 def _send_email(
     recipient_id: str,
     sender_id: str,
@@ -834,9 +867,7 @@ def send_post_signup_email(
             return
 
     recipient_username = user_services.get_username(user_id)
-    email_footer = platform_parameter_services.get_platform_parameter_value(
-        platform_parameter_list.ParamName.EMAIL_FOOTER.value
-    )
+    email_footer = _get_rendered_email_footer()
     email_body = 'Hi %s,<br><br>%s<br><br>%s' % (
         recipient_username,
         email_body_content,
@@ -946,9 +977,7 @@ def send_moderator_action_email(
     # called.
     assert callable(email_signoff_html_fn)
     email_signoff_html = email_signoff_html_fn(sender_username)
-    email_footer = platform_parameter_services.get_platform_parameter_value(
-        platform_parameter_list.ParamName.EMAIL_FOOTER.value
-    )
+    email_footer = _get_rendered_email_footer()
     full_email_content = '%s<br><br>%s<br><br>%s<br><br>%s' % (
         email_salutation_html,
         email_body,
@@ -1052,9 +1081,7 @@ def send_role_notification_email(
     rights_html = EDITOR_ROLE_EMAIL_RIGHTS_FOR_ROLE[role_description]
 
     email_subject = email_subject_template % exploration_title
-    email_footer = platform_parameter_services.get_platform_parameter_value(
-        platform_parameter_list.ParamName.EMAIL_FOOTER.value
-    )
+    email_footer = _get_rendered_email_footer()
     email_body = email_body_template % (
         recipient_username,
         inviter_username,
@@ -1143,11 +1170,7 @@ def send_emails_to_subscribers(
     assert isinstance(noreply_email_address, str)
     for index, username in enumerate(recipients_usernames):
         if recipients_preferences[index].can_receive_subscription_email:
-            email_footer = (
-                platform_parameter_services.get_platform_parameter_value(
-                    platform_parameter_list.ParamName.EMAIL_FOOTER.value
-                )
-            )
+            email_footer = _get_rendered_email_footer()
             email_body = email_body_template % (
                 username,
                 creator_name,
@@ -1234,9 +1257,7 @@ def send_feedback_message_email(
         (count_messages, 's') if count_messages > 1 else ('a', '')
     )
 
-    email_footer = platform_parameter_services.get_platform_parameter_value(
-        platform_parameter_list.ParamName.EMAIL_FOOTER.value
-    )
+    email_footer = _get_rendered_email_footer()
 
     email_body = email_body_template % (
         recipient_username,
@@ -1354,9 +1375,7 @@ def send_suggestion_email(
     can_users_receive_email = can_users_receive_thread_email(
         recipient_list, exploration_id, True
     )
-    email_footer = platform_parameter_services.get_platform_parameter_value(
-        platform_parameter_list.ParamName.EMAIL_FOOTER.value
-    )
+    email_footer = _get_rendered_email_footer()
     noreply_email_address = (
         platform_parameter_services.get_platform_parameter_value(
             platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS.value
@@ -1437,9 +1456,7 @@ def send_instant_feedback_message_email(
     recipient_preferences = user_services.get_email_preferences(recipient_id)
 
     if recipient_preferences.can_receive_feedback_message_email:
-        email_footer = platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.EMAIL_FOOTER.value
-        )
+        email_footer = _get_rendered_email_footer()
         email_body = email_body_template % (
             recipient_username,
             thread_title,
@@ -1505,9 +1522,7 @@ def send_flag_exploration_email(
 
     reporter_username = user_services.get_username(reporter_id)
 
-    email_footer = platform_parameter_services.get_platform_parameter_value(
-        platform_parameter_list.ParamName.EMAIL_FOOTER.value
-    )
+    email_footer = _get_rendered_email_footer()
 
     email_body = email_body_template % (
         reporter_username,
@@ -1587,9 +1602,7 @@ def send_mail_to_onboard_new_reviewers(
 
     # Send email only if recipient wants to receive.
     if can_user_receive_email:
-        email_footer = platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.EMAIL_FOOTER.value
-        )
+        email_footer = _get_rendered_email_footer()
         email_body = email_body_template % (
             recipient_username,
             category,
@@ -1655,9 +1668,7 @@ def send_mail_to_notify_users_to_review(
 
     # Send email only if recipient wants to receive.
     if can_user_receive_email:
-        email_footer = platform_parameter_services.get_platform_parameter_value(
-            platform_parameter_list.ParamName.EMAIL_FOOTER.value
-        )
+        email_footer = _get_rendered_email_footer()
         email_body = email_body_template % (
             recipient_username,
             category,
@@ -2284,9 +2295,7 @@ def send_mail_to_notify_contributor_dashboard_reviewers(
         )
     )
 
-    email_footer = platform_parameter_services.get_platform_parameter_value(
-        platform_parameter_list.ParamName.EMAIL_FOOTER.value
-    )
+    email_footer = _get_rendered_email_footer()
     noreply_email_address = (
         platform_parameter_services.get_platform_parameter_value(
             platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS.value

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -561,7 +561,7 @@ def require_sender_id_is_valid(intent: str, sender_id: str) -> None:
         )
 
 
-def _get_rendered_email_footer() -> str:
+def get_rendered_email_footer() -> str:
     """Returns the email footer with its preferences-page URL resolved.
 
     EMAIL_FOOTER may contain
@@ -867,7 +867,7 @@ def send_post_signup_email(
             return
 
     recipient_username = user_services.get_username(user_id)
-    email_footer = _get_rendered_email_footer()
+    email_footer = get_rendered_email_footer()
     email_body = 'Hi %s,<br><br>%s<br><br>%s' % (
         recipient_username,
         email_body_content,
@@ -977,7 +977,7 @@ def send_moderator_action_email(
     # called.
     assert callable(email_signoff_html_fn)
     email_signoff_html = email_signoff_html_fn(sender_username)
-    email_footer = _get_rendered_email_footer()
+    email_footer = get_rendered_email_footer()
     full_email_content = '%s<br><br>%s<br><br>%s<br><br>%s' % (
         email_salutation_html,
         email_body,
@@ -1081,7 +1081,7 @@ def send_role_notification_email(
     rights_html = EDITOR_ROLE_EMAIL_RIGHTS_FOR_ROLE[role_description]
 
     email_subject = email_subject_template % exploration_title
-    email_footer = _get_rendered_email_footer()
+    email_footer = get_rendered_email_footer()
     email_body = email_body_template % (
         recipient_username,
         inviter_username,
@@ -1170,7 +1170,7 @@ def send_emails_to_subscribers(
     assert isinstance(noreply_email_address, str)
     for index, username in enumerate(recipients_usernames):
         if recipients_preferences[index].can_receive_subscription_email:
-            email_footer = _get_rendered_email_footer()
+            email_footer = get_rendered_email_footer()
             email_body = email_body_template % (
                 username,
                 creator_name,
@@ -1257,7 +1257,7 @@ def send_feedback_message_email(
         (count_messages, 's') if count_messages > 1 else ('a', '')
     )
 
-    email_footer = _get_rendered_email_footer()
+    email_footer = get_rendered_email_footer()
 
     email_body = email_body_template % (
         recipient_username,
@@ -1375,7 +1375,7 @@ def send_suggestion_email(
     can_users_receive_email = can_users_receive_thread_email(
         recipient_list, exploration_id, True
     )
-    email_footer = _get_rendered_email_footer()
+    email_footer = get_rendered_email_footer()
     noreply_email_address = (
         platform_parameter_services.get_platform_parameter_value(
             platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS.value
@@ -1456,7 +1456,7 @@ def send_instant_feedback_message_email(
     recipient_preferences = user_services.get_email_preferences(recipient_id)
 
     if recipient_preferences.can_receive_feedback_message_email:
-        email_footer = _get_rendered_email_footer()
+        email_footer = get_rendered_email_footer()
         email_body = email_body_template % (
             recipient_username,
             thread_title,
@@ -1522,7 +1522,7 @@ def send_flag_exploration_email(
 
     reporter_username = user_services.get_username(reporter_id)
 
-    email_footer = _get_rendered_email_footer()
+    email_footer = get_rendered_email_footer()
 
     email_body = email_body_template % (
         reporter_username,
@@ -1602,7 +1602,7 @@ def send_mail_to_onboard_new_reviewers(
 
     # Send email only if recipient wants to receive.
     if can_user_receive_email:
-        email_footer = _get_rendered_email_footer()
+        email_footer = get_rendered_email_footer()
         email_body = email_body_template % (
             recipient_username,
             category,
@@ -1668,7 +1668,7 @@ def send_mail_to_notify_users_to_review(
 
     # Send email only if recipient wants to receive.
     if can_user_receive_email:
-        email_footer = _get_rendered_email_footer()
+        email_footer = get_rendered_email_footer()
         email_body = email_body_template % (
             recipient_username,
             category,
@@ -2295,7 +2295,7 @@ def send_mail_to_notify_contributor_dashboard_reviewers(
         )
     )
 
-    email_footer = _get_rendered_email_footer()
+    email_footer = get_rendered_email_footer()
     noreply_email_address = (
         platform_parameter_services.get_platform_parameter_value(
             platform_parameter_list.ParamName.NOREPLY_EMAIL_ADDRESS.value

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -2607,9 +2607,7 @@ class RenderedEmailFooterTest(test_utils.GenericTestBase):
     )
     def test_preserves_custom_footer_without_placeholder(self) -> None:
         """Tests that a custom footer is returned unchanged."""
-        footer = (
-            email_manager._get_rendered_email_footer()
-        )  # pylint: disable=protected-access
+        footer = email_manager.get_rendered_email_footer()
         self.assertEqual(
             footer,
             'You can change your email preferences via the '

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -2607,9 +2607,9 @@ class RenderedEmailFooterTest(test_utils.GenericTestBase):
     )
     def test_preserves_custom_footer_without_placeholder(self) -> None:
         """Tests that a custom footer is returned unchanged."""
-        # pylint: disable=protected-access
-        footer = email_manager._get_rendered_email_footer()
-        # pylint: enable=protected-access
+        footer = (
+            email_manager._get_rendered_email_footer()
+        )  # pylint: disable=protected-access
         self.assertEqual(
             footer,
             'You can change your email preferences via the '

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -2543,6 +2543,81 @@ class FlagExplorationEmailTest(test_utils.EmailTestBase):
             sent_email_model.intent, feconf.EMAIL_INTENT_REPORT_BAD_CONTENT
         )
 
+    @test_utils.set_platform_parameters(
+        [
+            (param_list.ParamName.SERVER_CAN_SEND_EMAILS, True),
+            (
+                param_list.ParamName.EMAIL_FOOTER,
+                'You can change your email preferences via the '
+                '<a href="LINK_TO_PREFERENCES_PAGE">'
+                'Preferences</a> page.',
+            ),
+            (param_list.ParamName.EMAIL_SENDER_NAME, 'Site Admin'),
+            (
+                param_list.ParamName.ADMIN_EMAIL_ADDRESS,
+                'testadmin@example.com',
+            ),
+            (
+                param_list.ParamName.SYSTEM_EMAIL_ADDRESS,
+                'system@example.com',
+            ),
+            (
+                param_list.ParamName.NOREPLY_EMAIL_ADDRESS,
+                'noreply@example.com',
+            ),
+            (
+                param_list.ParamName.OPPIA_SITE_URL_FOR_EMAILS,
+                'https://www.oppia.org',
+            ),
+        ]
+    )
+    def test_flag_exploration_email_replaces_preferences_link(self) -> None:
+        """Tests that the email footer preferences link is rendered."""
+        email_manager.send_flag_exploration_email(
+            self.exploration.title,
+            self.exploration.id,
+            self.new_user_id,
+            self.report_text,
+        )
+
+        messages = self._get_sent_email_messages(self.MODERATOR_EMAIL)
+        self.assertEqual(len(messages), 1)
+        self.assertIn(
+            'href="https://www.oppia.org/preferences"',
+            messages[0].html,
+        )
+        self.assertNotIn(
+            'LINK_TO_PREFERENCES_PAGE',
+            messages[0].html,
+        )
+
+
+class RenderedEmailFooterTest(test_utils.GenericTestBase):
+    """Tests the email-footer rendering helper."""
+
+    @test_utils.set_platform_parameters(
+        [
+            (
+                param_list.ParamName.EMAIL_FOOTER,
+                'You can change your email preferences via the '
+                '<a href="https://custom.example/account/preferences">'
+                'Preferences</a> page.',
+            ),
+        ]
+    )
+    def test_preserves_custom_footer_without_placeholder(self) -> None:
+        """Tests that a custom footer is returned unchanged."""
+        footer = (
+            email_manager._get_rendered_email_footer()
+        )  # pylint: disable=protected-access,line-too-long
+
+        self.assertEqual(
+            footer,
+            'You can change your email preferences via the '
+            '<a href="https://custom.example/account/preferences">'
+            'Preferences</a> page.',
+        )
+
 
 class OnboardingReviewerInstantEmailTests(test_utils.EmailTestBase):
     """Test that correct email is sent while onboarding reviewers."""

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -2609,7 +2609,7 @@ class RenderedEmailFooterTest(test_utils.GenericTestBase):
         """Tests that a custom footer is returned unchanged."""
         footer = (
             email_manager._get_rendered_email_footer()
-        )  # pylint: disable=protected-access,line-too-long
+        )  # pylint: disable=protected-access
 
         self.assertEqual(
             footer,

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -2607,10 +2607,9 @@ class RenderedEmailFooterTest(test_utils.GenericTestBase):
     )
     def test_preserves_custom_footer_without_placeholder(self) -> None:
         """Tests that a custom footer is returned unchanged."""
-        footer = (
-            email_manager._get_rendered_email_footer()
-        )  # pylint: disable=protected-access
-
+        # pylint: disable=protected-access
+        footer = email_manager._get_rendered_email_footer()
+        # pylint: enable=protected-access
         self.assertEqual(
             footer,
             'You can change your email preferences via the '

--- a/core/domain/platform_parameter_registry.py
+++ b/core/domain/platform_parameter_registry.py
@@ -378,12 +378,15 @@ Registry.create_platform_parameter(
 
 Registry.create_platform_parameter(
     ParamName.EMAIL_FOOTER,
-    'The footer to append to all outgoing emails. (This should '
-    'be written in HTML and include an unsubscribe link.)',
+    'The footer to append to all outgoing emails. This should be '
+    'written in HTML and include an unsubscribe link. The '
+    'LINK_TO_PREFERENCES_PAGE placeholder is replaced with the '
+    'preferences page URL before sending.',
     platform_parameter_domain.DataTypes.STRING,
     default=(
         'You can change your email preferences via the '
-        '<a href="LINK_TO_PREFERENCES_PAGE">Preferences</a> page.'
+        '<a href="%s">Preferences</a> page.'
+        % feconf.EMAIL_FOOTER_PREFERENCES_LINK_PLACEHOLDER
     ),
 )
 

--- a/core/feconf.py
+++ b/core/feconf.py
@@ -543,6 +543,9 @@ VALID_MAILCHIMP_FIELD_KEYS = ['NAME']
 # Valid Mailchimp tags.
 VALID_MAILCHIMP_TAGS = ['Account', 'Android', 'Web']
 
+# Placeholder for the preferences-page URL in email footers.
+EMAIL_FOOTER_PREFERENCES_LINK_PLACEHOLDER = 'LINK_TO_PREFERENCES_PAGE'
+
 GAE_DEVELOPMENT_SERVER_PORT = 8181
 GAE_ADMIN_SERVER_PORT = 8000
 


### PR DESCRIPTION
## Overview

1. This PR fixes #22726.

2. This PR resolves the `LINK_TO_PREFERENCES_PAGE` placeholder in the `EMAIL_FOOTER` platform parameter before the footer is added to outgoing email HTML.

   The default email footer contains:

   ```html
   <a href="LINK_TO_PREFERENCES_PAGE">Preferences</a>
   ```

   Previously, this placeholder was inserted directly into outgoing email bodies without being replaced by the actual preferences-page URL.

   This PR adds a central `get_rendered_email_footer()` helper in `core/domain/email_manager.py`. The helper:

   * Fetches the configured `EMAIL_FOOTER`.

   * Returns the footer unchanged when it does not contain the placeholder. This preserves custom administrator-configured footers.

   * Fetches `OPPIA_SITE_URL_FOR_EMAILS` only when the placeholder is present.

   * Constructs the preferences-page URL using:

     ```python
     oppia_site_url_for_emails + feconf.PREFERENCES_URL
     ```

   * Replaces `LINK_TO_PREFERENCES_PAGE` with the complete preferences-page URL before the footer is added to the email body.

   This PR also adds the shared constant:

   ```python
   EMAIL_FOOTER_PREFERENCES_LINK_PLACEHOLDER
   ```

   to `core/feconf.py`.

   The description of the `EMAIL_FOOTER` platform parameter has also been updated to explain that the placeholder is replaced with the preferences-page URL before the email is sent.

   All 11 functions in `email_manager.py` that append `EMAIL_FOOTER` to outgoing HTML emails now use `get_rendered_email_footer()`:

   * `send_post_signup_email`
   * `send_moderator_action_email`
   * `send_role_notification_email`
   * `send_emails_to_subscribers`
   * `send_feedback_message_email`
   * `send_suggestion_email`
   * `send_instant_feedback_message_email`
   * `send_flag_exploration_email`
   * `send_mail_to_onboard_new_reviewers`
   * `send_mail_to_notify_users_to_review`
   * `send_mail_to_notify_contributor_dashboard_reviewers`

   The existing `_send_email()` HTML-cleaning logic, HTML mismatch check, and allowed URL schemes have not been changed. Invalid custom email HTML will therefore continue to be rejected by the existing sanitizer.

3. The original bug occurred because the default `EMAIL_FOOTER` platform parameter contained the literal `LINK_TO_PREFERENCES_PAGE` placeholder, but this placeholder was not resolved before the footer reached `_send_email()`.

   `html_cleaner.clean()` only permits valid HTTP or HTTPS URLs in an anchor tag's `href` attribute. It therefore changed:

   ```diff
   - <a href="LINK_TO_PREFERENCES_PAGE">Preferences</a>
   + <a>Preferences</a>
   ```

   `_send_email()` compares the original email HTML body with the cleaned HTML body. Since the invalid `href` was removed, the two HTML bodies did not match, and `_send_email()` returned without sending the email.

   Git history indicates that the `LINK_TO_PREFERENCES_PAGE` placeholder was introduced in PR #20809 without adding the corresponding runtime replacement before the footer was passed to `_send_email()`.

## Reproduction before the fix

I reproduced the issue locally using the following steps:

1. Enabled the `server_can_send_emails` platform parameter.
2. Created a separate user and assigned that user the moderator role.
3. Created and published an exploration.
4. Logged in as a regular user.
5. Opened the **Report this exploration** modal.
6. Selected a report reason, entered additional details, and submitted the report.

Before the fix, the server logged:

```text
ERROR:root:Found invalid URL href: LINK_TO_PREFERENCES_PAGE
ERROR:root:Original email HTML body does not match cleaned HTML body
```

The original email footer contained:

```html
<a href="LINK_TO_PREFERENCES_PAGE">Preferences</a>
```

The cleaned email footer contained:

```html
<a>Preferences</a>
```

Because the original and cleaned email bodies differed, `_send_email()` returned without sending the moderator email.

**Before-fix server-log screenshot:**

<img width="1826" height="207" alt="Screenshot 2026-07-17 184542" src="https://github.com/user-attachments/assets/2a957102-8a42-4cf1-89aa-0eb5792f74bb" />
<img width="1107" height="1022" alt="Screenshot 2026-07-17 183355" src="https://github.com/user-attachments/assets/f7c5881b-d0a4-4a3f-ada2-aaa2c900781c" />

## Regression tests

### Placeholder replacement test

I added:

```python
test_flag_exploration_email_replaces_preferences_link
```

to `FlagExplorationEmailTest`.

The test:

* Enables `SERVER_CAN_SEND_EMAILS`.

* Sets `EMAIL_FOOTER` to the unresolved placeholder value.

* Sets `OPPIA_SITE_URL_FOR_EMAILS` to `https://www.oppia.org`.

* Calls `send_flag_exploration_email()`.

* Verifies that exactly one email is produced.

* Verifies that the final email HTML contains:

  ```html
  href="https://www.oppia.org/preferences"
  ```

* Verifies that `LINK_TO_PREFERENCES_PAGE` is absent from the final email HTML.

Before the production change, this regression test failed as expected:

```text
AssertionError: 0 != 1
```

The test logs also showed:

```text
ERROR:root:Found invalid URL href: LINK_TO_PREFERENCES_PAGE
ERROR:root:Original email HTML body does not match cleaned HTML body
```

This confirms that the regression test directly detects the reported issue.

After applying the production change, the same test passes.

**Before-fix regression-test screenshot:**

<img width="1920" height="1020" alt="Screenshot 2026-07-18 013033" src="https://github.com/user-attachments/assets/86451178-936a-4ab0-95f5-fc191872827e" />

**After-fix regression-test screenshot:**

<img width="1920" height="1020" alt="Screenshot 2026-07-18 021949" src="https://github.com/user-attachments/assets/12da63b8-844b-41d5-89ec-35fe9d2cc743" />

### Custom-footer test

I also added:

```python
RenderedEmailFooterTest.test_preserves_custom_footer_without_placeholder
```
<img width="1920" height="1020" alt="Screenshot 2026-07-18 022623" src="https://github.com/user-attachments/assets/f970580c-9cc5-42d1-94f6-60728644f552" />

This test verifies that an administrator-configured footer such as:

```html
<a href="https://custom.example/account/preferences">Preferences</a>
```

is returned unchanged.

The test intentionally does not configure `OPPIA_SITE_URL_FOR_EMAILS`. This verifies that `get_rendered_email_footer()` does not fetch the site URL when the footer does not contain `LINK_TO_PREFERENCES_PAGE`.

## Verification after the fix

I repeated the browser reproduction after applying the fix.

The report request completed successfully:

```text
POST /flagexplorationhandler/EmDf2srWs10x HTTP/1.1" 200
```

The server no longer logged:

```text
Found invalid URL href: LINK_TO_PREFERENCES_PAGE
```

or:

```text
Original email HTML body does not match cleaned HTML body
```

The previously failing flag-exploration email regression test also passed locally after the fix.

This confirms that the unresolved placeholder no longer reaches `html_cleaner` during either the automated test or the real report-exploration flow.

**After-fix screen recording:**


https://github.com/user-attachments/assets/785a337d-5461-42ce-b32e-7720beea32ba


## Files changed

The change is limited to:

```text
core/feconf.py
core/domain/platform_parameter_registry.py
core/domain/email_manager.py
core/domain/email_manager_test.py
```

## Essential Checklist

Please follow the [[instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request)](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

* [x] I have referenced the issue that this PR fixes on line 1 above. Once I open the PR, I will check that #22726 is listed in the **Development** section of the sidebar.
* [x] I have checked the **Files Changed** tab and confirmed that the changes are what I want to make.
* [x] I have written tests for my code.
* [x] The PR title starts with `Fix #22726:` followed by a short, clear summary of the change.
* [x] I have assigned the correct reviewers to this PR, or I will leave a comment containing `@reviewer_username PTAL` if I cannot assign them directly.

## Testing doc

N/A. This PR does not add or modify a Beam job and does not modify production server data.

## Proof that changes are correct

### Before the fix

The regression test failed because the unresolved placeholder caused `_send_email()` to reject the email:

```text
FAIL: test_flag_exploration_email_replaces_preferences_link
AssertionError: 0 != 1
```

The server also logged:

```text
ERROR:root:Found invalid URL href: LINK_TO_PREFERENCES_PAGE
ERROR:root:Original email HTML body does not match cleaned HTML body
```

**Proof:**

<img width="1826" height="207" alt="Screenshot 2026-07-17 184542" src="https://github.com/user-attachments/assets/aa4e7c07-762e-4bf2-8593-f40bd36ccf18" />

### After the fix

The same regression test passes after the placeholder is replaced with the complete preferences-page URL.

The browser reproduction also completed successfully, and the previous invalid-URL and HTML-mismatch messages were no longer present in the server logs.

**Proof:**

<img width="1920" height="1020" alt="Screenshot 2026-07-18 021949" src="https://github.com/user-attachments/assets/cff6a9de-7789-468c-8136-42e7140d01ad" />

#### Proof of changes on desktop with slow/throttled network

N/A. This is a backend email-rendering change. It does not modify the user interface, browser rendering, or network behavior.

The existing desktop report-exploration flow was manually verified after applying the fix.

#### Proof of changes on mobile phone

N/A. This PR does not modify the mobile interface or responsive behavior.

#### Proof of changes in Arabic language

N/A. This PR does not modify the user interface, translated content, layout, or right-to-left behavior.


## PR Pointers

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
* Some e2e tests are flaky and can fail for reasons unrelated to this PR. If a build fails, check the [["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR)](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
* See the [[Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers)](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for the checks code owners expect.