### PR TITLE
Fix N/A: Enable --warn-unreachable in mypy checks with an allowlist for pre-existing errors

### DIFF
--- a/scripts/run_mypy_checks.py
+++ b/scripts/run_mypy_checks.py
@@ -20,12 +20,13 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 
 from scripts import common
 
-from typing import Final, List, Optional
+from typing import Final, List, Optional, Tuple
 
 # List of directories whose files won't be type-annotated ever.
 EXCLUDED_DIRECTORIES: Final = [
@@ -41,7 +42,60 @@ EXCLUDED_DIRECTORIES: Final = [
     'core/tests/data/',
 ]
 
+# Files that are known to contain code mypy currently reports as
+# unreachable (via --warn-unreachable), due to its inability to
+# narrow certain type patterns (see issue #21747). Each file here
+# should have (or link to) a tracking "good first issue" to fix the
+# narrowing and get removed from this list. Do NOT add a file here
+# to silence a *different* kind of mypy error - only unreachable-code
+# errors from these files are suppressed; every other mypy error in
+# these files, and every error (including new unreachable errors) in
+# every other file, still fails the build.
+NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE: Final = [
+    'extensions/objects/models/objects.py',
+    'core/schema_utils.py',
+    'core/storage/user/gae_models.py',
+    'core/storage/suggestion/gae_models.py',
+    'core/storage/blog/gae_models.py',
+    'core/domain/html_validation_service.py',
+    'core/domain/story_domain.py',
+    'core/domain/draft_upgrade_services.py',
+    'core/domain/email_services.py',
+    'core/domain/user_services.py',
+    'core/domain/topic_services.py',
+    'core/domain/suggestion_services.py',
+    'core/domain/suggestion_registry.py',
+    'core/domain/story_services.py',
+    'core/domain/skill_services.py',
+    'core/domain/question_services.py',
+    'core/domain/opportunity_services.py',
+    'core/domain/exp_services.py',
+    'core/domain/collection_services.py',
+    'core/domain/learner_progress_services.py',
+    'core/jobs/batch_jobs/number_with_units_audit_jobs.py',
+    'core/domain/app_feedback_report_services.py',
+    'core/controllers/story_viewer.py',
+    'core/controllers/library.py',
+    'core/controllers/reader.py',
+    'core/jobs/transforms/validation/base_validation.py',
+    'core/controllers/access_validators.py',
+    'scripts/run_typescript_checks_test.py',
+    'scripts/run_frontend_tests_test.py',
+    'core/storage/base_model/gae_models_test.py',
+    'core/domain/user_services_test.py',
+    'core/domain/takeout_service_test.py',
+    'core/domain/question_fetchers_test.py',
+    'core/domain/event_services_test.py',
+    'core/controllers/reader_test.py',
+]
+
 CONFIG_FILE_PATH: Final = os.path.join('.', 'mypy.ini')
+
+# Matches lines like:
+# core/domain/exp_services.py:672: error: ... [unreachable]
+_UNREACHABLE_LINE_REGEX: Final = re.compile(
+    r'^(?P<filepath>[^:]+\.py):\d+: error: .* \[unreachable\]\s*$'
+)
 
 _PARSER: Final = argparse.ArgumentParser(
     description='Python type checking using mypy script.'
@@ -64,7 +118,12 @@ def get_mypy_cmd(files: Optional[List[str]]) -> List[str]:
     mypy_cmd = 'mypy'
 
     if files:
-        cmd = [mypy_cmd, '--config-file', CONFIG_FILE_PATH] + files
+        cmd = [
+            mypy_cmd,
+            '--config-file',
+            CONFIG_FILE_PATH,
+            '--warn-unreachable',
+        ] + files
     else:
         excluded_files_regex = '|'.join(EXCLUDED_DIRECTORIES)
         cmd = [
@@ -73,9 +132,103 @@ def get_mypy_cmd(files: Optional[List[str]]) -> List[str]:
             excluded_files_regex,
             '--config-file',
             CONFIG_FILE_PATH,
+            '--warn-unreachable',
             '.',
         ]
     return cmd
+
+
+def _is_allowlisted(filepath: str) -> bool:
+    """Checks whether the given mypy-reported filepath (which may use
+    either OS-specific separators) matches an entry in the unreachable-
+    code allowlist.
+    """
+    normalized = filepath.replace(os.sep, '/')
+    return normalized in NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE
+
+
+_ERROR_LINE_REGEX: Final = re.compile(r'^[^:]+\.py:\d+: error: ')
+_SUMMARY_LINE_REGEX: Final = re.compile(r'^Found \d+ errors? in \d+ files?')
+
+
+def filter_unreachable_errors_for_allowlisted_files(
+    mypy_output: str, check_stale_entries: bool
+) -> Tuple[str, int, bool]:
+    """Removes '[unreachable]' error lines that originate from files on
+    the allowlist, leaving every other line (including unreachable
+    errors from non-allowlisted files) untouched. Also rewrites mypy's
+    trailing summary line to reflect the filtered error count, since
+    mypy generates that line itself and it would otherwise still show
+    the pre-filter count.
+
+    Args:
+        mypy_output: str. Raw stdout produced by mypy.
+        check_stale_entries: bool. Whether to flag allowlist entries
+            that produced no unreachable error this run. Only valid
+            when mypy was run against the full repo - a targeted
+            `--files` run doesn't scan most allowlisted files at all,
+            so their absence from the output means nothing.
+
+    Returns:
+        Tuple[str, int, bool]. The filtered output, the count of
+        remaining (non-suppressed) per-line errors, and whether any
+        allowlisted file's unreachable error was actually suppressed
+        during this run.
+    """
+    kept_lines = []
+    remaining_error_count = 0
+    allowlisted_files_hit = set()
+    for line in mypy_output.splitlines():
+        unreachable_match = _UNREACHABLE_LINE_REGEX.match(line)
+        if unreachable_match and _is_allowlisted(
+            unreachable_match.group('filepath')
+        ):
+            allowlisted_files_hit.add(
+                unreachable_match.group('filepath').replace(os.sep, '/')
+            )
+            continue
+        if _SUMMARY_LINE_REGEX.match(line):
+            # Drop mypy's own summary line; we regenerate it below from
+            # the errors that actually survived filtering.
+            continue
+        if _ERROR_LINE_REGEX.match(line):
+            remaining_error_count += 1
+        kept_lines.append(line)
+
+    # Flag allowlist entries that no longer produce any unreachable
+    # error - these should be removed so the allowlist doesn't quietly
+    # accumulate stale, already-fixed entries. Only meaningful on a
+    # full-repo run; see the check_stale_entries docstring above.
+    if check_stale_entries:
+        stale_entries = (
+            set(NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE)
+            - allowlisted_files_hit
+        )
+        if stale_entries:
+            remaining_error_count += len(stale_entries)
+            stale_entries_str = ', '.join(sorted(stale_entries))
+            kept_lines.append(
+                'error: The following files no longer produce unreachable-'
+                'code errors and must be removed from '
+                'NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE in '
+                f'scripts/run_mypy_checks.py: {stale_entries_str}'
+            )
+
+    if remaining_error_count:
+        kept_lines.append(
+            f'Found {remaining_error_count} error(s) '
+            'after filtering allowlisted unreachable code.'
+        )
+    else:
+        kept_lines.append(
+            'Success: no issues found after filtering '
+            'allowlisted unreachable code.'
+        )
+    return (
+        '\n'.join(kept_lines),
+        remaining_error_count,
+        bool(allowlisted_files_hit),
+    )
 
 
 def main(args: Optional[List[str]] = None) -> int:
@@ -97,10 +250,29 @@ def main(args: Optional[List[str]] = None) -> int:
     stdout, stderr = process.communicate()
     # Standard and error output is in bytes, we need to decode the line to
     # print it.
-    print(stdout.decode('utf-8'))
+    raw_stdout = stdout.decode('utf-8')
+    filtered_stdout, remaining_error_count, suppressed_something = (
+        filter_unreachable_errors_for_allowlisted_files(
+            raw_stdout, check_stale_entries=not parsed_args.files
+        )
+    )
+    print(filtered_stdout)
     print(stderr.decode('utf-8'))
-    if process.returncode == 0:
+
+    mypy_originally_failed = process.returncode != 0
+    if mypy_originally_failed and not suppressed_something:
+        # Mypy failed for a reason we didn't suppress anything for (a
+        # bad invocation, a config error, a non-unreachable error type,
+        # etc.) - trust mypy's own verdict rather than our error count,
+        # since we have no evidence this run's failure has anything to
+        # do with the allowlist.
+        mypy_check_passed = False
+    else:
+        mypy_check_passed = remaining_error_count == 0
+
+    if mypy_check_passed:
         print('Mypy type checks successful.')
+        return 0
     else:
         print(
             'Mypy type checks unsuccessful. Please fix the errors. '
@@ -108,7 +280,6 @@ def main(args: Optional[List[str]] = None) -> int:
             'https://github.com/oppia/oppia/wiki/Backend-Type-Annotations'
         )
         sys.exit(1)
-    return process.returncode
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/scripts/run_mypy_checks.py
+++ b/scripts/run_mypy_checks.py
@@ -93,8 +93,15 @@ CONFIG_FILE_PATH: Final = os.path.join('.', 'mypy.ini')
 
 # Matches lines like:
 # core/domain/exp_services.py:672: error: ... [unreachable]
+# stubs/yaml/__init__.pyi:9: error: ...
+# Also tolerates optional column and end-line:end-column suffixes
+# (file.py:LINE:COL: error: ... or file.py:LINE:COL:ENDLINE:ENDCOL: error: ...)
+# in case mypy.ini or the invocation ever turns on show_column_numbers/
+# show_error_end - the current config doesn't, but the parser shouldn't
+# silently go blind if that changes.
 _UNREACHABLE_LINE_REGEX: Final = re.compile(
-    r'^(?P<filepath>[^:]+\.py):\d+: error: .* \[unreachable\]\s*$'
+    r'^(?P<filepath>[^:]+\.pyi?):\d+(?::\d+(?::\d+:\d+)?)?: error: '
+    r'.* \[unreachable\]\s*$'
 )
 
 _PARSER: Final = argparse.ArgumentParser(
@@ -147,7 +154,9 @@ def _is_allowlisted(filepath: str) -> bool:
     return normalized in NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE
 
 
-_ERROR_LINE_REGEX: Final = re.compile(r'^[^:]+\.py:\d+: error: ')
+_ERROR_LINE_REGEX: Final = re.compile(
+    r'^[^:]+\.pyi?:\d+(?::\d+(?::\d+:\d+)?)?: error: '
+)
 _SUMMARY_LINE_REGEX: Final = re.compile(r'^Found \d+ errors? in \d+ files?')
 
 

--- a/scripts/run_mypy_checks_test.py
+++ b/scripts/run_mypy_checks_test.py
@@ -28,6 +28,19 @@ from typing import Final, List, Optional, Tuple
 PYTHON_CMD: Final = 'python3'
 MYPY_SCRIPT_MODULE: Final = 'scripts.run_mypy_checks'
 
+# Fixtures for filter_unreachable_errors_for_allowlisted_files tests.
+# 'dir1/foo.py' is the file these tests treat as allowlisted; keep it
+# in sync with the ALLOWLISTED_FILES swap set up in setUp().
+_MYPY_OUTPUT_WITH_ALLOWLISTED_UNREACHABLE_ERROR: Final = (
+    'dir1/foo.py:12: error: Statement is unreachable  [unreachable]\n'
+    'Found 1 errors in 1 files (checked 5 source files)\n'
+)
+_MYPY_OUTPUT_WITH_NON_ALLOWLISTED_UNREACHABLE_ERROR: Final = (
+    'dir2/bar.py:7: error: Statement is unreachable  [unreachable]\n'
+    'Found 1 errors in 1 files (checked 5 source files)\n'
+)
+_CLEAN_MYPY_OUTPUT: Final = 'Success: no issues found in 5 source files\n'
+
 
 class Ret:
     """Return object that gives user-prefix error."""
@@ -85,6 +98,25 @@ class MypyScriptChecks(test_utils.GenericTestBase):
             run_mypy_checks, 'EXCLUDED_DIRECTORIES', ['dir1/', 'dir2/']
         )
 
+        # The mocked Popen output ('test\n') has nothing to do with real
+        # mypy output, so none of the real allowlist entries would ever
+        # show up as "hit" in it. Without this swap, any full-run test
+        # using the success/failure mocks below would incorrectly trip
+        # the stale-allowlist-entry check, since it'd look like every
+        # real allowlisted file stopped producing unreachable errors.
+        self.empty_allowlist_swap = self.swap(
+            run_mypy_checks, 'NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE', []
+        )
+
+        # Shared by the filter_unreachable_errors_for_allowlisted_files
+        # tests below - treats 'dir1/foo.py' as the sole allowlisted
+        # file, matching the _MYPY_OUTPUT_* fixtures above.
+        self.allowlist_swap = self.swap(
+            run_mypy_checks,
+            'NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE',
+            ['dir1/foo.py'],
+        )
+
     def test_get_mypy_cmd_without_files(self) -> None:
         expected_cmd = [
             'mypy',
@@ -92,6 +124,7 @@ class MypyScriptChecks(test_utils.GenericTestBase):
             'dir1/|dir2/',
             '--config-file',
             './mypy.ini',
+            '--warn-unreachable',
             '.',
         ]
         with self.directories_swap:
@@ -103,6 +136,7 @@ class MypyScriptChecks(test_utils.GenericTestBase):
             'mypy',
             '--config-file',
             './mypy.ini',
+            '--warn-unreachable',
             'file1.py',
             'file2.py',
         ]
@@ -127,12 +161,15 @@ class MypyScriptChecks(test_utils.GenericTestBase):
             self.assertEqual(output[0], b'')
 
     def test_main_with_files_without_mypy_errors(self) -> None:
+        # No empty_allowlist_swap needed here: passing --files means
+        # check_stale_entries is False, so the allowlist is never
+        # consulted for this run regardless of its contents.
         with self.popen_swap_success:
             process = run_mypy_checks.main(args=['--files', 'file1.py'])
             self.assertEqual(process, 0)
 
     def test_main_without_mypy_errors(self) -> None:
-        with self.popen_swap_success:
+        with self.popen_swap_success, self.empty_allowlist_swap:
             process = run_mypy_checks.main(args=[])
             self.assertEqual(process, 0)
 
@@ -141,6 +178,61 @@ class MypyScriptChecks(test_utils.GenericTestBase):
             run_mypy_checks.main(args=['--files', 'file1.py'])
 
     def test_main_failure_due_to_mypy_errors(self) -> None:
-        with self.popen_swap_failure:
+        with self.popen_swap_failure, self.empty_allowlist_swap:
             with self.assertRaisesRegex(SystemExit, '1'):
                 run_mypy_checks.main(args=[])
+
+    def test_filter_unreachable_errors_suppresses_allowlisted_file(
+        self,
+    ) -> None:
+        with self.allowlist_swap:
+            filtered, remaining_error_count, suppressed_something = (
+                run_mypy_checks.filter_unreachable_errors_for_allowlisted_files(
+                    _MYPY_OUTPUT_WITH_ALLOWLISTED_UNREACHABLE_ERROR,
+                    check_stale_entries=True,
+                )
+            )
+        self.assertNotIn('dir1/foo.py', filtered)
+        self.assertEqual(remaining_error_count, 0)
+        self.assertTrue(suppressed_something)
+
+    def test_filter_unreachable_errors_keeps_non_allowlisted_file(self) -> None:
+        with self.allowlist_swap:
+            filtered, remaining_error_count, suppressed_something = (
+                run_mypy_checks.filter_unreachable_errors_for_allowlisted_files(
+                    _MYPY_OUTPUT_WITH_NON_ALLOWLISTED_UNREACHABLE_ERROR,
+                    check_stale_entries=True,
+                )
+            )
+        self.assertIn('dir2/bar.py', filtered)
+        # 'dir1/foo.py' never showed up, so it's flagged stale on top of
+        # dir2/bar.py's genuine, non-allowlisted error.
+        self.assertEqual(remaining_error_count, 2)
+        self.assertFalse(suppressed_something)
+
+    def test_filter_unreachable_errors_flags_stale_allowlist_entry(
+        self,
+    ) -> None:
+        with self.allowlist_swap:
+            filtered, remaining_error_count, suppressed_something = (
+                run_mypy_checks.filter_unreachable_errors_for_allowlisted_files(
+                    _CLEAN_MYPY_OUTPUT, check_stale_entries=True
+                )
+            )
+        self.assertIn('dir1/foo.py', filtered)
+        self.assertIn('must be removed from', filtered)
+        self.assertEqual(remaining_error_count, 1)
+        self.assertFalse(suppressed_something)
+
+    def test_filter_unreachable_errors_skips_stale_check_for_files_run(
+        self,
+    ) -> None:
+        with self.allowlist_swap:
+            filtered, remaining_error_count, suppressed_something = (
+                run_mypy_checks.filter_unreachable_errors_for_allowlisted_files(
+                    _CLEAN_MYPY_OUTPUT, check_stale_entries=False
+                )
+            )
+        self.assertNotIn('must be removed from', filtered)
+        self.assertEqual(remaining_error_count, 0)
+        self.assertFalse(suppressed_something)

--- a/scripts/run_mypy_checks_test.py
+++ b/scripts/run_mypy_checks_test.py
@@ -39,6 +39,17 @@ _MYPY_OUTPUT_WITH_NON_ALLOWLISTED_UNREACHABLE_ERROR: Final = (
     'dir2/bar.py:7: error: Statement is unreachable  [unreachable]\n'
     'Found 1 errors in 1 files (checked 5 source files)\n'
 )
+_MYPY_OUTPUT_WITH_PYI_ERROR: Final = (
+    'dir2/bar.pyi:9: error: Name "NotARealType" is not defined  '
+    '[name-defined]\n'
+    'Found 1 errors in 1 files (checked 5 source files)\n'
+)
+_MYPY_OUTPUT_WITH_ALLOWLISTED_UNREACHABLE_AND_PYI_ERROR: Final = (
+    'dir1/foo.py:12: error: Statement is unreachable  [unreachable]\n'
+    'dir2/bar.pyi:9: error: Name "NotARealType" is not defined  '
+    '[name-defined]\n'
+    'Found 2 errors in 2 files (checked 5 source files)\n'
+)
 _CLEAN_MYPY_OUTPUT: Final = 'Success: no issues found in 5 source files\n'
 
 
@@ -236,3 +247,33 @@ class MypyScriptChecks(test_utils.GenericTestBase):
         self.assertNotIn('must be removed from', filtered)
         self.assertEqual(remaining_error_count, 0)
         self.assertFalse(suppressed_something)
+
+    def test_filter_unreachable_errors_keeps_pyi_file_error(self) -> None:
+        with self.allowlist_swap:
+            filtered, remaining_error_count, suppressed_something = (
+                run_mypy_checks.filter_unreachable_errors_for_allowlisted_files(
+                    _MYPY_OUTPUT_WITH_PYI_ERROR, check_stale_entries=True
+                )
+            )
+        self.assertIn('dir2/bar.pyi', filtered)
+        # 'dir1/foo.py' never showed up in this run either, so it's
+        # flagged stale on top of dir2/bar.pyi's genuine error - same
+        # pattern as test_filter_unreachable_errors_keeps_non_allowlisted_file.
+        self.assertEqual(remaining_error_count, 2)
+        self.assertFalse(suppressed_something)
+
+    def test_filter_unreachable_errors_pyi_error_not_masked_by_suppressed_allowlisted_error(
+        self,
+    ) -> None:
+        with self.allowlist_swap:
+            filtered, remaining_error_count, suppressed_something = (
+                run_mypy_checks.filter_unreachable_errors_for_allowlisted_files(
+                    _MYPY_OUTPUT_WITH_ALLOWLISTED_UNREACHABLE_AND_PYI_ERROR,
+                    check_stale_entries=True,
+                )
+            )
+        self.assertNotIn('dir1/foo.py', filtered)
+        self.assertIn('dir2/bar.pyi', filtered)
+        self.assertTrue(suppressed_something)
+        self.assertEqual(remaining_error_count, 1)
+        self.assertNotIn('Success: no issues found', filtered)


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes N/A
2. This PR does the following:
   - Adds `--warn-unreachable` to both branches of `get_mypy_cmd()` in `scripts/run_mypy_checks.py` (previously a prior PR had only added it to the full-repo-run branch, leaving the `--files`-targeted branch - used by pre-commit / partial runs - without unreachable checking).
   - Adds `NOT_FULLY_COVERED_FILES_FOR_UNREACHABLE_CODE`, an allowlist of files with pre-existing unreachable-code errors that mypy's type narrowing can't currently resolve.
   - Adds `filter_unreachable_errors_for_allowlisted_files()`, which suppresses only the `[unreachable]` error lines from allowlisted files - every other mypy error in those files, and every error in every other file, still fails the build as before.
   - On a full-repo run only, also flags any allowlist entry whose file no longer produces an unreachable error, so entries can't go stale once the underlying code is fixed (whether fixed as part of a tracked good-first-issue or incidentally by unrelated work).
   - If mypy fails for a reason unrelated to anything this PR suppresses (e.g. a bad invocation or config error), the original
     mypy failure is still respected rather than silently passing.
   - This unblocks filing individual good-first-issues per file/batch to fix the underlying type-narrowing issues and shrink the allowlist over time, without breaking CI in the meantime.
   - Tracking issue - https://github.com/oppia/oppia/issues/22113
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
