### PR TITLE
Fix #23395: Resolve flaky E2E test in Translation Reviewer filter

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -111,52 +111,53 @@ export class Contributor extends ExplorationEditor {
   ): Promise<ElementHandle | null> {
     await this.page.waitForNetworkIdle();
 
-    const translationOpportunitiesPreset = await this.isElementVisible(
-      opportunityItemSelector
-    );
-
-    // Sometimes, the opportunities refreshes after they have been loaded.
-    // This causes problem that older node gets detached from the DOM.
-    // So, we are ensuring that the opportunity list hasn't been changed
-    // for 200 ms.
-    let previousElementIds: string[] = [];
-    let opportunityItemListChanged = true;
-
-    // TODO(#23395): Currently, the opportunity list is refreshed after the
-    // page is loaded. This causes the test to fail. We are using a workaround
-    // for now, by waiting for the opportunity list to be loaded.
-    // Once the issue is fixed, remove the following do-while loop.
-    do {
-      await this.page.waitForTimeout(200);
-
-      const currentElementIds = await this.page.evaluate((selector: string) => {
-        const elements = document.querySelectorAll(selector);
-        return Array.from(elements).map((el, index) => {
-          return el.textContent?.trim() || `element-${index}`;
-        });
-      }, opportunityItemSelector);
-
-      opportunityItemListChanged =
-        previousElementIds.length !== currentElementIds.length ||
-        !previousElementIds.every(
-          (id, index) => id === currentElementIds[index]
-        );
-
-      previousElementIds = currentElementIds;
-    } while (opportunityItemListChanged);
-
-    // Handle the case where no translation opportunity is present.
-    if (!translationOpportunitiesPreset) {
+    try {
+      await this.page.waitForFunction(
+        (
+          itemSelector: string,
+          headingSelector: string,
+          subheadingSelector: string,
+          expectedHeading: string,
+          expectedSubheading: string,
+          shouldBeVisible: boolean
+        ) => {
+          const elements = document.querySelectorAll(itemSelector);
+          let found = false;
+          for (const el of elements) {
+            const elHeading = el.querySelector(headingSelector)?.textContent?.trim();
+            const elSubheading = el.querySelector(subheadingSelector)?.textContent?.trim();
+            if (elHeading === expectedHeading && elSubheading?.includes(expectedSubheading)) {
+              found = true;
+              break;
+            }
+          }
+          return found === shouldBeVisible;
+        },
+        {timeout: 10000},
+        opportunityItemSelector,
+        opportunityItemHeadingSelector,
+        opportunitySubHeadingSelector,
+        heading,
+        subheading,
+        visible
+      );
+    } catch (e) {
       if (visible) {
         throw new Error(
           `Translation opportunity for ${heading} in ${subheading} not found.`
         );
       } else {
-        showMessage(
-          `Success: Translation opportunity for ${heading} in ${subheading} not found.`
+        throw new Error(
+          `Failure: Translation opportunity for ${heading} in ${subheading} was found.`
         );
-        return null;
       }
+    }
+
+    if (!visible) {
+      showMessage(
+        `Success: Translation opportunity for ${heading} in ${subheading} not found.`
+      );
+      return null;
     }
 
     // Get the opportunity item element.
@@ -177,23 +178,10 @@ export class Contributor extends ExplorationEditor {
         opportunityItemHeading === heading &&
         opportunityItemSubHeading?.includes(subheading)
       ) {
-        if (!visible) {
-          throw new Error(
-            `Failure: Translation opportunity for ${heading} in ${opportunityItemSubHeading} was found.`
-          );
-        }
         return opportunityItemElement;
       }
     }
 
-    if (visible) {
-      throw new Error(
-        `Translation opportunity for ${heading} in ${subheading} not found.`
-      );
-    }
-    showMessage(
-      `Success: Translation opportunity for ${heading} in ${subheading} not found.`
-    );
     return null;
   }
 


### PR DESCRIPTION
## Overview

1. This PR fixes #23395.
2. This PR does the following: Resolves the flaky E2E test in the Translation Reviewer filter to ensure more stable CI builds.
3. The original bug occurred because: The E2E test was experiencing intermittent timing or synchronization issues during execution.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is an E2E test stability fix and does not contain user-facing UI changes.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.