### PR TITLE
Fix #27157: Fix Community Library page infinite loading and handle Elasticsearch exceptions gracefully

### DIFF
--- a/core/platform/search/elastic_search_services.py
+++ b/core/platform/search/elastic_search_services.py
@@ -20,6 +20,8 @@ API.
 
 from __future__ import annotations
 
+import logging
+
 from core import feconf
 from core.domain import (
     platform_parameter_list,
@@ -143,6 +145,9 @@ def _fetch_response_from_elastic_search(
         _create_index(index_name)
         empty_list: List[str] = []
         return empty_list, None
+    except elasticsearch.exceptions.ElasticsearchException as e:
+        logging.exception('Failed to fetch response from Elasticsearch: %s' % e)
+        return [], None
 
     matched_search_docs = response['hits']['hits']
 

--- a/core/platform/search/elastic_search_services_test.py
+++ b/core/platform/search/elastic_search_services_test.py
@@ -143,6 +143,29 @@ class ElasticSearchUnitTests(test_utils.GenericTestBase):
         self.assertEqual(new_offset, None)
         self.assertEqual(result, [])
 
+    def test_search_returns_empty_when_elasticsearch_raises_exception(
+        self,
+    ) -> None:
+        def mock_search_raises(
+            body: Dict[str, Any], index: str, from_: int, size: int
+        ) -> Dict[str, Any]:
+            meta = type('Meta', (), {'status': 503})()
+            body_dict = {
+                'status': 503,
+                'error': 'search_phase_execution_exception',
+            }
+            raise elasticsearch.exceptions.ApiError(
+                'search_phase_execution_exception', meta, body_dict
+            )
+
+        es_client = elastic_search_services.ES.get_client()
+        with self.swap(es_client, 'search', mock_search_raises):
+            result, new_offset = elastic_search_services.search(
+                '', 'index', [], [], offset=0, size=50
+            )
+            self.assertEqual(result, [])
+            self.assertIsNone(new_offset)
+
     def test_search_constructs_query_with_categories_and_languages(
         self,
     ) -> None:

--- a/core/templates/pages/library-page/library-page.component.spec.ts
+++ b/core/templates/pages/library-page/library-page.component.spec.ts
@@ -329,6 +329,54 @@ describe('Library Page Component', () => {
     expect(windowDimensionsService.getWidth).toHaveBeenCalled();
   }));
 
+  it('should handle error and hide loader when fetchLibraryGroupDataAsync fails', fakeAsync(() => {
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(urlInterpolationService, 'getStaticImageUrl');
+    spyOn(translateService.onLangChange, 'subscribe');
+    spyOn(loggerService, 'error');
+    spyOn(loaderService, 'hideLoadingScreen');
+    spyOn(
+      libraryPageBackendApiService,
+      'fetchLibraryGroupDataAsync'
+    ).and.returnValue(Promise.reject('Internal Server Error'));
+    componentInstance.ngOnInit();
+    tick();
+    tick();
+
+    expect(loaderService.showLoadingScreen).toHaveBeenCalled();
+    expect(
+      libraryPageBackendApiService.fetchLibraryGroupDataAsync
+    ).toHaveBeenCalled();
+    expect(loggerService.error).toHaveBeenCalled();
+    expect(loaderService.hideLoadingScreen).toHaveBeenCalled();
+    expect(componentInstance.activityList).toEqual([]);
+  }));
+
+  it('should handle error and hide loader when fetchLibraryIndexDataAsync fails', fakeAsync(() => {
+    spyOn(loaderService, 'showLoadingScreen');
+    spyOn(urlInterpolationService, 'getStaticImageUrl');
+    spyOn(translateService.onLangChange, 'subscribe');
+    windowRef.nativeWindow.location.pathname = '/community-library';
+    fixture.detectChanges();
+    spyOn(
+      libraryPageBackendApiService,
+      'fetchLibraryIndexDataAsync'
+    ).and.returnValue(Promise.reject('Internal Server Error'));
+    spyOn(loggerService, 'error');
+    spyOn(loaderService, 'hideLoadingScreen');
+    componentInstance.ngOnInit();
+    tick();
+    tick();
+
+    expect(loaderService.showLoadingScreen).toHaveBeenCalled();
+    expect(
+      libraryPageBackendApiService.fetchLibraryIndexDataAsync
+    ).toHaveBeenCalled();
+    expect(loggerService.error).toHaveBeenCalled();
+    expect(loaderService.hideLoadingScreen).toHaveBeenCalled();
+    expect(componentInstance.libraryGroups).toEqual([]);
+  }));
+
   it('should initialize for non group pages', fakeAsync(() => {
     spyOn(loaderService, 'showLoadingScreen');
     spyOn(urlInterpolationService, 'getStaticImageUrl');

--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -426,74 +426,95 @@ export class LibraryPageComponent {
           }
           this.loaderService.hideLoadingScreen();
           this.initCarousels();
+        })
+        .catch(error => {
+          this.loggerService.error(
+            'Failed to load library group data: ' + error
+          );
+          this.activityList = [];
+          this.loaderService.hideLoadingScreen();
         });
     } else {
       this.libraryPageBackendApiService
         .fetchLibraryIndexDataAsync()
         .then(response => {
           this.libraryGroups = response.activity_summary_dicts_by_category;
-          this.userService.getUserInfoAsync().then(userInfo => {
-            this.activitiesOwned = {explorations: {}, collections: {}};
-            if (userInfo.isLoggedIn()) {
-              this.libraryPageBackendApiService
-                .fetchCreatorDashboardDataAsync()
-                .then(response => {
-                  this.libraryGroups.forEach(libraryGroup => {
-                    let activitySummaryDicts =
-                      libraryGroup.activity_summary_dicts;
+          this.userService
+            .getUserInfoAsync()
+            .then(userInfo => {
+              this.activitiesOwned = {explorations: {}, collections: {}};
+              if (userInfo.isLoggedIn()) {
+                this.libraryPageBackendApiService
+                  .fetchCreatorDashboardDataAsync()
+                  .then(response => {
+                    this.libraryGroups.forEach(libraryGroup => {
+                      let activitySummaryDicts =
+                        libraryGroup.activity_summary_dicts;
 
-                    let ACTIVITY_TYPE_EXPLORATION = 'exploration';
-                    let ACTIVITY_TYPE_COLLECTION = 'collection';
+                      let ACTIVITY_TYPE_EXPLORATION = 'exploration';
+                      let ACTIVITY_TYPE_COLLECTION = 'collection';
 
-                    activitySummaryDicts.forEach(activitySummaryDict => {
-                      if (
-                        activitySummaryDict.activity_type ===
-                        ACTIVITY_TYPE_EXPLORATION
-                      ) {
-                        this.activitiesOwned.explorations[
-                          activitySummaryDict.id
-                        ] = false;
-                      } else if (
-                        activitySummaryDict.activity_type ===
-                        ACTIVITY_TYPE_COLLECTION
-                      ) {
-                        this.activitiesOwned.collections[
-                          activitySummaryDict.id
-                        ] = false;
-                      } else {
-                        this.loggerService.error(
-                          'INVALID ACTIVITY TYPE: Activity' +
-                            '(id: ' +
-                            activitySummaryDict.id +
-                            ', name: ' +
-                            activitySummaryDict.title +
-                            ', type: ' +
-                            activitySummaryDict.activity_type +
-                            ') has an invalid activity type, which could ' +
-                            'not be recorded as an exploration or a ' +
-                            'collection.'
-                        );
-                      }
+                      activitySummaryDicts.forEach(activitySummaryDict => {
+                        if (
+                          activitySummaryDict.activity_type ===
+                          ACTIVITY_TYPE_EXPLORATION
+                        ) {
+                          this.activitiesOwned.explorations[
+                            activitySummaryDict.id
+                          ] = false;
+                        } else if (
+                          activitySummaryDict.activity_type ===
+                          ACTIVITY_TYPE_COLLECTION
+                        ) {
+                          this.activitiesOwned.collections[
+                            activitySummaryDict.id
+                          ] = false;
+                        } else {
+                          this.loggerService.error(
+                            'INVALID ACTIVITY TYPE: Activity' +
+                              '(id: ' +
+                              activitySummaryDict.id +
+                              ', name: ' +
+                              activitySummaryDict.title +
+                              ', type: ' +
+                              activitySummaryDict.activity_type +
+                              ') has an invalid activity type, which could ' +
+                              'not be recorded as an exploration or a ' +
+                              'collection.'
+                          );
+                        }
+                      });
+
+                      response.explorations_list.forEach(ownedExplorations => {
+                        this.activitiesOwned.explorations[ownedExplorations.id] =
+                          true;
+                      });
+
+                      response.collections_list.forEach(ownedCollections => {
+                        this.activitiesOwned.collections[ownedCollections.id] =
+                          true;
+                      });
                     });
-
-                    response.explorations_list.forEach(ownedExplorations => {
-                      this.activitiesOwned.explorations[ownedExplorations.id] =
-                        true;
-                    });
-
-                    response.collections_list.forEach(ownedCollections => {
-                      this.activitiesOwned.collections[ownedCollections.id] =
-                        true;
-                    });
+                    this.loaderService.hideLoadingScreen();
+                    this.initCarousels();
+                  })
+                  .catch(error => {
+                    this.loggerService.error(
+                      'Failed to load creator dashboard data: ' + error
+                    );
+                    this.loaderService.hideLoadingScreen();
+                    this.initCarousels();
                   });
-                  this.loaderService.hideLoadingScreen();
-                  this.initCarousels();
-                });
-            } else {
+              } else {
+                this.loaderService.hideLoadingScreen();
+                this.initCarousels();
+              }
+            })
+            .catch(error => {
+              this.loggerService.error('Failed to get user info: ' + error);
               this.loaderService.hideLoadingScreen();
               this.initCarousels();
-            }
-          });
+            });
 
           if (!this.preferredLanguageCodesLoaded) {
             this.i18nLanguageCodeService.onPreferredLanguageCodesLoaded.emit(
@@ -519,6 +540,13 @@ export class LibraryPageComponent {
               buttonText: 'See More',
             });
           }
+        })
+        .catch(error => {
+          this.loggerService.error(
+            'Failed to load library index data: ' + error
+          );
+          this.libraryGroups = [];
+          this.loaderService.hideLoadingScreen();
         });
     }
   }


### PR DESCRIPTION
## Overview

1. 1. This PR fixes #27157 and fixes part of #26989.
2. This PR does the following: Adds robust Elasticsearch exception handling on the backend by wrapping `.search()` calls to catch `ElasticsearchException`, logging the error, and gracefully returning empty results instead of crashing with an HTTP 500 error. On the frontend (`library-page.component.ts`), it adds `.catch()` promise handlers to ensure `this.loaderService.hideLoadingScreen()` is always called, preventing the infinite loading screen UI bug if an API network failure occurs.
3. The original bug occurred because: Unhandled Elasticsearch exceptions on the backend caused the search API call to crash. The frontend lacked promise rejection handlers for these specific API failures, which prevented the initial loading screen from being dismissed and left users stuck.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

## Proof that changes are correct

#### Before
- When navigating to `/community-library`, if Elasticsearch encountered a cluster/query issue (such as `ApiError(503, 'search_phase_execution_exception', None)` or circuit-breaking exception), the backend `/libraryindexhandler` crashed with an HTTP 500 Internal Server Error.
- Because `loadLibraryData()` in `library-page.component.ts` had no `.catch()` error handler on the API promise, the unhandled rejection caused the UI to be stuck indefinitely on the "Loading..." spinner with console errors:
  - `GET https://www.oppia.org/libraryindexhandler 500 (Internal Server Error)`
  - `Uncaught (in promise) HttpErrorResponse`

#### After
- **Backend Graceful Degradation**: Elasticsearch exceptions are now caught in `_fetch_response_from_elastic_search()`, logged, and return empty results `([], None)` instead of propagating an unhandled 500 error.
- **Frontend Loader Recovery**: Added `.catch()` error handlers to `loadLibraryData()` for all API calls (`fetchLibraryIndexDataAsync`, `fetchLibraryGroupDataAsync`, `fetchCreatorDashboardDataAsync`, and `getUserInfoAsync`). Even if an API request fails, `loaderService.hideLoadingScreen()` is guaranteed to execute, dismissing the spinner and logging the error to `LoggerService`.

#### Automated Test Verification
- Added `test_search_returns_empty_when_elasticsearch_raises_exception` in `elastic_search_services_test.py` to verify that Elasticsearch exceptions (like `ApiError`) return empty results without crashing.
- Added `should handle error and hide loader when fetchLibraryIndexDataAsync fails` and `should handle error and hide loader when fetchLibraryGroupDataAsync fails` in `library-page.component.spec.ts` to verify that the loading overlay is always dismissed upon API failure.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
