### PR TITLE
Fix #27050: Prevent TODO lint false positives in string literals

### DIFF
--- a/scripts/check_backend_associated_test_file.py
+++ b/scripts/check_backend_associated_test_file.py
@@ -43,6 +43,7 @@ FILES_WITHOUT_ASSOCIATED_TEST_FILES = [
     'scripts/linters/test_files/invalid_request.py',
     'scripts/linters/test_files/invalid_tabs.py',
     'scripts/linters/test_files/invalid_todo.py',
+    'scripts/linters/test_files/valid_todo_in_string.py',
     'scripts/linters/test_files/invalid_urlopen.py',
     'scripts/linters/test_files/valid.py',
     'scripts/linters/test_files/valid_job_imports.py',

--- a/scripts/linters/general_purpose_linter.py
+++ b/scripts/linters/general_purpose_linter.py
@@ -32,13 +32,28 @@ if MYPY:  # pragma: no cover
     from scripts.linters import run_lint_checks
 
 
-class BadPatternRegexpDict(TypedDict):
-    """Dictionary representation of bad pattern regular expressions."""
+class _BadPatternRegexpDictRequiredFields(TypedDict):
+    """Required fields for bad pattern regular expression dictionaries."""
 
     regexp: Pattern[str]
     message: str
     excluded_files: Tuple[str, ...]
     excluded_dirs: Tuple[str, ...]
+
+
+class BadPatternRegexpDict(_BadPatternRegexpDictRequiredFields, total=False):
+    """Dictionary representation of bad pattern regular expressions.
+
+    Optional fields:
+        strip_strings: bool. When True, quoted string literals are removed
+            from each line before the regex is applied. This prevents
+            false positives where the pattern text appears inside a string
+            value rather than as actual code or a comment. Should only be
+            enabled for patterns (e.g. the TODO rule) where matching inside
+            string literals would be a false positive.
+    """
+
+    strip_strings: bool
 
 
 class BadPatternsDict(TypedDict):
@@ -193,6 +208,10 @@ BAD_PATTERNS_REGEXP: List[BadPatternRegexpDict] = [
         'in the format TODO(#issuenum): XXX. ',
         'excluded_files': (),
         'excluded_dirs': (),
+        # Strip quoted string literals before matching so that the word
+        # 'TODO' appearing inside a string value (e.g. as a UI message or
+        # test data) does not trigger a false-positive lint error.
+        'strip_strings': True,
     }
 ]
 
@@ -351,6 +370,30 @@ def is_filepath_excluded_for_bad_patterns_check(
     )
 
 
+# Regex that matches quoted string literals in a single source line. Used by
+# check_bad_pattern_in_file when a pattern has 'strip_strings': True. Handles:
+#   - Triple-double-quoted strings ("""..."""), including unclosed opening/
+#     closing lines that span multiple source lines.
+#   - Triple-single-quoted strings ('''...'''), same handling as above.
+#   - Double-quoted strings with escape sequences ("…").
+#   - Single-quoted strings with escape sequences ('…').
+#   - Backtick template literals with escape sequences (`…`).
+# The alternation order matters: triple-quote patterns must come before
+# single/double-quote patterns so that the simpler patterns do not partially
+# consume an opening or closing triple-quote.
+_QUOTED_STRING_REGEXP: Final = re.compile(
+    r'(""".*?"""'
+    r"|'''.*?'''"
+    r'|""".*'
+    r"|'''.*"
+    r'|.*"""'
+    r"|.*'''"
+    r'|"[^"\\]*(?:\\.[^"\\]*)*"'
+    r"|'[^'\\]*(?:\\.[^'\\]*)*'"
+    r'|`[^`\\]*(?:\\.[^`\\]*)*`)'
+)
+
+
 def check_bad_pattern_in_file(
     filepath: str, file_content: Tuple[str, ...], pattern: BadPatternRegexpDict
 ) -> Tuple[bool, List[str]]:
@@ -392,7 +435,21 @@ def check_bad_pattern_in_file(
                 stripped_line = line
             if stripped_line.endswith('disable-bad-pattern-check'):
                 continue
-            if regexp.search(stripped_line):
+            if pattern.get('strip_strings'):
+                # For patterns that opt in to string stripping, remove quoted
+                # string literals before matching. This prevents the pattern
+                # from firing when the matched text appears inside a string
+                # value (e.g. a UI message) rather than as actual code or a
+                # comment. Only patterns that explicitly set
+                # 'strip_strings': True in their entry use this path; all
+                # other patterns (HTML, Python, etc.) receive the original
+                # line and are not affected.
+                line_to_check = re.sub(
+                    _QUOTED_STRING_REGEXP, '""', stripped_line
+                )
+            else:
+                line_to_check = stripped_line
+            if regexp.search(line_to_check):
                 error_message = '%s --> Line %s: %s' % (
                     filepath,
                     line_num,

--- a/scripts/linters/general_purpose_linter_test.py
+++ b/scripts/linters/general_purpose_linter_test.py
@@ -117,6 +117,9 @@ INVALID_MERGE_CONFLICT_FILEPATH: Final = os.path.join(
     LINTER_TESTS_DIR, 'invalid_merge_conflict.py'
 )
 INVALID_TODO_FILEPATH: Final = os.path.join(LINTER_TESTS_DIR, 'invalid_todo.py')
+VALID_TODO_IN_STRING_FILEPATH: Final = os.path.join(
+    LINTER_TESTS_DIR, 'valid_todo_in_string.py'
+)
 INVALID_COPYRIGHT_FILEPATH: Final = os.path.join(
     LINTER_TESTS_DIR, 'invalid_copyright.py'
 )
@@ -335,6 +338,36 @@ class GeneralLintTests(test_utils.LinterTestBase):
     def test_invalid_use_of_todo(self) -> None:
         linter = general_purpose_linter.GeneralPurposeLinter(
             [INVALID_TODO_FILEPATH], FILE_CACHE
+        )
+        lint_task_report = linter.check_bad_patterns()
+        self.assert_same_list_elements(
+            [
+                'Line 30: Please link TODO comments to an issue in the format'
+                ' TODO(#issuenum): XXX.'
+            ],
+            lint_task_report.trimmed_messages,
+        )
+        self.assertEqual('Bad pattern', lint_task_report.name)
+        self.assertTrue(lint_task_report.failed)
+
+    def test_valid_use_of_todo_in_string(self) -> None:
+        linter = general_purpose_linter.GeneralPurposeLinter(
+            [VALID_TODO_IN_STRING_FILEPATH], FILE_CACHE
+        )
+        lint_task_report = linter.check_bad_patterns()
+        self.assertEqual([], lint_task_report.trimmed_messages)
+        self.assertEqual('Bad pattern', lint_task_report.name)
+        self.assertFalse(lint_task_report.failed)
+
+    def test_invalid_todo_still_detected_alongside_string_todos(self) -> None:
+        # Passing both files together exercises that:
+        # 1. The invalid comment TODO in invalid_todo.py is still caught.
+        # 2. The valid string TODOs in valid_todo_in_string.py do not cause
+        #    spurious errors.
+        # This guards against regressions where string stripping for the TODO
+        # rule could silently suppress real lint violations.
+        linter = general_purpose_linter.GeneralPurposeLinter(
+            [INVALID_TODO_FILEPATH, VALID_TODO_IN_STRING_FILEPATH], FILE_CACHE
         )
         lint_task_report = linter.check_bad_patterns()
         self.assert_same_list_elements(

--- a/scripts/linters/test_files/valid_todo_in_string.py
+++ b/scripts/linters/test_files/valid_todo_in_string.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+#
+# Copyright 2026 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python file with valid TODO in string literals, used by scripts/linters/
+general_purpose_linter_test.py.
+"""
+
+from __future__ import annotations
+
+
+class FakeClass:
+    """This is a fake class for testing valid TODO in strings."""
+
+    def __init__(self, fake_arg: str) -> None:
+        self.fake_arg = fake_arg
+
+    def fake_method(self) -> str:
+        """This returns a string with TODO.
+
+        Returns:
+            str. A string containing TODO.
+        """
+        single_quote_todo_str = 'TODO #123'
+        double_quote_todo_str = "TODO fix later"
+        return single_quote_todo_str + double_quote_todo_str


### PR DESCRIPTION
## Overview

This PR fixes #27050, where the TODO lint check incorrectly flags `TODO` text when it appears inside string literals.

For example:

```typescript
const name = "TODO #123";
```

This should not trigger the TODO comment lint rule because the TODO text is part of a string literal, not an actual TODO comment.

## Changes Made

- Extended `BadPatternRegexpDict` with an optional `strip_strings: bool` field (backed by a `_BadPatternRegexpDictRequiredFields` base TypedDict with `total=True`) so that individual patterns can opt in to string-stripping without affecting every other pattern checked by the linter.
- - Added a module-level `_QUOTED_STRING_REGEXP` that matches single-quoted, double-quoted, backtick, and triple-quoted string literals on a single source line.
- - In `check_bad_pattern_in_file`, when a pattern has `strip_strings=True`, all matched string literals are replaced with `""` before running the bad-pattern regex. All other patterns continue to use the original line -- no regression risk.
- - Set `strip_strings: True` only on the existing TODO bad-pattern entry in `BAD_PATTERNS_REGEXP`.
- - Added test fixture `scripts/linters/test_files/valid_todo_in_string.py` containing string literals with `TODO` text.
- - Added unit tests:
-   - `test_valid_use_of_todo_in_string`: asserts zero lint errors on the new fixture.
-   - `test_invalid_todo_still_detected_alongside_string_todos`: passes both the invalid-TODO and valid-string-TODO fixtures together, asserting that real violations are still caught and no spurious errors appear.
- - Registered `valid_todo_in_string.py` in `FILES_WITHOUT_ASSOCIATED_TEST_FILES` (consistent with other linter test fixtures like `invalid_todo.py`).
## Testing

Verified that:

- Unlinked TODO comments still fail linting.
- - Correctly linked TODO comments still pass.
- - TODO text inside string literals does not trigger the TODO lint rule.
- - Invalid TODO comments remain detectable alongside valid strings.
- - `git diff --check` passes.
- - String stripping is NOT applied globally -- only the TODO bad-pattern rule enables it via the opt-in `strip_strings` flag.
- - All other bad-pattern rules preserve their original behavior.
Focused linter tests were run locally against the modified module directly. The full backend test suite requires a virtual environment with Redis/Datastore infrastructure not available in this local environment -- that will be verified by CI.

## Issue

Fixes #27050