### PR TITLE
Ensure python package is generated after ng build

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -808,10 +808,14 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     )
     if options.prod_env:
         generate_hashes()
-        generate_python_package()
         if not options.skip_ng_build:
             build_using_ng()
             sync_angular_css_hashes()
+        # This must run after build_using_ng(), which uses Angular CLI's
+        # default deleteOutputPath behavior to clear out the 'build/'
+        # directory before writing its own output. Generating the package
+        # first would have it wiped out by the Angular build.
+        generate_python_package()
         rename_assets_with_hashes()
         generate_app_yaml(deploy_mode=options.deploy_mode)
 

--- a/scripts/build_test.py
+++ b/scripts/build_test.py
@@ -649,6 +649,43 @@ class BuildTests(test_utils.GenericTestBase):
                 with generate_python_package_swap, sync_angular_css_hashes_swap:
                     build.main(args=['--prod_env'])
 
+    def test_build_with_prod_env_generates_python_package_after_ng_build(
+        self,
+    ) -> None:
+        call_order: List[str] = []
+
+        def mock_build_using_ng() -> None:
+            call_order.append('build_using_ng')
+
+        def mock_generate_python_package() -> None:
+            call_order.append('generate_python_package')
+
+        ensure_files_exist_swap = self.swap(
+            build, '_ensure_files_exist', lambda _: None
+        )
+        build_using_ng_swap = self.swap(
+            build, 'build_using_ng', mock_build_using_ng
+        )
+        generate_python_package_swap = self.swap(
+            build, 'generate_python_package', mock_generate_python_package
+        )
+        modify_constants_swap = self.swap(
+            common, 'modify_constants', lambda **_: None
+        )
+        clean_swap = self.swap(build, 'clean', lambda: None)
+        sync_angular_css_hashes_swap = self.swap(
+            build, 'sync_angular_css_hashes', lambda: None
+        )
+
+        with ensure_files_exist_swap, clean_swap:
+            with modify_constants_swap, build_using_ng_swap:
+                with generate_python_package_swap, sync_angular_css_hashes_swap:
+                    build.main(args=['--prod_env'])
+
+        self.assertEqual(
+            call_order, ['build_using_ng', 'generate_python_package']
+        )
+
     def test_build_with_prod_source_maps(self) -> None:
         ensure_files_exist_swap = self.swap(
             build, '_ensure_files_exist', lambda _: None


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #[NA] or fixes part of #[fill_in_number_here].
2. This PR does the following: Ensure python package is generated after ng build. 
3. (For bug-fixing PRs only) The original bug occurred because: 
PR #26078 migrated the frontend build to Angular CLI and pointed its output to the build/ directory, which unintentionally shared the same destination folder as the generated Python package tarball. Because scripts/build.py was running generate_python_package() before build_using_ng(), Angular CLI’s default behavior of clearing the output folder before building was silently wiping out the Python package tarball immediately after it was created.


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
