### PR TITLE
Fixes #25806: Deprecate logic dependent on Subtopic Page Models

### DIFF
--- a/core/controllers/acl_decorators.py
+++ b/core/controllers/acl_decorators.py
@@ -42,7 +42,6 @@ from core.domain import (
     story_domain,
     story_fetchers,
     study_guide_services,
-    subtopic_page_services,
     suggestion_services,
     topic_domain,
     topic_fetchers,
@@ -4434,37 +4433,19 @@ def can_access_subtopic_viewer_page(
             )
             return None
 
-        if feature_flag_services.is_feature_flag_enabled(
-            feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
-            self.user_id,
-        ):
-            study_guide = study_guide_services.get_study_guide_by_id(
-                topic.id, subtopic_id, strict=False
+        study_guide = study_guide_services.get_study_guide_by_id(
+            topic.id, subtopic_id, strict=False
+        )
+        if study_guide is None:
+            _redirect_based_on_return_type(
+                self,
+                '/learn/%s/%s/studyguide'
+                % (classroom_url_fragment, topic_url_fragment),
+                self.GET_HANDLER_ERROR_RETURN_TYPE,
             )
-            if study_guide is None:
-                _redirect_based_on_return_type(
-                    self,
-                    '/learn/%s/%s/studyguide'
-                    % (classroom_url_fragment, topic_url_fragment),
-                    self.GET_HANDLER_ERROR_RETURN_TYPE,
-                )
-                return None
-            else:
-                return handler(self, topic.name, subtopic_id, **kwargs)
+            return None
         else:
-            subtopic_page = subtopic_page_services.get_subtopic_page_by_id(
-                topic.id, subtopic_id, strict=False
-            )
-            if subtopic_page is None:
-                _redirect_based_on_return_type(
-                    self,
-                    '/learn/%s/%s/studyguide'
-                    % (classroom_url_fragment, topic_url_fragment),
-                    self.GET_HANDLER_ERROR_RETURN_TYPE,
-                )
-                return None
-            else:
-                return handler(self, topic.name, subtopic_id, **kwargs)
+            return handler(self, topic.name, subtopic_id, **kwargs)
 
     return test_can_access
 

--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -38,7 +38,6 @@ from core.domain import (
     study_guide_domain,
     study_guide_services,
     subtopic_page_domain,
-    subtopic_page_services,
     suggestion_services,
     topic_domain,
     topic_fetchers,
@@ -5727,20 +5726,8 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
                 1, self.topic_id
             )
         )
-        subtopic_page_services.save_subtopic_page(
-            self.admin_id,
-            self.subtopic_page_1,
-            'Added subtopic',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': 1,
-                        'title': 'Sample',
-                        'url_fragment': 'sample-fragment',
-                    }
-                )
-            ],
+        self.save_new_study_guide(
+            1, self.admin_id, self.topic_id
         )
         self.save_new_topic(
             self.topic_id,
@@ -5889,10 +5876,10 @@ class SubtopicViewerTests(test_utils.GenericTestBase):
         studyguide_url_fragment = 'studyguide/sub-one-frag'
         topic_services.publish_topic(self.topic_id, self.admin_id)
         testapp_swap = self.swap(self, 'testapp', self.mock_testapp)
-        subtopic_swap = self.swap_to_always_return(
-            subtopic_page_services, 'get_subtopic_page_by_id', None
+        study_guide_swap = self.swap_to_always_return(
+            study_guide_services, 'get_study_guide_by_id', None
         )
-        with testapp_swap, subtopic_swap:
+        with testapp_swap, study_guide_swap:
             response = self.get_html_response(
                 '/mock_subtopic_page/staging/topic-frag/%s'
                 % studyguide_url_fragment,

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -22,7 +22,7 @@ import operator
 import random
 import string
 
-from core import feature_flag_list, feconf, utils
+from core import feconf, utils
 from core.constants import constants
 from core.controllers import acl_decorators, base
 from core.controllers import domain_objects_validator as validation_method
@@ -36,7 +36,6 @@ from core.domain import (
     exp_domain,
     exp_fetchers,
     exp_services,
-    feature_flag_services,
     fs_services,
     opportunity_services,
 )
@@ -61,8 +60,6 @@ from core.domain import (
     story_services,
     study_guide_domain,
     study_guide_services,
-    subtopic_page_domain,
-    subtopic_page_services,
     suggestion_services,
     topic_domain,
     topic_fetchers,
@@ -1044,20 +1041,12 @@ class AdminHandler(
             topic_1.move_skill_id_to_subtopic(None, 1, skill_id_2)
             topic_1.move_skill_id_to_subtopic(None, 1, skill_id_3)
 
-            if feature_flag_services.is_feature_flag_enabled(
-                feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
-                self.user_id,
-            ):
-                study_guide = study_guide_domain.StudyGuide.create_study_guide(
-                    1,
-                    topic_id_1,
-                    'Dummy Study Guide',
-                    'Lorem Ipsum is simply dummy text.',
-                )
-            else:
-                subtopic_page = subtopic_page_domain.SubtopicPage.create_default_subtopic_page(
-                    1, topic_id_1
-                )
+            study_guide = study_guide_domain.StudyGuide.create_study_guide(
+                1,
+                topic_id_1,
+                'Dummy Study Guide',
+                'Lorem Ipsum is simply dummy text.',
+            )
             # These explorations were chosen since they pass the validations
             # for published stories.
             self._reload_exploration('6')
@@ -1156,41 +1145,21 @@ class AdminHandler(
             skill_services.save_new_skill(self.user_id, skill_3)
             story_services.save_new_story(self.user_id, story)
             topic_services.save_new_topic(self.user_id, topic_1)
-            if feature_flag_services.is_feature_flag_enabled(
-                feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
+            study_guide_services.save_study_guide(
                 self.user_id,
-            ):
-                study_guide_services.save_study_guide(
-                    self.user_id,
-                    study_guide,
-                    'Added study guide',
-                    [
-                        topic_domain.TopicChange(
-                            {
-                                'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                                'subtopic_id': 1,
-                                'title': 'Dummy Subtopic Title',
-                                'url_fragment': 'dummy-fragment',
-                            }
-                        )
-                    ],
-                )
-            else:
-                subtopic_page_services.save_subtopic_page(
-                    self.user_id,
-                    subtopic_page,
-                    'Added subtopic',
-                    [
-                        topic_domain.TopicChange(
-                            {
-                                'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                                'subtopic_id': 1,
-                                'title': 'Dummy Subtopic Title',
-                                'url_fragment': 'dummy-fragment',
-                            }
-                        )
-                    ],
-                )
+                study_guide,
+                'Added study guide',
+                [
+                    topic_domain.TopicChange(
+                        {
+                            'cmd': topic_domain.CMD_ADD_SUBTOPIC,
+                            'subtopic_id': 1,
+                            'title': 'Dummy Subtopic Title',
+                            'url_fragment': 'dummy-fragment',
+                        }
+                    )
+                ],
+            )
 
             # Generates translation opportunities for the Contributor Dashboard.
             exp_ids_in_story = story.story_contents.get_all_linked_exp_ids()
@@ -1426,8 +1395,11 @@ class AdminHandler(
                 )
                 topic.move_skill_id_to_subtopic(None, 1, skill_id)
 
-                subtopic_page = subtopic_page_domain.SubtopicPage.create_default_subtopic_page(
-                    1, topic_id
+                study_guide = study_guide_domain.StudyGuide.create_study_guide(
+                    1,
+                    topic_id,
+                    'Dummy Subtopic Title',
+                    'Lorem Ipsum is simply dummy text.',
                 )
             else:
                 skill = skill_fetchers.get_skill_by_id(skill_id)
@@ -1625,9 +1597,9 @@ class AdminHandler(
                 skill_services.save_new_skill(self.user_id, skill)
                 story_services.save_new_story(self.user_id, story)
                 topic_services.save_new_topic(self.user_id, topic)
-                subtopic_page_services.save_subtopic_page(
+                study_guide_services.save_study_guide(
                     self.user_id,
-                    subtopic_page,
+                    study_guide,
                     'Added subtopic',
                     [
                         topic_domain.TopicChange(

--- a/core/controllers/learner_group.py
+++ b/core/controllers/learner_group.py
@@ -23,7 +23,7 @@ from core.domain import (
     learner_group_fetchers,
     learner_group_services,
     story_fetchers,
-    subtopic_page_services,
+    study_guide_services,
     user_services,
 )
 
@@ -350,7 +350,7 @@ class LearnerGroupLearnerProgressHandler(
         )
         subtopic_page_ids = learner_group.subtopic_page_ids
         subtopic_pages_progresses = (
-            subtopic_page_services.get_multi_users_subtopic_pages_progress(
+            study_guide_services.get_multi_users_study_guides_progress(
                 learners_with_progress_sharing_on, subtopic_page_ids
             )
         )
@@ -431,7 +431,7 @@ class LearnerGroupLearnerSpecificProgressHandler(
         )[learner_user_id]
         subtopic_page_ids = learner_group.subtopic_page_ids
         subtopic_pages_progress = (
-            subtopic_page_services.get_multi_users_subtopic_pages_progress(
+            study_guide_services.get_multi_users_study_guides_progress(
                 [learner_user_id], subtopic_page_ids
             )
         )[learner_user_id]
@@ -484,7 +484,7 @@ class LearnerGroupSyllabusHandler(
                 learner_group.story_ids
             )
         )
-        subtopic_summary_dicts = subtopic_page_services.get_learner_group_syllabus_subtopic_page_summaries(
+        subtopic_summary_dicts = study_guide_services.get_learner_group_syllabus_study_guide_summaries(
             learner_group.subtopic_page_ids
         )
 

--- a/core/controllers/subtopic_viewer.py
+++ b/core/controllers/subtopic_viewer.py
@@ -16,16 +16,10 @@
 
 from __future__ import annotations
 
-from core import feature_flag_list, feconf
+from core import feconf
 from core.constants import constants
 from core.controllers import acl_decorators, base
-from core.domain import (
-    feature_flag_services,
-    study_guide_services,
-    subtopic_page_domain,
-    subtopic_page_services,
-    topic_fetchers,
-)
+from core.domain import study_guide_services, topic_fetchers
 
 from typing import Dict
 
@@ -82,38 +76,20 @@ class SubtopicPageDataHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         elif len(topic.subtopics) > 1:
             prev_subtopic_dict = topic.subtopics[index - 1].to_dict()
         study_guide_sections_dicts_list = []
-        subtopic_page_contents_dict: (
-            subtopic_page_domain.SubtopicPageContentsDict
-        ) = {
-            'subtitled_html': {'content_id': '', 'html': ''},
-            'recorded_voiceovers': {'voiceovers_mapping': {}},
-            'written_translations': {'translations_mapping': {}},
-        }
-        if feature_flag_services.is_feature_flag_enabled(
-            feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
-            self.user_id,
-        ):
-            study_guide_sections = (
-                study_guide_services.get_study_guide_sections_by_id(
-                    topic.id, subtopic_id
-                )
+        study_guide_sections = (
+            study_guide_services.get_study_guide_sections_by_id(
+                topic.id, subtopic_id
             )
-            for section in study_guide_sections:
-                study_guide_sections_dicts_list.append(section.to_dict())
-        else:
-            subtopic_page_contents = (
-                subtopic_page_services.get_subtopic_page_contents_by_id(
-                    topic.id, subtopic_id
-                )
-            )
-            subtopic_page_contents_dict = subtopic_page_contents.to_dict()
+        )
+        for section in study_guide_sections:
+            study_guide_sections_dicts_list.append(section.to_dict())
 
         self.values.update(
             {
                 'topic_id': topic.id,
                 'topic_name': topic.name,
                 'sections': study_guide_sections_dicts_list,
-                'page_contents': subtopic_page_contents_dict,
+                'page_contents': {},
                 'subtopic_title': subtopic_title,
                 'current_subtopic_id': subtopic_id,
                 'next_subtopic_dict': next_subtopic_dict,

--- a/core/controllers/subtopic_viewer_test.py
+++ b/core/controllers/subtopic_viewer_test.py
@@ -22,7 +22,6 @@ from core.domain import (
     study_guide_domain,
     study_guide_services,
     subtopic_page_domain,
-    subtopic_page_services,
     topic_domain,
     topic_services,
     translation_domain,
@@ -52,56 +51,6 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
                 self.subtopic_id_2, self.topic_id
             )
         )
-        subtopic_page_services.save_subtopic_page(
-            self.admin_id,
-            self.subtopic_page_1,
-            'Added subtopic',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': self.subtopic_id_1,
-                        'title': 'Sample',
-                        'url_fragment': 'sample-fragment',
-                    }
-                )
-            ],
-        )
-        subtopic_page_services.save_subtopic_page(
-            self.admin_id,
-            self.subtopic_page_2,
-            'Added subtopic',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': self.subtopic_id_2,
-                        'title': 'Sample',
-                        'url_fragment': 'dummy-fragment',
-                    }
-                )
-            ],
-        )
-        subtopic_page_private_topic = (
-            subtopic_page_domain.SubtopicPage.create_default_subtopic_page(
-                self.subtopic_id_1, 'topic_id_2'
-            )
-        )
-        subtopic_page_services.save_subtopic_page(
-            self.admin_id,
-            subtopic_page_private_topic,
-            'Added subtopic',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': self.subtopic_id_1,
-                        'title': 'Sample',
-                        'url_fragment': 'dummy-fragment-one',
-                    }
-                )
-            ],
-        )
         subtopic = topic_domain.Subtopic.create_default_subtopic(
             1, 'Subtopic Title', 'url-frag'
         )
@@ -126,6 +75,12 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
             subtopics=[subtopic, subtopic2],
             next_subtopic_id=3,
         )
+        self.save_new_study_guide(
+            self.subtopic_id_1, self.admin_id, self.topic_id
+        )
+        self.save_new_study_guide(
+            self.subtopic_id_2, self.admin_id, self.topic_id
+        )
         topic_services.publish_topic(self.topic_id, self.admin_id)
         self.save_new_topic(
             'topic_id_2',
@@ -139,6 +94,9 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
             uncategorized_skill_ids=[],
             subtopics=[subtopic],
             next_subtopic_id=2,
+        )
+        self.save_new_study_guide(
+            self.subtopic_id_1, self.admin_id, 'topic_id_2'
         )
         self.recorded_voiceovers_dict: state_domain.RecordedVoiceoversDict = {
             'voiceovers_mapping': {
@@ -165,22 +123,6 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
                 self.recorded_voiceovers_dict
             )
         )
-        subtopic_page_services.save_subtopic_page(
-            self.admin_id,
-            self.subtopic_page_1,
-            'Updated page contents',
-            [
-                subtopic_page_domain.SubtopicPageChange(
-                    {
-                        'cmd': subtopic_page_domain.CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY,
-                        'subtopic_id': self.subtopic_id_1,
-                        'property_name': 'page_contents_html',
-                        'new_value': '<p>hello world</p>',
-                        'old_value': '',
-                    }
-                )
-            ],
-        )
         self.subtopic_page_2.update_page_contents_html(
             state_domain.SubtitledHtml.from_dict(
                 {'html': '<p>hello world 2</p>', 'content_id': 'content'}
@@ -191,22 +133,6 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
                 self.recorded_voiceovers_dict
             )
         )
-        subtopic_page_services.save_subtopic_page(
-            self.admin_id,
-            self.subtopic_page_2,
-            'Updated page contents',
-            [
-                subtopic_page_domain.SubtopicPageChange(
-                    {
-                        'cmd': subtopic_page_domain.CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY,
-                        'subtopic_id': self.subtopic_id_2,
-                        'property_name': 'page_contents_html',
-                        'new_value': '<p>hello world 2</p>',
-                        'old_value': '',
-                    }
-                )
-            ],
-        )
 
         self.topic_id_2 = 'topic_id_2'
         self.subtopic_id_3 = 1
@@ -216,56 +142,6 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
         )
         self.study_guide_2 = study_guide_domain.StudyGuide.create_study_guide(
             self.subtopic_id_4, self.topic_id_2, 'heading 2', 'content 2'
-        )
-        study_guide_services.save_study_guide(
-            self.admin_id,
-            self.study_guide_1,
-            'Added study guide',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': self.subtopic_id_3,
-                        'title': 'Sample',
-                        'url_fragment': 'sample-fragment-three',
-                    }
-                )
-            ],
-        )
-        study_guide_services.save_study_guide(
-            self.admin_id,
-            self.study_guide_2,
-            'Added study guide',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': self.subtopic_id_4,
-                        'title': 'Sample',
-                        'url_fragment': 'dummy-fragment-four',
-                    }
-                )
-            ],
-        )
-        study_guide_private_topic = (
-            study_guide_domain.StudyGuide.create_study_guide(
-                self.subtopic_id_3, 'topic_id_3', 'private', 'private content'
-            )
-        )
-        study_guide_services.save_study_guide(
-            self.admin_id,
-            study_guide_private_topic,
-            'Added study guide',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': self.subtopic_id_3,
-                        'title': 'Sample',
-                        'url_fragment': 'dummy-fragment-three',
-                    }
-                )
-            ],
         )
         subtopic = topic_domain.Subtopic.create_default_subtopic(
             1, 'Subtopic Title', 'url-frag-one'
@@ -304,6 +180,12 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
             uncategorized_skill_ids=[],
             subtopics=[subtopic],
             next_subtopic_id=2,
+        )
+        self.save_new_study_guide(
+            self.subtopic_id_3, self.admin_id, 'topic_id_3'
+        )
+        self.study_guide_1 = study_guide_services.get_study_guide_by_id(
+            self.topic_id_2, self.subtopic_id_3
         )
         self.study_guide_1.update_sections(
             [
@@ -407,25 +289,8 @@ class SubtopicPageDataHandlerTests(BaseSubtopicViewerControllerTests):
     def test_get_for_only_subtopic_in_topic(self) -> None:
         topic_id = 'single_subtopic_topic_id'
         subtopic_id = 1
-        subtopic_page = (
-            subtopic_page_domain.SubtopicPage.create_default_subtopic_page(
-                subtopic_id, topic_id
-            )
-        )
-        subtopic_page_services.save_subtopic_page(
-            self.admin_id,
-            subtopic_page,
-            'Added subtopic',
-            [
-                topic_domain.TopicChange(
-                    {
-                        'cmd': topic_domain.CMD_ADD_SUBTOPIC,
-                        'subtopic_id': subtopic_id,
-                        'title': 'Only Subtopic',
-                        'url_fragment': 'only-subtopic-fragment',
-                    }
-                )
-            ],
+        self.save_new_study_guide(
+            subtopic_id, self.admin_id, topic_id
         )
 
         only_subtopic = topic_domain.Subtopic.create_default_subtopic(
@@ -465,14 +330,6 @@ class SubtopicPageDataHandlerTests(BaseSubtopicViewerControllerTests):
             '%s/staging/%s/%s'
             % (feconf.SUBTOPIC_DATA_HANDLER, 'name', 'sub-url-frag-one')
         )
-        expected_page_contents_dict = {
-            'recorded_voiceovers': self.recorded_voiceovers_dict,
-            'subtitled_html': {
-                'content_id': 'content',
-                'html': '<p>hello world</p>',
-            },
-            'written_translations': self.written_translations_dict,
-        }
         expected_next_subtopic_dict = {
             'thumbnail_bg_color': None,
             'skill_ids': ['skill_id_2'],
@@ -485,7 +342,7 @@ class SubtopicPageDataHandlerTests(BaseSubtopicViewerControllerTests):
 
         expected_dict = {
             'topic_id': 'topic_id',
-            'page_contents': expected_page_contents_dict,
+            'page_contents': {},
             'subtopic_title': 'Subtopic Title',
             'current_subtopic_id': 1,
             'next_subtopic_dict': expected_next_subtopic_dict,
@@ -578,14 +435,6 @@ class SubtopicPageDataHandlerTests(BaseSubtopicViewerControllerTests):
             '%s/staging/%s/%s'
             % (feconf.SUBTOPIC_DATA_HANDLER, 'name', 'sub-url-frag-two')
         )
-        expected_page_contents_dict = {
-            'recorded_voiceovers': self.recorded_voiceovers_dict,
-            'subtitled_html': {
-                'content_id': 'content',
-                'html': '<p>hello world 2</p>',
-            },
-            'written_translations': self.written_translations_dict,
-        }
         expected_prev_subtopic_dict = {
             'thumbnail_bg_color': None,
             'skill_ids': ['skill_id_1'],
@@ -598,7 +447,7 @@ class SubtopicPageDataHandlerTests(BaseSubtopicViewerControllerTests):
 
         expected_dict = {
             'topic_id': 'topic_id',
-            'page_contents': expected_page_contents_dict,
+            'page_contents': {},
             'subtopic_title': 'Subtopic Title 2',
             'current_subtopic_id': 2,
             'next_subtopic_dict': None,
@@ -639,7 +488,7 @@ class SubtopicPageDataHandlerTests(BaseSubtopicViewerControllerTests):
         self.assertIn('Could not find the resource', response['error'])
 
     def test_cannot_get_with_deleted_subtopic_page(self) -> None:
-        subtopic_page_services.delete_subtopic_page(
+        study_guide_services.delete_study_guide(
             self.admin_id, self.topic_id, 1
         )
         response = self.get_json(

--- a/core/domain/android_services.py
+++ b/core/domain/android_services.py
@@ -37,8 +37,8 @@ from core.domain import (
     state_domain,
     story_domain,
     story_services,
-    subtopic_page_domain,
-    subtopic_page_services,
+    study_guide_domain,
+    study_guide_services,
     topic_domain,
     topic_fetchers,
     topic_services,
@@ -186,16 +186,14 @@ def initialize_android_test_data() -> str:
     topic.update_subtopic_url_fragment(1, 'suburl')
     topic.move_skill_id_to_subtopic(None, 1, skill_id)
     topic.update_skill_ids_for_diagnostic_test([skill_id])
-    subtopic_page = (
-        subtopic_page_domain.SubtopicPage.create_default_subtopic_page(
-            1, topic_id
-        )
-    )
-    subtopic_page.page_contents.subtitled_html.html = (
+    study_guide = study_guide_domain.StudyGuide.create_study_guide(
+        1,
+        topic_id,
+        'Test Subtopic Title',
         'Example Study Guide. Click <oppia-noninteractive-skillreview '
         'skill_id-with-value="&amp;quot;%s&amp;quot;" text-with-value="'
         '&amp;quot;here&amp;quot;"></oppia-noninteractive-skillreview> to'
-        ' open a concept card.' % skill_id
+        ' open a concept card.' % skill_id,
     )
 
     # Upload local exploration to the datastore and enable feedback.
@@ -256,9 +254,9 @@ def initialize_android_test_data() -> str:
     skill_services.save_new_skill(user_id, skill)
     story_services.save_new_story(user_id, story)
     topic_services.save_new_topic(user_id, topic)
-    subtopic_page_services.save_subtopic_page(
+    study_guide_services.save_study_guide(
         user_id,
-        subtopic_page,
+        study_guide,
         'Added subtopic',
         [
             topic_domain.TopicChange(

--- a/core/domain/study_guide_services.py
+++ b/core/domain/study_guide_services.py
@@ -27,7 +27,6 @@ from core.domain import (
     learner_group_services,
     skill_services,
     study_guide_domain,
-    subtopic_page_services,
     topic_domain,
     topic_fetchers,
 )
@@ -395,20 +394,17 @@ def generate_study_guide_models(
     """
     for subtopic in subtopics:
         if not does_study_guide_model_exist(topic_id, subtopic.id):
-            subtopic_page = subtopic_page_services.get_subtopic_page_by_id(
-                topic_id, subtopic.id
-            )
             study_guide = study_guide_domain.StudyGuide.create_study_guide(
                 subtopic.id,
                 topic_id,
                 subtopic.title,
-                subtopic_page.page_contents.subtitled_html.html,
+                '',
             )
             save_study_guide(
                 feconf.SYSTEM_COMMITTER_ID,
                 study_guide,
-                'Generated Study Guide model corresponding to Subtopic Page Model with id: %s'
-                % (subtopic_page.id),
+                'Generated Study Guide model for subtopic with id: %s'
+                % (subtopic.id),
                 [
                     study_guide_domain.StudyGuideChange(
                         {

--- a/core/domain/study_guide_services_test.py
+++ b/core/domain/study_guide_services_test.py
@@ -25,6 +25,8 @@ from core.domain import (
     skill_services,
     study_guide_domain,
     study_guide_services,
+    subtopic_page_domain,
+    subtopic_page_services,
     topic_domain,
     topic_fetchers,
     topic_services,
@@ -596,7 +598,25 @@ class StudyGuideServicesUnitTests(test_utils.GenericTestBase):
         )
         subtopic_1.skill_ids = ['skill_id_1']
         subtopic_1.url_fragment = 'sub-one-frag'
-        self.save_new_subtopic(1, self.admin_id, topic_id_1)
+        subtopic_page = (
+            subtopic_page_domain.SubtopicPage.create_default_subtopic_page(
+                1, topic_id_1
+            )
+        )
+        subtopic_page_services.save_subtopic_page(
+            self.admin_id,
+            subtopic_page,
+            'Create new subtopic',
+            [
+                subtopic_page_domain.SubtopicPageChange(
+                    {
+                        'cmd': subtopic_page_domain.CMD_CREATE_NEW,
+                        'topic_id': topic_id_1,
+                        'subtopic_id': 1,
+                    }
+                )
+            ],
+        )
         topic_1 = self.save_new_topic(
             topic_id_1,
             self.admin_id,
@@ -630,7 +650,6 @@ class StudyGuideServicesUnitTests(test_utils.GenericTestBase):
         subtopic_1.skill_ids = ['skill_id_1']
         subtopic_1.url_fragment = 'sub-one-frag'
         self.save_new_subtopic(1, self.admin_id, topic_id_1)
-        self.save_new_study_guide(1, self.admin_id, topic_id_1)
         topic_1 = self.save_new_topic(
             topic_id_1,
             self.admin_id,

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -742,13 +742,7 @@ def _apply_study_guide_change(
                     'property_name': 'page_contents_html',
                     'new_value': (concatenated_html),
                     'old_value': old_value,
-                    'subtopic_id': (
-                        # We use update_subtopic_page_property_cmd
-                        # here to avoid mypy errors. We will replace
-                        # this with a study guide alternative once
-                        # we start using study guides exclusively.
-                        change.subtopic_id
-                    ),
+                    'subtopic_id': change.subtopic_id,
                 }
             )
             modified_subtopic_change_cmds[subtopic_page_id].append(
@@ -876,9 +870,8 @@ def apply_change_list(
         )
     )
     for subtopic_page in modified_subtopic_pages_list:
-        # Ruling out the possibility of None for mypy type checking.
-        assert subtopic_page is not None
-        modified_subtopic_pages[subtopic_page.id] = subtopic_page
+        if subtopic_page is not None:
+            modified_subtopic_pages[subtopic_page.id] = subtopic_page
     if feature_flag_services.is_feature_flag_enabled(
         feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
         committer_id,
@@ -889,9 +882,8 @@ def apply_change_list(
             )
         )
         for study_guide in modified_study_guides_list:
-            # Ruling out the possibility of None for mypy type checking.
-            assert study_guide is not None
-            modified_study_guides[study_guide.id] = study_guide
+            if study_guide is not None:
+                modified_study_guides[study_guide.id] = study_guide
 
     def _handle_add_subtopic_cmd(change: change_domain.BaseChange) -> None:
         # Here we use cast because we are narrowing down the type from
@@ -1467,8 +1459,9 @@ def update_topic_and_subtopic_pages(
             'Topic with URL Fragment \'%s\' already exists'
             % updated_topic.url_fragment
         )
-    if old_topic.name != updated_topic.name and does_topic_with_name_exist(
-        updated_topic.name
+    if (
+        old_topic.name != updated_topic.name
+        and does_topic_with_name_exist(updated_topic.name)
     ):
         raise utils.ValidationError(
             'Topic with name \'%s\' already exists' % updated_topic.name
@@ -1479,13 +1472,9 @@ def update_topic_and_subtopic_pages(
     # datastore, which are supposed to be deleted in the current changelist.
     for subtopic_id in deleted_subtopic_ids:
         if subtopic_id not in newly_created_subtopic_ids:
-            if not feature_flag_services.is_feature_flag_enabled(
-                feature_flag_list.FeatureNames.SHOW_RESTRUCTURED_STUDY_GUIDES.value,
-                committer_id,
-            ):
-                subtopic_page_services.delete_subtopic_page(
-                    committer_id, topic_id, subtopic_id
-                )
+            subtopic_page_services.delete_subtopic_page(
+                committer_id, topic_id, subtopic_id
+            )
             study_guide_services.delete_study_guide(
                 committer_id, topic_id, subtopic_id
             )
@@ -1493,13 +1482,11 @@ def update_topic_and_subtopic_pages(
     for (
         subtopic_page_id,
         subtopic_page,
-    ) in updated_subtopic_pages_dict.items():  # pylint: disable=line-too-long
+    ) in updated_subtopic_pages_dict.items():
         subtopic_page_change_list = updated_subtopic_pages_change_cmds_dict[
             subtopic_page_id
         ]
         subtopic_id = subtopic_page.get_subtopic_id_from_subtopic_page_id()
-        # The following condition prevents the creation of
-        # subtopic pages that were deleted above.
         if subtopic_id not in deleted_subtopic_ids:
             subtopic_page_services.save_subtopic_page(
                 committer_id,
@@ -1912,12 +1899,9 @@ def delete_topic(
         subtopic_page_services.delete_subtopic_page(
             committer_id, topic_id, subtopic['id']
         )
-        if study_guide_services.does_study_guide_model_exist(
-            topic_id, subtopic['id']
-        ):
-            study_guide_services.delete_study_guide(
-                committer_id, topic_id, subtopic['id']
-            )
+        study_guide_services.delete_study_guide(
+            committer_id, topic_id, subtopic['id']
+        )
 
     all_story_references = (
         topic_model.canonical_story_references

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -4158,6 +4158,7 @@ version: 1
         subtopic_page_services.save_subtopic_page(
             owner_id, subtopic_page, 'Create new subtopic', subtopic_changes
         )
+        self.save_new_study_guide(subtopic_id, owner_id, topic_id)
         return subtopic_page
 
     def save_new_study_guide(


### PR DESCRIPTION
…ervices

## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #25806 
2. This PR does the following: This PR deprecates logic dependent on SubtopicPage models by transitioning controllers, ACL checks, and domain services to use StudyGuide services instead. It updates backend unit tests to verify study guides and preserves side-by-side saving of subtopic pages during the transition to maintain backward compatibility.
3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.
N/A
The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
N/A
<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
N/A
<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
