### PR TITLE
Deduplicate user info handler race condition

### DIFF
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -874,23 +874,19 @@ class UserInfoHandler(
         self.response.cache_control.no_store = True
         if self.username:
             assert self.user_id is not None
-            user_actions = user_services.get_user_actions_info(
-                self.user_id
-            ).actions
-            user_settings = user_services.get_user_settings(
-                self.user_id, strict=True
+            roles, user_actions, user_settings = (
+                user_services.get_user_roles_and_actions(self.user_id)
             )
+            assert user_settings is not None
             self.render_json(
                 {
-                    'roles': self.roles,
-                    'is_moderator': (user_services.is_moderator(self.user_id)),
-                    'is_curriculum_admin': user_services.is_curriculum_admin(
-                        self.user_id
+                    'roles': roles,
+                    'is_moderator': feconf.ROLE_ID_MODERATOR in roles,
+                    'is_curriculum_admin': (
+                        feconf.ROLE_ID_CURRICULUM_ADMIN in roles
                     ),
                     'is_super_admin': self.current_user_is_super_admin,
-                    'is_topic_manager': (
-                        user_services.is_topic_manager(self.user_id)
-                    ),
+                    'is_topic_manager': feconf.ROLE_ID_TOPIC_MANAGER in roles,
                     'can_create_collections': bool(
                         role_services.ACTION_CREATE_COLLECTION in user_actions
                     ),

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -48,6 +48,7 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Tuple,
     TypedDict,
     overload,
 )
@@ -1018,6 +1019,34 @@ def get_user_actions_info(
     )
     actions = role_services.get_all_actions(roles)
     return user_domain.UserActionsInfo(user_id, roles, actions)
+
+
+def get_user_roles_and_actions(
+    user_id: str,
+) -> Tuple[List[str], List[str], Optional[user_domain.UserSettings]]:
+    """Returns the roles, actions and settings of a user in a single call.
+
+    This fetches the user's settings once and derives both the roles and the
+    actions from it, avoiding the repeated UserSettings reads that calling
+    get_user_roles_from_id and get_user_settings separately would incur.
+
+    Args:
+        user_id: str. The unique ID of the user.
+
+    Returns:
+        tuple(list(str), list(str), UserSettings|None). A tuple containing the
+        roles of the user, the actions the user can perform, and the user's
+        settings. Roles and actions default to guest values and the settings to
+        None if the user does not exist.
+    """
+    user_settings = get_user_settings(user_id, strict=False)
+    roles = (
+        user_settings.roles
+        if user_settings is not None
+        else [feconf.ROLE_ID_GUEST]
+    )
+    actions = role_services.get_all_actions(roles)
+    return roles, actions, user_settings
 
 
 def get_system_user() -> user_domain.UserActionsInfo:

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -2499,6 +2499,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         )
         self.assertEqual(roles, [feconf.ROLE_ID_FULL_USER])
         self.assertEqual(actions, expected_actions)
+        assert user_settings is not None
         self.assertEqual(user_settings.user_id, user_id)
 
         user_services.add_user_role(user_id, feconf.ROLE_ID_CURRICULUM_ADMIN)

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -34,6 +34,7 @@ from core.domain import (
     exp_services,
     platform_parameter_list,
     rights_manager,
+    role_services,
     state_domain,
     suggestion_services,
     user_domain,
@@ -2483,6 +2484,43 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
 
         user_services.add_user_role(user_id, feconf.ROLE_ID_TOPIC_MANAGER)
         self.assertTrue(user_services.is_topic_manager(user_id))
+
+    def test_get_user_roles_and_actions(self) -> None:
+        auth_id = 'someUser'
+        user_email = 'user@example.com'
+
+        user_id = user_services.create_new_user(auth_id, user_email).user_id
+
+        roles, actions, user_settings = (
+            user_services.get_user_roles_and_actions(user_id)
+        )
+        expected_actions = role_services.get_all_actions(
+            [feconf.ROLE_ID_FULL_USER]
+        )
+        self.assertEqual(roles, [feconf.ROLE_ID_FULL_USER])
+        self.assertEqual(actions, expected_actions)
+        self.assertEqual(user_settings.user_id, user_id)
+
+        user_services.add_user_role(user_id, feconf.ROLE_ID_CURRICULUM_ADMIN)
+        roles, actions, _ = user_services.get_user_roles_and_actions(user_id)
+        expected_roles = [
+            feconf.ROLE_ID_FULL_USER,
+            feconf.ROLE_ID_CURRICULUM_ADMIN,
+        ]
+        expected_actions = role_services.get_all_actions(expected_roles)
+        self.assertEqual(roles, expected_roles)
+        self.assertEqual(actions, expected_actions)
+
+    def test_get_user_roles_and_actions_for_non_existent_user(self) -> None:
+        roles, actions, user_settings = (
+            user_services.get_user_roles_and_actions('nonExistentUser')
+        )
+        self.assertEqual(roles, [feconf.ROLE_ID_GUEST])
+        self.assertEqual(
+            actions,
+            role_services.get_all_actions([feconf.ROLE_ID_GUEST]),
+        )
+        self.assertIsNone(user_settings)
 
     def test_create_login_url(self) -> None:
         return_url = 'sample_url'

--- a/core/templates/services/user.service.spec.ts
+++ b/core/templates/services/user.service.spec.ts
@@ -227,6 +227,48 @@ describe('User Api Service', () => {
       flushMicrotasks();
     }));
 
+    it('should retry the request after it fails', fakeAsync(() => {
+      const sampleUserInfoBackendObject = {
+        roles: ['USER_ROLE'],
+        is_moderator: false,
+        is_curriculum_admin: false,
+        is_super_admin: false,
+        is_topic_manager: false,
+        can_create_collections: true,
+        preferred_site_language_code: null,
+        username: 'tester',
+        email: 'test@test.com',
+        user_is_logged_in: true,
+      };
+      const sampleUserInfo = UserInfo.createFromBackendDict(
+        sampleUserInfoBackendObject
+      );
+
+      let firstCallSucceeded = false;
+      userService.getUserInfoAsync().then(
+        () => {
+          firstCallSucceeded = true;
+        },
+        () => {}
+      );
+      const req = httpTestingController.expectOne('/userinfohandler');
+      req.flush('Server Error', {status: 500, statusText: 'Error'});
+
+      flushMicrotasks();
+      expect(firstCallSucceeded).toBeFalse();
+
+      // A later call should fire a brand new request instead of reusing the
+      // rejected promise.
+      userService.getUserInfoAsync().then(userInfo => {
+        expect(userInfo).toEqual(sampleUserInfo);
+      });
+      const newReq = httpTestingController.expectOne('/userinfohandler');
+      expect(newReq.request.method).toEqual('GET');
+      newReq.flush(sampleUserInfoBackendObject);
+
+      flushMicrotasks();
+    }));
+
     it('should return new userInfo data if user is not logged', fakeAsync(() => {
       const sampleUserInfoBackendObject = {
         role: 'USER_ROLE',

--- a/core/templates/services/user.service.spec.ts
+++ b/core/templates/services/user.service.spec.ts
@@ -192,6 +192,41 @@ describe('User Api Service', () => {
       flushMicrotasks();
     }));
 
+    it('should share a single HTTP request when called concurrently', fakeAsync(() => {
+      const sampleUserInfoBackendObject = {
+        roles: ['USER_ROLE'],
+        is_moderator: false,
+        is_curriculum_admin: false,
+        is_super_admin: false,
+        is_topic_manager: false,
+        can_create_collections: true,
+        preferred_site_language_code: null,
+        username: 'tester',
+        email: 'test@test.com',
+        user_is_logged_in: true,
+      };
+      const sampleUserInfo = UserInfo.createFromBackendDict(
+        sampleUserInfoBackendObject
+      );
+
+      const firstCallPromise = userService.getUserInfoAsync();
+      const secondCallPromise = userService.getUserInfoAsync();
+
+      firstCallPromise.then(userInfo => {
+        expect(userInfo).toEqual(sampleUserInfo);
+      });
+      secondCallPromise.then(userInfo => {
+        expect(userInfo).toEqual(sampleUserInfo);
+      });
+
+      // Both calls must be served by a single shared request.
+      const req = httpTestingController.expectOne('/userinfohandler');
+      expect(req.request.method).toEqual('GET');
+      req.flush(sampleUserInfoBackendObject);
+
+      flushMicrotasks();
+    }));
+
     it('should return new userInfo data if user is not logged', fakeAsync(() => {
       const sampleUserInfoBackendObject = {
         role: 'USER_ROLE',

--- a/core/templates/services/user.service.ts
+++ b/core/templates/services/user.service.ts
@@ -51,6 +51,14 @@ export class UserService {
 
   // This property will be null when the user is not logged in.
   private userInfo: UserInfo | null = null;
+
+  // The in-flight (or resolved) request for the user info. Storing the Promise
+  // itself (instead of only the resolved value) ensures that concurrent callers
+  // share the same HTTP request, rather than each firing a separate request
+  // because they all observe this.userInfo === null before the first one
+  // resolves. This property will be null until the first call is made.
+  private asyncGetUserInfoPromise: Promise<UserInfo> | null = null;
+
   private returnUrl = '';
 
   async getUserInfoAsync(): Promise<UserInfo> {
@@ -58,10 +66,15 @@ export class UserService {
     if (['/logout', '/signup'].includes(pathname)) {
       return UserInfo.createDefault();
     }
-    if (this.userInfo === null) {
-      this.userInfo = await this.userBackendApiService.getUserInfoAsync();
+    if (this.asyncGetUserInfoPromise === null) {
+      this.asyncGetUserInfoPromise = this.userBackendApiService
+        .getUserInfoAsync()
+        .then(userInfo => {
+          this.userInfo = userInfo;
+          return userInfo;
+        });
     }
-    return this.userInfo;
+    return this.asyncGetUserInfoPromise;
   }
 
   getProfileImageDataUrl(username: string): [string, string] {

--- a/core/templates/services/user.service.ts
+++ b/core/templates/services/user.service.ts
@@ -69,10 +69,19 @@ export class UserService {
     if (this.asyncGetUserInfoPromise === null) {
       this.asyncGetUserInfoPromise = this.userBackendApiService
         .getUserInfoAsync()
-        .then(userInfo => {
-          this.userInfo = userInfo;
-          return userInfo;
-        });
+        .then(
+          userInfo => {
+            this.userInfo = userInfo;
+            return userInfo;
+          },
+          error => {
+            // Clear the cached promise on failure so that later calls retry
+            // instead of reusing the rejected promise, then propagate the
+            // error to the current callers.
+            this.asyncGetUserInfoPromise = null;
+            throw error;
+          }
+        );
     }
     return this.asyncGetUserInfoPromise;
   }


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes N/A
2. This PR fixes the issue below: 
    - **Problem:** [UserService.getUserInfoAsync()](https://github.com/oppia/oppia/blob/88bc4e18b40b9ede4664dea7ada75d39e59cf47f/core/templates/services/user.service.ts#L53) has a null-check cache that stores the resolved value, not the Promise. During bootstrap, components call getUserInfoAsync() concurrently. The first call triggers an await that hasn't resolved when the second call arrives, so the second caller also sees this.userInfo === null and fires its own HTTP request. This produces 5 parallel XHR calls to /userinfohandler on the CI machine — all returning identical data (login status, roles, username, email). The responses from calls `#2-#5` are discarded.
    - Each server-side request is also wasteful: [UserInfoHandler.get()](https://github.com/oppia/oppia/blob/537b99934405b6acaf97c5820aecc87890b7082c/core/controllers/profile.py#L849) calls get_user_actions_info, get_user_settings, is_moderator, is_curriculum_admin, is_topic_manager; each independently calling UserSettingsModel.get_multi([user_id]) for the same entity. That's 5 DB reads per request in the handler, plus 4 more per request in [BaseHandler.__init__()](https://github.com/oppia/oppia/blob/80e1985c4d92bacb30a98a9a53b68efd9f203d20/core/controllers/base.py#L248),  **9 reads per request × 5 requests = 45 total DB round-trips**, all reading the same UserSettingsModel row.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

**Before**
<img width="1919" height="937" alt="image" src="https://github.com/user-attachments/assets/216cbad1-4c73-40fe-ad8d-6f718b35b790" />

**After**
<img width="1919" height="937" alt="image" src="https://github.com/user-attachments/assets/4b67b639-7d37-4ef9-8dc1-4519a901f753" />


<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
