### PR TITLE
Fix part of #26844: Migrate voiceover submitter acceptance tests to Playwright

### DIFF
--- a/core/tests/ci-test-suite-configs/acceptance.json
+++ b/core/tests/ci-test-suite-configs/acceptance.json
@@ -552,8 +552,8 @@
     },
     {
       "name": "voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "blog-admin/assign-and-remove-blog-editor-and-blog-admin-roles",

--- a/core/tests/playwright-acceptance-tests/specs/voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/voiceover-submitter/create-delete-and-update-status-of-voiceovers-of-the-explorations.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The Oppia Authors. All Rights Reserved.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
  * VS.1. Add, remove, and update the status of a single voiceover.
  */
 
+import {test} from '@playwright/test';
 import testConstants from '../../utilities/common/test-constants';
 import {UserFactory} from '../../utilities/common/user-factory';
 import {CurriculumAdmin} from '../../utilities/user/curriculum-admin';
@@ -33,7 +34,9 @@ import {VoiceoverSubmitter} from '../../utilities/user/voiceover-submitter';
 
 const ROLES = testConstants.Roles;
 
-describe('Voiceover Submitter', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Voiceover Submitter', function () {
   let voiceoverSubmitter: VoiceoverSubmitter &
     ExplorationEditor &
     LoggedOutUser;
@@ -41,17 +44,21 @@ describe('Voiceover Submitter', function () {
   let releaseCoordinator: ReleaseCoordinator;
   let explorationId: string;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
+    test.setTimeout(600000);
+
     // Create users with the required roles.
     curriculumAdm = await UserFactory.createNewUser(
       'curriculumAdm',
       'curriculum_admin@example.com',
+      browser,
       [ROLES.CURRICULUM_ADMIN, ROLES.VOICEOVER_ADMIN]
     );
 
     releaseCoordinator = await UserFactory.createNewUser(
       'releaseCoordinator',
       'release_coordinator@example.com',
+      browser,
       [ROLES.RELEASE_COORDINATOR]
     );
 
@@ -119,12 +126,13 @@ describe('Voiceover Submitter', function () {
     voiceoverSubmitter = await UserFactory.createNewUser(
       'voiceoverSubmitter',
       'voiceover_submitter@example.com',
+      browser,
       [ROLES.VOICEOVER_SUBMITTER],
       explorationId
     );
-  }, 600000);
+  });
 
-  it('should see content for voiceover in exploration language', async function () {
+  test('should see content for voiceover in exploration language', async function () {
     // Navigate to the exploration editor.
     await voiceoverSubmitter.navigateToExplorationEditor(explorationId);
     await voiceoverSubmitter.dismissWelcomeModal();
@@ -161,7 +169,7 @@ describe('Voiceover Submitter', function () {
     await voiceoverSubmitter.expectSolutionVoiceoverToContain('5');
   });
 
-  it('should see correct accessibility labels in the voiceover translation tab', async function () {
+  test('should see correct accessibility labels in the voiceover translation tab', async function () {
     // Select "Content" voiceover option.
     await voiceoverSubmitter.selectVoiceoverContentType('Content');
 
@@ -213,7 +221,7 @@ describe('Voiceover Submitter', function () {
     await voiceoverSubmitter.saveExplorationDraft();
   });
 
-  it('should be able to add and remove voiceovers to explorations', async function () {
+  test('should be able to add and remove voiceovers to explorations', async function () {
     // Add voiceover in English (India).
     await voiceoverSubmitter.addVoiceoverToContent(
       'English',
@@ -261,9 +269,9 @@ describe('Voiceover Submitter', function () {
     await voiceoverSubmitter.navigateToPreviewTab();
     await voiceoverSubmitter.expandVoiceoverBar();
     await voiceoverSubmitter.expectVoiceoverPlayButtonToBe('disabled');
-  }, 450000);
+  });
 
-  it('should not be able to upload a non-audio file', async function () {
+  test('should not be able to upload a non-audio file', async function () {
     await voiceoverSubmitter.navigateToTranslationsTab();
     await voiceoverSubmitter.clickOnAddManualVoiceoverButton();
     await voiceoverSubmitter.uploadFile(testConstants.data.profilePicture);
@@ -272,7 +280,7 @@ describe('Voiceover Submitter', function () {
     );
   });
 
-  it('should not be able to upload audio file larger than 5 minutes', async function () {
+  test('should not be able to upload audio file larger than 5 minutes', async function () {
     await voiceoverSubmitter.uploadFile(
       testConstants.data.VoiceoverEnglishIndiaOver5Min
     );
@@ -282,7 +290,7 @@ describe('Voiceover Submitter', function () {
     );
   });
 
-  it('should be able to mark/unmark voiceover as stale', async function () {
+  test('should be able to mark/unmark voiceover as stale', async function () {
     // Mark voiceover as stale.
     await voiceoverSubmitter.uploadFile(
       testConstants.data.VoiceoverEnglishIndia
@@ -292,14 +300,14 @@ describe('Voiceover Submitter', function () {
     await voiceoverSubmitter.expectCurrentVoiceStatusButtonToBe('needs update');
     // Stale voiceovers should count as incomplete.
     await voiceoverSubmitter.expectTranslationNumericalStatusToBe('1/7');
-    await voiceoverSubmitter.expectNodeWariningSignToBeVisible(true);
+    await voiceoverSubmitter.expectNodeWarningSignToBeVisible(true);
 
     // Mark voiceover as up to date.
     await voiceoverSubmitter.toggleAudioNeedsUpdateButton();
     await voiceoverSubmitter.expectCurrentVoiceStatusButtonToBe('upto date');
   });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/utilities/common/playwright-utils.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/common/playwright-utils.ts
@@ -27,6 +27,7 @@ const backgroundBanner = '.oppia-background-image';
 const libraryBanner = '.e2e-test-library-banner';
 
 const toastMessageSelector = '.e2e-test-toast-message';
+const uploadErrorMessageDivSelector = '.e2e-test-upload-error-message';
 
 const VIEWPORT_WIDTH_BREAKPOINTS = testConstants.ViewportWidthBreakpoints;
 
@@ -1238,6 +1239,37 @@ export class BaseUser {
     showMessage(
       `Element ${elementDesc} did not stabilize within ${timeout} ms`
     );
+  }
+
+  /**
+   * Checks if the upload error message contains the expected text.
+   * @param expectedErrorMessage The expected text of the upload error message.
+   */
+  async expectUploadErrorMessageToBe(
+    expectedErrorMessage: string
+  ): Promise<void> {
+    await this.expectElementToBeVisible(uploadErrorMessageDivSelector);
+    await this.expectTextContentToContain(
+      uploadErrorMessageDivSelector,
+      expectedErrorMessage
+    );
+  }
+
+  /**
+   * Checks if an element has the expected attribute value.
+   * @param {string} selector - The selector of the element.
+   * @param {string} attributeName - The name of the attribute.
+   * @param {string} expectedValue - The expected value of the attribute.
+   */
+  async expectElementAttributeToBe(
+    selector: string,
+    attributeName: string,
+    expectedValue: string
+  ): Promise<void> {
+    await this.expectElementToBeVisible(selector);
+    const actualValue =
+      (await this.page.locator(selector).getAttribute(attributeName)) || '';
+    expect(actualValue.trim()).toBe(expectedValue.trim());
   }
 }
 

--- a/core/tests/playwright-acceptance-tests/utilities/common/user-factory.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/common/user-factory.ts
@@ -36,6 +36,10 @@ import {
 } from '../user/curriculum-admin';
 import {ReleaseCoordinatorFactory} from '../user/release-coordinator';
 import {TopicManager, TopicManagerFactory} from '../user/topic-manager';
+import {
+  VoiceoverSubmitter,
+  VoiceoverSubmitterFactory,
+} from '../user/voiceover-submitter';
 
 const ROLES = testConstants.Roles;
 const cookieBannerAcceptButton =
@@ -52,6 +56,7 @@ const USER_ROLE_MAPPING = {
   [ROLES.RELEASE_COORDINATOR]: ReleaseCoordinatorFactory,
   [ROLES.TOPIC_MANAGER]: TopicManagerFactory,
   [ROLES.VOICEOVER_ADMIN]: VoiceoverAdminFactory,
+  [ROLES.VOICEOVER_SUBMITTER]: VoiceoverSubmitterFactory,
 } as const;
 
 // Roles that are not reflected on the admin page after assignment.
@@ -81,7 +86,8 @@ type BasicRolesUser = LoggedOutUser &
   LoggedInUser &
   ExplorationEditor &
   CurriculumAdmin &
-  TopicManager;
+  TopicManager &
+  VoiceoverSubmitter;
 
 /**
  * Global user instances that are created and can be reused again.
@@ -155,6 +161,17 @@ export class UserFactory {
             args as string
           );
           break;
+        case ROLES.VOICEOVER_SUBMITTER:
+          if (typeof args !== 'string') {
+            throw new Error(
+              'Exploration ID is required to assign a voiceover submitter.'
+            );
+          }
+          await superAdminInstance.addVoiceoverArtistToExplorationWithID(
+            args as string,
+            user.username
+          );
+          break;
         default:
           await superAdminInstance.assignRoleToUser(user.username, role);
           break;
@@ -204,6 +221,7 @@ export class UserFactory {
       ExplorationEditorFactory(page),
       CurriculumAdminFactory(page),
       TopicManagerFactory(page),
+      VoiceoverSubmitterFactory(page),
     ]);
 
     user.username = username;

--- a/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
@@ -119,6 +119,12 @@ const mobileTranslationTabButton = '.e2e-test-mobile-translation-tab';
 const mainTabButton = '.e2e-test-main-tab';
 const mobileMainTabButton = '.e2e-test-mobile-main-tab';
 const mainTabContainerSelector = '.e2e-test-exploration-main-tab';
+const previewTabButton = '.e2e-test-preview-tab';
+const previewTabContainer = '.e2e-test-preview-tab-container';
+const mobilePreviewTabButton = '.e2e-test-mobile-preview-button';
+const interactionDiv = '.e2e-test-interaction';
+const textInputField = '.e2e-test-text-input';
+const nodeWarningSignSelector = '.e2e-test-node-warning-sign';
 const navigationDropdownInMobileVisibleSelector =
   '.oppia-exploration-editor-tabs-dropdown.show';
 const dropdownToggleIcon = '.e2e-test-mobile-options-dropdown';
@@ -374,6 +380,26 @@ export class ExplorationEditor extends BaseUser {
       await this.expectElementToBeVisible(addInteractionModalSelector, false);
     }
     showMessage(`${interactionToAdd} interaction has been added successfully.`);
+  }
+
+  /**
+   * Add a text input interaction to the card.
+   */
+  async addTextInputInteraction(): Promise<void> {
+    await this.addInteraction(INTERACTION_TYPES.TEXT_INPUT);
+  }
+
+  /**
+   * Update the optional text input interaction content.
+   * @param {string} content - The text input interaction content.
+   */
+  async updateTextInputInteraction(content: string): Promise<void> {
+    await this.expectElementToBeVisible(interactionDiv);
+    await this.clickOnElementWithSelector(interactionDiv);
+    await this.expectElementToBeVisible(textInputField);
+    await this.typeInInputField(textInputField, content);
+    await this.clickOnElementWithSelector(saveInteractionButton);
+    await this.expectElementToBeVisible(addInteractionModalSelector, false);
   }
 
   /**
@@ -985,6 +1011,21 @@ export class ExplorationEditor extends BaseUser {
   }
 
   /**
+   * Function to navigate to exploration editor with a specific exploration ID.
+   * @param {string | null} explorationId - ID of the exploration.
+   */
+  async navigateToExplorationEditor(
+    explorationId: string | null
+  ): Promise<void> {
+    if (!explorationId) {
+      throw new Error('Cannot navigate to editor: explorationId is null');
+    }
+    const editorUrl = `${baseUrl}/create/${explorationId}`;
+    await this.goto(editorUrl);
+    showMessage('Navigation to exploration editor is successful.');
+  }
+
+  /**
    * Function to navigate to exploration editor from Creator Dashboard.
    */
   async navigateToExplorationEditorFromCreatorDashboard(): Promise<void> {
@@ -1034,6 +1075,46 @@ export class ExplorationEditor extends BaseUser {
     }
 
     await this.expectElementToBeVisible(translationTabContainer);
+  }
+
+  /**
+   * Function to navigate to the preview tab.
+   */
+  async navigateToPreviewTab(): Promise<void> {
+    if (this.isViewportAtMobileWidth()) {
+      const element = await this.page.$(mobileNavbarOptions);
+      if (!element) {
+        await this.clickOnElementWithSelector(mobileOptionsButtonSelector);
+      }
+      await this.expectElementToBeVisible(mobileNavbarDropdown);
+      await this.clickOnElementWithSelector(mobileNavbarDropdown);
+      await this.expectElementToBeVisible(mobileNavbarPane);
+      await this.clickOnElementWithSelector(mobilePreviewTabButton);
+    } else {
+      await this.expectElementToBeVisible(previewTabButton);
+      await this.clickOnElementWithSelector(previewTabButton);
+    }
+
+    await this.expectElementToBeVisible(previewTabContainer);
+    await this.waitForPageToFullyLoad();
+  }
+
+  /**
+   * Expects the node warning sign to be visible or not visible.
+   * @param {boolean} visible - Whether the node warning sign should be visible or not.
+   */
+  async expectNodeWarningSignToBeVisible(
+    visible: boolean = true
+  ): Promise<void> {
+    if (this.isViewportAtMobileWidth()) {
+      showMessage(
+        'Skipping node warning sign check on mobile viewport, ' +
+          'as nodes are not visible on mobile viewport.'
+      );
+      return;
+    }
+
+    await this.expectElementToBeVisible(nodeWarningSignSelector, visible);
   }
 
   /**

--- a/core/tests/playwright-acceptance-tests/utilities/user/voiceover-admin.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/voiceover-admin.ts
@@ -7,7 +7,7 @@
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS-IS" BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -19,7 +19,10 @@
 import {Page} from '@playwright/test';
 import {BaseUser} from '../common/playwright-utils';
 import testConstants from '../common/test-constants';
+import {showMessage} from '../common/show-message';
+import {ExplorationEditorModal} from '../common/exploration-editor';
 
+const baseURL = testConstants.URLs.BaseURL;
 const voiceoverAdminURL = testConstants.URLs.VoiceoverAdmin;
 
 const languageAccentOptionSelector =
@@ -28,6 +31,22 @@ const addNewLanguageAccentButtonSelector =
   '.e2e-test-add-new-language-accent-button';
 const languageAccentDropdownSelector =
   '.e2e-test-language-accent-dropdown-selector';
+
+const settingsTabSelector = 'a.e2e-test-exploration-settings-tab';
+const settingsContainerSelector =
+  '.oppia-editor-card.oppia-settings-card-container';
+const voiceArtistSectionHeaderSelector = '.e2e-test-voice-artists-header';
+const voiceArtistSectionBodySelector = '.e2e-test-voice-artists-content';
+const editVoiceoverArtistButton = 'span.e2e-test-edit-voice-artist-roles';
+const voiceArtistUsernameInputBox = 'input#newVoicAartistUsername';
+const saveVoiceoverArtistEditButton =
+  'button.e2e-test-add-voice-artist-role-button';
+
+const mobileNavbarDropdown = 'div.e2e-test-mobile-options-dropdown';
+const mobileOptionsButtonSelector = 'i.e2e-test-mobile-options';
+const mobileSettingsBarSelector = 'li.e2e-test-mobile-settings-button';
+const mobileNavbarOptions = '.navbar-mobile-options';
+const mobileNavbarPane = '.oppia-exploration-editor-tabs-dropdown';
 
 export class VoiceoverAdmin extends BaseUser {
   /**
@@ -58,6 +77,81 @@ export class VoiceoverAdmin extends BaseUser {
    */
   async navigateToVoiceoverAdminPage(): Promise<void> {
     await this.goto(voiceoverAdminURL);
+  }
+
+  /**
+   * Function to navigate to exploration settings tab.
+   */
+  async navigateToExplorationSettingsTab(): Promise<void> {
+    await this.waitForPageToFullyLoad();
+    if (this.isViewportAtMobileWidth()) {
+      const element = await this.page.$(mobileNavbarOptions);
+      if (!element) {
+        await this.clickOnElementWithSelector(mobileOptionsButtonSelector);
+      }
+      await this.expectElementToBeVisible(mobileNavbarDropdown);
+      await this.clickOnElementWithSelector(mobileNavbarDropdown);
+      await this.expectElementToBeVisible(mobileNavbarPane);
+      await this.clickOnElementWithSelector(mobileSettingsBarSelector);
+    } else {
+      await this.expectElementToBeVisible(settingsTabSelector);
+      await this.clickOnElementWithSelector(settingsTabSelector);
+    }
+    await this.expectElementToBeVisible(settingsContainerSelector);
+  }
+
+  /**
+   * Function to dismiss exploration editor welcome modal.
+   * @param {boolean} failIfMissing - Whether to fail if the welcome modal is not found.
+   */
+  async dismissWelcomeModal(failIfMissing: boolean = true): Promise<void> {
+    const explorationEditor = new ExplorationEditorModal(this);
+    await explorationEditor.dismissWelcomeModal(failIfMissing);
+  }
+
+  /**
+   * Add voiceover artists to an exploration.
+   * @param {string[]} voiceArtists - The username list of the voiceover artists to add.
+   * @param {boolean} verify - Whether to verify artist presence after adding.
+   */
+  async addVoiceoverArtistsToExploration(
+    voiceArtists: string[],
+    verify: boolean = true
+  ): Promise<void> {
+    if (!(await this.isElementVisible(voiceArtistSectionBodySelector))) {
+      await this.clickOnElementWithSelector(voiceArtistSectionHeaderSelector);
+      await this.expectElementToBeVisible(voiceArtistSectionBodySelector);
+    }
+    for (let i = 0; i < voiceArtists.length; i++) {
+      await this.expectElementToBeVisible(editVoiceoverArtistButton);
+      await this.clickOnElementWithSelector(editVoiceoverArtistButton);
+      await this.expectElementToBeVisible(voiceArtistUsernameInputBox);
+      await this.clearAllTextFrom(voiceArtistUsernameInputBox);
+      await this.typeInInputField(voiceArtistUsernameInputBox, voiceArtists[i]);
+      await this.clickOnElementWithSelector(saveVoiceoverArtistEditButton);
+      if (verify) {
+        await this.expectElementToBeVisible(
+          `div.e2e-test-voice-artist-${voiceArtists[i]}`
+        );
+        showMessage(voiceArtists[i] + ' has been added as a voice artist.');
+      }
+    }
+  }
+
+  /**
+   * Function to add voiceover artist to an exploration.
+   * @param {string} explorationId - The exploration id.
+   * @param {string} voiceArtistUsername - The username of the voiceover artist to add.
+   */
+  async addVoiceoverArtistToExplorationWithID(
+    explorationId: string,
+    voiceArtistUsername: string
+  ): Promise<void> {
+    const editorUrl = `${baseURL}/create/${explorationId}`;
+    await this.goto(editorUrl);
+    await this.dismissWelcomeModal(false);
+    await this.navigateToExplorationSettingsTab();
+    await this.addVoiceoverArtistsToExploration([voiceArtistUsername]);
   }
 }
 

--- a/core/tests/playwright-acceptance-tests/utilities/user/voiceover-submitter.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/voiceover-submitter.ts
@@ -1,0 +1,377 @@
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Utility functions for voiceover submitter.
+ */
+
+import {expect, Page} from '@playwright/test';
+import {BaseUser} from '../common/playwright-utils';
+
+const voiceoverPlayPauseBtnSelector = '.e2e-test-play-voiceover-button';
+const voiceoverPlayIconSelector = `${voiceoverPlayPauseBtnSelector} .e2e-test-play`;
+const voiceoverPauseIconSelector = `${voiceoverPlayPauseBtnSelector} .e2e-test-pause`;
+const voiceoverProgressBarSelector = '.e2e-test-voiceover-progress-bar';
+const deleteVoiceoverBtnSelector = '.e2e-test-delete-voiceover-button';
+
+const voiceoverPlayBtnInAudioBarSelector = '.e2e-test-play-circle';
+const audioNotAvailableIconSelector = '.audio-controls-audio-not-available';
+const saveUploadedAudioBtnSelector = '.e2e-test-save-uploaded-audio-button';
+
+const addManualVoiceoverBtnSelector = '.e2e-test-voiceover-upload-audio';
+const audioStatusUpdateBtnSelector = '.e2e-test-audio-status-update-button';
+const audioNeedsUpdateIconSelector = '.needs-update-button-icon';
+const audioDoesNotNeedUpdateIconSelector = '.does-not-needs-update-button-icon';
+const translationNumericalStatusSelector =
+  '.e2e-test-translation-numerical-status';
+
+const contentVoiceoverTextSelector = '.e2e-test-content-text';
+const interactionVoiceoverTextSelector = '.e2e-test-interaction-text';
+const solutionVoiceoverTextSelector = '.e2e-test-solution-text';
+const uploadVoiceoverFileInputSelector = '.e2e-test-upload-audio-input';
+
+const voiceoverLanguageAccentSelector =
+  '.e2e-test-voiceover-language-accent-selector';
+
+const TRANSLATION_TAB_SELECTORS = {
+  Content: '.e2e-test-translation-content-tab',
+  Interaction: '.e2e-test-translation-interaction-tab',
+  Feedback: '.e2e-test-translation-feedback-tab',
+  Hints: '.e2e-test-translation-hints-tab',
+  Solution: '.e2e-test-translation-solution-tab',
+};
+
+const ACCESSIBLE_TAB_SELECTORS = {
+  Content: '.e2e-test-accessibility-translation-content',
+  Feedback: '.e2e-test-accessibility-translation-feedback',
+  Hints: '.e2e-test-accessibility-translation-hint',
+  Solution: '.e2e-test-accessibility-translation-solution',
+};
+
+export class VoiceoverSubmitter extends BaseUser {
+  /**
+   * Checks if the voiceover is playable in the translation tab by playing and pausing it.
+   */
+  async expectVoiceoverIsPlayableInTranslationTab(): Promise<void> {
+    await this.expectElementToBeVisible(voiceoverProgressBarSelector);
+    const initialVoiceoverProgress = parseInt(
+      (await this.page
+        .locator(voiceoverProgressBarSelector)
+        .getAttribute('aria-valuenow')) ?? ''
+    );
+
+    await this.expectElementToBeVisible(voiceoverPlayIconSelector);
+    await this.clickOnElementWithSelector(voiceoverPlayPauseBtnSelector);
+
+    await this.page.waitForFunction(
+      (selector: string, initialProgress: number) => {
+        const element = document.querySelector(selector);
+        return (
+          parseInt(element?.getAttribute('aria-valuenow') ?? '') >
+          initialProgress
+        );
+      },
+      {},
+      voiceoverProgressBarSelector,
+      initialVoiceoverProgress
+    );
+
+    await this.expectElementToBeVisible(voiceoverPauseIconSelector);
+    await this.clickOnElementWithSelector(voiceoverPlayPauseBtnSelector);
+    await this.expectElementToBeVisible(voiceoverPlayIconSelector);
+  }
+
+  /**
+   * Checks if the voiceover play button is visible, enabled, or hidden.
+   * @param status - The status of the voiceover play button.
+   */
+  async expectVoiceoverPlayButtonToBe(
+    status: 'enabled' | 'disabled'
+  ): Promise<void> {
+    await this.expectElementToBeVisible(voiceoverPlayBtnInAudioBarSelector);
+    await this.expectElementToBeVisible(
+      audioNotAvailableIconSelector,
+      status === 'disabled'
+    );
+  }
+
+  /**
+   * Deletes current voiceover in the current card.
+   */
+  async deleteVoiceoverInCurrentCard(): Promise<void> {
+    await this.expectElementToBeVisible(deleteVoiceoverBtnSelector);
+    await this.clickOnElementWithSelector(deleteVoiceoverBtnSelector);
+    await this.clickButtonInModal(
+      'Are you sure you want to remove this voiceover?',
+      'confirm'
+    );
+  }
+
+  /**
+   * Clicks on the add manual voiceover button.
+   */
+  async clickOnAddManualVoiceoverButton(): Promise<void> {
+    await this.expectElementToBeVisible(addManualVoiceoverBtnSelector);
+    await this.clickOnElementWithSelector(addManualVoiceoverBtnSelector);
+    await this.expectModalTitleToBe('Add Voiceover');
+  }
+
+  /**
+   * Clicks on the save uploaded audio button.
+   */
+  async clickOnSaveUploadVoiceoverButton(): Promise<void> {
+    await this.expectElementToBeVisible(saveUploadedAudioBtnSelector);
+    await this.clickOnElementWithSelector(saveUploadedAudioBtnSelector);
+    await this.expectElementToBeClickable(saveUploadedAudioBtnSelector, false);
+  }
+
+  /**
+   * Toggles the audio status update button.
+   */
+  async toggleAudioNeedsUpdateButton(): Promise<void> {
+    await this.expectElementToBeVisible(audioStatusUpdateBtnSelector);
+    const currentStatus = await this.isElementVisible(
+      `${audioStatusUpdateBtnSelector}${audioNeedsUpdateIconSelector}`
+    );
+
+    await this.clickOnElementWithSelector(audioStatusUpdateBtnSelector);
+
+    await this.expectElementToBeVisible(
+      `${audioStatusUpdateBtnSelector}${audioNeedsUpdateIconSelector}`,
+      !currentStatus
+    );
+  }
+
+  /**
+   * Checks if the current voice status button is upto date or needs update.
+   * @param status - The status of the current voice status button.
+   */
+  async expectCurrentVoiceStatusButtonToBe(
+    status: 'upto date' | 'needs update'
+  ): Promise<void> {
+    const statusSelector =
+      status === 'upto date'
+        ? `${audioStatusUpdateBtnSelector}${audioDoesNotNeedUpdateIconSelector}`
+        : `${audioStatusUpdateBtnSelector}${audioNeedsUpdateIconSelector}`;
+    await this.expectElementToBeVisible(statusSelector);
+  }
+
+  /**
+   * Checks if the translation numerical status is upto date or needs update.
+   * @param status - The status of the translation numerical status.
+   */
+  async expectTranslationNumericalStatusToBe(status: string): Promise<void> {
+    await this.expectTextContentToBe(
+      translationNumericalStatusSelector,
+      `(${status})`
+    );
+  }
+
+  /**
+   * Selects the specified voiceover content type tab in the translation tab.
+   * @param type - The voiceover content type to select.
+   */
+  async selectVoiceoverContentType(
+    type: 'Content' | 'Interaction' | 'Feedback' | 'Hints' | 'Solution'
+  ): Promise<void> {
+    const selector = TRANSLATION_TAB_SELECTORS[type];
+
+    await this.expectElementToBeVisible(selector);
+    await this.clickOnElementWithSelector(selector);
+
+    await this.page.waitForFunction(
+      (sel: string) => {
+        const el = document.querySelector(sel);
+        return el?.parentElement?.classList.contains(
+          'oppia-active-translation-tab'
+        );
+      },
+      {},
+      selector
+    );
+  }
+
+  /**
+   * Checks if the content voiceover text contains the specified expected text.
+   * @param expectedText - The expected text to be present in the content voiceover.
+   */
+  async expectContentVoiceoverToContain(expectedText: string): Promise<void> {
+    await this.expectTextContentToContain(
+      contentVoiceoverTextSelector,
+      expectedText
+    );
+  }
+
+  /**
+   * Checks if the interaction voiceover text contains the specified expected text.
+   * @param expectedText - The expected text to be present in the interaction voiceover.
+   */
+  async expectInteractionVoiceoverToContain(
+    expectedText: string
+  ): Promise<void> {
+    await this.expectTextContentToContain(
+      interactionVoiceoverTextSelector,
+      expectedText
+    );
+  }
+
+  /**
+   * Checks if the solution voiceover text contains the specified expected text.
+   * @param expectedText - The expected text to be present in the solution voiceover.
+   */
+  async expectSolutionVoiceoverToContain(expectedText: string): Promise<void> {
+    await this.expectTextContentToContain(
+      solutionVoiceoverTextSelector,
+      expectedText
+    );
+  }
+
+  /**
+   * Checks if the visible feedback texts contain the specified expected texts.
+   * @param expectedTexts - The list of expected feedback texts to verify.
+   */
+  async expectVisibleFeedbackTextsToContain(
+    expectedTexts: string[]
+  ): Promise<void> {
+    for (let i = 0; i < expectedTexts.length; i++) {
+      const cardSelector = `.e2e-test-feedback-${i}`;
+      const textSelector = `.e2e-test-feedback-${i}-text`;
+
+      await this.expectElementToBeVisible(cardSelector);
+      await this.waitForElementToStabilize(cardSelector);
+
+      await this.clickOnElementWithSelector(cardSelector);
+
+      await this.expectElementToBeVisible(textSelector);
+      await this.expectTextContentToContain(textSelector, expectedTexts[i]);
+    }
+  }
+
+  /**
+   * Checks if the visible hint texts contain the specified expected texts.
+   * @param expectedTexts - The list of expected hint texts to verify.
+   */
+  async expectVisibleHintTextsToContain(
+    expectedTexts: string[]
+  ): Promise<void> {
+    for (let i = 0; i < expectedTexts.length; i++) {
+      const hintSelector = `.e2e-test-hint-${i}`;
+      const hintTextSelector = `.e2e-test-hint-${i}-text`;
+
+      await this.expectElementToBeVisible(hintSelector);
+      await this.waitForElementToStabilize(hintSelector);
+
+      await this.clickOnElementWithSelector(hintSelector);
+
+      await this.expectElementToBeVisible(hintTextSelector);
+      await this.expectTextContentToContain(hintTextSelector, expectedTexts[i]);
+    }
+  }
+
+  /**
+   * Checks if the translation progress element has an aria-label matching the expected text.
+   * @param expectedText - The expected aria-label text for the translation progress element.
+   */
+  async expectTranslationProgressAriaLabelToMatch(
+    expectedText: string
+  ): Promise<void> {
+    await this.expectElementToBeVisible(translationNumericalStatusSelector);
+
+    await this.page.waitForFunction(
+      (selector: string) => {
+        const el = document.querySelector(selector);
+        const label = el?.getAttribute('aria-label') || '';
+
+        return (
+          label.includes('items translated') &&
+          !label.includes('NaN') &&
+          !label.includes('undefined')
+        );
+      },
+      {},
+      translationNumericalStatusSelector
+    );
+
+    const ariaLabel = await this.page
+      .locator(translationNumericalStatusSelector)
+      .evaluate(el => el.getAttribute('aria-label') || el.textContent);
+
+    expect(ariaLabel).toMatch(expectedText);
+  }
+
+  /**
+   * Checks if the specified translation sub-tab has the expected aria-label.
+   * @param tabName - The name of the translation sub-tab.
+   * @param expectedAriaLabel - The expected aria-label value of the sub-tab.
+   */
+  async expectTranslationSubTabAriaLabelToBe(
+    tabName: 'Content' | 'Feedback' | 'Hints' | 'Solution',
+    expectedAriaLabel: string
+  ): Promise<void> {
+    const selector = ACCESSIBLE_TAB_SELECTORS[tabName];
+    await this.expectElementAttributeToBe(
+      selector,
+      'aria-label',
+      expectedAriaLabel
+    );
+  }
+
+  /**
+   * Selects the specified voiceover language accent from the language accent dropdown.
+   * @param accentDescription - The description of the language accent to select.
+   */
+  async selectVoiceoverLanguageAccent(
+    accentDescription: string
+  ): Promise<void> {
+    await this.expectElementToBeVisible(voiceoverLanguageAccentSelector);
+    await this.clickOnElementWithSelector(voiceoverLanguageAccentSelector);
+    await this.selectMatOption(accentDescription);
+    await this.expectTextContentToContain(
+      voiceoverLanguageAccentSelector,
+      accentDescription
+    );
+  }
+
+  /**
+   * Checks if the upload voiceover file input has the expected accessible name.
+   * @param expectedAccessibleName - The expected aria-label of the upload voiceover file input.
+   */
+  async expectUploadVoiceoverFileButtonAccessibleNameToBe(
+    expectedAccessibleName: string
+  ): Promise<void> {
+    await this.expectElementAttributeToBe(
+      uploadVoiceoverFileInputSelector,
+      'aria-label',
+      expectedAccessibleName
+    );
+  }
+
+  /**
+   * Checks if the play voiceover button has the expected accessible name.
+   * @param expectedAccessibleName - The expected aria-label of the play voiceover button.
+   */
+  async expectPlayVoiceoverButtonAccessibleNameToBe(
+    expectedAccessibleName: string
+  ): Promise<void> {
+    await this.expectElementAttributeToBe(
+      voiceoverPlayPauseBtnSelector,
+      'aria-label',
+      expectedAccessibleName
+    );
+  }
+}
+
+export let VoiceoverSubmitterFactory = (page: Page): VoiceoverSubmitter => {
+  return new VoiceoverSubmitter(page);
+};


### PR DESCRIPTION
## Overview

1. This PR fixes part of #26844.

2. This PR migrates the `create-delete-and-update-status-of-voiceovers-of-the-explorations` acceptance test from Puppeteer to Playwright. It ports the existing acceptance test to Playwright, introduces the required `VoiceoverSubmitter` Playwright utility and supporting helper methods, updates the user factory to support the new role, and switches the acceptance test configuration to use the Playwright implementation.

3. N/A

## Test Cases

This PR preserves the behavior of the original Puppeteer acceptance test by verifying:

- Voiceover content is displayed correctly for all supported translation content types.
- Accessibility labels (`aria-label`) are correctly exposed in the voiceover translation interface.
- Voiceovers can be uploaded, played, and deleted successfully.
- Uploading a non-audio file displays the expected validation error.
- Uploading an audio file longer than the supported duration displays the appropriate error message.
- Voiceovers can be marked as stale and restored to the up-to-date state, with the corresponding UI updates and translation progress changes.

Validation performed:
- [ ] Desktop Playwright acceptance test
- [ ] Mobile Playwright acceptance test
- [ ] Acceptance test stress run (100 desktop + 100 mobile)