### PR TITLE
Fix #27087: Add isFirstTopic flag to reduce wait time

### DIFF
--- a/core/tests/playwright-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/community-library-browser/subscribe-to-a-favourite-creator.spec.ts
@@ -59,7 +59,8 @@ test.describe('Community Library Browser', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Fractions',
       'Basics of Fractions',
-      'fractions'
+      'fractions',
+      true
     );
     await curriculumAdmin.createAndPublishStoryWithChapter(
       'Story 1',

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/changes-site-language-to-rtl.spec.ts
@@ -105,7 +105,8 @@ test.describe('Logged-In Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Fractions',
       'Basics Of Fractions',
-      'fractions'
+      'fractions',
+      true
     );
 
     await curriculumAdmin.createAndPublishClassroom(

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/choose-new-lesson-to-play-from-learner-dashboard.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/choose-new-lesson-to-play-from-learner-dashboard.spec.ts
@@ -86,7 +86,8 @@ test.describe('Logged-In Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Algebra I',
       'Negative Numbers',
-      'Negative Numbers'
+      'Negative Numbers',
+      true
     );
 
     await curriculumAdmin.createAndPublishClassroom(

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/goes-through-the-sign-in-flow.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/goes-through-the-sign-in-flow.spec.ts
@@ -71,7 +71,8 @@ test.describe('Logged In Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Test Topic',
       'Test Skill',
-      'Test Skill'
+      'Test Skill',
+      true
     );
 
     await curriculumAdmin.createAndPublishClassroom(

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/interact-with-goals-in-learner-dashboard.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/interact-with-goals-in-learner-dashboard.spec.ts
@@ -70,7 +70,8 @@ test.describe('Logged-In Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Place Values',
       'Place Values',
-      'Place Values'
+      'Place Values',
+      true
     );
 
     await curriculumAdmin.addTopicToClassroom('Math', 'Place Values');

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/manage-classroom-progress-in-home-learner-dashboard.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/manage-classroom-progress-in-home-learner-dashboard.spec.ts
@@ -74,7 +74,8 @@ test.describe('Logged-In Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Division',
       'Division subtopics',
-      'Division skills'
+      'Division skills',
+      true
     );
     await curriculumAdmin.createAndPublishTopic(
       'Place Values',

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/manage-goals-in-learner-dashboard.spec.ts
@@ -70,7 +70,8 @@ test.describe('Logged-In Learner - Manage Goals', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Place Values',
       'Place Values',
-      'Place Values'
+      'Place Values',
+      true
     );
 
     await curriculumAdmin.addTopicToClassroom('Math', 'Place Values');

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/manage-in-progress-and-completed-lessons-and-skill.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/manage-in-progress-and-completed-lessons-and-skill.spec.ts
@@ -71,7 +71,8 @@ test.describe('Logged-in Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Place Values',
       'Place Values',
-      'Place Values'
+      'Place Values',
+      true
     );
     await curriculumAdmin.addTopicToClassroom('Math', 'Place Values');
     await curriculumAdmin.publishClassroom('Math');

--- a/core/tests/playwright-acceptance-tests/specs/logged-in-learner/sets-goal-on-learner-dashboard.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-in-learner/sets-goal-on-learner-dashboard.spec.ts
@@ -86,7 +86,8 @@ test.describe('Logged-In Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Algebra I',
       'Negative Numbers',
-      'Negative Numbers'
+      'Negative Numbers',
+      true
     );
 
     await curriculumAdmin.createAndPublishClassroom(

--- a/core/tests/playwright-acceptance-tests/specs/logged-out-learner/complete-some-practice-question.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-out-learner/complete-some-practice-question.spec.ts
@@ -58,7 +58,8 @@ test.describe('Logged-Out Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Fractions',
       'Algebra',
-      'fractions'
+      'fractions',
+      true
     );
 
     await curriculumAdmin.addStoryToTopic(

--- a/core/tests/playwright-acceptance-tests/specs/logged-out-learner/discover-the-website-and-navigate-to-math-classroom.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-out-learner/discover-the-website-and-navigate-to-math-classroom.spec.ts
@@ -65,7 +65,8 @@ test.describe('Logged-Out Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Fractions',
       'Algebra',
-      'fractions'
+      'fractions',
+      true
     );
     await curriculumAdmin.navigateToTopicsAndSkillsDashboardPageAsTopicManager();
 

--- a/core/tests/playwright-acceptance-tests/specs/logged-out-learner/listen-to-voiceovers-of-the-lessons-in-the-lesson-player.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-out-learner/listen-to-voiceovers-of-the-lessons-in-the-lesson-player.spec.ts
@@ -122,7 +122,8 @@ test.describe('Logged-Out Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Place Values',
       'Place Values',
-      'place values'
+      'place values',
+      true
     );
 
     await curriculumAdmin.createAndPublishClassroom(

--- a/core/tests/playwright-acceptance-tests/specs/logged-out-learner/pick-a-lesson-to-learn.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-out-learner/pick-a-lesson-to-learn.spec.ts
@@ -103,7 +103,8 @@ test.describe('Logged-Out Learner', function () {
     await curriculumAdmin.createAndPublishTopic(
       'Length Measurement',
       'Basics of Length Measurement',
-      'length-measurement'
+      'length-measurement',
+      true
     );
     await curriculumAdmin.createAndPublishClassroom(
       'Math',

--- a/core/tests/playwright-acceptance-tests/specs/logged-out-learner/play-a-complete-community-lesson.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/logged-out-learner/play-a-complete-community-lesson.spec.ts
@@ -54,7 +54,11 @@ test.describe('Logged-Out Learner', function () {
     );
 
     await curriculumAdmin.navigateToTopicsAndSkillsDashboardPageAsTopicManager();
-    await curriculumAdmin.createTopic('Introduction to Oppia', 'intro-oppia');
+    await curriculumAdmin.createTopic(
+      'Introduction to Oppia',
+      'intro-oppia',
+      true
+    );
     await curriculumAdmin.createSkillForTopic(
       'Math',
       'Introduction to Oppia',

--- a/core/tests/playwright-acceptance-tests/utilities/user/topic-manager.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/topic-manager.ts
@@ -594,11 +594,13 @@ export class TopicManager extends BaseUser {
   async createAndPublishTopic(
     topicName: string,
     subtopicName: string,
-    skillName: string
+    skillName: string,
+    isFirstTopic: boolean = false
   ): Promise<void> {
     await this.createTopic(
       topicName,
-      topicName.toLowerCase().replace(/ /g, '-')
+      topicName.toLowerCase().replace(/ /g, '-'),
+      isFirstTopic
     );
     await this.createSubtopicForTopic(
       subtopicName,
@@ -703,17 +705,23 @@ export class TopicManager extends BaseUser {
    * @param {string} urlFragment - The URL fragment for the topic.
    * @returns {Promise<string>} - A promise that resolves to the ID of the created topic.
    */
-  async createTopic(name: string, urlFragment: string): Promise<string> {
+  async createTopic(
+    name: string,
+    urlFragment: string,
+    isFirstTopic: boolean = false
+  ): Promise<string> {
     await this.navigateToTopicsAndSkillsDashboardPageAsTopicManager();
     let TopicSelectorElement = null;
-    try {
-      TopicSelectorElement = await this.expectElementToBeAttachedInDOM(
-        desktopTopicSelector,
-        this.page,
-        10000
-      );
-    } catch {
-      // Element didn't appear in 10 seconds — treat as not present.
+    if (!isFirstTopic) {
+      try {
+        TopicSelectorElement = await this.expectElementToBeAttachedInDOM(
+          desktopTopicSelector,
+          this.page,
+          10000
+        );
+      } catch {
+        // Element didn't appear in 10 seconds — treat as not present.
+      }
     }
 
     if (!TopicSelectorElement || !this.isViewportAtMobileWidth()) {


### PR DESCRIPTION
## Overview

1. This PR fixes #27087.
2. This PR does the following: Addresses an inefficiency in Playwright acceptance tests where `createTopic` spent a mandatory 10 seconds waiting for `desktopTopicSelector` in a `try/catch` block when called on an empty state (when no topics exist yet). As approved by the maintainer in #27087 (Approach 1), we resolved this by introducing an explicit `isFirstTopic: boolean = false` parameter to `createTopic` and propagating it from `createAndPublishTopic` in `topic-manager.ts`. We updated all 14 `.spec.ts` files that create an initial topic to pass `true` to this function. When `isFirstTopic` is passed as `true`, the test skips the unnecessary wait for the selector, significantly speeding up the test suite.
3. The original bug occurred because: The `createTopic` test utility did not know if a topic already existed on the screen, so it always executed a 10-second `expectElementToBeAttachedInDOM` wait inside a `try/catch` block just in case. The lack of an explicit argument to declare whether it should expect the element to be visible or hidden caused this ambiguity and delay.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

*Note: Since this PR exclusively modifies developer-facing test automation utilities (`topic-manager.ts`) and does not alter any user-facing frontend code, UI/Arabic/Mobile screenshots are not applicable.*

### Stress Test Verification
I successfully stress-tested the `logged-out-learner/play-a-complete-community-lesson` suite on GitHub Actions to ensure the new `createTopic` logic is stable and does not introduce flakiness:
[View Successful Stress Test Run](https://github.com/iHamza14/oppia/actions/runs/34172836937)

### Local Test Passing (Proof)
<img width="1633" height="621" alt="Screenshot 2026-09-08 at 8 53 14 AM" src="https://github.com/user-attachments/assets/a5d9ff18-1cbe-4f6e-a3b4-11da833490df" />


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.