### PR TITLE
Fix #27123: RejectTranslationSuggestionsForTranslatedContentsJob misses duplicate suggestions submitted on older exploration versions

### DIFF
--- a/core/jobs/batch_jobs/reject_invalid_suggestion_and_delete_invalid_translation_jobs.py
+++ b/core/jobs/batch_jobs/reject_invalid_suggestion_and_delete_invalid_translation_jobs.py
@@ -436,6 +436,15 @@ class ComputeSuggestionsInReviewForTranslatedContents(beam.DoFn):  # type: ignor
             and corresponding suggestion id.
         """
         with datastore_services.get_ndb_context():
+            exp_model = exp_models.ExplorationModel.get(
+                entity_translation_model.entity_id, strict=False
+            )
+            if (
+                exp_model is None
+                or exp_model.version != entity_translation_model.entity_version
+            ):
+                return
+
             content_ids_not_needing_update = []
             for content_id in entity_translation_model.translations.keys():
                 if (
@@ -446,14 +455,15 @@ class ComputeSuggestionsInReviewForTranslatedContents(beam.DoFn):  # type: ignor
                 ):
                     content_ids_not_needing_update.append(content_id)
 
+            if not content_ids_not_needing_update:
+                return
+
             suggestions: Sequence[suggestion_models.GeneralSuggestionModel] = (
                 suggestion_models.GeneralSuggestionModel.query(
                     suggestion_models.GeneralSuggestionModel.suggestion_type
                     == (feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT),
                     suggestion_models.GeneralSuggestionModel.target_id
                     == entity_translation_model.entity_id,
-                    suggestion_models.GeneralSuggestionModel.target_version_at_submission
-                    == (entity_translation_model.entity_version),
                     suggestion_models.GeneralSuggestionModel.language_code
                     == (entity_translation_model.language_code),
                     suggestion_models.GeneralSuggestionModel.status

--- a/core/jobs/batch_jobs/reject_invalid_suggestion_and_delete_invalid_translation_jobs_test.py
+++ b/core/jobs/batch_jobs/reject_invalid_suggestion_and_delete_invalid_translation_jobs_test.py
@@ -327,6 +327,119 @@ class RejectTranslationSuggestionsForTranslatedContentsJobTests(
             not_updated_suggestion.status, suggestion_models.STATUS_IN_REVIEW
         )
 
+    def test_invalid_suggestion_submitted_on_older_version_is_rejected(
+        self,
+    ) -> None:
+        self.exp_1.title = 'Updated Title'
+        self.exp_1.commit(
+            feconf.SYSTEM_COMMITTER_ID,
+            'Update exploration title',
+            [
+                {
+                    'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
+                    'property_name': 'title',
+                    'new_value': 'Updated Title',
+                }
+            ],
+        )
+
+        entity_translation_v2 = (
+            translation_models.EntityTranslationsModel.create_new(
+                feconf.ENTITY_TYPE_EXPLORATION,
+                self.EXP_1_ID,
+                self.exp_1.version,
+                'hi',
+                {
+                    'content_0': TRANSLATED_CONTENT_DICT,
+                },
+            )
+        )
+        self.put_multi([entity_translation_v2])
+
+        CHANGE_DICT['content_id'] = 'content_0'
+        invalid_suggestion = self.create_model(
+            suggestion_models.GeneralSuggestionModel,
+            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+            author_id='user1',
+            change_cmd=CHANGE_DICT,
+            score_category='irrelevant',
+            status=suggestion_models.STATUS_IN_REVIEW,
+            target_type=feconf.ENTITY_TYPE_EXPLORATION,
+            target_id=self.exp_1.id,
+            target_version_at_submission=1,
+            language_code='hi',
+        )
+        invalid_suggestion.update_timestamps()
+        suggestion_models.GeneralSuggestionModel.put_multi([invalid_suggestion])
+
+        errored_value = (
+            '{'
+            f'\'entity_id\': \'{self.exp_1.id}\', \'entity_version\': '
+            f'{self.exp_1.version}, \'entity_translation_model_id\': '
+            f'\'{entity_translation_v2.id}\', \'content_id\': '
+            f'\'content_0\', \'suggestion_id\': {invalid_suggestion.id}'
+            '}'
+        )
+
+        self.assert_job_output_is(
+            [
+                job_run_result.JobRunResult.as_stdout(
+                    f'Results are - {errored_value}'
+                ),
+                job_run_result.JobRunResult(
+                    stdout='REJECTED SUGGESTIONS COUNT SUCCESS: 1'
+                ),
+            ]
+        )
+
+        updated_suggestion = suggestion_models.GeneralSuggestionModel.get(
+            invalid_suggestion.id
+        )
+        self.assertEqual(
+            updated_suggestion.status, suggestion_models.STATUS_REJECTED
+        )
+
+    def test_suggestion_for_content_translated_only_at_older_version_is_not_rejected(
+        self,
+    ) -> None:
+        self.exp_1.title = 'Updated Title'
+        self.exp_1.commit(
+            feconf.SYSTEM_COMMITTER_ID,
+            'Update exploration title',
+            [
+                {
+                    'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
+                    'property_name': 'title',
+                    'new_value': 'Updated Title',
+                }
+            ],
+        )
+
+        CHANGE_DICT['content_id'] = 'content_0'
+        suggestion = self.create_model(
+            suggestion_models.GeneralSuggestionModel,
+            suggestion_type=feconf.SUGGESTION_TYPE_TRANSLATE_CONTENT,
+            author_id='user1',
+            change_cmd=CHANGE_DICT,
+            score_category='irrelevant',
+            status=suggestion_models.STATUS_IN_REVIEW,
+            target_type=feconf.ENTITY_TYPE_EXPLORATION,
+            target_id=self.exp_1.id,
+            target_version_at_submission=1,
+            language_code='hi',
+        )
+        suggestion.update_timestamps()
+        suggestion_models.GeneralSuggestionModel.put_multi([suggestion])
+
+        self.assert_job_output_is_empty()
+
+        unchanged_suggestion = suggestion_models.GeneralSuggestionModel.get(
+            suggestion.id
+        )
+        self.assertEqual(
+            unchanged_suggestion.status, suggestion_models.STATUS_IN_REVIEW
+        )
+
 
 class AuditRejectTranslationSuggestionsForTranslatedContentsJobTests(
     job_test_utils.JobTestBase


### PR DESCRIPTION
## Explanation

Fixes #27123 by ensuring `RejectTranslationSuggestionsForTranslatedContentsJob` and `AuditRejectTranslationSuggestionsForTranslatedContentsJob` check translation models at the exploration's current version and reject duplicate suggestions in review regardless of the version at which the suggestion was originally submitted.

### Changes made:
- **`core/jobs/batch_jobs/reject_invalid_suggestion_and_delete_invalid_translation_jobs.py`**:
  - In `ComputeSuggestionsInReviewForTranslatedContents.process`, verify that `entity_translation_model.entity_version == exp_model.version` so only translation models matching the current exploration version are checked.
  - Removed `target_version_at_submission == entity_translation_model.entity_version` filter from the suggestion query so obsolete suggestions submitted on older exploration versions are found and rejected.
- **`core/jobs/batch_jobs/reject_invalid_suggestion_and_delete_invalid_translation_jobs_test.py`**:
  - Added unit test `test_invalid_suggestion_submitted_on_older_version_is_rejected`.
  - Added unit test `test_suggestion_for_content_translated_only_at_older_version_is_not_rejected`.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27123".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.