### PR TITLE
Fix #26642: Save Draft button not visible in collection editor mobile view

### DIFF
--- a/core/templates/pages/collection-editor-page/collection-editor-page-root.component.html
+++ b/core/templates/pages/collection-editor-page/collection-editor-page-root.component.html
@@ -10,6 +10,11 @@
       </collection-editor-navbar>
     </nav-options>
 
+    <mobile-nav-options>
+      <collection-editor-navbar>
+      </collection-editor-navbar>
+    </mobile-nav-options>
+
     <content>
       <oppia-collection-editor-page></oppia-collection-editor-page>
     </content>

--- a/core/templates/pages/collection-editor-page/collection-editor-page.component.spec.ts
+++ b/core/templates/pages/collection-editor-page/collection-editor-page.component.spec.ts
@@ -24,6 +24,7 @@ import {TranslateService} from '@ngx-translate/core';
 import {Collection} from 'domain/collection/collection.model';
 import {UrlService} from 'services/contextual/url.service';
 import {PageTitleService} from 'services/page-title.service';
+import {BottomNavbarStatusService} from 'services/bottom-navbar-status.service';
 import {CollectionEditorPageComponent} from './collection-editor-page.component';
 import {CollectionEditorRoutingService} from './services/collection-editor-routing.service';
 import {CollectionEditorStateService} from './services/collection-editor-state.service';
@@ -44,6 +45,7 @@ describe('Collection editor page component', () => {
   let pageTitleService: PageTitleService;
   let urlService: UrlService;
   let translateService: TranslateService;
+  let bottomNavbarStatusService: BottomNavbarStatusService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -54,6 +56,7 @@ describe('Collection editor page component', () => {
         CollectionEditorStateService,
         PageTitleService,
         UrlService,
+        BottomNavbarStatusService,
         {
           provide: TranslateService,
           useClass: MockTranslateService,
@@ -73,6 +76,7 @@ describe('Collection editor page component', () => {
     pageTitleService = TestBed.inject(PageTitleService);
     urlService = TestBed.inject(UrlService);
     translateService = TestBed.inject(TranslateService);
+    bottomNavbarStatusService = TestBed.inject(BottomNavbarStatusService);
   });
 
   afterEach(() => {
@@ -87,6 +91,7 @@ describe('Collection editor page component', () => {
       collectionEditorStateService,
       'onCollectionInitialized'
     ).and.returnValue(mockOnCollectionInitializedEventEmitter);
+    spyOn(bottomNavbarStatusService, 'markBottomNavbarStatus');
     spyOn(collectionEditorStateService, 'loadCollection');
     spyOn(componentInstance, 'setTitle');
     spyOn(componentInstance, 'subscribeToOnLangChange');
@@ -98,6 +103,7 @@ describe('Collection editor page component', () => {
     mockOnCollectionInitializedEventEmitter.emit();
     fixture.detectChanges();
 
+    expect(bottomNavbarStatusService.markBottomNavbarStatus).toHaveBeenCalledWith(true);
     expect(componentInstance.setTitle).toHaveBeenCalled();
     expect(componentInstance.subscribeToOnLangChange).toHaveBeenCalled();
     expect(collectionEditorStateService.loadCollection).toHaveBeenCalledWith(

--- a/core/templates/pages/collection-editor-page/collection-editor-page.component.ts
+++ b/core/templates/pages/collection-editor-page/collection-editor-page.component.ts
@@ -22,6 +22,7 @@ import {Subscription} from 'rxjs';
 
 import {UrlService} from 'services/contextual/url.service';
 import {PageTitleService} from 'services/page-title.service';
+import {BottomNavbarStatusService} from 'services/bottom-navbar-status.service';
 import {CollectionEditorRoutingService} from './services/collection-editor-routing.service';
 import {CollectionEditorStateService} from './services/collection-editor-state.service';
 
@@ -37,10 +38,12 @@ export class CollectionEditorPageComponent implements OnInit, OnDestroy {
     private collectionEditorStateService: CollectionEditorStateService,
     private pageTitleService: PageTitleService,
     private urlService: UrlService,
-    private translateService: TranslateService
+    private translateService: TranslateService,
+    private bottomNavbarStatusService: BottomNavbarStatusService
   ) {}
 
   ngOnInit(): void {
+    this.bottomNavbarStatusService.markBottomNavbarStatus(true);
     this.directiveSubscriptions.add(
       this.collectionEditorStateService.onCollectionInitialized.subscribe(
         () => {

--- a/core/templates/pages/collection-editor-page/collection-editor-page.module.ts
+++ b/core/templates/pages/collection-editor-page/collection-editor-page.module.ts
@@ -32,7 +32,7 @@ import {CollectionEditorSaveModalComponent} from './modals/collection-editor-sav
 import {CollectionEditorPrePublishModalComponent} from './modals/collection-editor-pre-publish-modal.component';
 import {ToastrModule} from 'ngx-toastr';
 import {FormsModule} from '@angular/forms';
-import {NgModule} from '@angular/core';
+import {CUSTOM_ELEMENTS_SCHEMA, NgModule} from '@angular/core';
 import {CollectionEditorPageComponent} from './collection-editor-page.component';
 import {CollectionEditorPageAuthGuard} from './collection-editor-page-auth.guard';
 import {CollectionEditorPageRootComponent} from './collection-editor-page-root.component';
@@ -81,5 +81,6 @@ import {toastrConfig} from 'pages/oppia-root/app.module';
     CollectionSettingsTabComponent,
     CollectionStatisticsTabComponent,
   ],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class CollectionEditorPageModule {}

--- a/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.spec.ts
+++ b/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.spec.ts
@@ -300,7 +300,7 @@ describe('Collection editor navbar component', () => {
 
     spyOn(ngbModal, 'open').and.returnValue({
       componentInstance: {
-        isCollectionPrivate: false,
+        collectionIsPrivate: false,
       },
       result: {
         then: (

--- a/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.ts
+++ b/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.component.ts
@@ -144,7 +144,7 @@ export class CollectionEditorNavbarComponent {
       }
     );
 
-    modalRef.componentInstance.isCollectionPrivate =
+    modalRef.componentInstance.collectionIsPrivate =
       this.collectionRights.isPrivate();
 
     modalRef.result.then(


### PR DESCRIPTION
## Overview

1. This PR fixes #26642.

2. This PR does the following:
   - Adds the mobile navigation drawer to the Collection Editor so the Save Draft button is accessible on mobile viewports.
   - Integrates `BottomNavbarStatusService` to support the mobile options toggle.
   - Fixes a property name mismatch that caused the Save Draft modal to incorrectly display "Publish Changes" instead of "Save Draft" for private collections.
   - Updates the relevant unit tests.

3. The original bug occurred because the Collection Editor was missing the mobile navigation structure used by other editors, causing the Save Draft action to be hidden on mobile. Additionally, the navbar passed `isCollectionPrivate` while the save modal expected `collectionIsPrivate`, causing the incorrect modal text.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #26642: " followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly.

## Proof that changes are correct

### Proof of changes on desktop

Verified that the Save Draft button is visible in the Collection Editor navbar.

![Save Draft button visible on desktop](
<img width="1917" height="1087" alt="Screenshot 2026-07-21 133047" src="https://github.com/user-attachments/assets/11e9f00c-f2ac-4f14-abf9-2bca60e8a2f5" />
)

### Proof of changes on mobile phone

Verified using the browser's mobile emulator that the bottom options toggle opens the navigation drawer and the Save Draft button is visible.

![Save Draft button visible in mobile view](
<img width="1286" height="1078" alt="Screenshot 2026-07-21 132337" src="https://github.com/user-attachments/assets/7a32b722-044f-4e70-b9e3-9bb7db160fe4" />
)

### Proof of changes in Arabic language

Not applicable. No RTL-specific changes were made.made.


