### PR TITLE
Fix part of #24715: Migrate release-coordinator acceptance tests from Puppeteer to Playwright

### DIFF
--- a/core/tests/ci-test-suite-configs/acceptance.json
+++ b/core/tests/ci-test-suite-configs/acceptance.json
@@ -657,23 +657,23 @@
     },
     {
       "name": "release-coordinator/enable-feature-flag",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/enable-feature-flag.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/release-coordinator/enable-feature-flag.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "release-coordinator/enable-the-promo-bar",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/enable-the-promo-bar.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/release-coordinator/enable-the-promo-bar.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "release-coordinator/flush-the-memory-cache",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/flush-the-memory-cache.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/release-coordinator/flush-the-memory-cache.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "super-admin/edit-platform-parameter",

--- a/core/tests/playwright-acceptance-tests/specs/release-coordinator/enable-feature-flag.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/release-coordinator/enable-feature-flag.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The Oppia Authors. All Rights Reserved.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,24 +19,29 @@
  * RC.RD Enable feature flag.
  */
 
+import {test} from '@playwright/test';
 import testConstants from '../../utilities/common/test-constants';
 import {UserFactory} from '../../utilities/common/user-factory';
 import {ReleaseCoordinator} from '../../utilities/user/release-coordinator';
 
 const dummyFeatureFlagName = 'dummy_feature_flag_for_e2e_tests';
 
-describe('Release Coordinator', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Release Coordinator', function () {
   let releaseCoordinator: ReleaseCoordinator;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
+    test.setTimeout(900000);
     releaseCoordinator = await UserFactory.createNewUser(
       'releaseCoordinator',
       'releaseCoordinator@example.com',
+      browser,
       [testConstants.Roles.RELEASE_COORDINATOR]
     );
   });
 
-  it('should be able to view feature flags', async function () {
+  test('should be able to view feature flags', async function () {
     await releaseCoordinator.navigateToReleaseCoordinatorPage();
     await releaseCoordinator.navigateToFeaturesTab();
     await releaseCoordinator.expectFeatureFlagToBePresent(dummyFeatureFlagName);
@@ -51,8 +56,7 @@ describe('Release Coordinator', function () {
     );
   });
 
-  it('should be able to force enable a feature flag', async function () {
-    // Enable the feature flag.
+  test('should be able to force enable a feature flag', async function () {
     await releaseCoordinator.enableFeatureFlag(dummyFeatureFlagName);
     await releaseCoordinator.expectFeatureFlagForcedEnabledStatusToBe(
       dummyFeatureFlagName,
@@ -62,8 +66,8 @@ describe('Release Coordinator', function () {
       dummyFeatureFlagName,
       'disabled'
     );
-    // Verify that data is persisted on reload.
-    await releaseCoordinator.page.reload();
+
+    await releaseCoordinator.reloadPage();
     await releaseCoordinator.navigateToFeaturesTab();
     await releaseCoordinator.expectFeatureFlagForcedEnabledStatusToBe(
       dummyFeatureFlagName,
@@ -76,7 +80,7 @@ describe('Release Coordinator', function () {
     await releaseCoordinator.verifyDummyHandlerStatusInFeaturesTab(true);
   });
 
-  it('should be able to remove force-enabling of feature flag', async function () {
+  test('should be able to remove force-enabling of feature flag', async function () {
     await releaseCoordinator.enableFeatureFlag(dummyFeatureFlagName, false);
     await releaseCoordinator.expectFeatureFlagForcedEnabledStatusToBe(
       dummyFeatureFlagName,
@@ -88,8 +92,7 @@ describe('Release Coordinator', function () {
       0
     );
 
-    // Verify that data is persisted on reload.
-    await releaseCoordinator.page.reload();
+    await releaseCoordinator.reloadPage();
     await releaseCoordinator.navigateToFeaturesTab();
     await releaseCoordinator.expectFeatureFlagForcedEnabledStatusToBe(
       dummyFeatureFlagName,
@@ -101,12 +104,10 @@ describe('Release Coordinator', function () {
       0
     );
 
-    // Verify that dummy handler tag is removed.
     await releaseCoordinator.verifyDummyHandlerStatusInFeaturesTab(false);
   });
 
-  it('should be able to set a percentage rollout', async function () {
-    // Set a rollout percentage.
+  test('should be able to set a percentage rollout', async function () {
     await releaseCoordinator.editFeatureRolloutPercentage(
       dummyFeatureFlagName,
       50
@@ -121,8 +122,7 @@ describe('Release Coordinator', function () {
       50
     );
 
-    // Check that data is persisted on reload.
-    await releaseCoordinator.page.reload();
+    await releaseCoordinator.reloadPage();
     await releaseCoordinator.navigateToFeaturesTab();
     await releaseCoordinator.expectFeatureFlagForcedEnabledStatusToBe(
       dummyFeatureFlagName,
@@ -134,7 +134,6 @@ describe('Release Coordinator', function () {
       50
     );
 
-    // Reset the rollout percentage.
     await releaseCoordinator.editFeatureRolloutPercentage(
       dummyFeatureFlagName,
       0
@@ -150,32 +149,24 @@ describe('Release Coordinator', function () {
     );
   });
 
-  it('should be able to set rollout to a user group', async function () {
+  test('should be able to set rollout to a user group', async function () {
     await releaseCoordinator.navigateToMiscTab();
     await releaseCoordinator.addUserGroup('group1');
-    // TODO(#23330): Currently, adding a user to user group is not working.
-    // Once fixed, add a part to add user 'anotherUser' to user group 'group1'.
-    // Also, try adding the user again to the same user group. It should throw an error.
-    // Also, try using an invalid username. It should throw an error.
-
-    // Try to create a duplicate user group.
     await releaseCoordinator.addUserGroup('group1');
     await releaseCoordinator.expectUserGroupCreationErrorToBe(
       "The user group 'group1' already exists."
     );
 
-    // Create another user group.
     await releaseCoordinator.addUserGroup('group2');
     await releaseCoordinator.expectUserGroupToBePresent('group1');
     await releaseCoordinator.expectUserGroupToBePresent('group2');
 
-    // Remove the user group 'group2'.
     await releaseCoordinator.removeUserGroup('group2');
     await releaseCoordinator.expectUserGroupToBePresent('group1');
     await releaseCoordinator.expectUserGroupToBePresent('group2', false);
   });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/specs/release-coordinator/enable-the-promo-bar.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/release-coordinator/enable-the-promo-bar.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The Oppia Authors. All Rights Reserved.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,53 +19,52 @@
  * RC.PB Enable the promo bar.
  */
 
+import {test} from '@playwright/test';
 import testConstants from '../../utilities/common/test-constants';
 import {UserFactory} from '../../utilities/common/user-factory';
-import {LoggedOutUser} from '../../utilities/user/logged-out-user';
 import {ReleaseCoordinator} from '../../utilities/user/release-coordinator';
+import {LoggedOutUser} from '../../utilities/user/logged-out-user';
 
-describe('Release Coordinator', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Release Coordinator', function () {
   let releaseCoordinator: ReleaseCoordinator & LoggedOutUser;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
+    test.setTimeout(900000);
     releaseCoordinator = await UserFactory.createNewUser(
       'releaseCoordinator',
       'releaseCoordinator@example.com',
+      browser,
       [testConstants.Roles.RELEASE_COORDINATOR]
     );
   });
 
-  it('should be able to enable the promo bar', async function () {
+  test('should be able to enable the promo bar', async function () {
     await releaseCoordinator.navigateToCommunityLibraryPage();
     await releaseCoordinator.expectPromoBarToBeVisible(false);
 
-    // Enable the promo bar.
     await releaseCoordinator.navigateToReleaseCoordinatorPage();
     await releaseCoordinator.navigateToMiscTab();
     await releaseCoordinator.enterPromoBarMessage('testing');
     await releaseCoordinator.togglePromoBar();
     await releaseCoordinator.savePromoBarMessage();
-    await releaseCoordinator.expectActionStatusMessageToBe('Success!');
 
-    // Verify that the promo bar is visible.
     await releaseCoordinator.navigateToCommunityLibraryPage();
     await releaseCoordinator.expectPromoBarToBeVisible(true, 'testing');
   });
 
-  it('should be able to disable the promo bar', async function () {
-    // Disable the promo bar.
+  test('should be able to disable the promo bar', async function () {
     await releaseCoordinator.navigateToReleaseCoordinatorPage();
     await releaseCoordinator.navigateToMiscTab();
     await releaseCoordinator.togglePromoBar('disabled');
     await releaseCoordinator.savePromoBarMessage();
-    await releaseCoordinator.expectActionStatusMessageToBe('Success!');
 
-    // Verify that the promo bar is not visible.
     await releaseCoordinator.navigateToCommunityLibraryPage();
     await releaseCoordinator.expectPromoBarToBeVisible(false);
   });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/specs/release-coordinator/flush-the-memory-cache.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/release-coordinator/flush-the-memory-cache.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The Oppia Authors. All Rights Reserved.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,41 +19,42 @@
  * RC.MC Flush the memory cache.
  */
 
+import {test} from '@playwright/test';
 import testConstants from '../../utilities/common/test-constants';
 import {UserFactory} from '../../utilities/common/user-factory';
 import {ReleaseCoordinator} from '../../utilities/user/release-coordinator';
 
-describe('Release Coordinator', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Release Coordinator', function () {
   let releaseCoordinator: ReleaseCoordinator;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
+    test.setTimeout(900000);
     releaseCoordinator = await UserFactory.createNewUser(
       'releaseCoordinator',
       'releaseCoordinator@example.com',
+      browser,
       [testConstants.Roles.RELEASE_COORDINATOR]
     );
   });
 
-  it('should be able to flush the memory cache', async function () {
+  test('should be able to flush the memory cache', async function () {
     await releaseCoordinator.navigateToReleaseCoordinatorPage();
     await releaseCoordinator.navigateToMiscTab();
     await releaseCoordinator.getMemoryCacheProfile();
-    await releaseCoordinator.expectTotalKeysStoredToBeInRange(undefined, 10); // Min value is 10.
-
-    // Flush the cache.
-    await releaseCoordinator.flushCache();
-    await releaseCoordinator.expectSuccessMessage(
-      'Success! Memory Cache Flushed.'
+    await releaseCoordinator.expectTotalKeysStoredToBeInRange(
+      undefined,
+      10
     );
 
-    // Check memory cache profile again.
+    await releaseCoordinator.flushCache();
+
     await releaseCoordinator.getMemoryCacheProfile();
-    // TODO(#23307): Currently, the total keys stored is not updated after flushing the cache.
-    // Once fixed, reduct the max value in the below check to 5 from 100.
-    await releaseCoordinator.expectTotalKeysStoredToBeInRange(100, undefined); // Max value is 5.
+    await releaseCoordinator.expectTotalKeysStoredToBeInRange(100, undefined);
   });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/specs/release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/release-coordinator/navigate-to-the-release-coordinator-page-beam-jobs-tab.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The Oppia Authors. All Rights Reserved.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  * RC.BJ Navigate to the release coordinator page, Beam Jobs tab.
  */
 
+import {test} from '@playwright/test';
 import testConstants from '../../utilities/common/test-constants';
 import {UserFactory} from '../../utilities/common/user-factory';
 import {ReleaseCoordinator} from '../../utilities/user/release-coordinator';
@@ -29,53 +30,48 @@ const DUMMY_PASS_BEAM_JOB_OUTPUT = 'SUCCESS: Dummy job completed successfully';
 const DUMMY_FAIL_BEAM_JOB_ERROR =
   'Exception: DummyFailJob intentionally failed.';
 
-describe('Release Coordinator', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Release Coordinator', function () {
   let releaseCoordinator: ReleaseCoordinator;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
+    test.setTimeout(900000);
     releaseCoordinator = await UserFactory.createNewUser(
       'releaseCoordinator',
       'releaseCoordinator@example.com',
+      browser,
       [testConstants.Roles.RELEASE_COORDINATOR]
     );
   });
 
-  it('should be able to visit release coordinator page', async function () {
+  test('should be able to visit release coordinator page', async function () {
     await releaseCoordinator.navigateToReleaseCoordinatorPage();
     await releaseCoordinator.expectScreenshotToMatch(
-      'releaseCoordinatorPage',
-      __dirname
+      'releaseCoordinatorPage'
     );
   });
 
-  it('should be able to run beam job (success)', async function () {
+  test('should be able to run beam job (success)', async function () {
     await releaseCoordinator.selectAndRunJob(DUMMY_PASS_BEAM_JOB);
-    // Beam jobs, take a while to run.
     await releaseCoordinator.waitForJobToComplete();
-    await releaseCoordinator.expectJobStatusToBeSuccessful(
-      1, // First job.
-      true // Successful.
-    );
+    await releaseCoordinator.expectJobStatusToBeSuccessful(1, true);
 
     await releaseCoordinator.viewAndCopyJobOutput();
-    // Check if the job output is as expected.
     await releaseCoordinator.expectJobOutputToBe(DUMMY_PASS_BEAM_JOB_OUTPUT);
   });
 
-  it('should be able to handle beam job (failure)', async function () {
+  test('should be able to handle beam job (failure)', async function () {
     await releaseCoordinator.closeOutputModal();
     await releaseCoordinator.selectAndRunJob(DUMMY_FAIL_BEAM_JOB);
     await releaseCoordinator.waitForJobToComplete();
-    await releaseCoordinator.expectJobStatusToBeSuccessful(
-      1, // Latest job of DummyFailJob.
-      false // Failure.
-    );
+    await releaseCoordinator.expectJobStatusToBeSuccessful(1, false);
 
     await releaseCoordinator.viewJobOutput();
     await releaseCoordinator.expectJobOutputToBe(DUMMY_FAIL_BEAM_JOB_ERROR);
   });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/utilities/user/logged-out-user.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/logged-out-user.ts
@@ -31,6 +31,7 @@ const homeUrl = testConstants.URLs.Home;
 const LABEL_FOR_SUBMIT_BUTTON = 'Submit and start contributing';
 const signUpUsernameInputField = 'input.e2e-test-username-input';
 
+const promoBarTextSelector = '.e2e-test-promo-bar-text';
 const mobileNavbarButtonSelector = '.text-uppercase';
 const navbarLearnTab = 'a.e2e-test-navbar-learn-menu';
 const languageDropdown = '.e2e-test-language-dropdown';
@@ -1764,6 +1765,25 @@ export class LoggedOutUser extends BaseUser {
 
     // While mouse is over pause button, the pause button doesn't change its state.
     await this.page.mouse.move(10, 10);
+  }
+
+  /**
+   * Checks if the promo bar is visible and if the promotion content is correct.
+   * @param {boolean} visible - Whether the promo bar should be visible or not.
+   * @param {string} promotionContent - The expected promotion content.
+   */
+  async expectPromoBarToBeVisible(
+    visible: boolean = true,
+    promotionContent?: string
+  ): Promise<void> {
+    await this.expectElementToBeVisible(promoBarTextSelector, visible);
+
+    if (visible && promotionContent) {
+      await this.expectTextContentToBe(
+        promoBarTextSelector,
+        promotionContent
+      );
+    }
   }
 }
 

--- a/core/tests/playwright-acceptance-tests/utilities/user/release-coordinator.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/release-coordinator.ts
@@ -16,27 +16,250 @@
  * @fileoverview Release coordinator users utility file.
  */
 
-import {Page} from '@playwright/test';
+import {ElementHandle, Page} from '@playwright/test';
 import {BaseUser} from '../common/playwright-utils';
 import testConstants from '../common/test-constants';
 import {showMessage} from '../common/show-message';
 
 // URLs.
 const releaseCoordinatorUrl = testConstants.URLs.ReleaseCoordinator;
+const splashUrl = testConstants.URLs.splash;
 
+// Selectors for buttons.
+const copyOutputButton = '.e2e-test-copy-output-button';
+const startNewJobButton = '.job-start-button';
+const startNewJobConfirmationButton = '.e2e-test-start-new-job-button';
+
+// Selectors for tabs.
 const featuresTab = '.e2e-test-features-tab';
 const mobileFeaturesTab = '.e2e-test-features-tab-mobile';
+const beamJobsTab = '.e2e-test-beam-jobs';
+const mobileBeamJobsTab = '.e2e-test-beam-jobs-mobile';
+const beamJobsTabContainerSelector = 'oppia-beam-jobs-tab';
 
 // Selectors for mobile navigation.
+const mobileMiscTab = '.e2e-test-misc-tab-mobile';
 const mobileNavBar = '.e2e-test-navbar-dropdown-toggle';
 
 // Selectors for feature flags.
 const saveButtonSelector = '.e2e-test-save-button';
 const featureFlagNameSelector = '.e2e-test-feature-name';
 const featureFlagDiv = '.e2e-test-feature-flag';
+const rolloutPercentageInputSelector = '.e2e-test-editor-int';
+const featureFlagSelector = '.e2e-test-feature-flag';
 const enableFeatureSelector = '.e2e-test-value-selector';
 
+// Selectors for jobs.
+const jobInputField = '.mat-input-element';
+const jobOutputRowSelector = '.mat-row';
+const beamJobRunOutputSelector = '.beam-job-run-output';
+
+const agDummyFeatureIndicator = '.e2e-test-angular-dummy-handler-indicator';
+
+const navbarElementSelector = '.oppia-clickable-navbar-element';
+const promoBarToggleSelector = '#mat-slide-toggle-1';
+const promoMessageInputSelector = '.mat-input-element';
+const actionStatusMessageSelector = '.e2e-test-status-message';
+const toastMessageSelector = '.toast-message';
+const memoryCacheProfileTableSelector = '.view-results-table';
+const getMemoryCacheProfileButton = '.e2e-test-get-memory-cache-profile';
+
+const miscTabContainerSelector =
+  '.e2e-test-release-coordiator-misc-tab-container';
+const promoBarSaveButtonSelector =
+  '.e2e-test-release-coordinator-promo-bar-button';
+const beamJobCloseOuputButtonSelector = '.e2e-test-close-beam-job-output';
+const addUserGroupContainerSelector = '.e2e-test-add-user-group-container';
+const userGroupItemSelector = '.e2e-test-user-group-item';
+const userGroupCreateErrorSelector = '.e2e-test-user-group-save-error';
+const removeUserGroupButtonSelector = '.e2e-test-remove-user-group-button';
+const beamJobsTableSelector = '.e2e-test-beam-jobs-table';
+const beamJobStatusSelectorPrefix = '.e2e-test-job-status-';
+
+const beamJobOutputDialogSelector = '.e2e-test-view-beam-job-output-dialog';
+
 export class ReleaseCoordinator extends BaseUser {
+  /**
+   * Navigate to the release coordinator page.
+   */
+  async navigateToReleaseCoordinatorPage(): Promise<void> {
+    await this.goto(releaseCoordinatorUrl);
+  }
+
+  /**
+   * Navigate to the features tab.
+   */
+  async navigateToFeaturesTab(): Promise<void> {
+    try {
+      if (this.isViewportAtMobileWidth()) {
+        await this.expectElementToBeVisible(mobileNavBar);
+        await this.clickOnElementWithSelector(mobileNavBar);
+        await this.clickOnElementWithSelector(mobileFeaturesTab);
+      } else {
+        await this.expectElementToBeVisible(featuresTab);
+        await this.clickOnElementWithSelector(featuresTab);
+      }
+
+      await this.page.waitForSelector(featureFlagSelector, {
+        state: 'visible',
+        timeout: 10000,
+      });
+      showMessage('Successfully navigated to features tab.');
+    } catch (error) {
+      console.error('Failed to navigate to features tab:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Navigates to the beam jobs tab.
+   */
+  async navigateToBeamJobsTab(): Promise<void> {
+    if (this.isViewportAtMobileWidth()) {
+      await this.expectElementToBeVisible(mobileNavBar);
+      await this.clickOnElementWithSelector(mobileNavBar);
+      await this.clickOnElementWithSelector(mobileBeamJobsTab);
+    } else {
+      await this.expectElementToBeVisible(beamJobsTab);
+      await this.clickOnElementWithSelector(beamJobsTab);
+    }
+
+    await this.expectElementToBeVisible(beamJobsTabContainerSelector);
+  }
+
+  /**
+   * Navigates to the Misc tab.
+   */
+  async navigateToMiscTab(): Promise<void> {
+    if (this.isViewportAtMobileWidth()) {
+      await this.clickOnElementWithSelector(mobileNavBar);
+      await this.page.waitForSelector(mobileMiscTab, {state: 'visible'});
+      await this.clickOnElementWithSelector(mobileMiscTab);
+    } else {
+      await this.page.waitForSelector(navbarElementSelector);
+      const navbarElements = await this.page.$$(navbarElementSelector);
+      await this.waitForElementToBeClickable(navbarElements[2]);
+      await navbarElements[2].click();
+    }
+
+    await this.expectElementToBeVisible(miscTabContainerSelector);
+  }
+
+  /**
+   * This function edits the rollout percentage for a specific feature flag.
+   * @param {string} featureName - The name of the feature flag to edit.
+   * @param {number} percentage - The rollout percentage to set for the feature flag.
+   */
+  async editFeatureRolloutPercentage(
+    featureName: string,
+    percentage: number
+  ): Promise<void> {
+    try {
+      await this.goto(releaseCoordinatorUrl);
+
+      if (this.isViewportAtMobileWidth()) {
+        await this.page.waitForSelector(mobileNavBar);
+        await this.clickOnElementWithSelector(mobileNavBar);
+        await this.page.waitForSelector(mobileFeaturesTab);
+        await this.clickOnElementWithSelector(mobileFeaturesTab);
+      } else {
+        await this.page.waitForSelector(featuresTab);
+        await this.clickOnElementWithSelector(featuresTab);
+      }
+
+      await this.page.waitForSelector(featureFlagDiv);
+      const featureFlags = await this.page.$$(featureFlagDiv);
+
+      for (let i = 0; i < featureFlags.length; i++) {
+        await featureFlags[i].waitForSelector(featureFlagNameSelector);
+        const featureFlagNameElement = await featureFlags[i].$(
+          featureFlagNameSelector
+        );
+        const featureFlagName = await this.page.evaluate(
+          (element: Element) => element.textContent?.trim(),
+          featureFlagNameElement as ElementHandle<Element>
+        );
+
+        if (featureFlagName === featureName) {
+          await featureFlags[i].waitForSelector(rolloutPercentageInputSelector);
+          const inputElement = await featureFlags[i].$(
+            rolloutPercentageInputSelector
+          );
+          if (inputElement) {
+            await inputElement.click({clickCount: 3});
+            await this.page.keyboard.press('Backspace');
+            await inputElement.type(percentage.toString());
+          } else {
+            throw new Error(
+              `Input field not found for feature flag: "${featureName}"`
+            );
+          }
+
+          await featureFlags[i].waitForSelector(saveButtonSelector);
+          const saveButton = await featureFlags[i].$(saveButtonSelector);
+          if (saveButton) {
+            await this.waitForElementToBeClickable(saveButton);
+            await saveButton.click();
+          } else {
+            throw new Error(
+              `Save button not found for feature flag: "${featureName}"`
+            );
+          }
+
+          await featureFlags[i].waitForSelector(
+            `${saveButtonSelector}[disabled]`,
+            {state: 'visible'}
+          );
+          showMessage(
+            `Feature flag: "${featureName}" rollout percentage has been set to ${percentage}%.`
+          );
+          return;
+        }
+      }
+
+      throw new Error(`Feature flag: "${featureName}" not found.`);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      console.error(
+        `Failed to edit feature flag: "${featureName}". Error: ${err.message}`
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * Checks if the force enabled status of a feature flag is as expected.
+   * @param {string} featureFlag - The name of the feature flag to expect.
+   * @param {boolean} forceEnabled - The expected force enabled status of the feature flag.
+   */
+  async expectFeatureFlagForcedEnabledStatusToBe(
+    featureFlag: string,
+    forceEnabled: boolean
+  ): Promise<void> {
+    const featureFlagDivElement = await this.expectFeatureFlagToBePresent(
+      featureFlag
+    );
+    const forceEnabledElement = await featureFlagDivElement.$(
+      enableFeatureSelector
+    );
+
+    if (!forceEnabledElement) {
+      throw new Error('Force enabled element not found.');
+    }
+
+    const forceEnabledSelectValue = await forceEnabledElement.evaluate(
+      (el: Element) => (el as HTMLSelectElement).value
+    );
+
+    if (forceEnabledSelectValue !== (forceEnabled ? '0: true' : '1: false')) {
+      throw new Error(
+        `Expected force enabled status to be "${
+          forceEnabled ? '0: true' : '1: false'
+        }", but got "${forceEnabledSelectValue}".`
+      );
+    }
+  }
+
   /**
    * This function enables a specific feature flag.
    * @param {string} featureName - The name of the feature flag to enable.
@@ -50,43 +273,55 @@ export class ReleaseCoordinator extends BaseUser {
       await this.goto(releaseCoordinatorUrl);
 
       if (this.isViewportAtMobileWidth()) {
-        await this.expectElementToBeVisible(mobileNavBar);
+        await this.page.waitForSelector(mobileNavBar);
         await this.clickOnElementWithSelector(mobileNavBar);
-        await this.expectElementToBeVisible(mobileFeaturesTab);
+        await this.page.waitForSelector(mobileFeaturesTab);
         await this.clickOnElementWithSelector(mobileFeaturesTab);
       } else {
-        await this.expectElementToBeVisible(featuresTab);
+        await this.page.waitForSelector(featuresTab);
         await this.clickOnElementWithSelector(featuresTab);
       }
 
-      await this.expectElementToBeVisible(featureFlagDiv);
+      await this.page.waitForSelector(featureFlagDiv);
       const featureFlags = await this.page.$$(featureFlagDiv);
 
       for (let i = 0; i < featureFlags.length; i++) {
-        const featureFlagNameElement = await this.getElementInParent(
-          featureFlagNameSelector,
-          featureFlags[i]
+        await featureFlags[i].waitForSelector(featureFlagNameSelector);
+        const featureFlagNameElement = await featureFlags[i].$(
+          featureFlagNameSelector
         );
         const featureFlagName = await this.page.evaluate(
-          element => element?.textContent?.trim() || '',
-          featureFlagNameElement
+          (element: Element) => element.textContent?.trim(),
+          featureFlagNameElement as ElementHandle<Element>
         );
 
         if (featureFlagName === featureName) {
-          const selectElement = await this.getElementInParent(
-            enableFeatureSelector,
-            featureFlags[i]
-          );
-          await selectElement.selectOption(enable ? '0: true' : '1: false');
+          await featureFlags[i].waitForSelector(enableFeatureSelector);
+          const selectElement = await featureFlags[i].$(enableFeatureSelector);
+          if (selectElement) {
+            await selectElement.selectOption(
+              enable ? '0: true' : '1: false'
+            );
+          } else {
+            throw new Error(
+              `Value selector not found for feature flag: "${featureName}"`
+            );
+          }
 
-          const saveButton = await this.getElementInParent(
-            saveButtonSelector,
-            featureFlags[i]
-          );
-          await this.clickOnElement(saveButton);
+          await featureFlags[i].waitForSelector(saveButtonSelector);
+          const saveButton = await featureFlags[i].$(saveButtonSelector);
+          if (saveButton) {
+            await this.waitForElementToBeClickable(saveButton);
+            await saveButton.click();
+          } else {
+            throw new Error(
+              `Save button not found for feature flag: "${featureName}"`
+            );
+          }
 
-          await this.expectElementToBeVisible(
-            `${saveButtonSelector}[disabled]`
+          await featureFlags[i].waitForSelector(
+            `${saveButtonSelector}[disabled]`,
+            {state: 'visible'}
           );
 
           showMessage(
@@ -105,8 +340,545 @@ export class ReleaseCoordinator extends BaseUser {
       throw err;
     }
   }
+
+  /**
+   * Enables or disables the promo bar.
+   * @param {'enabled' | 'disabled'} expectedState - The expected state of the promo bar.
+   */
+  async togglePromoBar(
+    expectedState: 'enabled' | 'disabled' = 'enabled'
+  ): Promise<void> {
+    await this.page.waitForSelector(promoBarToggleSelector);
+    await this.clickOnElementWithSelector(promoBarToggleSelector);
+
+    await this.page.waitForFunction(
+      ({selector, checked}: {selector: string; checked: boolean}) => {
+        const element = document.querySelector(selector);
+        return (element as HTMLInputElement)?.checked === checked;
+      },
+      {selector: `${promoBarToggleSelector} input`, checked: expectedState === 'enabled'}
+    );
+  }
+
+  /**
+   * Enters a message into the promo bar.
+   * @param {string} promoMessage - The message to enter into the promo bar.
+   */
+  async enterPromoBarMessage(promoMessage: string): Promise<void> {
+    await this.page.waitForSelector(promoMessageInputSelector);
+    await this.page.type(promoMessageInputSelector, promoMessage);
+
+    await this.expectElementToBeClickable(promoBarSaveButtonSelector);
+  }
+
+  /**
+   * Saves the promo bar message.
+   */
+  async savePromoBarMessage(): Promise<void> {
+    await this.clickOnElementWithText(' Save changes ');
+    await this.page.waitForSelector(actionStatusMessageSelector, {
+      state: 'visible',
+    });
+    await this.expectTextContentToBe(actionStatusMessageSelector, 'Success!');
+  }
+
+  /**
+   * Navigates to the splash page.
+   */
+  async navigateToSplash(): Promise<void> {
+    await this.goto(splashUrl);
+  }
+
+  /**
+   * Expects the promo message to be a certain value.
+   * @param {string} expectedMessage - The expected promo message.
+   */
+  async expectPromoMessageToBe(expectedMessage: string): Promise<void> {
+    await this.page.waitForSelector(toastMessageSelector, {state: 'visible'});
+    const actualMessage = await this.page.$eval(
+      toastMessageSelector,
+      el => el.textContent
+    );
+    if (actualMessage !== expectedMessage) {
+      throw new Error(
+        `Expected promo message to be "${expectedMessage}", but got "${actualMessage}".`
+      );
+    }
+    showMessage('Promo message is as expected.');
+  }
+
+  /**
+   * Clicks on the 'Flush Cache' button.
+   */
+  async flushCache(): Promise<void> {
+    await this.clickOnElementWithText('Flush Cache');
+    await this.expectActionStatusMessageToBe('Success! Memory Cache Flushed.');
+  }
+
+  /**
+   * Waits for a success message to appear and checks if it matches the expected message.
+   * @param {string} expectedMessage - The expected success message.
+   */
+  async expectSuccessMessage(expectedMessage: string): Promise<void> {
+    await this.page.waitForSelector(actionStatusMessageSelector, {
+      state: 'visible',
+    });
+    const actualMessage = await this.page.$eval(
+      actionStatusMessageSelector,
+      el => el.textContent?.trim()
+    );
+    if (actualMessage === expectedMessage.trim()) {
+      showMessage('Action was successful.');
+      return;
+    }
+    throw new Error(
+      `Action failed. Actual message: "${actualMessage}", expected message: "${expectedMessage}"`
+    );
+  }
+
+  /**
+   * Checks if the action status message is as expected.
+   * @param {string} statusMessage - The expected status message.
+   */
+  async expectActionStatusMessageToBe(statusMessage: string): Promise<void> {
+    await this.expectTextContentToContain(
+      actionStatusMessageSelector,
+      statusMessage
+    );
+  }
+
+  /**
+   * Clicks on the 'Get Memory Cache Profile' button and waits for the results table to appear.
+   */
+  async getMemoryCacheProfile(): Promise<void> {
+    await this.page.waitForSelector(getMemoryCacheProfileButton, {
+      state: 'visible',
+    });
+    await this.waitForStaticAssetsToLoad();
+    await this.page.evaluate((selector: string) => {
+      document.querySelector(selector)?.click();
+    }, getMemoryCacheProfileButton);
+    await this.page.waitForSelector(memoryCacheProfileTableSelector);
+  }
+
+  /**
+   * Checks if the memory cache profile has the expected properties.
+   * @param {string[]} expectedProperties - The properties that the memory cache profile is expected to have.
+   */
+  async expectCacheProfileToHaveProperties(
+    expectedProperties: string[]
+  ): Promise<void> {
+    await this.page.waitForSelector(memoryCacheProfileTableSelector, {
+      state: 'visible',
+    });
+
+    const memoryCacheProfile = await this.page.evaluate(() => {
+      const cells = Array.from(
+        document.querySelectorAll('.view-results-table tbody tr td')
+      );
+      const totalAllocatedInBytes = cells[0]?.textContent;
+      const peakAllocatedInBytes = cells[1]?.textContent;
+      const totalKeysStored = cells[2]?.textContent;
+
+      return {totalAllocatedInBytes, peakAllocatedInBytes, totalKeysStored};
+    });
+
+    for (const prop of expectedProperties) {
+      if (!(prop in memoryCacheProfile)) {
+        throw new Error(
+          `Expected memory cache profile to have property ${prop}`
+        );
+      }
+    }
+
+    if (
+      Object.values(memoryCacheProfile).some(
+        value => value === null || value === undefined
+      )
+    ) {
+      throw new Error(
+        'One or more properties of the memory cache profile are null or undefined'
+      );
+    }
+
+    showMessage('Memory cache profile has all expected properties.');
+  }
+
+  /**
+   * Checks if the 'totalKeysStored' property of the memory cache profile is less than a specified value.
+   * @param {number} maxValue - The value that 'totalKeysStored' is expected to be less than.
+   * @param {number} minValue - The value that 'totalKeysStored' is expected to be greater than.
+   */
+  async expectTotalKeysStoredToBeInRange(
+    maxValue?: number,
+    minValue?: number
+  ): Promise<void> {
+    await this.page.waitForSelector(memoryCacheProfileTableSelector, {
+      state: 'visible',
+    });
+
+    const totalKeysStored = await this.page.evaluate(() => {
+      const cells = Array.from(
+        document.querySelectorAll('.view-results-table tbody tr td')
+      );
+      const totalKeysStoredText = cells[2]?.textContent;
+      return totalKeysStoredText ? parseInt(totalKeysStoredText, 10) : null;
+    });
+
+    if (totalKeysStored === null) {
+      throw new Error('totalKeysStored is null');
+    }
+    if (maxValue !== undefined && totalKeysStored >= maxValue) {
+      throw new Error(
+        `Expected totalKeysStored to be less than ${maxValue}, but it was ${totalKeysStored}`
+      );
+    }
+    if (minValue !== undefined && totalKeysStored <= minValue) {
+      throw new Error(
+        `Expected totalKeysStored to be greater than ${minValue}, but it was ${totalKeysStored}`
+      );
+    }
+  }
+
+  /**
+   * Selects and runs a job.
+   * @param {string} jobName - The name of the job to run.
+   */
+  async selectAndRunJob(jobName: string): Promise<void> {
+    await this.expectElementToBeVisible(jobInputField);
+    await this.clearAllTextFrom(jobInputField);
+    await this.typeInInputField(jobInputField, jobName);
+    await this.page.keyboard.press('Enter');
+    await this.page.waitForSelector(startNewJobButton, {state: 'visible'});
+    await this.page.evaluate((selector: string) => {
+      const element = document.querySelector(selector) as HTMLElement;
+      element?.click();
+    }, startNewJobButton);
+    await this.page.waitForSelector(startNewJobConfirmationButton, {
+      state: 'visible',
+    });
+    await this.page.evaluate((selector: string) => {
+      const element = document.querySelector(selector) as HTMLElement;
+      element?.click();
+    }, startNewJobConfirmationButton);
+
+    await this.expectElementToBeClickable(startNewJobConfirmationButton, false);
+    showMessage('Job started');
+  }
+
+  /**
+   * Waits for a job to complete.
+   */
+  async waitForJobToComplete(): Promise<void> {
+    try {
+      await this.page.waitForSelector(jobOutputRowSelector, {
+        state: 'visible',
+      });
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw new Error(
+        `Job did not complete within the timeout: ${err.message}`
+      );
+    }
+    showMessage('Job completed');
+  }
+
+  /**
+   * Clicks on "View Output" of the latest beam job run.
+   */
+  async viewJobOutput(): Promise<void> {
+    await this.clickOnElementWithText('View Output');
+    await this.expectElementToBeVisible(beamJobOutputDialogSelector);
+  }
+
+  /**
+   * View and copy the output of a job.
+   */
+  async viewAndCopyJobOutput(): Promise<string> {
+    await this.viewJobOutput();
+    await this.page.waitForSelector(beamJobRunOutputSelector, {
+      state: 'visible',
+    });
+
+    const output = await this.page.$eval(
+      beamJobRunOutputSelector,
+      el => el.textContent
+    );
+
+    await this.clickOnElementWithSelector(copyOutputButton);
+
+    const clipboardData = await this.page.evaluate(async () => {
+      return await navigator.clipboard.readText();
+    });
+
+    if (clipboardData !== output) {
+      throw new Error(
+        'Data was not copied correctly\n' +
+          `Expected: "${output}"\n` +
+          `Actual: "${clipboardData}"`
+      );
+    }
+    showMessage('Data was copied correctly');
+
+    return output ?? '';
+  }
+
+  /**
+   * Expects the output of a job to be a certain value.
+   * @param {string} expectedOutput - The expected output of the job.
+   */
+  async expectJobOutputToBe(expectedOutput: string): Promise<void> {
+    await this.expectTextContentToContain(
+      beamJobRunOutputSelector,
+      expectedOutput
+    );
+  }
+
+  /**
+   * Closes the output modal by clicking on "Close" button.
+   */
+  async closeOutputModal(): Promise<void> {
+    await this.expectElementToBeVisible(beamJobCloseOuputButtonSelector);
+    await this.page.click(beamJobCloseOuputButtonSelector);
+    await this.expectElementToBeVisible(
+      beamJobCloseOuputButtonSelector,
+      false
+    );
+    showMessage('Output modal closed');
+  }
+
+  /**
+   * Expects the feature flag to be present in the features tab.
+   * @param {string} featureFlag - The name of the feature flag to expect.
+   */
+  async expectFeatureFlagToBePresent(
+    featureFlag: string
+  ): Promise<ElementHandle<Element>> {
+    await this.expectElementToBeVisible(featureFlagNameSelector);
+    const featureFlagNames = await this.page.$$eval(
+      featureFlagNameSelector,
+      elements => elements.map(element => element.textContent?.trim())
+    );
+    if (!featureFlagNames.includes(featureFlag)) {
+      throw new Error(
+        `Feature flag "${featureFlag}" not found in the list of feature flags.`
+      );
+    }
+
+    await this.expectElementToBeVisible(featureFlagDiv);
+    const featureFlagDivs = await this.page.$$(featureFlagDiv);
+    let featureFlagDivElement: ElementHandle<Element> | null = null;
+    for (const ffDiv of featureFlagDivs) {
+      const featureFlagDivElementText = await ffDiv.$eval(
+        featureFlagNameSelector,
+        (el: Element) => el.textContent?.trim()
+      );
+      if (featureFlagDivElementText === featureFlag) {
+        featureFlagDivElement = ffDiv;
+        break;
+      }
+    }
+
+    if (!featureFlagDivElement) {
+      throw new Error(`Feature flag "${featureFlag}" not found.`);
+    }
+
+    return featureFlagDivElement;
+  }
+
+  /**
+   * Checks if the rollout percentage input is enabled or disabled.
+   * @param {string} featureFlag - The name of the feature flag to expect.
+   * @param {'enabled' | 'disabled'} state - The expected state of the rollout percentage input.
+   * @param {number} value - The expected value of the rollout percentage input.
+   */
+  async expectRolloutPercentageInputToBe(
+    featureFlag: string,
+    state: 'enabled' | 'disabled',
+    value?: number
+  ): Promise<void> {
+    const featureFlagDivElement = await this.expectFeatureFlagToBePresent(
+      featureFlag
+    );
+    const rolloutPercentageInputElement = await featureFlagDivElement.$(
+      rolloutPercentageInputSelector
+    );
+    if (!rolloutPercentageInputElement) {
+      throw new Error('Rollout percentage input not found.');
+    }
+    await this.page.waitForFunction(
+      ({
+        selector,
+        disabled,
+      }: {
+        selector: string;
+        disabled: boolean;
+      }) => {
+        const element = document.querySelector(selector);
+        return (element as HTMLInputElement)?.disabled === disabled;
+      },
+      {selector: rolloutPercentageInputSelector, disabled: state === 'disabled'},
+      {timeout: 10000}
+    );
+
+    if (value !== undefined) {
+      const rolloutPercentageInputValue =
+        await rolloutPercentageInputElement.evaluate(
+          (el: Element) => (el as HTMLInputElement).value
+        );
+      if (rolloutPercentageInputValue !== value.toString()) {
+        throw new Error(
+          `Expected rollout percentage to be "${value}", but got "${rolloutPercentageInputValue}".`
+        );
+      }
+    }
+  }
+
+  /**
+   * Verifies the status of the Dummy Handler in the Features Tab.
+   * @param {boolean} enabled - Expected status of the Dummy Handler.
+   */
+  async verifyDummyHandlerStatusInFeaturesTab(enabled: boolean): Promise<void> {
+    await this.navigateToReleaseCoordinatorPage();
+    await this.navigateToFeaturesTab();
+
+    try {
+      await this.page.waitForSelector(agDummyFeatureIndicator, {
+        timeout: 5000,
+      });
+
+      if (!enabled) {
+        throw new Error(
+          'Dummy handler is expected to be disabled but it is enabled'
+        );
+      }
+    } catch (error) {
+      if (enabled) {
+        throw new Error(
+          'Dummy handler is expected to be enabled but it is disabled'
+        );
+      }
+    }
+
+    showMessage(
+      `Dummy handler is ${enabled ? 'enabled' : 'disabled'}, as expected`
+    );
+  }
+
+  /**
+   * Checks if the user group is present in the user groups list.
+   * @param {string} groupName - The name of the user group to check.
+   * @param {boolean} present - Whether the user group is expected to be present.
+   */
+  async expectUserGroupToBePresent(
+    groupName: string,
+    present: boolean = true
+  ): Promise<void> {
+    await this.page.waitForFunction(
+      ({
+        selector,
+        groupName,
+        present,
+      }: {
+        selector: string;
+        groupName: string;
+        present: boolean;
+      }) => {
+        const elements = document.querySelectorAll(selector);
+        return (
+          Array.from(elements).some(
+            element => element.textContent?.trim() === groupName
+          ) === present
+        );
+      },
+      {selector: userGroupItemSelector, groupName, present}
+    );
+  }
+
+  /**
+   * Adds a new user group with the given name.
+   * @param {string} groupName - The name of the user group to add.
+   */
+  async addUserGroup(groupName: string): Promise<void> {
+    const userGroupInputSelector = `${addUserGroupContainerSelector} input`;
+    const addNewUserGroupButtonSelector = `${addUserGroupContainerSelector} button`;
+
+    await this.expectElementToBeVisible(addUserGroupContainerSelector);
+    await this.clearAllTextFrom(userGroupInputSelector);
+    await this.typeInInputField(userGroupInputSelector, groupName);
+    await this.clickOnElementWithSelector(addNewUserGroupButtonSelector);
+
+    await this.expectUserGroupToBePresent(groupName);
+  }
+
+  /**
+   * Deletes the user group with the given name.
+   * @param {string} groupName - The name of the user group to delete.
+   */
+  async removeUserGroup(groupName: string): Promise<void> {
+    await this.expectElementToBeVisible(userGroupItemSelector);
+    const userGroupElements = await this.page.$$(userGroupItemSelector);
+    const userGroupNames = await this.page.$$eval(
+      userGroupItemSelector,
+      elements => elements.map(element => element.textContent?.trim())
+    );
+
+    const index = userGroupNames.indexOf(groupName);
+
+    if (index === -1) {
+      throw new Error(`User group "${groupName}" not found.`);
+    }
+
+    const userGroupElement = userGroupElements[index];
+    if (!userGroupElement) {
+      throw new Error(`User group "${groupName}" not found.`);
+    }
+    await userGroupElement.click();
+    const removeUserGroupBtn = await userGroupElement.$(
+      removeUserGroupButtonSelector
+    );
+    if (!removeUserGroupBtn) {
+      throw new Error('Remove user group button not found.');
+    }
+    await removeUserGroupBtn.click();
+
+    await this.expectUserGroupToBePresent(groupName, false);
+  }
+
+  /**
+   * Checks if the user group creation error is present.
+   * @param {string} errorMessage - The expected error message.
+   */
+  async expectUserGroupCreationErrorToBe(errorMessage: string): Promise<void> {
+    await this.expectTextContentToContain(
+      userGroupCreateErrorSelector,
+      errorMessage
+    );
+  }
+
+  /**
+   * Checks if the job status is as expected.
+   * @param {number} rowIndex - The 1-based index of the row to check.
+   * @param {boolean} expectedStatus - The expected status of the job.
+   */
+  async expectJobStatusToBeSuccessful(
+    rowIndex: number,
+    expectedStatus: boolean
+  ): Promise<void> {
+    const beamJobRowSelector = `${beamJobsTableSelector} tbody tr:nth-child(${rowIndex})`;
+    const rowElement = await this.page.waitForSelector(beamJobRowSelector);
+    if (!rowElement) {
+      throw new Error('Row element not found');
+    }
+
+    const statusSelector =
+      expectedStatus === true
+        ? beamJobStatusSelectorPrefix + 'success'
+        : beamJobStatusSelectorPrefix + 'failure';
+
+    await rowElement.waitForSelector(statusSelector, {state: 'visible'});
+  }
 }
 
-export const ReleaseCoordinatorFactory = (page: Page): ReleaseCoordinator => {
-  return new ReleaseCoordinator(page);
-};
+export let ReleaseCoordinatorFactory = (page: Page): ReleaseCoordinator =>
+  new ReleaseCoordinator(page);


### PR DESCRIPTION
1. This PR fixes part of #24715.
2. This PR migrates 4 release-coordinator acceptance test specs from
   Puppeteer to Playwright:
   - enable-feature-flag.spec.ts
   - enable-the-promo-bar.spec.ts
   - flush-the-memory-cache.spec.ts
   - navigate-to-the-release-coordinator-page-beam-jobs-tab.spec.ts

   Changes:
   - Added ~30 utility methods to the Playwright ReleaseCoordinator class
   - Added expectPromoBarToBeVisible to Playwright LoggedOutUser
   - Created 4 Playwright spec files in
     core/tests/playwright-acceptance-tests/specs/release-coordinator/
   - Updated acceptance.json to use "framework": "playwright"
   - Removed old Puppeteer spec files
3. N/A (not a bug fix)

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on
      line 1 above.
- [x] I have checked the "Files Changed" tab and confirmed that the changes
      are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
      followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR.