### PR TITLE
Fix #21984: Gracefully handle unauthorized suggestion fetch on contributor dashboard

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.spec.ts
@@ -1801,6 +1801,57 @@ describe('Contributions and review component', () => {
         });
       });
 
+      it(
+        'should return an empty list when the user is not authorized ' +
+          'to make suggestions',
+        fakeAsync(() => {
+          getUserCreatedTranslationSuggestionsAsyncSpy.and.returnValue(
+            Promise.reject({status: 401})
+          );
+
+          component.switchToTab(
+            component.TAB_TYPE_CONTRIBUTIONS,
+            'translate_content'
+          );
+
+          let response = null;
+          component
+            .loadContributions(null)
+            .then(({opportunitiesDicts, more}) => {
+              response = {opportunitiesDicts, more};
+            });
+          tick();
+
+          expect(response).toEqual({opportunitiesDicts: [], more: false});
+        })
+      );
+
+      it(
+        'should rethrow the error when the request fails for a reason ' +
+          'other than authorization',
+        fakeAsync(() => {
+          getUserCreatedTranslationSuggestionsAsyncSpy.and.returnValue(
+            Promise.reject({status: 500})
+          );
+
+          component.switchToTab(
+            component.TAB_TYPE_CONTRIBUTIONS,
+            'translate_content'
+          );
+
+          let rejectionStatus = null;
+          component.loadContributions(null).then(
+            () => {},
+            error => {
+              rejectionStatus = error.status;
+            }
+          );
+          tick();
+
+          expect(rejectionStatus).toEqual(500);
+        })
+      );
+
       it('should not overwrite previously fetched data', fakeAsync(() => {
         const mockSuggestions: Record<
           string,

--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.ts
@@ -26,6 +26,7 @@ import {
   HostListener,
   Input,
 } from '@angular/core';
+import {HttpErrorResponse} from '@angular/common/http';
 import {NgbModalRef, NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {AppConstants} from 'app.constants';
 import cloneDeep from 'lodash/cloneDeep';
@@ -824,17 +825,29 @@ export class ContributionsAndReview implements OnInit, OnDestroy, OnChanges {
         this.activeTabType
       ];
 
-    return fetchFunction(shouldResetOffset).then(response => {
-      Object.keys(response.suggestionIdToDetails).forEach(id => {
-        this.contributions[id] = response.suggestionIdToDetails[id];
+    return fetchFunction(shouldResetOffset)
+      .then(response => {
+        Object.keys(response.suggestionIdToDetails).forEach(id => {
+          this.contributions[id] = response.suggestionIdToDetails[id];
+        });
+        return {
+          opportunitiesDicts: this.getContributionSummaries(
+            response.suggestionIdToDetails
+          ),
+          more: response.more,
+        };
+      })
+      .catch((error: HttpErrorResponse) => {
+        // A banned or otherwise non-full-user has no ACTION_SUGGEST_CHANGES
+        // permission, so the suggestion endpoints respond with 401. Handle it
+        // gracefully by showing an empty state instead of letting the
+        // rejection surface as an unhandled promise rejection. Any other
+        // error is rethrown.
+        if (error.status === 401) {
+          return {opportunitiesDicts: [], more: false};
+        }
+        throw error;
       });
-      return {
-        opportunitiesDicts: this.getContributionSummaries(
-          response.suggestionIdToDetails
-        ),
-        more: response.more,
-      };
-    });
   }
 
   loadOpportunities(): Promise<GetOpportunitiesResponse> {


### PR DESCRIPTION
## Overview

1. This PR fixes #21984.
2. This PR does the following: The contributor dashboard calls the suggestion endpoints (`/getssubmittedsuggestions/...`) to load a user's submitted contributions. When the request is rejected with a 401, `loadContributions` in `contributions-and-review.component.ts` never handled the rejected promise, so it surfaced as an unhandled promise rejection (a production server error). This PR catches the 401 in `loadContributions` and returns an empty result so the dashboard renders a normal empty state instead of throwing. Any non-401 error is rethrown so genuine failures are not masked.
3. (For bug-fixing PRs only) The original bug occurred because: A logged-in user without the `ACTION_SUGGEST_CHANGES` permission - primarily a **banned** user, whose roles are emptied - hits the `can_suggest_changes` - guarded suggestion endpoints. The backend correctly returns a 401(`UnauthorizedUserException: You do not have credentials to make suggestions.`), but the frontend left that rejection uncaught. The backend authorization is working as intended; the fix is to handle the rejection gracefully on the frontend (approach confirmed with @VirenPassi on the issue). 

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

The bug is reproduced by banning a user (Admin → Roles tab → "Mark as banned") and then visiting `/contributor-dashboard` as that user.

**Before the fix** — the dashboard loads but the console shows an unhandled promise rejection for the 401:
`Uncaught (in promise): HttpErrorResponse ... /getsubmittedsuggestions/all/translate_content ... "You do not have credentials to make suggestions.", "status_code":401`

<img width="1470" height="956" alt="Screenshot 2026-09-08 at 8 07 55 PM" src="https://github.com/user-attachments/assets/ec4d568c-7fb0-4cfa-b37b-e0fbce8bed04" />

**After the fix** — the same banned user visits the dashboard; the 401 is handled gracefully, the dashboard shows the normal empty state ("No opportunity available!"), and there is no unhandled promise rejection in the console:

<img width="1470" height="956" alt="Screenshot 2026-09-08 at 7 18 34 PM" src="https://github.com/user-attachments/assets/ca3f2d45-dc29-4dd7-9ff7-c242d2c1493a" />

(Note: the `Failed to load resource ... 401` network log line still appears in both cases — that is the browser's network log for the backend's correct 401 response, not an application error. The fix removes the unhandled promise rejection.)


#### Proof of changes on mobile phone

N/A — this is a console-only fix (unhandled promise rejection); UI is unchanged, empty-state renders identically across viewports/languages

#### Proof of changes in Arabic language

N/A — this is a console-only fix (unhandled promise rejection); UI is unchanged, empty-state renders identically across viewports/languages

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
