### PR TITLE
Fix #26944: Remove obsolete top-navigation navbar truncation logic

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -63,7 +63,6 @@
           class="nav oppia-navbar-tabs">
         <li [ngClass]="{'show' : activeMenuName === 'homeMenu'}"
             *ngIf="!userIsLoggedIn"
-            [hidden]="!navElementsVisibilityStatus.I18N_TOPNAV_HOME"
             aria-hidden="false"
             class="nav-item  oppia-navbar-clickable-dropdown e2e-test-home-oppia-list-item">
           <a (keydown)="onMenuKeypress($event, 'homeMenu', {shiftTab: ACTION_CLOSE, enter: ACTION_OPEN})"
@@ -80,7 +79,6 @@
         <li [ngClass]="{'show' : activeMenuName === 'learnMenu'}"
             ngbDropdown
             #learnDropdown="ngbDropdown"
-            [hidden]="!navElementsVisibilityStatus.I18N_TOPNAV_LEARN"
             aria-hidden="false"
             class="nav-item  dropdown oppia-navbar-clickable-dropdown e2e-test-classroom-oppia-list-item">
           <a ngbDropdownAnchor
@@ -159,7 +157,6 @@
         <li [ngClass]="{'show': activeMenuName === 'aboutMenu'}"
             ngbDropdown
             #aboutDropdown="ngbDropdown"
-            [hidden]="!navElementsVisibilityStatus.I18N_TOPNAV_ABOUT"
             class="nav-item dropdown oppia-navbar-clickable-dropdown e2e-test-about-oppia-list-item">
           <a ngbDropdownAnchor
              (click)="aboutDropdown.toggle()"
@@ -231,7 +228,6 @@
         <li [ngClass]="{'show': activeMenuName === 'getInvolvedMenu'}"
             ngbDropdown
             #getInvolvedDropdown="ngbDropdown"
-            [hidden]="navElementsVisibilityStatus.I18N_TOPNAV_GET_INVOLVED"
             class="nav-item oppia-navbar-clickable-dropdown e2e-test-about-oppia-list-item">
           <a ngbDropdownAnchor
              class="nav-link oppia-navbar-tab dropdown-toggle get-involved e2e-test-navbar-get-involved-menu"
@@ -317,7 +313,6 @@
         </li>
         <li [ngClass]="{'show': activeMenuName === 'donateMenu'}"
             ngbDropdown
-            [hidden]="!navElementsVisibilityStatus.I18N_TOPNAV_DONATE"
             class="nav-item e2e-test-about-oppia-list-item">
           <a class="nav-link oppia-navbar-tab donate-tab e2e-test-navbar-donate-desktop-button"
              tabindex="0"

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.spec.ts
@@ -259,20 +259,6 @@ describe('TopNavigationBarComponent', () => {
     component.ngOnDestroy();
   });
 
-  it('should truncate navbar after search bar is loaded', fakeAsync(() => {
-    spyOn(component, 'truncateNavbar').and.stub();
-
-    component.ngOnInit();
-    tick(10);
-
-    searchService.onSearchBarLoaded.emit();
-    tick(101);
-
-    fixture.whenStable().then(() => {
-      expect(component.truncateNavbar).toHaveBeenCalled();
-    });
-  }));
-
   it('should unsubscribe upon component destruction', () => {
     spyOn(component.directiveSubscriptions, 'unsubscribe');
 
@@ -280,28 +266,6 @@ describe('TopNavigationBarComponent', () => {
 
     expect(component.directiveSubscriptions.unsubscribe).toHaveBeenCalled();
   });
-
-  it(
-    'should try displaying the hidden navbar elements if resized' +
-      ' window is larger',
-    fakeAsync(() => {
-      let donateElement = 'I18N_TOPNAV_DONATE';
-      spyOn(component, 'truncateNavbar').and.stub();
-
-      component.ngOnInit();
-      tick(10);
-
-      component.currentWindowWidth = 600;
-      component.navElementsVisibilityStatus[donateElement] = false;
-
-      mockResizeEmitter.emit();
-      tick(501);
-
-      fixture.whenStable().then(() => {
-        expect(component.navElementsVisibilityStatus[donateElement]).toBe(true);
-      });
-    })
-  );
 
   it("should show Oppia's logos", () => {
     expect(component.getStaticImageUrl('/logo/288x128_logo_white.webp')).toBe(
@@ -514,21 +478,6 @@ describe('TopNavigationBarComponent', () => {
     expect(component.checkIfI18NCompleted()).toBe(true);
   });
 
-  it('should not truncate navbar if the window is narrow', () => {
-    // The truncateNavbar() function returns, as soon as the check for
-    // narrow window passes.
-    spyOn(wds, 'isWindowNarrow').and.returnValue(true);
-    spyOn(component, 'checkIfI18NCompleted');
-    spyOn(document, 'querySelector');
-
-    // We also, check if the subsequent function calls have been made or not,
-    // thus confirming that the returned 'undefined' value is because of
-    // narrow window.
-    expect(component.truncateNavbar()).toBe(undefined);
-    expect(component.checkIfI18NCompleted).not.toHaveBeenCalled();
-    expect(document.querySelector).not.toHaveBeenCalled();
-  });
-
   it('should show logo and language dropdown when component is embedded', () => {
     expect(component.getStaticImageUrl('/logo/288x128_logo_white.webp')).toBe(
       '/assets/images/logo/288x128_logo_white.webp'
@@ -546,52 +495,6 @@ describe('TopNavigationBarComponent', () => {
     );
     expect(languageChangeElement).toBeTruthy();
   });
-
-  it(
-    'should retry calling truncate navbar if i18n is not' + ' complete',
-    fakeAsync(() => {
-      spyOn(wds, 'isWindowNarrow').and.returnValues(false, true);
-      spyOn(document, 'querySelector').and.stub();
-      spyOn(component, 'checkIfI18NCompleted').and.returnValue(false);
-
-      component.truncateNavbar();
-      tick(101);
-
-      fixture.whenStable().then(() => {
-        expect(document.querySelector).not.toHaveBeenCalled();
-      });
-    })
-  );
-
-  it("should hide navbar if it's height more than 60px", fakeAsync(() => {
-    spyOn(wds, 'isWindowNarrow').and.returnValues(false, true);
-    const mockElement = document.createElement('div');
-    Object.defineProperty(mockElement, 'clientHeight', {value: 61});
-    spyOn(document, 'querySelector')
-      .withArgs('div.collapse.navbar-collapse')
-      .and.returnValue(mockElement);
-
-    component.navElementsVisibilityStatus = {
-      I18N_TOPNAV_DONATE: true,
-      I18N_TOPNAV_LEARN: true,
-      I18N_TOPNAV_ABOUT: true,
-      I18N_TOPNAV_LIBRARY: true,
-      I18N_TOPNAV_HOME: true,
-    };
-
-    component.truncateNavbar();
-    tick(51);
-
-    fixture.whenStable().then(() => {
-      expect(component.navElementsVisibilityStatus).toEqual({
-        I18N_TOPNAV_DONATE: false,
-        I18N_TOPNAV_LEARN: true,
-        I18N_TOPNAV_ABOUT: true,
-        I18N_TOPNAV_LIBRARY: true,
-        I18N_TOPNAV_HOME: true,
-      });
-    });
-  }));
 
   it('should emit language change event when URL contains lesson', () => {
     const langCode = 'hi';
@@ -616,7 +519,6 @@ describe('TopNavigationBarComponent', () => {
   });
 
   it('should check if learner groups feature is enabled', fakeAsync(() => {
-    spyOn(component, 'truncateNavbar').and.stub();
     spyOn(
       learnerGroupBackendApiService,
       'isLearnerGroupFeatureEnabledAsync'
@@ -636,8 +538,7 @@ describe('TopNavigationBarComponent', () => {
         i18nLanguageCodeService,
         'onI18nLanguageCodeChange'
       ).and.returnValue(onI18nLanguageCodeChangeEmitter);
-      spyOn(component, 'truncateNavbar').and.stub();
-
+  
       component.ngOnInit();
 
       component.currentLanguageCode = 'hi';
@@ -662,7 +563,6 @@ describe('TopNavigationBarComponent', () => {
       'tester@example.com',
       true
     );
-    spyOn(component, 'truncateNavbar').and.stub();
     spyOn(userService, 'getUserInfoAsync').and.resolveTo(userInfo);
     spyOn(
       i18nLanguageCodeService,
@@ -708,7 +608,6 @@ describe('TopNavigationBarComponent', () => {
       'tester@example.com',
       true
     );
-    spyOn(component, 'truncateNavbar').and.stub();
     spyOn(userService, 'getUserInfoAsync').and.resolveTo(userInfo);
 
     expect(component.isModerator).toBe(false);
@@ -730,7 +629,6 @@ describe('TopNavigationBarComponent', () => {
   }));
 
   it('should set default profile pictures when username is null', fakeAsync(() => {
-    spyOn(component, 'truncateNavbar').and.stub();
     let userInfo = {
       isModerator: () => false,
       isCurriculumAdmin: () => false,
@@ -781,8 +679,7 @@ describe('TopNavigationBarComponent', () => {
         true
       );
 
-      spyOn(component, 'truncateNavbar').and.stub();
-      spyOn(userService, 'getUserInfoAsync').and.resolveTo(userInfo);
+        spyOn(userService, 'getUserInfoAsync').and.resolveTo(userInfo);
       const fetchDataSpy = spyOn(
         feedbackUpdatesBackendApiService,
         'fetchFeedbackUpdatesDataAsync'
@@ -822,8 +719,7 @@ describe('TopNavigationBarComponent', () => {
         true
       );
 
-      spyOn(component, 'truncateNavbar').and.stub();
-      spyOn(userService, 'getUserInfoAsync').and.resolveTo(userInfo);
+        spyOn(userService, 'getUserInfoAsync').and.resolveTo(userInfo);
       const fetchDataSpy = spyOn(
         feedbackUpdatesBackendApiService,
         'fetchFeedbackUpdatesDataAsync'
@@ -880,7 +776,6 @@ describe('TopNavigationBarComponent', () => {
   });
 
   it('should check if dropdown offsets are updated', fakeAsync(() => {
-    spyOn(component, 'truncateNavbar').and.stub();
     spyOn(component, 'getDropdownOffset')
       .withArgs('.learn-tab', '.classroom-enabled')
       .and.returnValue(-10)
@@ -1008,7 +903,6 @@ describe('TopNavigationBarComponent', () => {
   });
 
   it('should not check learner groups feature on signup page', fakeAsync(() => {
-    spyOn(component, 'truncateNavbar').and.stub();
     const learnerGroupSpy = spyOn(
       learnerGroupBackendApiService,
       'isLearnerGroupFeatureEnabledAsync'
@@ -1142,7 +1036,6 @@ describe('TopNavigationBarComponent', () => {
       'tester@example.com',
       true
     );
-    spyOn(component, 'truncateNavbar').and.stub();
     spyOn(userService, 'getUserInfoAsync').and.resolveTo(userInfo);
 
     expect(component.authStatusResolved).toBe(false);
@@ -1154,7 +1047,6 @@ describe('TopNavigationBarComponent', () => {
   }));
 
   it('should set authStatusResolved to true even if getUserInfoAsync fails', fakeAsync(() => {
-    spyOn(component, 'truncateNavbar').and.stub();
     spyOn(userService, 'getUserInfoAsync').and.rejectWith('Auth error');
 
     expect(component.authStatusResolved).toBe(false);

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.ts
@@ -183,23 +183,12 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
   ];
 
   currentWindowWidth = this.windowDimensionsService.getWidth();
-  // The order of the elements in this array specifies the order in
-  // which they will be hidden. Earlier elements will be hidden first.
-  NAV_ELEMENTS_ORDER = [
-    'I18N_TOPNAV_DONATE',
-    'I18N_TOPNAV_LEARN',
-    'I18N_TOPNAV_ABOUT',
-    'I18N_TOPNAV_LIBRARY',
-    'I18N_TOPNAV_HOME',
-  ];
-
   LEARNER_GROUPS_FEATURE_IS_ENABLED = false;
   FEEDBACK_UPDATES_IN_PROFILE_PIC_DROP_DOWN_IS_ENABLED = false;
   googleSignInIconUrl = this.urlInterpolationService.getStaticImageUrl(
     '/google_signin_buttons/google_signin.svg'
   );
 
-  navElementsVisibilityStatus: Record<string, boolean> = {};
   PAGES_REGISTERED_WITH_FRONTEND = AppConstants.PAGES_REGISTERED_WITH_FRONTEND;
 
   constructor(
@@ -281,14 +270,6 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     // variable in place of the 'this' keyword.
     let that = this;
 
-    this.directiveSubscriptions.add(
-      this.searchService.onSearchBarLoaded.subscribe(() => {
-        setTimeout(function () {
-          that.truncateNavbar();
-        }, 100);
-      })
-    );
-
     this.i18nService.updateViewToUserPreferredSiteLanguage();
 
     this.userService
@@ -356,30 +337,15 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
         this.authStatusResolved = true;
       });
 
-    for (var i = 0; i < this.NAV_ELEMENTS_ORDER.length; i++) {
-      this.navElementsVisibilityStatus[this.NAV_ELEMENTS_ORDER[i]] = true;
-    }
-
     this.directiveSubscriptions.add(
       this.windowDimensionsService.getResizeEvent().subscribe(evt => {
         this.windowIsNarrow = this.windowDimensionsService.isWindowNarrow();
-        // If window is resized larger, try displaying the hidden
-        // elements.
-        if (this.currentWindowWidth < this.windowDimensionsService.getWidth()) {
-          for (var i = 0; i < this.NAV_ELEMENTS_ORDER.length; i++) {
-            if (!this.navElementsVisibilityStatus[this.NAV_ELEMENTS_ORDER[i]]) {
-              this.navElementsVisibilityStatus[this.NAV_ELEMENTS_ORDER[i]] =
-                true;
-            }
-          }
-        }
 
         // Close the sidebar, if necessary.
         this.sidebarStatusService.closeSidebar();
         this.sidebarIsShown = this.sidebarStatusService.isSidebarShown();
         this.currentWindowWidth = this.windowDimensionsService.getWidth();
         this.windowRef.nativeWindow.document.body.style.overflowY = 'auto';
-        debounce(this.truncateNavbar, 500);
       })
     );
 
@@ -409,14 +375,6 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
       this.changeDetectorRef.detectChanges();
     }
 
-    // The function needs to be run after i18n. A timeout of 0 appears
-    // to run after i18n in Chrome, but not other browsers. The
-    // will check if i18n is complete and set a new timeout if it is
-    // not. Since a timeout of 0 works for at least one browser,
-    // it is used here.
-    setTimeout(function () {
-      that.truncateNavbar();
-    }, 0);
   }
 
   ngAfterViewChecked(): void {
@@ -575,68 +533,6 @@ export class TopNavigationBarComponent implements OnInit, OnDestroy {
     this.directiveSubscriptions.unsubscribe();
 
     this.windowRef.nativeWindow.document.body.style.overflowY = 'auto';
-  }
-
-  /**
-   * Checks if i18n has been run.
-   * If i18n has not yet run, the <a> and <span> tags will have
-   * no text content, so their innerText.length value will be 0.
-   * @returns {boolean}
-   */
-  checkIfI18NCompleted(): boolean {
-    var i18nCompleted = true;
-    var tabs = document.querySelectorAll('.oppia-navbar-tab-content');
-    for (var i = 0; i < tabs.length; i++) {
-      if ((tabs[i] as HTMLElement).innerText.length === 0) {
-        i18nCompleted = false;
-        break;
-      }
-    }
-    return i18nCompleted;
-  }
-
-  /**
-   * Checks if window is >768px and i18n is completed, then checks
-   * for overflow. If overflow is detected, hides the least important
-   * tab and then calls itself again after a 50ms delay.
-   */
-  truncateNavbar(): void {
-    // If the window is narrow, the standard nav tabs are not shown.
-    if (this.windowDimensionsService?.isWindowNarrow()) {
-      return;
-    }
-
-    let that = this;
-    // If i18n hasn't completed, retry after 100ms.
-    if (!this.checkIfI18NCompleted()) {
-      setTimeout(function () {
-        that.truncateNavbar();
-      }, 100);
-      return;
-    }
-
-    // The value of 60px used here comes from measuring the normal
-    // height of the navbar (56px) in Chrome's inspector and rounding
-    // up. If the height of the navbar is changed in the future this
-    // will need to be updated.
-    let navbar = document.querySelector('div.collapse.navbar-collapse');
-    if (navbar && navbar.clientHeight > 60) {
-      for (var i = 0; i < this.NAV_ELEMENTS_ORDER.length; i++) {
-        if (this.navElementsVisibilityStatus[this.NAV_ELEMENTS_ORDER[i]]) {
-          // Hide one element, then check again after 50ms.
-          // This gives the browser time to render the visibility
-          // change.
-          this.navElementsVisibilityStatus[this.NAV_ELEMENTS_ORDER[i]] = false;
-          // Force a digest cycle to hide element immediately.
-          // Otherwise it would be hidden after the next call.
-          // This is due to setTimeout use in debounce.
-          setTimeout(function () {
-            that.truncateNavbar();
-          }, 50);
-          return;
-        }
-      }
-    }
   }
 
   isHackyTopicTitleTranslationDisplayed(index: number): boolean {


### PR DESCRIPTION
## Explanation

Fixes #26944 by removing obsolete top-navigation navbar truncation logic (`truncateNavbar()`, `checkIfI18NCompleted()`, `NAV_ELEMENTS_ORDER`, and `navElementsVisibilityStatus`).

### Changes made:
- **`top-navigation-bar.component.ts`**: Removed `truncateNavbar()`, `checkIfI18NCompleted()`, `NAV_ELEMENTS_ORDER`, `navElementsVisibilityStatus`, and all associated search/resize/i18n call paths.
- **`top-navigation-bar.component.html`**: Removed `[hidden]="!navElementsVisibilityStatus..."` template bindings.
- **`top-navigation-bar.component.spec.ts`**: Removed unit tests and `spyOn(component, 'truncateNavbar')` calls targeting the removed behavior.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #26944".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.