### PR TITLE
Provide close_pr_on_force_push permission to write to PR thread

### DIFF
--- a/.github/workflows/close_pr_on_force_push.yml
+++ b/.github/workflows/close_pr_on_force_push.yml
@@ -2,44 +2,40 @@ name: Close PR on force-push or rebase
 on:
   pull_request:
     types:
+        - opened
         - synchronize
+        - reopened
 permissions: read-all
 jobs:
   detect_force_push:
     runs-on: ubuntu-24.04
     permissions:
+        issues: write
         pull-requests: write
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
       - name: Close PR if branch was force-pushed or rebased
         uses: actions/github-script@v6
         with:
           script: |
             const pr = context.payload.pull_request;
-            const before = context.payload.before;
-            const after = context.payload.after;
 
-            // A normal (fast-forward) push always keeps 'before' as an
-            // ancestor of 'after', so the comparison reports 0 commits
-            // behind. A force-push or rebase rewrites history, so commits
-            // that were previously on the branch are no longer reachable
-            // from the new head, and 'before' ends up behind/diverged from
-            // 'after' instead. This also correctly does not flag a normal
-            // 'merge the base branch into my PR branch' commit, since that
-            // keeps 'before' as an ancestor of the new merge commit.
-            const { data: comparison } = await github.rest.repos.compareCommits({
+            // head_ref_force_pushed is the same timeline event GitHub's own
+            // UI uses to show the "force-pushed" badge on a PR, so this
+            // reflects any rewrite the PR's branch has undergone since the
+            // PR was created, regardless of which of opened/synchronize/
+            // reopened this run was triggered by.
+            const { data: timeline } = await github.rest.issues.listEventsForTimeline({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              base: before,
-              head: after,
+              issue_number: pr.number,
+              per_page: 100,
             });
+            const wasForcePushed = timeline.some(
+              (e) => e.event === 'head_ref_force_pushed'
+            );
 
-            if (comparison.behind_by > 0) {
-              const author = pr.user.login;
-              const comment = `Hi @${author}, this PR's branch appears to have been force-pushed or rebased, which rewrites commit history. Per our [contribution guidelines](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change), force-pushing to a PR branch is not allowed, so this PR is being closed. Please open a new PR from a fresh branch instead of force-pushing. Thanks!`;
+            if (wasForcePushed) {
+              const comment = `Hi @${pr.user.login}, this PR's branch appears to have been force-pushed or rebased, which rewrites commit history. Per our [contribution guidelines](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change), force-pushing to a PR branch is not allowed, so this PR is being closed. Please open a new PR from a fresh branch instead of force-pushing. Thanks!`;
 
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/.github/workflows/close_pr_on_force_push.yml
+++ b/.github/workflows/close_pr_on_force_push.yml
@@ -24,15 +24,25 @@ jobs:
             // reflects any rewrite the PR's branch has undergone since the
             // PR was created, regardless of which of opened/synchronize/
             // reopened this run was triggered by.
-            const { data: timeline } = await github.rest.issues.listEventsForTimeline({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              per_page: 100,
-            });
-            const wasForcePushed = timeline.some(
-              (e) => e.event === 'head_ref_force_pushed'
+            // NOTE: timelineItems' totalCount always reflects ALL timeline
+            // items on the PR and is NOT affected by the itemTypes filter
+            // (a documented GitHub GraphQL API quirk) -- so we check the
+            // length of the (correctly filtered) nodes list instead.
+            const result = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    timelineItems(first: 1, itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT]) {
+                      nodes {
+                        __typename
+                      }
+                    }
+                  }
+                }
+              }`,
+              { owner: context.repo.owner, repo: context.repo.repo, number: pr.number }
             );
+            const wasForcePushed = result.repository.pullRequest.timelineItems.nodes.length > 0;
 
             if (wasForcePushed) {
               const comment = `Hi @${pr.user.login}, this PR's branch appears to have been force-pushed or rebased, which rewrites commit history. Per our [contribution guidelines](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change), force-pushing to a PR branch is not allowed, so this PR is being closed. Please open a new PR from a fresh branch instead of force-pushing. Thanks!`;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #[NA] or fixes part of #[fill_in_number_here].
2. This PR does the following: close_pr_on_force_push seems to correctly detect force-pushed commit but fails to add a comment in such cases because it lacks the "issues: write" permission -- which has been fixed in this PR. It should fix this error: https://github.com/oppia/oppia/actions/runs/30956434559/job/92150474419?pr=27035

Separately, I've updated the approach to rely on Github's event timeline to look for force-push (same indicator that Github's UI uses) on PR open/re-open and synchronise events.

3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
