### PR TITLE
Fix #26899: Save Draft modal in Collection Editor shifts on custom viewport sizes

### DIFF
--- a/core/templates/pages/collection-editor-page/modals/collection-editor-save-modal.component.html
+++ b/core/templates/pages/collection-editor-page/modals/collection-editor-save-modal.component.html
@@ -8,20 +8,19 @@
   <p>
     <span *ngIf="collectionIsPrivate">(Optional)</span>
     Please enter a brief description of what you have changed:
-    <textarea rows="3"
-              cols="50"
-              [attr.maxlength]="MAX_COMMIT_MESSAGE_LENGTH"
-              [(ngModel)]="commitMessage"
-              oppiaFocusOn="saveChangesModalOpened"
-              class="e2e-test-commit-message-input"
-              autofocus>
-    </textarea>
   </p>
+  <textarea rows="3"
+            [attr.maxlength]="MAX_COMMIT_MESSAGE_LENGTH"
+            [(ngModel)]="commitMessage"
+            oppiaFocusOn="saveChangesModalOpened"
+            class="e2e-test-commit-message-input w-100 form-control"
+            autofocus>
+  </textarea>
 </div>
 <div class="modal-footer">
   <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
   <button class="btn btn-success e2e-test-close-save-modal-button"
-          (disabled)="!collectionIsPrivate && !commitMessage"
+          [disabled]="!collectionIsPrivate && !commitMessage"
           (click)="confirm(commitMessage)">
     <span *ngIf="collectionIsPrivate">Save Draft</span>
     <span *ngIf="!collectionIsPrivate">Publish Changes</span>


### PR DESCRIPTION
## Explanation

Fixes #26899 by ensuring the Save Draft modal in the Collection Editor remains responsive and properly aligned across custom viewport sizes.

### Changes made:
- **`collection-editor-save-modal.component.html`**:
  - Replaced hardcoded fixed column layout (`cols="50"`) on commit message textarea with responsive Bootstrap form utility classes (`w-100 form-control`).
  - Extracted textarea out of `<p>` tag container to allow flexible block layout inside `.modal-body`.
  - Corrected `(disabled)` event binding syntax to `[disabled]` property binding on the submit button.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #26899".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.