### PR TITLE
Fix #27215

### DIFF
--- a/core/templates/pages/library-page/search-bar/search-bar.component.html
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.html
@@ -1,120 +1,99 @@
 <div class="oppia-same-row-container">
   <form class="search-bar-float-start oppia-search-bar-form" role="search">
     <div class="mb-3">
-      <div class="input-group oppia-input-group inptcls" [ngClass]="{'classroom-page-input-group': isSearchButtonActive()}">
+      <div class="input-group oppia-input-group inptcls"
+        [ngClass]="{'classroom-page-input-group': isSearchButtonActive()}">
         <div class="input-group-text oppia-search-bar-icon">
           <i class="fas fa-search oppia-translate-icon-down md-18" *ngIf="!isSearchInProgress()"></i>
           <span *ngIf="isSearchInProgress()">
             <i class="fas fa-sync oppia-animate-spin"></i>
           </span>
         </div>
-        <input type="text"
-               class="form-control oppia-search-bar-input oppia-search-bar-text-input e2e-test-search-input"
-               [placeholder]="searchBarPlaceholder"
-               [(ngModel)]="searchQuery"
-               (ngModelChange)="searchButtonIsActive ? null : onSearchQueryChangeExec()"
-               [ngModelOptions]="{ updateOn: 'blur', standalone:'true' }"
-               aria-label="Search bar"
-               (keydown.enter)="$event.target.blur(); onSearchQueryChangeExec()"
-               (input)="searchToBeExec($event)">
+        <input type="text" class="form-control oppia-search-bar-input oppia-search-bar-text-input e2e-test-search-input"
+          [placeholder]="searchBarPlaceholder" [(ngModel)]="searchQuery"
+          (ngModelChange)="searchButtonIsActive ? null : onSearchQueryChangeExec()"
+          [ngModelOptions]="{ updateOn: 'blur', standalone:'true' }" aria-label="Search bar"
+          (keydown.enter)="$event.target.blur(); onSearchQueryChangeExec()" (input)="searchToBeExec($event)">
       </div>
     </div>
   </form>
 </div>
 
 <div class="oppia-same-row-container">
-  <div [ngClass]="{'open' : activeMenuName === 'category', 'dropup' : enableDropup}"
-       ngbDropdown
-       autoClose="outside"
-       (openChange)="triggerSearchOnDropdownClose($event)"
-       class="search-bar-float-start oppia-navbar-button-container oppia-search-bar-category-selector e2e-test-search-bar-category-selector dropdown">
-    <button ngbDropdownToggle
-            type="button"
-            class="btn e2e-test-search-bar-dropdown-toggle oppia-search-bar-dropdown-toggle oppia-search-bar-input oppia-search-bar-category-input dropdown-toggle catbtn"
-            title="{{ selectionDetails.categories.description | translate }}">
+  <div [ngClass]="{'open' : activeMenuName === 'category', 'dropup' : enableDropup}" ngbDropdown autoClose="outside"
+    (openChange)="triggerSearchOnDropdownClose($event,'categories')"
+    class="search-bar-float-start oppia-navbar-button-container oppia-search-bar-category-selector e2e-test-search-bar-category-selector dropdown">
+    <button ngbDropdownToggle type="button"
+      class="btn e2e-test-search-bar-dropdown-toggle oppia-search-bar-dropdown-toggle oppia-search-bar-input oppia-search-bar-category-input dropdown-toggle catbtn"
+      title="{{ selectionDetails.categories.description | translate }}">
       <i *ngIf="isMobileViewActive()" class="fas fa-shapes category-selector-icon"></i>
       <span class="btn-text spnel">
         {{ categoryButtonText | truncate:14 }}
       </span>
     </button>
     <ul ngbDropdownMenu
-        class="e2e-test-search-bar-dropdown-menu oppia-search-bar-dropdown-menu oppia-search-bar-dropdown-menu-section dropdown-menu"
-        role="menu">
+      class="e2e-test-search-bar-dropdown-menu oppia-search-bar-dropdown-menu oppia-search-bar-dropdown-menu-section dropdown-menu"
+      role="menu">
       <ng-container *ngFor="let item of selectionDetails.categories.masterList">
         <li ngbDropdownItem *ngIf="selectionDetails.categories.selections[item.id]">
-          <a (click)="toggleSelection('categories', item.id)"
-             (keydown.enter)="toggleSelection('categories', item.id)"
-             [attr.aria-label]="( item.text | translate ) +  ' selected'"
-             tabindex="0"
-             *ngIf="!first && !last"
-             class="dropdown-item">
+          <a (click)="toggleSelection('categories', item.id)" (keydown.enter)="toggleSelection('categories', item.id)"
+            [attr.aria-label]="( item.text | translate ) +  ' selected'" tabindex="0" *ngIf="!first && !last"
+            class="dropdown-item">
             <span class="e2e-test-selected">
               {{ item.text | translate }}
             </span>
             <i *ngIf="selectionDetails.categories.selections[item.id]"
-               class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
             </i>
           </a>
-          <a (click)="toggleSelection('categories', item.id)"
-             (keydown.enter)="toggleSelection('categories', item.id)"
-             [attr.aria-label]="( item.text | translate ) +  ' selected'"
-             tabindex="0"
-             *ngIf="first"
-             (keydown)="onMenuKeypress($event, 'category', {shiftTab: ACTION_CLOSE})"
-             class="dropdown-item">
+          <a (click)="toggleSelection('categories', item.id)" (keydown.enter)="toggleSelection('categories', item.id)"
+            [attr.aria-label]="( item.text | translate ) +  ' selected'" tabindex="0" *ngIf="first"
+            (keydown)="onMenuKeypress($event, 'category', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]"
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
           </a>
-          <a (click)="toggleSelection('categories', item.id)"
-             (keydown.enter)="toggleSelection('categories', item.id)"
-             [attr.aria-label]="( item.text | translate ) +  ' selected'"
-             *ngIf="last"
-             tabindex="0"
-             (keydown)="onMenuKeypress($event, 'category', {tab: ACTION_CLOSE})"
-             class="dropdown-item">
+          <a (click)="toggleSelection('categories', item.id)" (keydown.enter)="toggleSelection('categories', item.id)"
+            [attr.aria-label]="( item.text | translate ) +  ' selected'" *ngIf="last" tabindex="0"
+            (keydown)="onMenuKeypress($event, 'category', {tab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]"
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
       <li ngbDropdownItem *ngIf="selectionDetails.categories.numSelections > 1">
-        <a tabindex="0"
-           (keydown.enter)="deselectAll('categories')"
-           (click)="deselectAll('categories')"
-           class="dropdown-item">
+        <a tabindex="0" (keydown.enter)="deselectAll('categories')" (click)="deselectAll('categories')"
+          class="dropdown-item">
           <i>Deselect All</i>
         </a>
       </li>
       <hr *ngIf="selectionDetails.categories.numSelections > 0" class="oppia-search-bar-hr">
       <ng-container *ngFor="let item of selectionDetails.categories.masterList">
-        <li ngbDropdownItem
-            *ngIf="!selectionDetails.categories.selections[item.id]">
-          <a tabindex="0"
-             (keydown.enter)="toggleSelection('categories', item.id)"
-             (click)="toggleSelection('categories', item.id)"
-             *ngIf="!first && !last"
-             class="dropdown-item">
+        <li ngbDropdownItem *ngIf="!selectionDetails.categories.selections[item.id]">
+          <a tabindex="0" (keydown.enter)="toggleSelection('categories', item.id)"
+            (click)="toggleSelection('categories', item.id)" *ngIf="!first && !last" class="dropdown-item">
             <span class="e2e-test-deselected">
               {{ item.text | translate }}
             </span>
             <i *ngIf="selectionDetails.categories.selections[item.id]"
-               class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
             </i>
           </a>
-          <a tabindex="0" (keydown.enter)="toggleSelection('categories', item.id)" (click)="toggleSelection('categories', item.id)" *ngIf="first" (keydown)="onMenuKeypress($event, 'category', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
+          <a tabindex="0" (keydown.enter)="toggleSelection('categories', item.id)"
+            (click)="toggleSelection('categories', item.id)" *ngIf="first"
+            (keydown)="onMenuKeypress($event, 'category', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
             <i *ngIf="selectionDetails.categories.selections[item.id]"
-               class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
             </i>
           </a>
-          <a tabindex="0"
-             (keydown.enter)="toggleSelection('categories', item.id)"
-             (click)="toggleSelection('categories', item.id)"
-             *ngIf="last"
-             (keydown)="onMenuKeypress($event, 'category', {tab: ACTION_CLOSE})"
-             class="dropdown-item">
+          <a tabindex="0" (keydown.enter)="toggleSelection('categories', item.id)"
+            (click)="toggleSelection('categories', item.id)" *ngIf="last"
+            (keydown)="onMenuKeypress($event, 'category', {tab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]"
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
@@ -123,108 +102,84 @@
 </div>
 
 <div class="oppia-same-row-container">
-  <div ngbDropdown
-       autoClose="outside"
-       [ngClass]="{'open' : activeMenuName === 'language', 'dropup' : enableDropup}"
-       (openChange)="triggerSearchOnDropdownClose($event)"
-       class="search-bar-float-start oppia-navbar-button-container oppia-search-bar-language-selector e2e-test-search-bar-language-selector dropdown">
-    <button ngbDropdownToggle
-            type="button"
-            class="btn e2e-test-search-bar-dropdown-toggle oppia-search-bar-input oppia-search-bar-language-input dropdown-toggle language-dropdown-toggle oppia-search-bar-dropdown-toggle-button langbtn"
-            title="{{selectionDetails.languageCodes.description | translate}}">
+  <div ngbDropdown autoClose="outside" [ngClass]="{'open' : activeMenuName === 'language', 'dropup' : enableDropup}"
+    (openChange)="triggerSearchOnDropdownClose($event,'languageCodes')"
+    class="search-bar-float-start oppia-navbar-button-container oppia-search-bar-language-selector e2e-test-search-bar-language-selector dropdown">
+    <button ngbDropdownToggle type="button"
+      class="btn e2e-test-search-bar-dropdown-toggle oppia-search-bar-input oppia-search-bar-language-input dropdown-toggle language-dropdown-toggle oppia-search-bar-dropdown-toggle-button langbtn"
+      title="{{selectionDetails.languageCodes.description | translate}}">
       <i *ngIf="isMobileViewActive()" class="fas fa-globe language-selector-icon"></i>
       <span class="btn-text spnel">
         {{ languageButtonText | truncate:14 }}
       </span>
     </button>
     <ul ngbDropdownMenu class="e2e-test-search-bar-dropdown-menu oppia-search-bar-dropdown-menu-section dropdown-menu"
-        role="menu">
+      role="menu">
       <ng-container *ngFor="let item of selectionDetails.languageCodes.masterList">
-        <li ngbDropdownItem
-            *ngIf="selectionDetails.languageCodes.selections[item.id]">
-          <a tabindex="0"
-             [attr.aria-label]="item.ariaLabelInEnglish + ' selected'"
-             (keydown.enter)="toggleSelection('languageCodes', item.id)"
-             (click)="toggleSelection('languageCodes', item.id)"
-             *ngIf="!first && !last"
-             class="dropdown-item">
+        <li ngbDropdownItem *ngIf="selectionDetails.languageCodes.selections[item.id]">
+          <a tabindex="0" [attr.aria-label]="item.ariaLabelInEnglish + ' selected'"
+            (keydown.enter)="toggleSelection('languageCodes', item.id)"
+            (click)="toggleSelection('languageCodes', item.id)" *ngIf="!first && !last" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
             <i *ngIf="selectionDetails.languageCodes.selections[item.id]"
-               class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
             </i>
           </a>
-          <a tabindex="0"
-             [attr.aria-label]="item.ariaLabelInEnglish + ' selected'"
-             (keydown.enter)="toggleSelection('languageCodes', item.id)"
-             (click)="toggleSelection('languageCodes', item.id)"
-             *ngIf="first"
-             (keydown)="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE})"
-             class="dropdown-item">
+          <a tabindex="0" [attr.aria-label]="item.ariaLabelInEnglish + ' selected'"
+            (keydown.enter)="toggleSelection('languageCodes', item.id)"
+            (click)="toggleSelection('languageCodes', item.id)" *ngIf="first"
+            (keydown)="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
             <i *ngIf="selectionDetails.languageCodes.selections[item.id]"
-               class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
             </i>
           </a>
-          <a tabindex="0"
-             [attr.aria-label]="item.ariaLabelInEnglish + ' selected'"
-             (keydown.enter)="toggleSelection('languageCodes', item.id)"
-             (click)="toggleSelection('languageCodes', item.id)"
-             *ngIf="last"
-             (keydown)="onMenuKeypress($event, 'language', {tab: ACTION_CLOSE})"
-             class="dropdown-item">
+          <a tabindex="0" [attr.aria-label]="item.ariaLabelInEnglish + ' selected'"
+            (keydown.enter)="toggleSelection('languageCodes', item.id)"
+            (click)="toggleSelection('languageCodes', item.id)" *ngIf="last"
+            (keydown)="onMenuKeypress($event, 'language', {tab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]"
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
-      <li ngbDropdownItem
-          *ngIf="selectionDetails.languageCodes.numSelections > 1">
-        <a tabindex="0" (keydown.enter)="deselectAll('languageCodes')"
-           (click)="deselectAll('languageCodes')"
-           class="dropdown-item">
+      <li ngbDropdownItem *ngIf="selectionDetails.languageCodes.numSelections > 1">
+        <a tabindex="0" (keydown.enter)="deselectAll('languageCodes')" (click)="deselectAll('languageCodes')"
+          class="dropdown-item">
           <i>Deselect All</i>
         </a>
       </li>
       <hr *ngIf="selectionDetails.languageCodes.numSelections > 0" class="oppia-search-bar-hr">
       <ng-container *ngFor="let item of selectionDetails.languageCodes.masterList">
-        <li ngbDropdownItem
-            *ngIf="!selectionDetails.languageCodes.selections[item.id]">
-          <a (click)="toggleSelection('languageCodes', item.id)"
-             [attr.aria-label]="item.ariaLabelInEnglish"
-             (keydown.enter)="toggleSelection('languageCodes', item.id)"
-             tabindex="0"
-             *ngIf="!first && !last"
-             class="dropdown-item">
+        <li ngbDropdownItem *ngIf="!selectionDetails.languageCodes.selections[item.id]">
+          <a (click)="toggleSelection('languageCodes', item.id)" [attr.aria-label]="item.ariaLabelInEnglish"
+            (keydown.enter)="toggleSelection('languageCodes', item.id)" tabindex="0" *ngIf="!first && !last"
+            class="dropdown-item">
             <span class="e2e-test-deselected">
               {{ item.text | translate }}
             </span>
             <i *ngIf="selectionDetails.languageCodes.selections[item.id]"
-               class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
             </i>
           </a>
-          <a tabindex="0"
-             (keydown.enter)="toggleSelection('languageCodes', item.id)"
-             (click)="toggleSelection('languageCodes', item.id)"
-             [attr.aria-label]="item.ariaLabelInEnglish"
-             *ngIf="first"
-             (keydown)="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE})"
-             class="dropdown-item">
+          <a tabindex="0" (keydown.enter)="toggleSelection('languageCodes', item.id)"
+            (click)="toggleSelection('languageCodes', item.id)" [attr.aria-label]="item.ariaLabelInEnglish"
+            *ngIf="first" (keydown)="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE})"
+            class="dropdown-item">
             <span class="e2e-test-deselected">
               {{ item.text | translate }}
             </span>
             <i *ngIf="selectionDetails.languageCodes.selections[item.id]"
-               class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol">
             </i>
           </a>
-          <a tabindex="0"
-             (keydown.enter)="toggleSelection('languageCodes', item.id)"
-             [attr.aria-label]="item.ariaLabelInEnglish"
-             (click)="toggleSelection('languageCodes', item.id)"
-             *ngIf="last"
-             (keydown)="onMenuKeypress($event, 'language', {tab: ACTION_CLOSE})"
-             class="dropdown-item">
+          <a tabindex="0" (keydown.enter)="toggleSelection('languageCodes', item.id)"
+            [attr.aria-label]="item.ariaLabelInEnglish" (click)="toggleSelection('languageCodes', item.id)" *ngIf="last"
+            (keydown)="onMenuKeypress($event, 'language', {tab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]"
+              class="fas fa-check float-end oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
@@ -232,12 +187,9 @@
   </div>
   <div class="oppia-same-row-container">
     <div class="search-bar-float-start oppia-navbar-button-container">
-      <div *ngIf="searchButtonIsActive"
-           class="oppia-search-button e2e-test-search-button"
-           (click)="onSearchQueryChangeExec()"
-           tabindex="0"
-           (keydown.enter)="onSearchQueryChangeExec()"
-           title="Click here to search">
+      <div *ngIf="searchButtonIsActive" class="oppia-search-button e2e-test-search-button"
+        (click)="onSearchQueryChangeExec()" tabindex="0" (keydown.enter)="onSearchQueryChangeExec()"
+        title="Click here to search">
         <i class="fas fa-search search-button-icon"></i>
       </div>
     </div>
@@ -245,74 +197,84 @@
 </div>
 <style>
   :lang(ar) .oppia-search-bar-dropdown-toggle-button:after {
-     margin-right: 30px;
+    margin-right: 30px;
   }
+
   :lang(ar) .oppia-search-bar-dropdown-toggle:after {
     margin-right: 2px;
   }
+
   @media (max-width: 445px) {
 
-.classroom-page-input-group.inptcls {
+    .classroom-page-input-group.inptcls {
       font-size: 15.7px;
       width: 14em;
- }
+    }
 
-/* stylelint-disable order/properties-alphabetical-order */
-.search-bar-float-start .oppia-search-bar-dropdown-toggle.catbtn {
-  font-size: 13px;
-  position: relative;
-  left: 5rem;
-  width: 11em;
-}
-.oppia-search-bar-language-selector .langbtn {
-  font-size: 13px;
-  position: relative;
-  left: 3rem;
-  width: 11em;
-}
-  /* stylelint-enable order/properties-alphabetical-order */
-  :lang(ar) .classroom-page-input-group.inptcls {
-    font-size: 12px;
-    width: 14em;
-  }
-  :lang(ar) .search-bar-float-start .oppia-search-bar-dropdown-toggle.catbtn {
- font-size: 13px;
- position: relative;
- right: 9rem;
- width: 10em;
-  }
-  :lang(ar) .oppia-search-bar-language-selector .langbtn {
- font-size: 13px;
- padding-left: 3rem;
- position: relative;
- right: 8rem;
- width: 10em;
-  }
-}
-@media (max-width : 340px) {
+    /* stylelint-disable order/properties-alphabetical-order */
+    .search-bar-float-start .oppia-search-bar-dropdown-toggle.catbtn {
+      font-size: 13px;
+      position: relative;
+      left: 5rem;
+      width: 11em;
+    }
 
- :lang(ar) .oppia-search-bar-language-selector .langbtn {
- font-size: 13px;
- padding-left: 3rem;
- position: relative;
- right: 8rem;
- width: 10em;
+    .oppia-search-bar-language-selector .langbtn {
+      font-size: 13px;
+      position: relative;
+      left: 3rem;
+      width: 11em;
+    }
+
+    /* stylelint-enable order/properties-alphabetical-order */
+    :lang(ar) .classroom-page-input-group.inptcls {
+      font-size: 12px;
+      width: 14em;
+    }
+
+    :lang(ar) .search-bar-float-start .oppia-search-bar-dropdown-toggle.catbtn {
+      font-size: 13px;
+      position: relative;
+      right: 9rem;
+      width: 10em;
+    }
+
+    :lang(ar) .oppia-search-bar-language-selector .langbtn {
+      font-size: 13px;
+      padding-left: 3rem;
+      position: relative;
+      right: 8rem;
+      width: 10em;
+    }
   }
-}
-@media (max-width : 285px) {
-  .classroom-page-input-group.inptcls {
-    font-size: 13.4px;
-    width: 13.4em;
+
+  @media (max-width : 340px) {
+
+    :lang(ar) .oppia-search-bar-language-selector .langbtn {
+      font-size: 13px;
+      padding-left: 3rem;
+      position: relative;
+      right: 8rem;
+      width: 10em;
+    }
   }
-  .search-bar-float-start .oppia-search-bar-dropdown-toggle.catbtn {
-  font-size: 10px;
- left: 10rem;
- width: 12em;
+
+  @media (max-width : 285px) {
+    .classroom-page-input-group.inptcls {
+      font-size: 13.4px;
+      width: 13.4em;
+    }
+
+    .search-bar-float-start .oppia-search-bar-dropdown-toggle.catbtn {
+      font-size: 10px;
+      left: 10rem;
+      width: 12em;
+    }
+
+    .oppia-search-bar-language-selector .langbtn {
+      font-size: 10px;
+      left: 4.8rem;
+      width: 12em;
+    }
   }
-  .oppia-search-bar-language-selector .langbtn {
-    font-size: 10px;
-    left: 4.8rem;
-    width: 12em;
-  }
-}
 </style>

--- a/core/templates/pages/library-page/search-bar/search-bar.component.spec.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.spec.ts
@@ -296,13 +296,50 @@ describe('Search bar component', () => {
     expect(component.refreshSearchBarLabels).toHaveBeenCalled();
   });
 
-  it('should trigger search query only when dropdown is closed', () => {
+  it('should not trigger search when dropdown opens', () => {
     spyOn(component, 'onSearchQueryChangeExec');
-    component.triggerSearchOnDropdownClose(true);
+    component.triggerSearchOnDropdownClose(true, 'languageCodes');
     expect(component.onSearchQueryChangeExec).not.toHaveBeenCalled();
-    component.triggerSearchOnDropdownClose(false);
-    expect(component.onSearchQueryChangeExec).toHaveBeenCalled();
   });
+
+  it(
+    'should not trigger search when dropdown closes with no ' +
+      'selection change',
+    () => {
+      spyOn(component, 'onSearchQueryChangeExec');
+      component.triggerSearchOnDropdownClose(true, 'languageCodes');
+      component.triggerSearchOnDropdownClose(false, 'languageCodes');
+      expect(component.onSearchQueryChangeExec).not.toHaveBeenCalled();
+    }
+  );
+
+  it(
+    'should trigger search when dropdown closes after a selection ' + 'change',
+    () => {
+      spyOn(component, 'onSearchQueryChangeExec');
+      component.triggerSearchOnDropdownClose(true, 'languageCodes');
+      component.selectionDetails.languageCodes.selections.en = true;
+      component.triggerSearchOnDropdownClose(false, 'languageCodes');
+      expect(component.onSearchQueryChangeExec).toHaveBeenCalled();
+    }
+  );
+
+  it(
+    'should track categories and languageCodes selections ' + 'independently',
+    () => {
+      spyOn(component, 'onSearchQueryChangeExec');
+      component.triggerSearchOnDropdownClose(true, 'categories');
+      component.triggerSearchOnDropdownClose(true, 'languageCodes');
+      component.selectionDetails.categories.selections.id_1 = true;
+      // Closing languageCodes should not fire, since only categories
+      // changed.
+      component.triggerSearchOnDropdownClose(false, 'languageCodes');
+      expect(component.onSearchQueryChangeExec).not.toHaveBeenCalled();
+      // Closing categories should fire, since it changed.
+      component.triggerSearchOnDropdownClose(false, 'categories');
+      expect(component.onSearchQueryChangeExec).toHaveBeenCalled();
+    }
+  );
 
   it('should deselectAll', () => {
     spyOn(component, 'updateSelectionDetails');

--- a/core/templates/pages/library-page/search-bar/search-bar.component.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.ts
@@ -67,6 +67,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   searchQueryChanged: Subject<string> = new Subject<string>();
   translationData: Record<string, number> = {};
   activeMenuName: string = '';
+  private selectionsOnDropdownOpen: Record<string, string> = {};
   @Input() enableDropup: boolean = false;
 
   constructor(
@@ -191,11 +192,26 @@ export class SearchBarComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Triggers a search query when the dropdown menu is closed.
+   * Snapshots a dropdown's selections when it opens, and only
+   * triggers a search when it closes if the selections actually
+   * changed — not merely because the user clicked outside to
+   * dismiss it.
    * @param {boolean} isOpen - The new open state of the dropdown.
+   * @param {string} itemsType - Which selectionDetails entry this
+   * dropdown controls ('categories' or 'languageCodes').
    */
-  triggerSearchOnDropdownClose(isOpen: boolean): void {
-    if (!isOpen) {
+  triggerSearchOnDropdownClose(isOpen: boolean, itemsType: string): void {
+    if (isOpen) {
+      this.selectionsOnDropdownOpen[itemsType] = JSON.stringify(
+        this.selectionDetails[itemsType].selections
+      );
+      return;
+    }
+
+    let currentSelections = JSON.stringify(
+      this.selectionDetails[itemsType].selections
+    );
+    if (currentSelections !== this.selectionsOnDropdownOpen[itemsType]) {
       this.onSearchQueryChangeExec();
     }
   }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes #27215.
2. This PR does the following: Fixes the search bar's category and language
   dropdowns so that a search is only triggered when the user's selections
   actually change, rather than on every dropdown close event.
3. (For bug-fixing PRs only) The original bug occurred because: `triggerSearchOnDropdownClose` was wired to the dropdown's `openChange`
   event and fired `onSearchQueryChangeExec()` on every close, with no check
   for whether a selection had changed. Since `autoClose="outside"` fires
   `openChange(false)` even when the user clicks away without selecting
   anything, this caused an unwanted search/redirect on every dismiss.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
##Before bug fix

https://github.com/user-attachments/assets/b097aeb0-3d08-4da3-abdb-9c723e71d985

##After bug fix

https://github.com/user-attachments/assets/3b43f536-e969-483d-802b-3b6fba7daa73


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
