### PR TITLE
Fix #27079: Navigation menu dropdowns overlap incorrectly when hovering from right to left

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.component.css
@@ -443,8 +443,12 @@
   font-size: 22px;
   margin-top: -5px;
 }
+.oppia-top-navigation-bar .oppia-navbar-clickable-dropdown:hover {
+  z-index: 1000;
+}
 .oppia-top-navigation-bar .oppia-navbar-clickable-dropdown:hover ul.dropdown-menu {
   display: block;
+  z-index: 1000;
 }
 .oppia-top-navigation-bar .oppia-navbar-menu:hover {
   opacity: 1;


### PR DESCRIPTION
## Explanation

Fixes #27079 where top navigation menu dropdowns overlapped incorrectly when hovering menus from right to left because adjacent dropdown menus lacked an explicit elevated `z-index` when hovered.

### Changes made:
- **`top-navigation-bar.component.css`**: Added `z-index: 1000;` rule for `.oppia-navbar-clickable-dropdown:hover` and `.oppia-navbar-clickable-dropdown:hover ul.dropdown-menu` to ensure the hovered menu dropdown always renders cleanly above neighboring dropdowns.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27079".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.