### PR TITLE
Fix #27050: Fix Lint checks to not fail if string contains TODO text

### DIFF
--- a/scripts/linters/general_purpose_linter.py
+++ b/scripts/linters/general_purpose_linter.py
@@ -188,7 +188,9 @@ BAD_PATTERNS: Dict[str, BadPatternsDict] = {
 
 BAD_PATTERNS_REGEXP: List[BadPatternRegexpDict] = [
     {
-        'regexp': re.compile(r'TODO[^\(]*[^\)][^:]*[^A-Z]+[^\w]*$'),
+        'regexp': re.compile(
+            r'(?:#|//|/\*|<!--)\s*TODO[^\(]*[^\)][^:]*[^A-Z]+[^\w]*$'
+        ),
         'message': 'Please link TODO comments to an issue '
         'in the format TODO(#issuenum): XXX. ',
         'excluded_files': (),

--- a/scripts/linters/general_purpose_linter_test.py
+++ b/scripts/linters/general_purpose_linter_test.py
@@ -347,6 +347,17 @@ class GeneralLintTests(test_utils.LinterTestBase):
         self.assertEqual('Bad pattern', lint_task_report.name)
         self.assertTrue(lint_task_report.failed)
 
+    def test_todo_in_string_literal_does_not_fail(self) -> None:
+        def _mock_readlines_valid_todo_string(unused_self: str) -> List[str]:
+            return ['const name = "TODO #123"\n']
+
+        with self.swap(FILE_CACHE, 'readlines', _mock_readlines_valid_todo_string):
+            linter = general_purpose_linter.GeneralPurposeLinter(
+                [INVALID_TODO_FILEPATH], FILE_CACHE
+            )
+            lint_task_report = linter.check_bad_patterns()
+            self.assertFalse(lint_task_report.failed)
+
     def test_error_message_includes_filepath(self) -> None:
         def _mock_readlines_error(unused_self: str) -> None:
             raise Exception('filecache error')


### PR DESCRIPTION
## Explanation

Fixes #27050 where string literals containing "TODO" text (such as `const name = "TODO #123"`) were incorrectly failing the TODO comment linting check.

### Changes made:
- **`scripts/linters/general_purpose_linter.py`**: Updated `BAD_PATTERNS_REGEXP` for TODO comment checking to require a comment marker prefix (`(?:#|//|/\*|<!--)\s*TODO`), ensuring string literals containing "TODO" are not falsely flagged.
- **`scripts/linters/general_purpose_linter_test.py`**: Added unit test `test_todo_in_string_literal_does_not_fail` to prevent regression.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27050".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.