### PR TITLE
Fix part of #21308: Add tests for backend branch coverage

### DIFF
--- a/core/domain/learner_group_fetchers_test.py
+++ b/core/domain/learner_group_fetchers_test.py
@@ -19,7 +19,10 @@
 from __future__ import annotations
 
 from core.domain import learner_group_fetchers, learner_group_services
+from core.platform import models
 from core.tests import test_utils
+
+(user_models,) = models.Registry.import_models([models.Names.USER])
 
 
 class LearnerGroupFetchersUnitTests(test_utils.GenericTestBase):
@@ -152,3 +155,53 @@ class LearnerGroupFetchersUnitTests(test_utils.GenericTestBase):
         )
         self.assertEqual(len(learner_groups), 1)
         self.assertEqual(learner_groups[0].group_id, self.LEARNER_GROUP_ID)
+
+    def test_get_learner_group_models_by_ids_strict_false(self) -> None:
+        learner_group_models = (
+            learner_group_fetchers.get_learner_group_models_by_ids(
+                ['unknown_user'], strict=False
+            )
+        )
+        self.assertEqual(learner_group_models, [None])
+
+    def test_can_multi_learners_share_progress_loop_branches(self) -> None:
+        model = user_models.LearnerGroupsUserModel(
+            id='user_abc',
+            learner_groups_user_details=[
+                {
+                    'group_id': 'other_group',
+                    'progress_sharing_is_turned_on': False,
+                },
+                {
+                    'group_id': 'target_group',
+                    'progress_sharing_is_turned_on': True,
+                },
+            ],
+        )
+        model.update_timestamps()
+        model.put()
+
+        permissions = learner_group_fetchers.can_multi_learners_share_progress(
+            ['user_abc'], 'target_group'
+        )
+        self.assertEqual(permissions, [True])
+
+        permissions_empty = (
+            learner_group_fetchers.can_multi_learners_share_progress(
+                ['user_abc'], 'non_existent_group'
+            )
+        )
+        self.assertEqual(permissions_empty, [])
+
+        model.update_timestamps()
+        model.put()
+        permissions = learner_group_fetchers.can_multi_learners_share_progress(
+            ['user_abc'], 'target_group'
+        )
+        self.assertEqual(permissions, [True])
+        permissions_empty = (
+            learner_group_fetchers.can_multi_learners_share_progress(
+                ['user_abc'], 'non_existent_group'
+            )
+        )
+        self.assertEqual(permissions_empty, [])

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -116,6 +116,42 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             user_domain.ModifiableUserData.from_raw_dict(new_user_data_dict)
         )
 
+    def test_get_user_roles_from_id_for_nonexistent_user_returns_guest_role(
+        self,
+    ) -> None:
+        """Test that getting roles for a nonexistent user returns the guest role."""
+        roles = user_services.get_user_roles_from_id('nonexistent_user_id_123')
+        self.assertEqual(roles, [feconf.ROLE_ID_GUEST])
+
+    def test_get_usernames_with_nonexistent_user_returns_none_in_list(
+        self,
+    ) -> None:
+        """Test that getting usernames for a nonexistent user returns a list with None."""
+        usernames = user_services.get_usernames(
+            ['nonexistent_user_id_123'], strict=False
+        )
+        self.assertEqual(usernames, [None])
+
+    def test_record_user_created_an_exploration_with_nonexistent_user(
+        self,
+    ) -> None:
+        """Test that recording exploration creation for a nonexistent user exits gracefully."""
+        user_services.record_user_created_an_exploration(
+            'nonexistent_user_id_123'
+        )
+
+    def test_migrate_dashboard_stats_with_valid_schema_exits_gracefully(
+        self,
+    ) -> None:
+        """Test that a valid schema version exits without raising an exception."""
+        valid_stats_model = user_models.UserStatsModel(
+            id='user_1',
+            schema_version=feconf.CURRENT_DASHBOARD_STATS_SCHEMA_VERSION,
+        )
+        user_services.migrate_dashboard_stats_to_latest_schema(
+            valid_stats_model
+        )
+
     def test_set_and_get_username(self) -> None:
         auth_id = 'someUser'
         username = 'username'
@@ -2625,6 +2661,20 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
                 'invalid_user_id', 'exp_1', strict=True
             )
 
+    def test_get_checkpoints_in_order_with_no_default_outcome_returns_gracefully(
+        self,
+    ) -> None:
+        """Test get_checkpoints_in_order when default_outcome is None."""
+        state = state_domain.State.create_default_state(
+            'state_1', 'content_0', 'default_outcome_1'
+        )
+        state.interaction.default_outcome = None
+        states = {'Introduction': state}
+        checkpoints = user_services.get_checkpoints_in_order(
+            'Introduction', states
+        )
+        self.assertEqual(checkpoints, [])
+
 
 class UserCheckpointProgressUpdateTests(test_utils.GenericTestBase):
     """Tests whether user checkpoint progress is updated correctly"""
@@ -3042,6 +3092,116 @@ title: Title
         self.assertIsNone(
             exp_user_data.most_recently_reached_checkpoint_state_name
         )
+
+    def test_update_checkpoint_progress_with_same_version(self) -> None:
+        self.login(self.VIEWER_EMAIL)
+        user_services.update_learner_checkpoint_progress(
+            self.viewer_id, self.EXP_ID, 'Introduction', 1
+        )
+        user_services.update_learner_checkpoint_progress(
+            self.viewer_id, self.EXP_ID, 'Introduction', 1
+        )
+        self.logout()
+
+    def test_update_checkpoint_progress_when_checkpoint_deleted(self) -> None:
+        self.login(self.VIEWER_EMAIL)
+        user_services.update_learner_checkpoint_progress(
+            self.viewer_id, self.EXP_ID, 'Introduction', 1
+        )
+        change_list = [
+            exp_domain.ExplorationChange(
+                {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'Introduction',
+                    'property_name': exp_domain.STATE_PROPERTY_CARD_IS_CHECKPOINT,
+                    'new_value': False,
+                }
+            )
+        ]
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, change_list, 'remove checkpoint'
+        )
+        user_services.update_learner_checkpoint_progress(
+            self.viewer_id, self.EXP_ID, 'Introduction', 2
+        )
+        self.logout()
+
+    def test_clear_checkpoint_progress_for_nonexistent_model(self) -> None:
+        user_services.clear_learner_checkpoint_progress('fake_user', 'fake_exp')
+
+    def test_update_checkpoint_progress_when_checkpoint_exists_in_new_version(
+        self,
+    ) -> None:
+        self.login(self.VIEWER_EMAIL)
+        user_services.update_learner_checkpoint_progress(
+            self.viewer_id, self.EXP_ID, 'Introduction', 1
+        )
+        change_list = [
+            exp_domain.ExplorationChange(
+                {
+                    'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
+                    'property_name': 'objective',
+                    'new_value': 'new objective',
+                }
+            )
+        ]
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, change_list, 'update obj'
+        )
+        user_services.update_learner_checkpoint_progress(
+            self.viewer_id, self.EXP_ID, 'Introduction', 2
+        )
+        self.logout()
+
+    def test_sync_checkpoint_no_change_in_new_version(self) -> None:
+        self.login(self.VIEWER_EMAIL)
+        user_services.update_learner_checkpoint_progress(
+            self.viewer_id, self.EXP_ID, 'Introduction', 1
+        )
+        change_list = [
+            exp_domain.ExplorationChange(
+                {
+                    'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
+                    'property_name': 'objective',
+                    'new_value': 'new objective',
+                }
+            )
+        ]
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, change_list, 'update obj'
+        )
+        user_services.sync_logged_in_learner_checkpoint_progress_with_current_exp_version(
+            self.viewer_id, self.EXP_ID
+        )
+        self.logout()
+
+    def test_update_checkpoint_progress_earlier_state_new_version(self) -> None:
+        from unittest import mock
+
+        self.login(self.VIEWER_EMAIL)
+        with mock.patch(
+            'core.domain.user_services.get_checkpoints_in_order'
+        ) as mock_checkpoints:
+            mock_checkpoints.return_value = ['Introduction', 'Second State']
+            user_services.update_learner_checkpoint_progress(
+                self.viewer_id, self.EXP_ID, 'Second State', 1
+            )
+            change_list = [
+                exp_domain.ExplorationChange(
+                    {
+                        'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
+                        'property_name': 'objective',
+                        'new_value': 'newer objective',
+                    }
+                )
+            ]
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, change_list, 'update obj'
+            )
+            user_services.update_learner_checkpoint_progress(
+                self.viewer_id, self.EXP_ID, 'Introduction', 2
+            )
+        self.logout()
 
 
 class UpdateContributionMsecTests(test_utils.GenericTestBase):
@@ -3974,6 +4134,26 @@ class CommunityContributionStatsUnitTests(test_utils.GenericTestBase):
     REVIEWER_1_EMAIL: Final = 'reviewer1@community.org'
     REVIEWER_2_EMAIL: Final = 'reviewer2@community.org'
 
+    def test_remove_translation_rights_with_multiple_reviewers_keeps_count_above_zero(
+        self,
+    ) -> None:
+        """Test that removing a translation reviewer doesn't delete the language if others exist."""
+        user_services.allow_user_to_review_translation_in_language(
+            'user_1', 'es'
+        )
+        user_services.allow_user_to_review_translation_in_language(
+            'user_2', 'es'
+        )
+
+        user_services.remove_translation_review_rights_in_language(
+            'user_1', 'es'
+        )
+
+        stats_model = suggestion_models.CommunityContributionStatsModel.get()
+        self.assertEqual(
+            stats_model.translation_reviewer_counts_by_lang_code['es'], 1
+        )
+
     def _assert_community_contribution_stats_is_in_default_state(self) -> None:
         """Checks if the community contribution stats is in its default
         state.
@@ -4114,12 +4294,15 @@ class CommunityContributionStatsUnitTests(test_utils.GenericTestBase):
         user_services.allow_user_to_review_translation_in_language(
             self.reviewer_1_id, 'en'
         )
+        user_services.allow_user_to_review_translation_in_language(
+            self.reviewer_2_id, 'hi'
+        )
         # Assert that the translation reviewer count increased by one.
         stats = suggestion_services.get_community_contribution_stats()
         self.assertEqual(stats.question_reviewer_count, 0)
         self.assertEqual(stats.question_suggestion_count, 0)
         self.assertDictEqual(
-            stats.translation_reviewer_counts_by_lang_code, {'hi': 1, 'en': 1}
+            stats.translation_reviewer_counts_by_lang_code, {'hi': 2, 'en': 1}
         )
         self.assertDictEqual(
             stats.translation_suggestion_counts_by_lang_code, {}
@@ -4135,7 +4318,7 @@ class CommunityContributionStatsUnitTests(test_utils.GenericTestBase):
         self.assertEqual(stats.question_reviewer_count, 0)
         self.assertEqual(stats.question_suggestion_count, 0)
         self.assertDictEqual(
-            stats.translation_reviewer_counts_by_lang_code, {'en': 1}
+            stats.translation_reviewer_counts_by_lang_code, {'hi': 1, 'en': 1}
         )
         self.assertDictEqual(
             stats.translation_suggestion_counts_by_lang_code, {}
@@ -4825,6 +5008,10 @@ class UserContributionReviewRightsTests(test_utils.GenericTestBase):
             constants.CD_USER_RIGHTS_CATEGORY_SUBMIT_QUESTION
         )
         self.assertEqual(usernames, [self.QUESTION_SUBMITTER_USERNAME])
+
+    def test_remove_contribution_reviewer_with_nonexistent_user(self) -> None:
+        """Test that removing a nonexistent contribution reviewer exits gracefully."""
+        user_services.remove_contribution_reviewer('nonexistent_user_id_123')
 
     def test_remove_question_submit_rights(self) -> None:
         auth_id = 'someUser'


### PR DESCRIPTION
## Overview

1. This PR fixes part of #21308.
2. This PR does the following:
   - Adds tests to cover previously uncovered branches in `core/domain/learner_group_fetchers.py`.
   - Adds tests to cover previously uncovered branches in `core/domain/user_services.py`.
   - Adds coverage for edge cases involving learner-group fetching and user contribution/reviewer rights.
   - Updates the relevant existing test expectations where required by the added coverage.
   
   These changes improve the backend test coverage of the affected domain services and ensure that the previously uncovered branches are exercised by tests.

3. (For bug-fixing PRs only) N/A

## Essential Checklist

Please follow the instructions for making a code change.

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A — this PR does not contain Beam jobs that modify production server data.

## Proof that changes are correct

No proof of changes needed because this PR only adds/updates backend tests to improve branch coverage and does not introduce any user-facing changes.

No user-facing changes are introduced by this PR. This is a backend test-coverage improvement, so screenshots/videos of the user-facing interface are not applicable.

#### Proof of changes on desktop with slow/throttled network

N/A — this is a backend-only test-coverage change with no user-facing UI changes.

#### Proof of changes on mobile phone

N/A — this is a backend-only test-coverage change with no user-facing UI changes.

#### Proof of changes in Arabic language

N/A — this PR does not modify the UI.

## Test Results

The following relevant backend test suites pass locally:

- `core.domain.learner_group_fetchers_test`: 9 tests passed
- `core.domain.user_services_test`: 213 tests passed

The local coverage report shows:

- `core/domain/learner_group_fetchers.py`: 100% line and branch coverage
- `core/domain/user_services.py`: 100% line and branch coverage

Proof Attached :
<img width="717" height="215" alt="Screenshot 2026-08-31 235817" src="https://github.com/user-attachments/assets/c11cbb46-d927-4f06-a2ce-d323cf83f4b7" />

<img width="865" height="217" alt="Screenshot 2026-08-31 232341" src="https://github.com/user-attachments/assets/5c0cbedd-b0d9-4121-be7b-f2ec1ee6580f" />


Coverage result:

- Statements missed: 0
- Branches partially covered: 0
- Overall coverage: 100%

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow the instructions in the Oppia PR guidelines.
- Some acceptance tests are flaky, and can fail for reasons unrelated to the PR.
- See the Code Owner's wiki page for what code owners will expect.