### PR TITLE
Fix #27078: npx uses global node instead of project specific node binary

### DIFF
--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -36,6 +36,8 @@ import sys
 
 from typing import Final, List, Optional, Tuple
 
+from . import common
+
 # When executing Python scripts using `python -m ...` from oppia/oppia,
 # Python adds the repository root to sys.path. See the documentation at
 #
@@ -74,9 +76,7 @@ KEYS_UPDATED_IN_CONSTANTS: Final = [
     b'FIREBASE_CONFIG_STORAGE_BUCKET',
     b'FIREBASE_CONFIG_GOOGLE_CLIENT_ID',
 ]
-NPX_CMD: Final = os.path.join(
-    os.pardir, 'oppia_tools', 'node-16.13.0', 'bin', 'npx'
-)
+NPX_CMD: Final = common.NPX_BIN_PATH
 
 
 def install_hook() -> None:
@@ -206,7 +206,10 @@ def check_changes_in_config() -> None:
 
 def run_formatters() -> None:
     """Runs prettier and black formatters."""
-    subprocess.run([NPX_CMD, 'lint-staged'], check=True)
+    node_bin_dir = os.path.abspath(os.path.join(common.NODE_PATH, 'bin'))
+    env = os.environ.copy()
+    env['PATH'] = f'{node_bin_dir}{os.pathsep}{env.get("PATH", "")}'
+    subprocess.run([NPX_CMD, 'lint-staged'], env=env, check=True)
 
 
 def main(args: Optional[List[str]] = None) -> None:

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -25,8 +25,9 @@ import subprocess
 
 from core.tests import test_utils
 
-from typing import List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
+from . import common
 from . import pre_commit_hook
 
 
@@ -419,10 +420,15 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             check_function_calls['check_changes_in_config_is_called'] = True
 
         def mock_npx_subprocess(  # pylint: disable=unused-argument
-            cmds: List[str], check: bool
+            cmds: List[str], check: bool, **kwargs: Any
         ) -> None:
             self.assertTrue(cmds[0].endswith('npx'))
             self.assertEqual(cmds[1], 'lint-staged')
+            if 'env' in kwargs and kwargs['env'] is not None:
+                self.assertIn(
+                    os.path.abspath(os.path.join(common.NODE_PATH, 'bin')),
+                    kwargs['env']['PATH'],
+                )
             check_function_calls['check_npx_subprocess_is_called'] = True
 
         package_lock_swap = self.swap(


### PR DESCRIPTION
## Explanation

Fixes #27078 where `npx lint-staged` run in `scripts/pre_commit_hook.py` failed when node was not installed in the global system PATH because `NPX_CMD` used a hardcoded node path and child processes spawned by `npx` did not have `../oppia_tools/node-*/bin` in their `PATH` environment variable.

### Changes made:
- **`scripts/pre_commit_hook.py`**:
  - Replaced hardcoded `NPX_CMD` path with `common.NPX_BIN_PATH`.
  - Prepended `common.NODE_PATH/bin` to `PATH` in `env` when running `subprocess.run([NPX_CMD, 'lint-staged'], env=env, check=True)` in `run_formatters()`.
- **`scripts/pre_commit_hook_test.py`**:
  - Updated mock for `subprocess.run` to accept `**kwargs` and verify that `common.NODE_PATH` is included in `env['PATH']`.

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", or "Fixes #27078".
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- [x] I have tested the changes locally.