### PR TITLE
Fix #27003: Visible Focus Indicators Missing In LEARN Menu

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -38,6 +38,14 @@
 .oppia-top-navigation-bar .get-involved-dropdown a {
   text-decoration: none;
 }
+
+.oppia-top-navigation-bar .learn-dropdown-menu a:focus,
+.oppia-top-navigation-bar .about-dropdown-menu a:focus,
+.oppia-top-navigation-bar .get-involved-dropdown a:focus {
+  outline: 2px solid #00645c;
+  outline-offset: 2px;
+  text-decoration: underline;
+}
 .oppia-top-navigation-bar .learn-dropdown-menu .nav-item-top-link a {
   color: #333;
   font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
## Explanation

Fixes #27003 by adding visible focus outline indicators to all links in the LEARN dropdown menu (as well as ABOUT and GET INVOLVED dropdown menus) during keyboard tab navigation.

### Changes made:
- **`top-navigation-bar.component.css`**: Added focus selector rules for `.learn-dropdown-menu a:focus`, `.about-dropdown-menu a:focus`, and `.get-involved-dropdown a:focus` with `outline: 2px solid #00645c; outline-offset: 2px; text-decoration: underline;`.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27003".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.