### PR TITLE
Fix #27040: Language Menu Items Display In Other Languages But Are Read In English

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.html
@@ -355,7 +355,7 @@
           (mouseover)="openSubmenu($event, 'languageMenu')"
           (mouseleave)="closeSubmenuIfNotMobile($event)">
         <li class="nav-item" [ngClass]="'e2e-test-i18n-language-' + language.id" *ngFor="let language of supportedSiteLanguages; let last = last">
-          <a (click)="changeLanguage(language.id)" tabindex="0" [attr.aria-label]="language.ariaLabelInEnglish" (keydown.enter)="changeLanguage(language.id)"
+          <a (click)="changeLanguage(language.id)" tabindex="0" [attr.aria-label]="language.text" [attr.lang]="language.id" (keydown.enter)="changeLanguage(language.id)"
              (blur)="last ? languageDropdown.close() : null">
             <div class="language-element oppia-nav-right-dropdown" [ngClass]="{'language-element-selected': currentLanguageCode === language.id}">
               <span *ngIf="currentLanguageCode === language.id">


### PR DESCRIPTION
## Explanation

Fixes #27040 by updating the accessible name and language markup on the language menu dropdown items so screen readers announce native language text (e.g. "Español" instead of "Spanish") with correct native pronunciation rules.

### Changes made:
- **`top-navigation-bar.component.html`**:
  - Replaced `[attr.aria-label]="language.ariaLabelInEnglish"` with `[attr.aria-label]="language.text"` to ensure the accessible name matches visible text (WCAG 2.5.3: Label in Name).
  - Added `[attr.lang]="language.id"` (`lang="es"`, `lang="hi"`, etc.) so screen readers apply appropriate native pronunciation synthesizers (WCAG 3.1.2: Language of Parts).

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27040".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.