### PR TITLE
Fix #26984: Creator Dashboard: Icons and text overflow/get cut off on exploration cards

### DIFF
--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
@@ -603,8 +603,9 @@
     height: 260px;
     margin-left: 7.5px;
     margin-right: 7.5px;
+    overflow: hidden;
     padding: 0;
-    position: static;
+    position: relative;
     width: 184px;
   }
 
@@ -619,10 +620,15 @@
   }
 
   .oppia-dashboard-card-view-item .exp-private-text {
+    display: -webkit-box;
     font-size: 13px;
+    overflow: hidden;
     padding-left: 0.5em;
     padding-right: 0.5em;
     padding-top: 0.8em;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
   }
 
   .oppia-dashboard-card-view-item .metrics {
@@ -637,7 +643,9 @@
 
   .oppia-dashboard-card-view-item .oppia-sharing-links {
     font-size: 24px;
-    margin: 10px;
+    margin: 5px;
+    max-width: 100%;
+    overflow: hidden;
   }
 
   .oppia-dashboard-card-view-item .oppia-sharing-links .share-option-img,


### PR DESCRIPTION
## Explanation

Fixes #26984 by addressing layout and overflow issues on exploration cards in the Creator Dashboard.

### Changes made:
- **`creator-dashboard-page.component.html`**:
  - Changed `.oppia-dashboard-card-view-item` from `position: static` to `position: relative` and added `overflow: hidden` to contain inner elements within card bounds.
  - Added multiline text truncation (`-webkit-line-clamp: 4; text-overflow: ellipsis;`) to `.exp-private-text` so status messages do not spill out below the card.
  - Adjusted `.oppia-sharing-links` margins and added `max-width: 100%` so share icons (Facebook/Twitter) fit completely inside card boundaries without being sliced off.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #26984".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.