### PR TITLE
Fix #26965: Update merge-develop-and-set-up-dependencies/action.yml

### DIFF
--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -45,7 +45,6 @@ runs:
 
     - name: Show where pip installs its packages, and the contents of that folder.
       run: |
-        pip --version
         pip show certifi
         ls -la /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages
         ls -la /opt/hostedtoolcache/Python/3.10.16/x64/bin
@@ -82,6 +81,23 @@ runs:
           /home/runner/work/oppia/oppia/node_modules
           /home/runner/work/oppia/oppia/third_party/python_libs
           /home/runner/work/oppia/oppia/third_party/static
+
+    - name: Check Yarn Cache
+      run: |
+        # Move outside repository root to ignore the configs in
+        # oppia/.yarnrc. These configs specify that yarn should use the
+        # Oppia-managed yarn executable, which hasn't been downloaded
+        # yet.
+        cd ..
+        # Create a new .yarnrc file to check what is already in the
+        # Oppia-managed yarn cache.
+        echo 'cache-folder "yarn_cache"' > .yarnrc
+        yarn cache list
+        # Delete the .yarnrc file that we just created.
+        rm .yarnrc
+        # Move back to the repository root.
+        cd -
+      shell: bash
 
     - name: Print requirements files (before)
       run: |

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -50,6 +50,23 @@ runs:
         ls -la /opt/hostedtoolcache/Python/3.10.16/x64/bin
       shell: bash
 
+    - name: Check Yarn Cache
+      run: |
+        # Move outside repository root to ignore the configs in
+        # oppia/.yarnrc. These configs specify that yarn should use the
+        # Oppia-managed yarn executable, which hasn't been downloaded
+        # yet.
+        cd ..
+        # Create a new .yarnrc file to check what is already in the
+        # Oppia-managed yarn cache.
+        echo 'cache-folder "yarn_cache"' > .yarnrc
+        yarn cache list
+        # Delete the .yarnrc file that we just created.
+        rm .yarnrc
+        # Move back to the repository root.
+        cd -
+      shell: bash
+
     # Production pip dependencies are installed in a custom folder rather than
     # the pip cache (see "Caching Python dependencies" in the README at
     # https://github.com/actions/setup-python?tab=readme-ov-file).
@@ -81,23 +98,6 @@ runs:
           /home/runner/work/oppia/oppia/node_modules
           /home/runner/work/oppia/oppia/third_party/python_libs
           /home/runner/work/oppia/oppia/third_party/static
-
-    - name: Check Yarn Cache
-      run: |
-        # Move outside repository root to ignore the configs in
-        # oppia/.yarnrc. These configs specify that yarn should use the
-        # Oppia-managed yarn executable, which hasn't been downloaded
-        # yet.
-        cd ..
-        # Create a new .yarnrc file to check what is already in the
-        # Oppia-managed yarn cache.
-        echo 'cache-folder "yarn_cache"' > .yarnrc
-        yarn cache list
-        # Delete the .yarnrc file that we just created.
-        rm .yarnrc
-        # Move back to the repository root.
-        cd -
-      shell: bash
 
     - name: Print requirements files (before)
       run: |

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -39,6 +39,8 @@ runs:
         retry_on: error
         shell: bash
         timeout_minutes: 30
+        # Note that the effects of this don't seem to be cached by setup-python,
+        # resulting in the occasional "No module named PIL" errors in CI.
         command: python -m scripts.install_python_dev_dependencies
 
     - name: Show where pip installs its packages, and the contents of that folder.

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -32,27 +32,13 @@ runs:
         echo "${{ steps.setup_python.outputs.python-version }}" > /home/runner/work/.pyversion
       shell: bash
 
-    - name: Cache Python dev dependencies
-      id: restore_python_dev_dependencies_cache
-      uses: actions/cache@v4
-      # We need to include install_python_dev_dependencies.py in the cache key
-      # because it has the version numbers for pip, pip-tools and setuptools.
-      with:
-        key: ${{ runner.os }}-devdeps-python-${{ hashFiles('/home/runner/work/.pyversion', 'requirements_dev.txt', 'scripts/install_python_dev_dependencies.py') }}
-        path: |
-          /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages
-          /opt/hostedtoolcache/Python/3.10.16/x64/bin
-
     - name: Install third-party Python dev dependencies
-      if: steps.restore_python_dev_dependencies_cache.outputs.cache-hit != 'true'
       uses: nick-fields/retry@v3
       with:
         max_attempts: 3
         retry_on: error
         shell: bash
         timeout_minutes: 30
-        # Note that the effects of this don't seem to be cached by setup-python,
-        # resulting in the occasional "No module named PIL" errors in CI.
         command: python -m scripts.install_python_dev_dependencies
 
     - name: Show where pip installs its packages, and the contents of that folder.

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -38,33 +38,13 @@ runs:
       # We need to include install_python_dev_dependencies.py in the cache key
       # because it has the version numbers for pip, pip-tools and setuptools.
       with:
-        key: ${{ runner.os }}-proddeps-${{ hashFiles('/home/runner/work/.pyversion', 'requirements_dev.txt', 'scripts/install_python_dev_dependencies.py') }}
+        key: ${{ runner.os }}-devdeps-python-${{ hashFiles('/home/runner/work/.pyversion', 'requirements_dev.txt', 'scripts/install_python_dev_dependencies.py') }}
         path: |
-          /opt/hostedtoolcache/Python/3.10.16/x64
-
-    # TODO (#22567): Fix pip not working properly when fetched from cache.
-    - name: Check pip installation and fix if needed
-      run: |
-        set -e
-        echo "Checking if pip is properly installed..."
-
-        # This shows pip-related environment and configuration info for debugging:
-        # https://pip.pypa.io/en/stable/cli/pip_debug/
-        if ! python -m pip debug; then
-          echo "pip is broken. Clearing pip cache..."
-          python -m pip cache purge || true
-          echo "Reinstalling pip and dev dependencies via install_python_dev_dependencies.py..."
-          curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-          python -m pip uninstall pip -y
-          python /tmp/get-pip.py pip==25.3
-          python -m scripts.install_python_dev_dependencies
-        else
-          echo "pip is working correctly."
-        fi
-      shell: bash
+          /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages
+          /opt/hostedtoolcache/Python/3.10.16/x64/bin
 
     - name: Install third-party Python dev dependencies
-      if: steps.restore_python_dev_dependencies_cache.outputs.cache-hit == false
+      if: steps.restore_python_dev_dependencies_cache.outputs.cache-hit != 'true'
       uses: nick-fields/retry@v3
       with:
         max_attempts: 3
@@ -82,23 +62,6 @@ runs:
         ls -la /opt/hostedtoolcache/Python/3.10.16/x64/bin
       shell: bash
 
-    - name: Check Yarn Cache
-      run: |
-        # Move outside repository root to ignore the configs in
-        # oppia/.yarnrc. These configs specify that yarn should use the
-        # Oppia-managed yarn executable, which hasn't been downloaded
-        # yet.
-        cd ..
-        # Create a new .yarnrc file to check what is already in the
-        # Oppia-managed yarn cache.
-        echo 'cache-folder "yarn_cache"' > .yarnrc
-        yarn cache list
-        # Delete the .yarnrc file that we just created.
-        rm .yarnrc
-        # Move back to the repository root.
-        cd -
-      shell: bash
-
     # Production pip dependencies are installed in a custom folder rather than
     # the pip cache (see "Caching Python dependencies" in the README at
     # https://github.com/actions/setup-python?tab=readme-ov-file).
@@ -111,11 +74,6 @@ runs:
     # Note that, in the case of a cache miss, the cache is populated when the
     # job completes successfully. See
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#cache-hits-and-misses
-    - name: Write the exact Python version to a file for cache-busting.
-      run: |
-        echo "${{ steps.setup_python.outputs.python-version }}" > /home/runner/work/.pyversion
-      shell: bash
-
     - name: Cache third_party and node_modules
       id: restore_third_party_and_node_modules_cache
       uses: actions/cache@v4
@@ -145,7 +103,7 @@ runs:
       shell: bash
 
     - name: Install third-party libs on cache miss (retries on error)
-      if: steps.restore_third_party_and_node_modules_cache.outputs.cache-hit == false
+      if: steps.restore_third_party_and_node_modules_cache.outputs.cache-hit != 'true'
       uses: nick-fields/retry@v3
       with:
         max_attempts: 3
@@ -163,7 +121,6 @@ runs:
       shell: bash
 
     - name: Check Yarn Cache
-      # Check the yarn cache again to see what packages were just
-      # installed.
+      # Check the yarn cache to see what packages were installed.
       run: yarn cache list
       shell: bash

--- a/.github/actions/merge-develop-and-set-up-dependencies/action.yml
+++ b/.github/actions/merge-develop-and-set-up-dependencies/action.yml
@@ -57,6 +57,7 @@ runs:
 
     - name: Show where pip installs its packages, and the contents of that folder.
       run: |
+        pip --version
         pip show certifi
         ls -la /opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages
         ls -la /opt/hostedtoolcache/Python/3.10.16/x64/bin


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #26965
2. This PR does the following: Updates merge-develop-and-setup-up-dependencies
    - Removes custom caching of dev_dependencies entirely, as it already cached by setup_python@v5
    - Removes temporary pip fix. The temporary fix was introduced to fix https://github.com/oppia/oppia/issues/22567 where a pip was corrupting due improper caching. It was being corrupted due to duplicate pip caching (which we have removed completely). 
4. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved caching and installation behavior for Python development and production dependencies in automated workflows.
  * Removed redundant cache inspection and Python version tracking steps.
  * Updated dependency cache conditions for more reliable setup execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->