### PR TITLE
Fix #20124: Guard CD admin stats jobs against missing-total false positives and the translation-reviewer empty-list crash

### DIFF
--- a/core/jobs/batch_jobs/contributor_admin_stats_jobs.py
+++ b/core/jobs/batch_jobs/contributor_admin_stats_jobs.py
@@ -304,6 +304,8 @@ class GenerateContributorAdminStatsJob(base_jobs.JobBase):
             >> beam.GroupByKey()
             | 'Transform translation reviewer stats'
             >> beam.MapTuple(self.transform_translation_review_stats)
+            | 'Filter total translation reviewer stats'
+            >> beam.Filter(lambda res: res is not None)
         )
 
         question_submitter_total_stats_model_results = (
@@ -605,7 +607,9 @@ class GenerateContributorAdminStatsJob(base_jobs.JobBase):
         translation_reviewer_stats: Iterable[
             suggestion_models.TranslationReviewStatsModel
         ],
-    ) -> suggestion_models.TranslationReviewerTotalContributionStatsModel:
+    ) -> Optional[
+        suggestion_models.TranslationReviewerTotalContributionStatsModel
+    ]:
         """Transforms TranslationReviewStatsModel to
         TranslationReviewerTotalContributionStatsModel.
 
@@ -618,21 +622,26 @@ class GenerateContributorAdminStatsJob(base_jobs.JobBase):
                 (language_code, reviewer_user_id).
 
         Returns:
-            suggestion_models
-            .TranslationReviewerTotalContributionStatsModel.
-            New TranslationReviewerTotalContributionStatsModel model.
+            Optional[suggestion_models.TranslationReviewerTotalContributionStatsModel].
+            A TranslationReviewerTotalContributionStatsModel if valid topic
+            stats exist, otherwise None when all topics are invalid/deleted.
         """
-
-        translation_reviewer_stats = list(translation_reviewer_stats)
 
         language_code, reviewer_user_id = keys
         entity_id = '%s.%s' % (language_code, reviewer_user_id)
 
-        for stat in translation_reviewer_stats:
-            if GenerateContributorAdminStatsJob.not_validate_topic(
+        translation_reviewer_stats = [
+            stat
+            for stat in translation_reviewer_stats
+            if not GenerateContributorAdminStatsJob.not_validate_topic(
                 stat.topic_id
-            ):
-                translation_reviewer_stats.remove(stat)
+            )
+        ]
+
+        if len(translation_reviewer_stats) == 0:
+            # No need to generate total reviewer stats if there is no valid
+            # stats model (e.g. all topics are invalid/deleted).
+            return None
 
         topic_ids = [v.topic_id for v in translation_reviewer_stats]
         reviewed_translations_count = sum(

--- a/core/jobs/batch_jobs/contributor_admin_stats_jobs.py
+++ b/core/jobs/batch_jobs/contributor_admin_stats_jobs.py
@@ -1858,6 +1858,11 @@ class ValidateTotalContributionStatsJob(base_jobs.JobBase):
             if len(totals) > 0:
                 return result.Ok(kv)
 
+            if len(contribs) == 0:
+                # A total contribution stats model cannot be generated when there are
+                # no corresponding base contribution stats models.
+                return None
+
             # Generate Logs.
             contrib_ids = [str(getattr(c, 'id', None)) for c in contribs]
             suggestion_ids = [str(getattr(s, 'id', None)) for s in suggestions]

--- a/core/jobs/batch_jobs/contributor_admin_stats_jobs_test.py
+++ b/core/jobs/batch_jobs/contributor_admin_stats_jobs_test.py
@@ -1711,6 +1711,19 @@ class GenerateContributorAdminStatsJobTests(ContributorDashboardTest):
 
         self.assert_job_output_is_empty()
 
+    def test_skip_generation_if_translation_review_has_only_invalid_topics(
+        self,
+    ) -> None:
+        self.translation_review_model_with_invalid_topic.update_timestamps()
+
+        self.put_multi(
+            [
+                self.translation_review_model_with_invalid_topic,
+            ]
+        )
+
+        self.assert_job_output_is_empty()
+
 
 class AuditGenerateContributorAdminStatsJobTests(ContributorDashboardTest):
 

--- a/core/jobs/batch_jobs/contributor_admin_stats_jobs_test.py
+++ b/core/jobs/batch_jobs/contributor_admin_stats_jobs_test.py
@@ -3118,6 +3118,84 @@ class ValidateTotalContributionStatsJobTests(ContributorDashboardTest):
             ]
         )
 
+    def test_translation_suggestion_without_contribution_stats_is_skipped(
+        self,
+    ) -> None:
+        # Create an exploration opportunity so that the translation suggestion
+        # is included in the validation pipeline.
+        exp_opportunity = self.create_model(
+            opportunity_models.ExplorationOpportunitySummaryModel,
+            id='exp_without_contribution_stats',
+            topic_id='topic_without_contribution_stats',
+            chapter_title='A chapter',
+            content_count=1,
+            story_id='story_without_contribution_stats',
+            story_title='A story',
+            topic_name='A topic',
+        )
+        exp_opportunity.update_timestamps()
+
+        # Create a suggestion without a corresponding
+        # TranslationContributionStatsModel or
+        # TranslationSubmitterTotalContributionStatsModel.
+        suggestion = self.create_model(
+            suggestion_models.GeneralSuggestionModel,
+            id='translation_suggestion_without_stats',
+            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+            target_type=feconf.ENTITY_TYPE_EXPLORATION,
+            target_id='exp_without_contribution_stats',
+            target_version_at_submission=1,
+            status=suggestion_models.STATUS_IN_REVIEW,
+            author_id='translation_author',
+            final_reviewer_id=None,
+            change_cmd={},
+            score_category='translation.hi',
+            language_code='hi',
+            edited_by_reviewer=False,
+            created_on=datetime.datetime.utcnow(),
+        )
+
+        self.put_multi([exp_opportunity, suggestion])
+
+        self.assert_job_output_is([])
+
+    def test_question_suggestion_without_contribution_stats_is_skipped(
+        self,
+    ) -> None:
+        # Create a skill opportunity so that the question suggestion is included
+        # in the validation pipeline.
+        skill_opportunity = self.create_model(
+            opportunity_models.SkillOpportunityModel,
+            id='skill_without_contribution_stats',
+            skill_description='A skill without contribution stats',
+            question_count=1,
+        )
+        skill_opportunity.update_timestamps()
+
+        # Create a suggestion without a corresponding
+        # QuestionContributionStatsModel or
+        # QuestionSubmitterTotalContributionStatsModel.
+        suggestion = self.create_model(
+            suggestion_models.GeneralSuggestionModel,
+            id='question_suggestion_without_stats',
+            suggestion_type=feconf.SUGGESTION_TYPE_ADD_QUESTION,
+            target_type=feconf.ENTITY_TYPE_SKILL,
+            target_id='skill_without_contribution_stats',
+            target_version_at_submission=1,
+            status=suggestion_models.STATUS_IN_REVIEW,
+            author_id='question_author',
+            final_reviewer_id=None,
+            change_cmd={},
+            score_category='question.skill_without_contribution_stats',
+            language_code=None,
+            edited_by_reviewer=False,
+            created_on=datetime.datetime.utcnow(),
+        )
+
+        self.put_multi([skill_opportunity, suggestion])
+
+        self.assert_job_output_is([])
+
     def test_question_missing_total_emits_missing_log(self) -> None:
         # Test missing QuestionSubmitterTotalContributionStatsModel.
 

--- a/core/jobs/batch_jobs/contributor_admin_stats_jobs_test.py
+++ b/core/jobs/batch_jobs/contributor_admin_stats_jobs_test.py
@@ -1724,6 +1724,52 @@ class GenerateContributorAdminStatsJobTests(ContributorDashboardTest):
 
         self.assert_job_output_is_empty()
 
+    def test_skip_generation_when_reviewed_topic_is_deleted(self) -> None:
+        # 1) Create a real topic via the service (sets up versioning
+        # correctly), mimicking a topic that a reviewer reviewed against.
+        topic = topic_domain.Topic.create_default_topic(
+            'topic_to_delete',
+            'topic-to-delete-name',
+            'topic-to-delete',
+            'description',
+            'fragm',
+        )
+        topic_services.save_new_topic(feconf.SYSTEM_COMMITTER_ID, topic)
+
+        # 2) Create a translation review stat that references that topic.
+        review_stat = self.create_model(
+            suggestion_models.TranslationReviewStatsModel,
+            id='es.reviewer_del.topic_to_delete',
+            language_code='es',
+            reviewer_user_id='reviewer_del',
+            topic_id='topic_to_delete',
+            reviewed_translations_count=self.REVIEWED_TRANSLATIONS_COUNT,
+            reviewed_translation_word_count=(
+                self.REVIEWED_TRANSLATION_WORD_COUNT
+            ),
+            accepted_translations_count=self.ACCEPTED_TRANSLATIONS_COUNT,
+            accepted_translations_with_reviewer_edits_count=(
+                self.ACCEPTED_TRANSLATIONS_WITH_REVIEWER_EDITS_COUNT
+            ),
+            accepted_translation_word_count=(
+                self.ACCEPTED_TRANSLATION_WORD_COUNT
+            ),
+            first_contribution_date=self.FIRST_CONTRIBUTION_DATE,
+            last_contribution_date=self.LAST_CONTRIBUTION_DATE,
+        )
+        review_stat.update_timestamps()
+        review_stat.put()
+
+        # 3) Delete the topic, mimicking a topic removed after the review
+        # was recorded.
+        topic_services.delete_topic(
+            feconf.SYSTEM_COMMITTER_ID, 'topic_to_delete'
+        )
+
+        # 4) The job should skip the now-invalid review stat and complete
+        # without raising 'min() arg is an empty sequence'.
+        self.assert_job_output_is_empty()
+
 
 class AuditGenerateContributorAdminStatsJobTests(ContributorDashboardTest):
 
@@ -1907,6 +1953,13 @@ class AuditGenerateContributorAdminStatsJobTests(ContributorDashboardTest):
             edited_by_reviewer=False,
         ).put()
 
+        self.assert_job_output_is_empty()
+
+    def test_skip_audit_if_translation_review_has_only_invalid_topics(
+        self,
+    ) -> None:
+        self.translation_review_model_with_invalid_topic.update_timestamps()
+        self.put_multi([self.translation_review_model_with_invalid_topic])
         self.assert_job_output_is_empty()
 
 


### PR DESCRIPTION
## Overview

1. This PR fixes #20124.

2. This PR does the following:
   - **Validator guard.** Adds a guard in
     `ValidateTotalContributionStatsJob._check_missing_total_fn` so that, when a group has no
     `Total…` model **and** no base contribution-stats models, it is skipped (`return None`)
     instead of being reported as a missing total. This removes the false-positive
     `Missing …TotalContributionStatsModel … -> …ContributionStatsModel: --None` errors for
     suggestion-only groups. Applied to both the translation and question pipelines.
   - **Translation-reviewer crash guard.** Guards
     `GenerateContributorAdminStatsJob.transform_translation_review_stats` against
     `ValueError: min() arg is an empty sequence`. The invalid-topic filter is rewritten as a list
     comprehension (removing a mutate-while-iterating bug), the function returns `None` (and its
     return type becomes `Optional[...]`) when the group has no valid-topic review stats, and a
     `beam.Filter(lambda res: res is not None)` is added to the reviewer branch of the pipeline.
   - Adds three regression tests: one for the reviewer crash
     (`test_skip_generation_if_translation_review_has_only_invalid_topics`) and two for the
     validator false positive
     (`test_translation_suggestion_without_contribution_stats_is_skipped`,
     `test_question_suggestion_without_contribution_stats_is_skipped`). Each fails before its guard
     and passes after.

3. (For bug-fixing PRs only) The original bug occurred because:
   - **Reviewer crash:** `transform_translation_review_stats` calls `min()`/`max()` on
     `translation_reviewer_stats` after filtering out invalid topics. When every
     `TranslationReviewStatsModel` for a `(language_code, reviewer_user_id)` group has an
     invalid/deleted topic, the list becomes empty and `min()` raises. The function has no
     `try/except` and its pipeline branch had no `None` filter, so it surfaced as an uncaught job
     failure (observed on the server — Dataflow job
     `2026-02-21_03_12_30-3761490124031858811`). This reviewer path was never guarded (the earlier
     submitter fixes in #22765 / #24201 did not touch it).
   - **Validator false positive:** `_check_missing_total_fn` reported a missing total for any group
     lacking a `Total…` model, even when there were also no base contribution stats to validate
     (the `--None` case), which is a legitimate state (e.g. a skill with an opportunity but no
     topic assignment, or a wiped-out `pid_` user).

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with "@{{reviewer_username}} PTAL").

## Testing doc (for PRs with Beam jobs that modify production server data)

- [ ] A testing doc has been written [TestingDocs](https://docs.google.com/document/d/1srmTdgamKfE71ZAXc2_r20MOOFHdD8rfUiFLLGfQGxI/edit?usp=sharing)
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct

No user-facing UI changes — these are backend Beam jobs. Proof of correctness is via backend
unit tests (red-green) plus the server run described in the testing doc.

Local backend test results:
Before 
GenerateContributorAdminStatsJobTests.test_skip_generation_if_translation_review_has_only_invalid_topics
<img width="1920" height="1020" alt="Screenshot 2026-08-04 183521" src="https://github.com/user-attachments/assets/de32b40c-b477-4a4c-a8f9-8c8f81f09352" />
ValidateTotalContributionStatsJobTests.test_translation_suggestion_without_contribution_stats_is_skipped
ValidateTotalContributionStatsJobTests.test_question_suggestion_without_contribution_stats_is_skipped
<img width="1920" height="1020" alt="Screenshot 2026-08-04 053317" src="https://github.com/user-attachments/assets/d1f1d1bf-b766-4d17-a7e9-96f89df9df1b" />
<img width="1920" height="1020" alt="Screenshot 2026-08-04 053432" src="https://github.com/user-attachments/assets/42217cca-5313-494e-9314-12aeb7f2db8c" />

After fix 
GenerateContributorAdminStatsJobTests.test_skip_generation_if_translation_review_has_only_invalid_topics
<img width="1920" height="1020" alt="Screenshot 2026-08-04 194958" src="https://github.com/user-attachments/assets/5b56b190-e18d-4db5-bd06-43fc1d6f0308" />
ValidateTotalContributionStatsJobTests.test_translation_suggestion_without_contribution_stats_is_skipped
ValidateTotalContributionStatsJobTests.test_question_suggestion_without_contribution_stats_is_skipped
<img width="1920" height="1020" alt="Screenshot 2026-08-04 053652" src="https://github.com/user-attachments/assets/fe4e4ab5-d107-4fa1-ac61-35cf6bc4aedf" />

Each new test fails on develop (reproducing either `min() arg is an empty sequence` in
`transform_translation_review_stats`, or the `--None` missing-total error) and passes with this
PR's guards. Existing genuine missing-total tests still report errors, confirming the validator
guard is narrow.
#### Proof of changes on desktop with slow/throttled network
N/A

#### Proof of changes on mobile phone
N/A

#### Proof of changes in Arabic language

N/A

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
