### PR TITLE
Remove Bootstrap JS bundle and migrate tooltips

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -95,9 +95,6 @@
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/codemirror/lib/codemirror.css",
               "node_modules/codemirror/addon/merge/merge.css"
-            ],
-            "scripts": [
-              "node_modules/bootstrap/dist/js/bootstrap.bundle.js"
             ]
           },
           "configurations": {
@@ -208,9 +205,6 @@
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/codemirror/lib/codemirror.css",
               "node_modules/codemirror/addon/merge/merge.css"
-            ],
-            "scripts": [
-              "node_modules/bootstrap/dist/js/bootstrap.bundle.js"
             ]
           },
           "configurations": {

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.html
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.html
@@ -53,11 +53,11 @@
               <li><span [innerHTML]="'I18N_ATTRIBUTION_HTML_STEP_ONE' | translate"></span></li>
               <li><span [innerHTML]="'I18N_ATTRIBUTION_HTML_STEP_TWO' | translate: { linkText: '<u>Oppia</u> // <u>CC BY SA 4.0</u>' }"></span></li>
             </ol>
-            <div data-bs-trigger="manual"
-                 data-bs-toggle="tooltip"
-                 data-bs-title="Copied!"
-                 data-bs-placement="bottom"
-                 data-bs-offset="0 20"
+            <div ngbTooltip="Copied!"
+                 triggers="manual"
+                 autoClose="false"
+                 placement="bottom"
+                 #htmlAttributionTooltip="ngbTooltip"
                  class="attribution-html-code font-monospace text-nowrap border border-secondary p-1 overflow-auto">
               &lt;a href="{{getPageUrl()}}"&gt;Oppia&lt;/a&gt; // &lt;a href="https://creativecommons.org/licenses/by-sa/4.0"&gt;CC BY SA 4.0&lt;/a&gt;
             </div>
@@ -69,11 +69,11 @@
               <li><span [innerHTML]="'I18N_ATTRIBUTION_PRINT_STEP_ONE' | translate"></span></li>
               <li><span [innerHTML]="'I18N_ATTRIBUTION_PRINT_STEP_TWO' | translate: { link: printAttributionLink }"></span></li>
             </ol>
-            <div data-bs-trigger="manual"
-                 data-bs-toggle="tooltip"
-                 data-bs-title="Copied!"
-                 data-bs-placement="bottom"
-                 data-bs-offset="0 20"
+            <div ngbTooltip="Copied!"
+                 triggers="manual"
+                 autoClose="false"
+                 placement="bottom"
+                 #printAttributionTooltip="ngbTooltip"
                  class="attribution-print-text font-monospace text-nowrap border border-secondary p-1 overflow-auto">
               "{{getExplorationTitle()}}" by {{getAuthors()}}. Oppia. {{getPageUrl()}}
             </div>

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.spec.ts
@@ -92,6 +92,8 @@ describe('Attribution Guide Component', function () {
   let i18nLanguageCodeService: I18nLanguageCodeService;
   let windowDimensionsService: WindowDimensionsService;
 
+  const MockNgbTooltip = jasmine.createSpyObj('NgbTooltip', ['open', 'close']);
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AttributionGuideComponent, MockTranslatePipe],
@@ -182,28 +184,74 @@ describe('Attribution Guide Component', function () {
     expect(component.getExplorationTitle()).toEqual('Place Values');
   });
 
-  it('should run the copy command and set and remove title attribute for tooltip', fakeAsync(() => {
+  it('should run the copy command and open and close the tooltip', fakeAsync(() => {
     let dummyDivElement = document.createElement('div');
     let dummyTextNode = document.createTextNode('Text to be copied');
-    dummyDivElement.className = 'class-name';
+    dummyDivElement.className = 'attribution-html-code';
     dummyDivElement.appendChild(dummyTextNode);
     const dummyDocumentFragment = document.createDocumentFragment();
     dummyDocumentFragment.appendChild(dummyDivElement);
 
     spyOn(document, 'getElementsByClassName')
-      .withArgs('class-name')
+      .withArgs('attribution-html-code')
       .and.returnValue(dummyDocumentFragment.children);
     spyOn(document, 'execCommand').withArgs('copy');
 
-    component.copyAttribution('class-name');
+    component.htmlAttributionTooltip = MockNgbTooltip;
+
+    component.copyAttribution('attribution-html-code');
 
     expect(document.execCommand).toHaveBeenCalled();
-    expect(dummyDivElement.getAttribute('title')).toBe('Copied!');
+    expect(MockNgbTooltip.open).toHaveBeenCalled();
 
     tick(1001);
 
-    expect(dummyDivElement.getAttribute('title')).toBeNull();
+    expect(MockNgbTooltip.close).toHaveBeenCalled();
   }));
+
+  it('should run the print attribution copy command and open and close the tooltip', fakeAsync(() => {
+    let dummyDivElement = document.createElement('div');
+    let dummyTextNode = document.createTextNode('Text to be copied');
+    dummyDivElement.className = 'attribution-print-text';
+    dummyDivElement.appendChild(dummyTextNode);
+    const dummyDocumentFragment = document.createDocumentFragment();
+    dummyDocumentFragment.appendChild(dummyDivElement);
+
+    spyOn(document, 'getElementsByClassName')
+      .withArgs('attribution-print-text')
+      .and.returnValue(dummyDocumentFragment.children);
+    spyOn(document, 'execCommand').withArgs('copy');
+
+    component.printAttributionTooltip = MockNgbTooltip;
+
+    component.copyAttribution('attribution-print-text');
+
+    expect(document.execCommand).toHaveBeenCalled();
+    expect(MockNgbTooltip.open).toHaveBeenCalled();
+
+    tick(1001);
+
+    expect(MockNgbTooltip.close).toHaveBeenCalled();
+  }));
+
+  it('should run the copy command without showing a tooltip if the tooltip reference is not found', () => {
+    const dummyDivElement = document.createElement('div');
+    const dummyTextNode = document.createTextNode('Text to be copied');
+    dummyDivElement.className = 'attribution-html-code';
+    dummyDivElement.appendChild(dummyTextNode);
+    const dummyDocumentFragment = document.createDocumentFragment();
+    dummyDocumentFragment.appendChild(dummyDivElement);
+
+    spyOn(document, 'getElementsByClassName')
+      .withArgs('attribution-html-code')
+      .and.returnValue(dummyDocumentFragment.children);
+    spyOn(document, 'execCommand').withArgs('copy');
+
+    expect(() =>
+      component.copyAttribution('attribution-html-code')
+    ).not.toThrowError();
+    expect(document.execCommand).toHaveBeenCalled();
+  });
 
   it('should return early if element is not found', () => {
     spyOn(document, 'getElementsByClassName')

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.ts
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.ts
@@ -16,7 +16,8 @@
  * @fileoverview Component for the attribution guide.
  */
 
-import {Component, OnInit, ViewEncapsulation} from '@angular/core';
+import {Component, OnInit, ViewChild, ViewEncapsulation} from '@angular/core';
+import {NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
 
 import {BrowserCheckerService} from 'domain/utilities/browser-checker.service';
 import {AttributionService} from 'services/attribution.service';
@@ -39,6 +40,10 @@ export class AttributionGuideComponent implements OnInit {
   generateAttibutionIsAllowed: boolean = false;
   maskIsShown: boolean = false;
   printAttributionLink: string = '';
+  @ViewChild('htmlAttributionTooltip', {static: false})
+  htmlAttributionTooltip!: NgbTooltip;
+  @ViewChild('printAttributionTooltip', {static: false})
+  printAttributionTooltip!: NgbTooltip;
   constructor(
     private attributionService: AttributionService,
     private browserCheckerService: BrowserCheckerService,
@@ -115,8 +120,18 @@ export class AttributionGuideComponent implements OnInit {
     selection?.addRange(range);
     document.execCommand('copy');
     selection?.removeAllRanges();
-    codeDiv.setAttribute('title', 'Copied!');
-    codeDiv.dispatchEvent(new Event('mouseenter'));
-    setTimeout(() => codeDiv.removeAttribute('title'), 1000);
+    this.showCopiedTooltip(className);
+  }
+
+  private showCopiedTooltip(className: string): void {
+    const tooltip =
+      className === 'attribution-html-code'
+        ? this.htmlAttributionTooltip
+        : this.printAttributionTooltip;
+    if (!tooltip) {
+      return;
+    }
+    tooltip.open();
+    setTimeout(() => tooltip.close(), 1000);
   }
 }

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
@@ -42,7 +42,7 @@
               <div class="oppia-rule-header-warning-placement e2e-test-response-self-loop-warning" *ngIf="isSelfLoopThatIsMarkedCorrect(answerGroup.outcome) || isSelfLoopWithNoFeedback(answerGroup.outcome)" (click)="changeActiveAnswerGroupIndex(index)"
                    ngbTooltip="{{getOutcomeTooltip(answerGroup.outcome)}}"
                    tabindex="0"
-                   data-bs-container="body"
+                   container="body"
                    placement="auto">
                 <div class="oppia-rule-header-warning-style">
                   ⚠

--- a/core/templates/pages/admin-page/navbar/admin-navbar.component.html
+++ b/core/templates/pages/admin-page/navbar/admin-navbar.component.html
@@ -26,7 +26,6 @@
             <ul class="nav oppia-navbar-tabs-admin oppia-admin-page-dropdown">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : dropdownMenuIsActive}">
                 <a ngbDropdownToggle class="nav-link dropdown-toggle oppia-navbar-tab oppia-navbar-dropdown-toggle e2e-test-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateDropdownMenu()"
                    (mouseleave)="deactivateDropdownMenu()">
                   <i class="fa fa-bars oppia-admin-page-dropdown-icon"></i>
@@ -92,7 +91,6 @@
             <ul class="nav oppia-navbar-tabs-admin">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : profileDropdownIsActive}">
                 <a ngbDropdownToggle class="nav-link oppia-navbar-dropdown-toggle e2e-test-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateProfileDropdown()"
                    (mouseleave)="deactivateProfileDropdown()">
                   <picture *ngIf="profilePicturePngDataUrl">

--- a/core/templates/pages/blog-admin-page/navbar/blog-admin-navbar.component.html
+++ b/core/templates/pages/blog-admin-page/navbar/blog-admin-navbar.component.html
@@ -26,7 +26,6 @@
             <ul class="nav oppia-navbar-tabs-blog-admin">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : profileDropdownIsActive}">
                 <a ngbDropdownToggle class="nav-link oppia-navbar-dropdown-toggle e2e-test-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateProfileDropdown()"
                    (mouseleave)="deactivateProfileDropdown()">
                   <picture *ngIf="profilePicturePngDataUrl">

--- a/core/templates/pages/classroom-admin-page/navbar/classroom-admin-navbar.component.html
+++ b/core/templates/pages/classroom-admin-page/navbar/classroom-admin-navbar.component.html
@@ -26,7 +26,6 @@
             <ul class="nav oppia-navbar-tabs-classroom-admin">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : profileDropdownIsActive}">
                 <a ngbDropdownToggle class="nav-link oppia-navbar-dropdown-toggle e2e-test-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateProfileDropdown()"
                    (mouseleave)="deactivateProfileDropdown()">
                   <picture *ngIf="profilePicturePngDataUrl">

--- a/core/templates/pages/contributor-dashboard-admin-page/navbar/contributor-dashboard-admin-navbar.component.html
+++ b/core/templates/pages/contributor-dashboard-admin-page/navbar/contributor-dashboard-admin-navbar.component.html
@@ -26,7 +26,6 @@
             <ul class="nav oppia-navbar-tabs-contributor-dashboard-admin">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : profileDropdownIsActive}">
                 <a ngbDropdownToggle class="nav-link oppia-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateProfileDropdown()"
                    (mouseleave)="deactivateProfileDropdown()">
                   <picture *ngIf="profilePicturePngDataUrl">

--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.html
@@ -2,7 +2,7 @@
 <div class="navbar-mobile-container">
   <div class="navbar-mobile-options e2e-test-mobile-navigation-bar-container" *ngIf="mobileNavOptionsAreShown">
     <div  placement="top-start" class="exp-nav-dropdown-container">
-      <div ngbDropdown class="exp-nav-dropdown-content" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <div ngbDropdown class="exp-nav-dropdown-content" id="dropdownMenuButton" aria-haspopup="true" aria-expanded="false">
         <a>
           <i class="fa fa-pen"></i>
           Options
@@ -112,7 +112,7 @@
           </div>
         </div>
 
-        <div ngbDropdownToggle class="exp-nav-dropdown-icon e2e-test-mobile-changes-dropdown" id="discardButtonPopup" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></div>
+        <div ngbDropdownToggle class="exp-nav-dropdown-icon e2e-test-mobile-changes-dropdown" id="discardButtonPopup" aria-haspopup="true" aria-expanded="false"></div>
 
         <ul ngbDropdownMenu class="dropdown-menu discard-publish e2e-test-state-changes-dropdown" aria-labelledby="discardButtonPopup">
           <button ngbDropdownItem class="btn btn-light e2e-test-mobile-exploration-discard-tab" (click)="discardChanges()" [disabled]="autosaveIsInProgress">

--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.html
@@ -10,7 +10,7 @@
         <div ngbDropdownToggle class="exp-nav-dropdown-icon e2e-test-mobile-options-dropdown"></div>
         <ul ngbDropdownMenu class="dropdown-menu oppia-exploration-editor-tabs-dropdown" aria-labelledby="dropdownMenuButton">
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" [class.dropdown]="countWarnings()">
-            <a href="#" ngbTooltip="Editor" [placement]="countWarnings() ? 'left' : 'bottom'" (click)="selectMainTab()"
+            <a href="#" ngbTooltip="Editor" [placement]="countWarnings() ? 'left' : 'bottom'" (click)="selectMainTab(); $event.preventDefault()"
                class="oppia-exploration-editor-tabs-dropdown-element e2e-test-mobile-main-tab">
               <i class="fa fa-pen oppia-mobile-exploration-editor-tabs-icon"></i>
               <span class="oppia-exploration-editor-tabs-dropdown-inner">Editor</span>
@@ -22,42 +22,42 @@
             </div>
           </li>
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item e2e-test-mobile-translation-tab" *ngIf="isUserLoggedIn()" [class.active]="getActiveTabName() === 'translation'">
-            <a href="#" ngbTooltip="Tmaterial-iconsmaterial-iconsranslations and Voiceovers" placement="bottom" (click)="selectTranslationTab()"
+            <a href="#" ngbTooltip="Tmaterial-iconsmaterial-iconsranslations and Voiceovers" placement="bottom" (click)="selectTranslationTab(); $event.preventDefault()"
                class="oppia-exploration-editor-tabs-dropdown-element">
               <i class="fa fa-microphone oppia-mobile-exploration-editor-tabs-icon"></i>
               <span class="oppia-exploration-editor-tabs-dropdown-inner">Translations</span>
             </a>
           </li>
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" *ngIf="isUserLoggedIn()" [class.active]="getActiveTabName() === 'preview'">
-            <a href="#" ngbTooltip="Preview" placement="bottom" (click)="selectPreviewTab()"
+            <a href="#" ngbTooltip="Preview" placement="bottom" (click)="selectPreviewTab(); $event.preventDefault()"
                class="oppia-exploration-editor-tabs-dropdown-element e2e-test-mobile-preview-button">
               <i class="fa fa-play oppia-mobile-exploration-editor-tabs-icon"></i>
               <span class="oppia-exploration-editor-tabs-dropdown-inner">Preview</span>
             </a>
           </li>
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item e2e-test-mobile-settings-button" [class.active]="getActiveTabName() === 'settings'">
-            <a href="#" ngbTooltip="Settings" placement="bottom" (click)="selectSettingsTab()"
+            <a href="#" ngbTooltip="Settings" placement="bottom" (click)="selectSettingsTab(); $event.preventDefault()"
                class="oppia-exploration-editor-tabs-dropdown-element e2e-test-mobile-settings-button">
               <i class="fa fa-cog oppia-mobile-exploration-editor-tabs-icon"></i>
               <span class="oppia-exploration-editor-tabs-dropdown-inner">Settings</span>
             </a>
           </li>
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item e2e-test-mobile-stats-button" [class.active]="getActiveTabName() === 'stats'">
-            <a href="#" ngbTooltip="Statistics" placement="bottom" (click)="selectStatsTab()"
+            <a href="#" ngbTooltip="Statistics" placement="bottom" (click)="selectStatsTab(); $event.preventDefault()"
                class="oppia-exploration-editor-tabs-dropdown-element">
               <i class="fa fa-poll oppia-mobile-exploration-editor-tabs-icon"></i>
               <span class="oppia-exploration-editor-tabs-dropdown-inner">Statistics</span>
             </a>
           </li>
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" [class.active]="getActiveTabName() === 'improvements'" *ngIf="isImprovementsTabEnabled()">
-            <a href="#" ngbTooltip="Improvements" placement="bottom" (click)="selectImprovementsTab()"
+            <a href="#" ngbTooltip="Improvements" placement="bottom" (click)="selectImprovementsTab(); $event.preventDefault()"
                class="oppia-exploration-editor-tabs-dropdown-element">
               <i class="fa fa-arrow-trend-up oppia-mobile-exploration-editor-tabs-icon"></i>
               <span class="oppia-exploration-editor-tabs-dropdown-inner">Improvements</span>
             </a>
           </li>
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" [class.active]="getActiveTabName() === 'history'">
-            <a href="#" ngbTooltip="History" placement="bottom" (click)="selectHistoryTab()"
+            <a href="#" ngbTooltip="History" placement="bottom" (click)="selectHistoryTab(); $event.preventDefault()"
                disabled="ExplorationRightsService.isCloned()"
                class="oppia-exploration-editor-tabs-dropdown-element e2e-test-mobile-history-button">
               <i class="fa fa-clock oppia-mobile-exploration-editor-tabs-icon"></i>
@@ -65,7 +65,7 @@
             </a>
           </li>
           <li ngbDropdownItem class="dropdown-item oppia-exploration-editor-tabs-dropdown-item e2e-test-mobile-feedback-button" [class.active]="getActiveTabName() === 'feedback'">
-            <a href="#" ngbTooltip="Feedback" placement="bottom" (click)="selectFeedbackTab()"
+            <a href="#" ngbTooltip="Feedback" placement="bottom" (click)="selectFeedbackTab(); $event.preventDefault()"
                class="oppia-exploration-editor-tabs-dropdown-element">
               <i class="fa fa-comment-alt oppia-mobile-exploration-editor-tabs-icon"></i>
               <span class="oppia-exploration-editor-tabs-dropdown-inner">Feedback</span>

--- a/core/templates/pages/exploration-editor-page/history-tab/history-tab.component.html
+++ b/core/templates/pages/exploration-editor-page/history-tab/history-tab.component.html
@@ -49,7 +49,7 @@
         </div>
         <div class="history-table-options e2e-test-history-list-options">
           <div ngbDropdown class="dropdown">
-            <button ngbDropdownToggle class="history-table-option e2e-test-history-table-option" type="button" id="{{ 'dropdownMenuButton-' + index }}" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0" role="button" aria-label="options">
+            <button ngbDropdownToggle class="history-table-option e2e-test-history-table-option" type="button" id="{{ 'dropdownMenuButton-' + index }}" aria-haspopup="true" aria-expanded="false" tabindex="0" role="button" aria-label="options">
               <i class="fa fa-ellipsis-v"></i>
             </button>
             <div ngbDropdownMenu class="dropdown-menu dropdown-menu-start" [attr.aria-label]="'dropdownMenuButton-' + index">

--- a/core/templates/pages/release-coordinator-page/navbar/release-coordinator-navbar.component.html
+++ b/core/templates/pages/release-coordinator-page/navbar/release-coordinator-navbar.component.html
@@ -25,7 +25,6 @@
             <ul class="nav oppia-navbar-tabs-release-coordinator oppia-release-coordinator-page-dropdown">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : dropdownMenuIsActive}">
                 <a ngbDropdownToggle class="nav-link dropdown-toggle oppia-navbar-tab oppia-navbar-dropdown-toggle e2e-test-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateDropdownMenu()"
                    (mouseleave)="deactivateDropdownMenu()">
                   <i class="fa fa-bars oppia-release-coordinator-page-dropdown-icon"></i>
@@ -112,7 +111,6 @@
             <ul class="nav oppia-navbar-tabs-release-coordinator">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : profileDropdownIsActive}">
                 <a ngbDropdownToggle class="nav-link oppia-navbar-dropdown-toggle e2e-test-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateProfileDropdown()"
                    (mouseleave)="deactivateProfileDropdown()">
                   <picture *ngIf="profilePicturePngDataUrl">

--- a/core/templates/pages/voiceover-admin-page/navbar/voiceover-admin-navbar.component.html
+++ b/core/templates/pages/voiceover-admin-page/navbar/voiceover-admin-navbar.component.html
@@ -27,7 +27,6 @@
             <ul class="nav oppia-navbar-tabs-voiceover-admin">
               <li ngbDropdown class="nav-item dropdown float-end" [ngClass]="{'open' : profileDropdownIsActive}">
                 <a ngbDropdownToggle class="nav-link oppia-navbar-dropdown-toggle e2e-test-navbar-dropdown-toggle"
-                   data-bs-toggle="dropdown"
                    (mouseenter)="activateProfileDropdown()"
                    (mouseleave)="deactivateProfileDropdown()">
                   <picture *ngIf="profilePicturePngDataUrl">


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes N/A
2. This PR does the following: 
    - **Removes the Bootstrap JS bundle (bootstrap.js)**, which cost a non-trivial performance overhead on every page load while being used in only a handful of places. The few interactions that did rely on it (dropdowns, tooltips) were migrated to native Angular/ng-bootstrap equivalents (ngbDropdown, ngbTooltip), so the bundle can be dropped without losing functionality.
## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).



## Proof that changes are correct

N/A

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer “Copied” feedback when copying HTML or print attribution text, with automatic dismissal.
  * Improved mobile editor navigation so selecting tabs no longer triggers unwanted page navigation.

* **Bug Fixes**
  * Updated dropdown menus across administration and editing areas for more consistent opening and selection behavior.
  * Improved tooltip placement for self-loop warnings.
  * Removed reliance on legacy Bootstrap interactions while preserving dropdown and tooltip functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->