### PR TITLE
Fix #27033: Blog bio tooltip is showing Edit Author name instead of Edit bio

### DIFF
--- a/core/templates/pages/blog-dashboard-page/blog-dashboard-page.component.html
+++ b/core/templates/pages/blog-dashboard-page/blog-dashboard-page.component.html
@@ -33,7 +33,7 @@
               {{ authorBio }}
             </span>
             <button class="fas fa-pen oppia-editor-edit-icon mb-auto e2e-test-update-blog-editor-bio"
-                    title="Edit Author Name"
+                    title="Edit Bio"
                     (click)="showAuthorDetailsEditor()">
             </button>
           </span>


### PR DESCRIPTION
## Explanation

Fixes #27033 by updating the `title` attribute tooltip on the bio edit button (`.e2e-test-update-blog-editor-bio`) in the Blog Dashboard from `"Edit Author Name"` to `"Edit Bio"`.

### Changes made:
- **`blog-dashboard-page.component.html`**: Updated `title="Edit Bio"` on the bio edit button.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27033".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.