### PR TITLE
Fix #5867: Exclude empty HTML fields from the translation progress tracker

### DIFF
--- a/core/templates/pages/exploration-editor-page/services/exploration-states.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-states.service.spec.ts
@@ -239,4 +239,24 @@ describe('ExplorationStatesService', () => {
       explorationStatesService.getSolicitAnswerDetailsMemento('Hola')
     ).toBe(true);
   });
+
+  describe('.getAllNonEmptyContentIdsByStateName', () => {
+    it('should exclude content ids whose html is empty', () => {
+      // In the Hola state, "content" has html '' (empty) while
+      // "feedback_1" has non-empty html, so only "content" should
+      // be dropped by the non-empty variant.
+      const allContentIds =
+        explorationStatesService.getAllContentIdsByStateName('Hola');
+      const nonEmptyContentIds =
+        explorationStatesService.getAllNonEmptyContentIdsByStateName('Hola');
+
+      // The existing method still includes the empty "content" field.
+      expect(allContentIds).toContain('content');
+
+      // The new method drops the empty "content" field...
+      expect(nonEmptyContentIds).not.toContain('content');
+      // ...but keeps the non-empty "feedback_1" field.
+      expect(nonEmptyContentIds).toContain('feedback_1');
+    });
+  });
 });

--- a/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
@@ -631,8 +631,8 @@ export class ExplorationStatesService {
       .filter(contentId => contentId !== undefined);
     return allContentIds.filter(contentId => {
       // Content ids present in this map (card content, customization args
-      // like choices, feedback, hints, solution) are dropped when their)
-      // HTML is emty, since empty fields don't need a translation. Content
+      // like choices, feedback, hints, solution) are dropped when their
+      // HTML is empty, since empty fields don't need a translation. Content
       // ids not in the map (e.g. rule inputs) are left untouched.
       if (contentId in contentIdToHtml) {
         return contentIdToHtml[contentId] !== '';

--- a/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
@@ -623,6 +623,24 @@ export class ExplorationStatesService {
     return allContentIds.filter(contentId => contentId !== undefined);
   }
 
+  getAllNonEmptyContentIdsByStateName(stateName: string): string[] {
+    const state = this._getStates().getState(stateName);
+    const contentIdToHtml = state.getContentIdToContents();
+    const allContentIds = state
+      .getAllContentIds()
+      .filter(contentId => contentId !== undefined);
+    return allContentIds.filter(contentId => {
+      // Content ids present in this map (card content, customization args
+      // like choices, feedback, hints, solution) are dropped when their)
+      // HTML is emty, since empty fields don't need a translation. Content
+      // ids not in the map (e.g. rule inputs) are left untouched.
+      if (contentId in contentIdToHtml) {
+        return contentIdToHtml[contentId] !== '';
+      }
+      return true;
+    });
+  }
+
   getCheckpointCount(): number {
     let count: number = 0;
     if (this._states) {

--- a/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
@@ -634,10 +634,9 @@ export class ExplorationStatesService {
       // like choices, feedback, hints, solution) are dropped when their
       // HTML is empty, since empty fields don't need a translation. Content
       // ids not in the map (e.g. rule inputs) are left untouched.
-      if (contentId in contentIdToHtml) {
-        return contentIdToHtml[contentId] !== '';
-      }
-      return true;
+      return (
+        !(contentId in contentIdToHtml) || contentIdToHtml[contentId] !== ''
+      );
     });
   }
 

--- a/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.spec.ts
@@ -424,13 +424,13 @@ describe('Translation status service', () => {
       ttams.activateVoiceoverMode();
       var explorationAudioRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationAudioRequiredCount).toBe(8);
+      expect(explorationAudioRequiredCount).toBe(5);
 
       ttams.activateTranslationMode();
       tls.setActiveLanguageCode('hi');
       var explorationTranslationsRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationTranslationsRequiredCount).toBe(8);
+      expect(explorationTranslationsRequiredCount).toBe(5);
 
       // To test changes after adding a new state.
       ess.addState('Fourth', () => {});
@@ -442,14 +442,14 @@ describe('Translation status service', () => {
       tls.setActiveLanguageCode('en');
       var explorationAudioRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationAudioRequiredCount).toBe(9);
+      expect(explorationAudioRequiredCount).toBe(5);
 
       ttams.activateTranslationMode();
       tls.setActiveLanguageCode('hi');
 
       var explorationTranslationsRequiredCount =
         tss.getExplorationContentRequiredCount();
-      expect(explorationTranslationsRequiredCount).toBe(9);
+      expect(explorationTranslationsRequiredCount).toBe(5);
     }
   );
 
@@ -493,12 +493,12 @@ describe('Translation status service', () => {
 
     ttams.activateVoiceoverMode();
 
-    expect(tss.getExplorationContentRequiredCount()).toBe(8);
+    expect(tss.getExplorationContentRequiredCount()).toBe(5);
 
     entityVoiceoversService.setActiveLanguageAccentCode('en-US');
 
     tss.refresh();
-    expect(tss.getExplorationContentNotAvailableCount()).toEqual(7);
+    expect(tss.getExplorationContentNotAvailableCount()).toEqual(4);
     let color = tss.getActiveStateContentIdStatusColor('content_0');
     expect(tss.NO_ASSETS_AVAILABLE_COLOR).toEqual(color);
 
@@ -509,7 +509,7 @@ describe('Translation status service', () => {
     } as FeatureStatusChecker);
 
     tss.refresh();
-    expect(tss.getExplorationContentNotAvailableCount()).toEqual(6);
+    expect(tss.getExplorationContentNotAvailableCount()).toEqual(3);
     color = tss.getActiveStateContentIdStatusColor('content_0');
     expect(tss.ALL_ASSETS_AVAILABLE_COLOR).toEqual(color);
 
@@ -518,7 +518,7 @@ describe('Translation status service', () => {
 
     entityVoiceoversService.setActiveLanguageAccentCode('en-IN');
     tss.refresh();
-    expect(tss.getExplorationContentNotAvailableCount()).toEqual(8);
+    expect(tss.getExplorationContentNotAvailableCount()).toEqual(5);
   });
 
   it('should return a correct count of audio not available in an exploration', () => {
@@ -534,7 +534,7 @@ describe('Translation status service', () => {
 
     explorationAudioNotAvailableCount =
       tss.getExplorationContentNotAvailableCount();
-    expect(explorationAudioNotAvailableCount).toBe(1);
+    expect(explorationAudioNotAvailableCount).toBe(0);
   });
 
   it(
@@ -546,7 +546,7 @@ describe('Translation status service', () => {
       tss.refresh();
       var explorationTranslationNotAvailableCount =
         tss.getExplorationContentNotAvailableCount();
-      expect(explorationTranslationNotAvailableCount).toBe(7);
+      expect(explorationTranslationNotAvailableCount).toBe(4);
 
       ess.addState('Fourth', () => {});
       ess.saveInteractionId('Third', 'MultipleChoiceInput');
@@ -556,7 +556,7 @@ describe('Translation status service', () => {
       tss.refresh();
       explorationTranslationNotAvailableCount =
         tss.getExplorationContentNotAvailableCount();
-      expect(explorationTranslationNotAvailableCount).toBe(8);
+      expect(explorationTranslationNotAvailableCount).toBe(4);
     }
   );
 

--- a/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/services/translation-status.service.ts
@@ -162,7 +162,9 @@ export class TranslationStatusService {
         let noVoiceoverCount = 0;
 
         let allContentIds =
-          this.explorationStatesService.getAllContentIdsByStateName(stateName);
+          this.explorationStatesService.getAllNonEmptyContentIdsByStateName(
+            stateName
+          );
         let interactionId =
           this.explorationStatesService.getInteractionIdMemento(stateName);
         // This is used to prevent users from adding unwanted hints audio, as

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -199,7 +199,8 @@
 
       <div>
         <ul class="oppia-translation-preview oppia-option-list nav-stacked nav-pills" role="tablist">
-          <li [ngClass]="{'active': activeAnswerGroupIndex === stateAnswerGroups.length}"
+          <li *ngIf="!stateDefaultOutcome.feedback.isEmpty()"
+              [ngClass]="{'active': activeAnswerGroupIndex === stateAnswerGroups.length}"
               class="oppia-rule-block e2e-test-translation-feedback">
             <a class="oppia-rule-tab oppia-default-rule-tab e2e-test-feedback-{{ stateAnswerGroups.length }} oppia-translation-preview-list"
                (click)="changeActiveAnswerGroupIndex(stateAnswerGroups.length)"

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.spec.ts
@@ -383,6 +383,29 @@ describe('State translation component', () => {
         }
       );
 
+      describe('empty default outcome feedback', () => {
+        it('should show the default outcome row when its feedback is non-empty', () => {
+          component.onTabClick('feedback');
+          fixture.detectChanges();
+
+          const defaultRow = fixture.nativeElement.querySelector(
+            '.oppia-default-rule-tab'
+          );
+          expect(defaultRow).not.toBeNull();
+        });
+
+        it('should hide the default outcome row when its feedback is empty', () => {
+          component.stateDefaultOutcome.feedback.html = '';
+          component.onTabClick('feedback');
+          fixture.detectChanges();
+
+          const defaultRow = fixture.nativeElement.querySelector(
+            '.oppia-default-rule-tab'
+          );
+          expect(defaultRow).toBeNull();
+        });
+      });
+
       it('should broadcast copy to ck editor when clicking on content', () => {
         spyOn(ckEditorCopyContentService, 'broadcastCopy').and.callFake(
           () => {}


### PR DESCRIPTION
## Overview

1. This PR fixes #5867.
2. This PR stops empty HTML content fields from being counted in the exploration translation progress tracker. Earlier, if a field like the default outcome's feedback was left empty, it still showed up red in the Feedback sub-tab and was counted as needing a translation. Now empty fields are excluded from the count and their row isn't shown, so the tracker only reflects content that actually needs translating.
3. (For bug-fixing PRs only) The original bug occurred because `_computeAllStatesStatus()` in `translation-status.service.ts` counted every content id returned by `getAllContentIdsByStateName()` without checking whether the underlying HTML was empty. The existing `default_outcome_` exclusion only applies to linear/terminal interactions, so for interactions like multiple choice the empty default-outcome feedback was still counted.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

Added a `getAllNonEmptyContentIdsByStateName()` helper in `exploration-states.service.ts`
that returns only content ids whose HTML is non-empty, and used it in `_computeAllStatesStatus()` so empty fields aren't counted. In `state-translation.component.html`, the default-outcome row is now guarded with `*ngIf="!stateDefaultOutcome.feedback.isEmpty()"` so an empty field doesn't render.

Unit tests cover the helper (empty content id excluded, non-empty kept) and the component behaviour (row shown when feedback is non-empty, hidden when empty). Frontend tests, coverage, and lint all pass locally.

**Frontend coverage checks passing:**

<img width="1467" height="919" alt="Screenshot 2026-08-03 at 4 16 51 AM" src="https://github.com/user-attachments/assets/dae54a03-7d7d-41db-8901-62d8e7640160" />

**Lint checks passing:**

<img width="1470" height="956" alt="Screenshot 2026-08-03 at 3 28 41 AM" src="https://github.com/user-attachments/assets/e64066da-344d-49ea-8e23-a010357d9f91" />


#### Proof of changes on desktop with slow/throttled network

**Before:** the default "all other answers" outcome has empty feedback, but it shows up red in the Feedback list and is counted in the progress tracker.


https://github.com/user-attachments/assets/1a49a438-82b4-4cda-9099-0aed1c307f35


**After:** with the fix, the empty field no longer appears in the list and isn't counted.


https://github.com/user-attachments/assets/53f4cc6c-ceda-47f1-9430-dfff57574792



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
