### PR TITLE
Fix #26819: Migrate community library browser acceptance test to Playwright

### DIFF
--- a/core/tests/ci-test-suite-configs/acceptance.json
+++ b/core/tests/ci-test-suite-configs/acceptance.json
@@ -572,8 +572,8 @@
     },
     {
       "name": "community-library-browser/subscribe-to-a-favourite-creator",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "topic-manager/access-dashboard-using-profile-dropdown",

--- a/core/tests/playwright-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The Oppia Authors. All Rights Reserved.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  * CL.5 Subscribe to a favourite creator
  */
 
+import {test} from '@playwright/test';
 import testConstants from '../../utilities/common/test-constants';
 import {UserFactory} from '../../utilities/common/user-factory';
 import {CurriculumAdmin} from '../../utilities/user/curriculum-admin';
@@ -26,18 +27,24 @@ import {ExplorationEditor} from '../../utilities/user/exploration-editor';
 import {LoggedInUser} from '../../utilities/user/logged-in-user';
 import {LoggedOutUser} from '../../utilities/user/logged-out-user';
 
-describe('Community Library Browser', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Community Library Browser', function () {
   let communityLibraryBrowser: LoggedInUser & LoggedOutUser;
   let curriculumAdmin: ExplorationEditor & CurriculumAdmin;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
+    test.setTimeout(500000); // Setup takes longer than the default timeout.
+
     communityLibraryBrowser = await UserFactory.createNewUser(
       'communityLibraryBrowser',
-      'community_library_browser@example.com'
+      'community_library_browser@example.com',
+      browser
     );
     curriculumAdmin = await UserFactory.createNewUser(
       'currAdm',
       'curriculum_adm@example.com',
+      browser,
       [testConstants.Roles.CURRICULUM_ADMIN]
     );
 
@@ -64,9 +71,9 @@ describe('Community Library Browser', function () {
       'math',
       'Fractions'
     );
-  }, 500000);
+  });
 
-  it('should be able to subscribe to creators', async function () {
+  test('should be able to subscribe to creators', async function () {
     // Start a community lesson.
     await communityLibraryBrowser.navigateToClassroomPage('math');
     await communityLibraryBrowser.selectAndOpenTopic('Fractions');
@@ -86,7 +93,7 @@ describe('Community Library Browser', function () {
     await communityLibraryBrowser.expectSubscribedCreatorsToContain('currAdm');
   });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -51,7 +51,9 @@ test.describe('Community Library Browser', function () {
     const explorationId =
       await curriculumAdmin.createAndPublishExplorationWithCards(
         'Solving problems without calculator',
-        'Algebra'
+        'Algebra',
+        2,
+        true
       );
 
     await curriculumAdmin.createAndPublishTopic(

--- a/core/tests/playwright-acceptance-tests/utilities/user/logged-in-user.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/logged-in-user.ts
@@ -106,6 +106,7 @@ const subjectInterestTagsInPreferencesPage = '.e2e-test-subject-interest-chip';
 const audioLanguageValueSelector = `${audioLanguageInputSelector} span.mat-select-min-line`;
 const explorationLanguagePerferenceChipsSelector =
   '.e2e-test-exploration-language-preference-chips';
+const subscribedCreatorSelector = '.e2e-test-subscription-name';
 const accountDeletionButtonInDeleteAccountPage =
   '.e2e-test-delete-my-account-button';
 const preferencesContainerSelector = '.e2e-test-preferences-container';
@@ -2465,6 +2466,19 @@ export class LoggedInUser extends BaseUser {
     showMessage(
       `Subscribed to the creator${username ? ` (${username})` : ''}.`
     );
+  }
+
+  /**
+   * Checks whether the subscribed creators include the given creator.
+   * Requires the user to be on the preferences page.
+   * @param {string} creatorName - The creator name to check.
+   */
+  async expectSubscribedCreatorsToContain(creatorName: string): Promise<void> {
+    const subscribedCreator = this.page
+      .locator(subscribedCreatorSelector)
+      .filter({hasText: creatorName});
+
+    await expect(subscribedCreator).toBeVisible();
   }
 
   /**


### PR DESCRIPTION
## Overview

1. This PR fixes #26819.
2. This PR migrates the `subscribe-to-a-favourite-creator` community-library acceptance test from Puppeteer to Playwright. It:
   - moves the spec into the Playwright acceptance-test suite;
   - updates the suite framework in `acceptance.json`;
   - adds the missing subscribed-creator assertion utility;
   - handles the expected first-time welcome modal during exploration creation.
3. N/A - this is a test-framework migration, not a production bug fix.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] The first-pass reviewer has been assigned automatically by OppiaBot.

## Proof that changes are correct

No proof of changes needed because this is a developer-facing acceptance-test migration and does not change the production UI. The automatic Playwright recordings and validation evidence are included below for completeness.

### Validation

- Complete issue-thread validation evidence (desktop and mobile recordings):
  https://github.com/oppia/oppia/issues/26819#issuecomment-5043100774

- Local desktop acceptance test: passed.
- Local mobile acceptance test: passed.
- Stress test: all 203 workflow jobs passed, covering 100 desktop and 100 mobile runs:
  https://github.com/HuzaifaAbdulRehman/oppia/actions/runs/29896087005
- Final tested commit:
  https://github.com/HuzaifaAbdulRehman/oppia/commit/61a039720edd86ebd99bc0b377e9f05ba7ac43a3

#### Proof of changes on desktop with slow/throttled network

The test is developer-facing, so network throttling is not applicable. Automatic desktop Playwright recording:

https://github.com/user-attachments/assets/a32c4a29-0cef-4a08-8764-78ae18573922

#### Proof of changes on mobile phone

Automatic mobile Playwright recording:

https://github.com/user-attachments/assets/939c4de6-8cd1-4ef0-8c57-adcb63dda6ac

#### Proof of changes in Arabic language

Not applicable because this PR changes the acceptance-test implementation only and does not change the production UI or translations.

## PR Pointers

- I will not force-push this branch.
- I will follow the repository instructions when responding to review comments and CI failures.

