### PR TITLE
Fix #27089:  Fixes frontend coverage and flake issues caused by #27004

### DIFF
--- a/core/templates/pages/exploration-editor-page/feedback-tab/feedback-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/feedback-tab/feedback-tab.component.spec.ts
@@ -140,9 +140,10 @@ describe('Feedback Tab Component', () => {
   let feedbackBackendApiService: FeedbackBackendApiService;
   let userExplorationPermissionsService: UserExplorationPermissionsService;
 
-  const createWindowWithHash = (): Window => {
+  const createWindowWithHash = (): Window & {triggerHashChange: () => void} => {
     let hash = '';
-    return {
+    let hashChangeListener: (() => void) | null = null;
+    const mockWindow = {
       location: {
         get hash(): string {
           return hash;
@@ -153,9 +154,23 @@ describe('Feedback Tab Component', () => {
         pathname: '',
         search: '',
       },
-      addEventListener: () => {},
-      removeEventListener: () => {},
-    } as Window;
+      addEventListener: (event: string, listener: () => void) => {
+        if (event === 'hashchange') {
+          hashChangeListener = listener;
+        }
+      },
+      removeEventListener: (event: string) => {
+        if (event === 'hashchange') {
+          hashChangeListener = null;
+        }
+      },
+      triggerHashChange: () => {
+        if (hashChangeListener) {
+          hashChangeListener();
+        }
+      },
+    };
+    return mockWindow as unknown as Window & {triggerHashChange: () => void};
   };
 
   class MockNgbModal {
@@ -1307,6 +1322,13 @@ describe('Feedback Tab Component', () => {
   it('should load report feedback detail when report row is clicked', fakeAsync(() => {
     const mockWindow = createWindowWithHash();
     spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
+
+    mockPlatformFeatureService.status.ExplorationEditorNewCreatorFeedbackTab.isEnabled =
+      true;
+    component.ngOnInit();
+    tick();
+    tick();
+
     component.currentCreatorFeedbackFilterState.creatorFeedbackType =
       CreatorFeedbackType.REPORT;
 
@@ -1318,9 +1340,9 @@ describe('Feedback Tab Component', () => {
     spyOn(assetsBackendApiService, 'getImageUrlForPreview').and.returnValue(
       'image-url'
     );
-    component.onCreatorFeedbackRowClick('report_id');
 
-    component.syncCreatorFeedbackFromUrl();
+    component.onCreatorFeedbackRowClick('report_id');
+    mockWindow.triggerHashChange();
     tick();
 
     expect(

--- a/core/templates/pages/exploration-editor-page/feedback-tab/feedback-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/feedback-tab/feedback-tab.component.spec.ts
@@ -48,6 +48,7 @@ import {
   CREATOR_DASHBOARD_FILTER_CONFIG,
   CreatorFeedbackType,
   FeedbackFilterState,
+  FeedbackModalType,
   FeedbackStatus,
   LessonFeedbackBackendResponse,
   LessonFeedbackDetailResponse,
@@ -139,6 +140,24 @@ describe('Feedback Tab Component', () => {
   let feedbackBackendApiService: FeedbackBackendApiService;
   let userExplorationPermissionsService: UserExplorationPermissionsService;
 
+  const createWindowWithHash = (): Window => {
+    let hash = '';
+    return {
+      location: {
+        get hash(): string {
+          return hash;
+        },
+        set hash(value: string) {
+          hash = value.startsWith('#') ? value : `#${value}`;
+        },
+        pathname: '',
+        search: '',
+      },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    } as Window;
+  };
+
   class MockNgbModal {
     open() {
       return {
@@ -167,6 +186,10 @@ describe('Feedback Tab Component', () => {
   }));
 
   beforeEach(() => {
+    mockPlatformFeatureService.status.ExplorationEditorNewCreatorFeedbackTab.isEnabled =
+      false;
+    window.history.replaceState(null, '', window.location.pathname);
+
     fixture = TestBed.createComponent(FeedbackTabComponent);
     component = fixture.componentInstance;
 
@@ -701,25 +724,29 @@ describe('Feedback Tab Component', () => {
   });
 
   it('should navigate to lesson feedback detail when lesson feedback row is clicked', () => {
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
     component.currentCreatorFeedbackFilterState.creatorFeedbackType =
       CreatorFeedbackType.FEEDBACK;
 
     component.onCreatorFeedbackRowClick('feedback_id');
 
     expect(component.selectedCreatorFeedbackId).toBe('feedback_id');
-    expect(windowRef.nativeWindow.location.hash).toBe(
+    expect(mockWindow.location.hash).toBe(
       '#/feedback/lesson_feedback/feedback_id'
     );
   });
 
   it('should navigate to lesson issue detail when report row is clicked', () => {
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
     component.currentCreatorFeedbackFilterState.creatorFeedbackType =
       CreatorFeedbackType.REPORT;
 
     component.onCreatorFeedbackRowClick('feedback_id');
 
     expect(component.selectedCreatorFeedbackId).toBe('feedback_id');
-    expect(windowRef.nativeWindow.location.hash).toBe(
+    expect(mockWindow.location.hash).toBe(
       '#/feedback/lesson_issue/feedback_id'
     );
   });
@@ -1177,6 +1204,7 @@ describe('Feedback Tab Component', () => {
   }));
 
   it('should load lesson feedback detail from URL on init', fakeAsync(() => {
+    tick();
     windowRef.nativeWindow.location.hash =
       '#/feedback/lesson_feedback/feedback_id';
 
@@ -1197,6 +1225,35 @@ describe('Feedback Tab Component', () => {
       'feedback_id'
     );
   }));
+
+  it('should return creator feedback detail from URL', () => {
+    windowRef.nativeWindow.location.hash =
+      '#/feedback/lesson_feedback/feedback%20id';
+
+    expect(component.getCreatorFeedbackDetailFromUrl()).toEqual({
+      feedbackType: FeedbackModalType.LESSON_FEEDBACK,
+      feedbackId: 'feedback id',
+    });
+  });
+
+  it('should return null when URL is not a creator feedback detail URL', () => {
+    windowRef.nativeWindow.location.hash = '#/feedback';
+
+    expect(component.getCreatorFeedbackDetailFromUrl()).toBeNull();
+  });
+
+  it('should clear stale creator feedback detail when URL has no detail', () => {
+    component.selectedCreatorFeedbackId = 'feedback_id';
+    component.creatorFeedbackDetailResponse = mockLessonFeedbackDetailResponse;
+    component.creatorFeedbackScreenshotDataUrl = 'image-url';
+    windowRef.nativeWindow.location.hash = '#/feedback';
+
+    component.syncCreatorFeedbackFromUrl();
+
+    expect(component.selectedCreatorFeedbackId).toBeNull();
+    expect(component.creatorFeedbackDetailResponse).toBeNull();
+    expect(component.creatorFeedbackScreenshotDataUrl).toBeNull();
+  });
 
   it('should do nothing when sending reply without selected feedback', () => {
     component.selectedCreatorFeedbackId = null;
@@ -1241,6 +1298,8 @@ describe('Feedback Tab Component', () => {
   });
 
   it('should load report feedback detail when report row is clicked', fakeAsync(() => {
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
     component.currentCreatorFeedbackFilterState.creatorFeedbackType =
       CreatorFeedbackType.REPORT;
 
@@ -1252,15 +1311,9 @@ describe('Feedback Tab Component', () => {
     spyOn(assetsBackendApiService, 'getImageUrlForPreview').and.returnValue(
       'image-url'
     );
-    mockPlatformFeatureService.status.ExplorationEditorNewCreatorFeedbackTab.isEnabled =
-      true;
-
-    component.ngOnInit();
-    tick();
-    fixture.detectChanges();
     component.onCreatorFeedbackRowClick('report_id');
 
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    component.syncCreatorFeedbackFromUrl();
     tick();
 
     expect(

--- a/core/templates/pages/exploration-editor-page/feedback-tab/feedback-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/feedback-tab/feedback-tab.component.spec.ts
@@ -784,12 +784,13 @@ describe('Feedback Tab Component', () => {
   });
 
   it('should navigate back to creator feedback list', () => {
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
     component.selectedCreatorFeedbackId = 'feedback_id';
-    windowRef.nativeWindow.location.hash =
-      '#/feedback/lesson_feedback/feedback_id';
+    mockWindow.location.hash = '#/feedback/lesson_feedback/feedback_id';
 
     component.navigateBackToCreatorFeedbackList();
-    expect(windowRef.nativeWindow.location.hash).toBe('#/feedback');
+    expect(mockWindow.location.hash).toBe('#/feedback');
   });
 
   it('should fetch next page of lesson feedback', fakeAsync(() => {
@@ -1204,9 +1205,10 @@ describe('Feedback Tab Component', () => {
   }));
 
   it('should load lesson feedback detail from URL on init', fakeAsync(() => {
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
     tick();
-    windowRef.nativeWindow.location.hash =
-      '#/feedback/lesson_feedback/feedback_id';
+    mockWindow.location.hash = '#/feedback/lesson_feedback/feedback_id';
 
     spyOn(
       feedbackBackendApiService,
@@ -1227,8 +1229,9 @@ describe('Feedback Tab Component', () => {
   }));
 
   it('should return creator feedback detail from URL', () => {
-    windowRef.nativeWindow.location.hash =
-      '#/feedback/lesson_feedback/feedback%20id';
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
+    mockWindow.location.hash = '#/feedback/lesson_feedback/feedback%20id';
 
     expect(component.getCreatorFeedbackDetailFromUrl()).toEqual({
       feedbackType: FeedbackModalType.LESSON_FEEDBACK,
@@ -1237,16 +1240,21 @@ describe('Feedback Tab Component', () => {
   });
 
   it('should return null when URL is not a creator feedback detail URL', () => {
-    windowRef.nativeWindow.location.hash = '#/feedback';
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
+    mockWindow.location.hash = '#/feedback';
 
     expect(component.getCreatorFeedbackDetailFromUrl()).toBeNull();
   });
 
   it('should clear stale creator feedback detail when URL has no detail', () => {
+    const mockWindow = createWindowWithHash();
+    spyOnProperty(windowRef, 'nativeWindow', 'get').and.returnValue(mockWindow);
+
     component.selectedCreatorFeedbackId = 'feedback_id';
     component.creatorFeedbackDetailResponse = mockLessonFeedbackDetailResponse;
     component.creatorFeedbackScreenshotDataUrl = 'image-url';
-    windowRef.nativeWindow.location.hash = '#/feedback';
+    mockWindow.location.hash = '#/feedback';
 
     component.syncCreatorFeedbackFromUrl();
 
@@ -1254,7 +1262,6 @@ describe('Feedback Tab Component', () => {
     expect(component.creatorFeedbackDetailResponse).toBeNull();
     expect(component.creatorFeedbackScreenshotDataUrl).toBeNull();
   });
-
   it('should do nothing when sending reply without selected feedback', () => {
     component.selectedCreatorFeedbackId = null;
     component.creatorFeedbackDetailResponse = null;


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/27089 and fixes https://github.com/oppia/oppia/issues/27093
2. This PR does the following: 
Adds unit tests:
    - Parses encoded feedback IDs from `#/feedback/<type>/<id>`.
    - Returns `null` when the current hash is not a creator feedback detail URL.
    - Clears stale selected feedback detail state when navigating back to a non-detail feedback URL.

  - Reset shared URL/feature-flag state in the feedback tab spec setup:
    - Resets `ExplorationEditorNewCreatorFeedbackTab.isEnabled`.
    - Clears the URL hash using `history.replaceState()` so the cleanup is synchronous and does not dispatch a native `hashchange` event.

  - Reworked flaky hash-dependent specs:
    - Added a small fake `WindowRef.nativeWindow` for specs that only need to verify hash reads/writes.
    - Updated row-click navigation tests to assert against the fake window hash instead of the global Karma browser location.

3. (For bug-fixing PRs only) The original bug occurred because: These tests were flaky in full frontend test runs because they depended on shared browser URL state and native hash-change behavior. In a large Karma run, other specs and browser navigation timing can interfere with immediate assertions against `window.location.hash` or with manually dispatched `hashchange` events.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [X] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [X] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [X] I have written tests for my code.
- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [X] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
All frontend tests are passing!

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for navigating directly to lesson feedback details through URL links.
  * Added validation for invalid or incomplete feedback URLs.
  * Verified that outdated feedback details are cleared and current details stay synchronized during navigation.
  * Improved test reliability across browser history and feature-configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->