### PR TITLE
Fix #N/A: Remove duplicate initExplorationPage() call causing interaction-customization modal race

### DIFF
--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
@@ -999,8 +999,13 @@ describe('Exploration editor page component', () => {
 
     it('should react to initExplorationPage broadcasts', fakeAsync(() => {
       explorationData.version = 1;
+      const stateEditorService = TestBed.inject(StateEditorService);
       spyOn(ics, 'startCheckingConnection');
       spyOn(cls, 'loadAutosavedChangeList');
+      spyOn(stateEditorService, 'getActiveStateName').and.returnValue(
+        'Introduction'
+      );
+      spyOn(sers.onRefreshStateEditor, 'emit');
       isLocationSetToNonStateEditorTabSpy.and.returnValue(true);
 
       expect(component.explorationEditorPageHasInitialized).toEqual(false);
@@ -1008,6 +1013,7 @@ describe('Exploration editor page component', () => {
       tick();
 
       expect(cls.loadAutosavedChangeList).toHaveBeenCalled();
+      expect(sers.onRefreshStateEditor.emit).toHaveBeenCalled();
       expect(component.explorationEditorPageHasInitialized).toEqual(true);
 
       flush();

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
@@ -816,8 +816,6 @@ export class ExplorationEditorPageComponent implements OnInit, OnDestroy {
     ).then(improvementsTabIsEnabledResponse => {
       this.improvementsTabIsEnabled = improvementsTabIsEnabledResponse;
     });
-
-    this.initExplorationPage();
   }
 
   isImprovementsTabEnabled(): boolean {


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes N/A
2. This PR removes a duplicate call to `initExplorationPage()` in `exploration-editor-page.component.ts`'s `ngOnInit()`. The method was being called twice back-to-back, causing two concurrent, independent fetch/init chains to run against the backend on every page load.
Because both calls are unordered async chains, either one can resolve last. The chain that resolves first unblocks the UI (hides the loading overlay via `onRefreshStateEditor`), allowing the user to start interacting — e.g. opening the "Add Interaction" modal and selecting an interaction. When the still-pending chain resolves afterward, it re-inits`explorationStatesService` with stale backend data and re-emits `onRefreshStateEditor`, which re-runs `stateInteractionIdService.init()` with the (still-null) saved interaction ID. This resets `stateInteractionIdService.displayed`, flipping the customize-interaction modal's header back to "Choose Interaction" even though the user had already selected an interaction.

In Playwright acceptance tests, this surfaced as a flaky `beforeAll` timeout in `completes-the-exploration-and-decides-what-to-do-next.spec.ts`:  `expectCustomizeInteractionTitleToBe`'s `waitForFunction` would poll indefinitely because the header text never stabilized, until the test's hook timeout force-closed the browser.

Link to failing run - 
https://github.com/oppia/oppia/actions/runs/29815296528/job/88587245199
I wasn't able to reproduce this even with 400 runs of stress tests.

3. The original bug occurred because `initExplorationPage()` was called twice in `ngOnInit()`, with unrelated code (an `isImprovementsTabEnabledAsync()` promise) in between the two calls. This looks like an accidental duplicate rather than an intentional retry path.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
Video recording - 
[page@cd347cb2b248c2bac926d20327ffeba2.webm](https://github.com/user-attachments/assets/66e6a38a-72b9-4ff6-b59c-982a6247ecba)

After changes Stress Test - https://github.com/Mohak51234/oppia/actions/runs/29922932747

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
