### PR TITLE
Fix #27050: Don't flag TODO lint check inside string literals

### DIFF
--- a/scripts/check_backend_associated_test_file.py
+++ b/scripts/check_backend_associated_test_file.py
@@ -47,6 +47,7 @@ FILES_WITHOUT_ASSOCIATED_TEST_FILES = [
     'scripts/linters/test_files/valid.py',
     'scripts/linters/test_files/valid_job_imports.py',
     'scripts/linters/test_files/valid_py_ignore_pragma.py',
+    'scripts/linters/test_files/valid_todo_in_string.py',
     'core/tests/build_sources/extensions/CodeRepl.py',
     'core/tests/build_sources/extensions/DragAndDropSortInput.py',
     'core/tests/data/failing_tests.py',

--- a/scripts/linters/general_purpose_linter.py
+++ b/scripts/linters/general_purpose_linter.py
@@ -32,13 +32,14 @@ if MYPY:  # pragma: no cover
     from scripts.linters import run_lint_checks
 
 
-class BadPatternRegexpDict(TypedDict):
+class BadPatternRegexpDict(TypedDict, total=False):
     """Dictionary representation of bad pattern regular expressions."""
 
     regexp: Pattern[str]
     message: str
     excluded_files: Tuple[str, ...]
     excluded_dirs: Tuple[str, ...]
+    only_check_in_comments: bool
 
 
 class BadPatternsDict(TypedDict):
@@ -193,6 +194,7 @@ BAD_PATTERNS_REGEXP: List[BadPatternRegexpDict] = [
         'in the format TODO(#issuenum): XXX. ',
         'excluded_files': (),
         'excluded_dirs': (),
+        'only_check_in_comments': True,
     }
 ]
 
@@ -393,6 +395,16 @@ def check_bad_pattern_in_file(
             if stripped_line.endswith('disable-bad-pattern-check'):
                 continue
             if regexp.search(stripped_line):
+                if pattern.get('only_check_in_comments'):
+                    comment_index = -1
+                    if '//' in stripped_line:
+                        comment_index = stripped_line.index('//')
+                    elif '#' in stripped_line:
+                        comment_index = stripped_line.index('#')
+                    if comment_index == -1:
+                        continue
+                    if not regexp.search(stripped_line[comment_index:]):
+                        continue
                 error_message = '%s --> Line %s: %s' % (
                     filepath,
                     line_num,

--- a/scripts/linters/general_purpose_linter_test.py
+++ b/scripts/linters/general_purpose_linter_test.py
@@ -117,6 +117,9 @@ INVALID_MERGE_CONFLICT_FILEPATH: Final = os.path.join(
     LINTER_TESTS_DIR, 'invalid_merge_conflict.py'
 )
 INVALID_TODO_FILEPATH: Final = os.path.join(LINTER_TESTS_DIR, 'invalid_todo.py')
+VALID_TODO_IN_STRING_FILEPATH: Final = os.path.join(
+    LINTER_TESTS_DIR, 'valid_todo_in_string.py'
+)
 INVALID_COPYRIGHT_FILEPATH: Final = os.path.join(
     LINTER_TESTS_DIR, 'invalid_copyright.py'
 )
@@ -831,4 +834,17 @@ class GeneralLintTests(test_utils.LinterTestBase):
         lint_task_report = linter.check_modal_component_patterns()
         self.assertEqual(lint_task_report.trimmed_messages, [])
         self.assertEqual('Modal component pattern', lint_task_report.name)
+        self.assertFalse(lint_task_report.failed)
+
+    def test_valid_todo_in_string_is_not_flagged(self) -> None:
+        linter = general_purpose_linter.GeneralPurposeLinter(
+            [VALID_TODO_IN_STRING_FILEPATH], FILE_CACHE
+        )
+        lint_task_report = linter.check_bad_patterns()
+
+        self.assertEqual(
+            [],
+            lint_task_report.trimmed_messages,
+        )
+        self.assertEqual('Bad pattern', lint_task_report.name)
         self.assertFalse(lint_task_report.failed)

--- a/scripts/linters/test_files/valid_todo_in_string.py
+++ b/scripts/linters/test_files/valid_todo_in_string.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test file containing a string literal with the substring "TODO", used
+to verify that the TODO-format lint check only applies inside actual
+comments, not inside string literals. See issue #27050.
+"""
+
+from __future__ import annotations
+
+sample_todo_string = 'TODO #123'


### PR DESCRIPTION
## Overview

1. This PR fixes #27050.
2. This PR does the following: Fixes the TODO-format lint check in
   `general_purpose_linter.py` so it only flags "TODO" text inside actual
   comments, not inside string literals like `const name = 'TODO #123';`.
   Added an `only_check_in_comments` flag to the bad-pattern regex config
   and applied it in the check logic. Added a regression test with a new
   fixture file (`scripts/linters/test_files/valid_todo_in_string.py`)
   containing "TODO" only inside a string literal, plus registered that
   fixture in `check_backend_associated_test_file.py`'s exemption list
   since it's test data with no logic of its own.
3. (For bug-fixing PRs only) The original bug occurred because the
   TODO-format regex matched the substring "TODO" anywhere on a line,
   without checking whether it was inside an actual comment.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes on line 1 above.
- [x] I have checked the "Files Changed" tab and confirmed the changes are what I want.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #27050: ..."
- [x] I have assigned the correct reviewers to this PR.

## Proof that changes are correct

No proof of changes needed because this PR only modifies a backend lint script and adds a regression test — there is no user-facing UI affected. Verified locally via `python -m scripts.run_backend_tests --test_target=scripts.linters.general_purpose_linter_test` (43/43 tests passed).