### PR TITLE
Fix #27038: Language Menu Items Are Missing Visible Focus Indicators

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -313,11 +313,16 @@
   color: #34665c;
   padding: 10px 0;
 }
-.oppia-top-navigation-bar .language-element:hover {
-  background-color: rgb(52, 102, 92, 0.1);
+.oppia-top-navigation-bar .language-element:hover,
+.oppia-top-navigation-bar .language-element:focus,
+.oppia-top-navigation-bar .language-dropdown button:focus,
+.oppia-top-navigation-bar .language-dropdown a:focus {
+  background-color: rgba(52, 102, 92, 0.15);
+  outline: 2px solid #00645c;
+  outline-offset: -2px;
 }
 .oppia-top-navigation-bar .language-element-selected {
-  background-color: rgb(52, 102, 92, 0.1);
+  background-color: rgba(52, 102, 92, 0.1);
 }
 .oppia-top-navigation-bar .oppia-nav-right-dropdown:focus,
 .oppia-top-navigation-bar .oppia-nav-right-dropdown:hover {


### PR DESCRIPTION
## Explanation

Fixes #27038 by adding visible focus indicators (high-contrast `#00645c` outline and background highlight) to language selection menu items during keyboard navigation.

### Changes made:
- **`top-navigation-bar.component.css`**: Added `:focus` style rules for `.language-element:focus`, `.language-dropdown button:focus`, and `.language-dropdown a:focus` with `outline: 2px solid #00645c; outline-offset: -2px; background-color: rgba(52, 102, 92, 0.15);`.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27038".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.