### PR TITLE
Fix part of #27171: Remove @ts-nocheck and fix strict TypeScript errors in Group 17 spec files

### DIFF
--- a/core/templates/pages/about-page/about-page.component.spec.ts
+++ b/core/templates/pages/about-page/about-page.component.spec.ts
@@ -16,8 +16,6 @@
  * @fileoverview Unit tests for the about page.
  */
 
-// @ts-nocheck
-
 import {TestBed} from '@angular/core/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {AboutPageComponent} from './about-page.component';
@@ -126,15 +124,18 @@ describe('About Page', () => {
 
   it('should subscribe to translateService, windowDimensionsService on init', () => {
     spyOn(translateService.onLangChange, 'subscribe');
+    const resizeEventObservable = of(new Event('resize'));
+    spyOn(resizeEventObservable, 'subscribe');
     const getResizeEventSpy = spyOn(
       windowDimensionsService,
       'getResizeEvent'
-    ).and.returnValue({subscribe: jasmine.createSpy()});
+    ).and.returnValue(resizeEventObservable);
 
     component.ngOnInit();
 
     expect(translateService.onLangChange.subscribe).toHaveBeenCalled();
-    expect(getResizeEventSpy().subscribe).toHaveBeenCalled();
+    expect(getResizeEventSpy).toHaveBeenCalled();
+    expect(resizeEventObservable.subscribe).toHaveBeenCalled();
   });
 
   it('should initialize with correct screen type and partnerships form link', () => {

--- a/core/templates/pages/blog-home-page/blog-home-page.component.spec.ts
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.spec.ts
@@ -16,8 +16,6 @@
  * @fileoverview Unit tests for Blog Home Page Component.
  */
 
-// @ts-nocheck
-
 import {EventEmitter, Pipe, PipeTransform} from '@angular/core';
 import {
   ComponentFixture,
@@ -45,6 +43,7 @@ import {
   SearchResponseData,
 } from 'domain/blog/blog-homepage-backend-api.service';
 import {UrlService} from 'services/contextual/url.service';
+import {of} from 'rxjs';
 import {Subject} from 'rxjs/internal/Subject';
 import {BlogCardComponent} from 'pages/blog-dashboard-page/blog-card/blog-card.component';
 import {TagFilterComponent} from './tag-filter/tag-filter.component';
@@ -105,6 +104,7 @@ describe('Blog home page component', () => {
   let component: BlogHomePageComponent;
   let fixture: ComponentFixture<BlogHomePageComponent>;
   let router: Router;
+  let activatedRoute: ActivatedRoute;
   let mockOnInitialSearchResultsLoaded = new EventEmitter<SearchResponseData>();
 
   let blogPostSummary: BlogPostSummaryBackendDict = {
@@ -157,6 +157,7 @@ describe('Blog home page component', () => {
     fixture = TestBed.createComponent(BlogHomePageComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
+    activatedRoute = TestBed.inject(ActivatedRoute);
     searchService = TestBed.inject(BlogPostSearchService);
     alertsService = TestBed.inject(AlertsService);
     blogHomePageBackendApiService = TestBed.inject(
@@ -195,17 +196,12 @@ describe('Blog home page component', () => {
 
     spyOn(component, 'loadPage');
 
-    spyOn(
-      (component as unknown as {route: ActivatedRoute}).route.queryParams,
-      'subscribe'
-    ).and.callFake((fn: (params: {q: string; tags: string}) => void) => {
-      fn(params);
-    });
+    activatedRoute.queryParams = of(params);
 
     component.ngOnInit();
 
-    expect(component.filterWasUsed).toBeTrue();
-    expect(component.searchPageIsActive).toBeTrue();
+    expect(component.filterWasUsed).toBe(true);
+    expect(component.searchPageIsActive).toBe(true);
     expect(component.searchQuery).toBe('search query');
     expect(component.selectedTags).toEqual(['Community']);
     expect(component.loadPage).toHaveBeenCalled();

--- a/core/templates/pages/donate-page/donate-page-root.component.spec.ts
+++ b/core/templates/pages/donate-page/donate-page-root.component.spec.ts
@@ -16,8 +16,6 @@
  * @fileoverview Unit tests for the donate page root component.
  */
 
-// @ts-nocheck
-
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 

--- a/core/templates/pages/login-page/login-page.component.spec.ts
+++ b/core/templates/pages/login-page/login-page.component.spec.ts
@@ -15,7 +15,6 @@
 /**
  * @fileoverview Unit tests for the login page.
  */
-// @ts-nocheck
 
 import {
   ComponentFixture,
@@ -149,7 +148,7 @@ describe('Login Page', () => {
   });
 
   it('should be in emulator mode by default', () => {
-    expect(loginPageComponent.emulatorModeIsEnabled).toBeTrue();
+    expect(loginPageComponent.emulatorModeIsEnabled).toBe(true);
   });
 
   it('should redirect to home page when already logged in', fakeAsync(() => {

--- a/core/templates/pages/moderator-page/moderator-page.component.spec.ts
+++ b/core/templates/pages/moderator-page/moderator-page.component.spec.ts
@@ -16,13 +16,12 @@
  * @fileoverview Unit tests for Moderator Page Component.
  */
 
-// @ts-nocheck
-
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {
   ComponentFixture,
   fakeAsync,
   TestBed,
+  tick,
   waitForAsync,
 } from '@angular/core/testing';
 import {NgbNavModule} from '@ng-bootstrap/ng-bootstrap';
@@ -42,12 +41,20 @@ import {
   RecentFeedbackMessages,
 } from './services/moderator-page-backend-api.service';
 
+interface MockErrorResponse {
+  status: number;
+  error: {
+    error: string;
+  };
+}
+
 describe('Moderator Page Component', () => {
   let fixture: ComponentFixture<ModeratorPageComponent>;
   let componentInstance: ModeratorPageComponent;
   let loaderService: LoaderService;
   let datetimeFormatService: DateTimeFormatService;
   let alertsService: AlertsService;
+  let moderatorPageBackendApiService: ModeratorPageBackendApiService;
   let threadMessageBackendDict: ThreadMessageBackendDict = {
     author_username: 'author',
     created_on_msecs: 123,
@@ -150,6 +157,9 @@ describe('Moderator Page Component', () => {
     alertsService = TestBed.inject(
       AlertsService
     ) as jasmine.SpyObj<AlertsService>;
+    moderatorPageBackendApiService = TestBed.inject(
+      ModeratorPageBackendApiService
+    );
   });
 
   it('should create', () => {
@@ -192,9 +202,9 @@ describe('Moderator Page Component', () => {
   });
 
   it('should tell if message is from exploration', () => {
-    expect(componentInstance.isMessageFromExploration(message)).toBeTrue();
+    expect(componentInstance.isMessageFromExploration(message)).toBe(true);
     message.entityType = 'other_than_exploration';
-    expect(componentInstance.isMessageFromExploration(message)).toBeFalse();
+    expect(componentInstance.isMessageFromExploration(message)).toBe(false);
   });
 
   it('should get exploration create url', () => {
@@ -221,15 +231,15 @@ describe('Moderator Page Component', () => {
     componentInstance.displayedFeaturedActivityReferences = [
       {id: '', type: 'emptyID'},
     ];
-    expect(
-      componentInstance.isSaveFeaturedActivitiesButtonDisabled()
-    ).toBeTrue();
+    expect(componentInstance.isSaveFeaturedActivitiesButtonDisabled()).toBe(
+      true
+    );
     componentInstance.displayedFeaturedActivityReferences = [
       {id: 'is', type: 'not'},
     ];
-    expect(
-      componentInstance.isSaveFeaturedActivitiesButtonDisabled()
-    ).toBeFalse();
+    expect(componentInstance.isSaveFeaturedActivitiesButtonDisabled()).toBe(
+      false
+    );
   });
 
   it('should save featured activity references', () => {
@@ -260,7 +270,7 @@ describe('Moderator Page Component', () => {
     );
   });
 
-  it('should display error message for nonexistent exploration', () => {
+  it('should display error message for nonexistent exploration', fakeAsync(() => {
     spyOn(alertsService, 'addWarning');
 
     let newValue: ActivityIdTypeDict[] = [
@@ -273,7 +283,7 @@ describe('Moderator Page Component', () => {
     componentInstance.displayedFeaturedActivityReferences = [];
     componentInstance.updateDisplayedFeaturedActivityReferences(newValue);
 
-    const mockError = {
+    const mockError: MockErrorResponse = {
       status: 400,
       error: {
         error:
@@ -282,28 +292,19 @@ describe('Moderator Page Component', () => {
     };
 
     spyOn(
-      componentInstance.moderatorPageBackendApiService,
+      moderatorPageBackendApiService,
       'saveFeaturedActivityReferencesAsync'
-    ).and.callFake(() => {
-      return {
-        then: () => {
-          return {
-            catch: (errorCallback: (err: string) => void) => {
-              errorCallback(mockError);
-            },
-          };
-        },
-      };
-    });
+    ).and.returnValue(Promise.reject(mockError));
 
     componentInstance.saveFeaturedActivityReferences();
+    tick();
 
     expect(alertsService.addWarning).toHaveBeenCalledWith(
       'These Exploration IDs do not exist: dne_exploration. Please enter a different ID.'
     );
-  });
+  }));
 
-  it('should display error message for nonexistent collection', () => {
+  it('should display error message for nonexistent collection', fakeAsync(() => {
     spyOn(alertsService, 'addWarning');
 
     let newValue: ActivityIdTypeDict[] = [
@@ -316,7 +317,7 @@ describe('Moderator Page Component', () => {
     componentInstance.displayedFeaturedActivityReferences = [];
     componentInstance.updateDisplayedFeaturedActivityReferences(newValue);
 
-    const mockError = {
+    const mockError: MockErrorResponse = {
       status: 400,
       error: {
         error:
@@ -325,28 +326,19 @@ describe('Moderator Page Component', () => {
     };
 
     spyOn(
-      componentInstance.moderatorPageBackendApiService,
+      moderatorPageBackendApiService,
       'saveFeaturedActivityReferencesAsync'
-    ).and.callFake(() => {
-      return {
-        then: () => {
-          return {
-            catch: (errorCallback: (err: string) => void) => {
-              errorCallback(mockError);
-            },
-          };
-        },
-      };
-    });
+    ).and.returnValue(Promise.reject(mockError));
 
     componentInstance.saveFeaturedActivityReferences();
+    tick();
 
     expect(alertsService.addWarning).toHaveBeenCalledWith(
       'These Collection IDs do not exist: dne_collection. Please enter a different ID.'
     );
-  });
+  }));
 
-  it('should display error message for private exploration', () => {
+  it('should display error message for private exploration', fakeAsync(() => {
     spyOn(alertsService, 'addWarning');
 
     let newValue: ActivityIdTypeDict[] = [
@@ -359,7 +351,7 @@ describe('Moderator Page Component', () => {
     componentInstance.displayedFeaturedActivityReferences = [];
     componentInstance.updateDisplayedFeaturedActivityReferences(newValue);
 
-    const mockError = {
+    const mockError: MockErrorResponse = {
       status: 400,
       error: {
         error:
@@ -368,28 +360,19 @@ describe('Moderator Page Component', () => {
     };
 
     spyOn(
-      componentInstance.moderatorPageBackendApiService,
+      moderatorPageBackendApiService,
       'saveFeaturedActivityReferencesAsync'
-    ).and.callFake(() => {
-      return {
-        then: () => {
-          return {
-            catch: (errorCallback: (err: string) => void) => {
-              errorCallback(mockError);
-            },
-          };
-        },
-      };
-    });
+    ).and.returnValue(Promise.reject(mockError));
 
     componentInstance.saveFeaturedActivityReferences();
+    tick();
 
     expect(alertsService.addWarning).toHaveBeenCalledWith(
       'These Exploration IDs are private: priv_exploration. Please enter a different ID.'
     );
-  });
+  }));
 
-  it('should display error message for private collection', () => {
+  it('should display error message for private collection', fakeAsync(() => {
     spyOn(alertsService, 'addWarning');
 
     let newValue: ActivityIdTypeDict[] = [
@@ -402,7 +385,7 @@ describe('Moderator Page Component', () => {
     componentInstance.displayedFeaturedActivityReferences = [];
     componentInstance.updateDisplayedFeaturedActivityReferences(newValue);
 
-    const mockError = {
+    const mockError: MockErrorResponse = {
       status: 400,
       error: {
         error:
@@ -411,31 +394,22 @@ describe('Moderator Page Component', () => {
     };
 
     spyOn(
-      componentInstance.moderatorPageBackendApiService,
+      moderatorPageBackendApiService,
       'saveFeaturedActivityReferencesAsync'
-    ).and.callFake(() => {
-      return {
-        then: () => {
-          return {
-            catch: (errorCallback: (err: string) => void) => {
-              errorCallback(mockError);
-            },
-          };
-        },
-      };
-    });
+    ).and.returnValue(Promise.reject(mockError));
 
     componentInstance.saveFeaturedActivityReferences();
+    tick();
 
     expect(alertsService.addWarning).toHaveBeenCalledWith(
       'These Collection IDs are private: priv_collection. Please enter a different ID.'
     );
-  });
+  }));
 
-  it('should display message for miscellaneous errors', () => {
+  it('should display message for miscellaneous errors', fakeAsync(() => {
     spyOn(alertsService, 'addWarning');
 
-    const mockError = {
+    const mockError: MockErrorResponse = {
       status: 404,
       error: {
         error: '',
@@ -443,24 +417,15 @@ describe('Moderator Page Component', () => {
     };
 
     spyOn(
-      componentInstance.moderatorPageBackendApiService,
+      moderatorPageBackendApiService,
       'saveFeaturedActivityReferencesAsync'
-    ).and.callFake(() => {
-      return {
-        then: () => {
-          return {
-            catch: (errorCallback: (err: string) => void) => {
-              errorCallback(mockError);
-            },
-          };
-        },
-      };
-    });
+    ).and.returnValue(Promise.reject(mockError));
 
     componentInstance.saveFeaturedActivityReferences();
+    tick();
 
     expect(alertsService.addWarning).toHaveBeenCalledWith(
       'An unexpected error occurred. Please try again later.'
     );
-  });
+  }));
 });

--- a/core/templates/pages/splash-page/splash-page.component.spec.ts
+++ b/core/templates/pages/splash-page/splash-page.component.spec.ts
@@ -16,8 +16,6 @@
  * @fileoverview Unit tests for the splash page.
  */
 
-// @ts-nocheck
-
 import {EventEmitter} from '@angular/core';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {TestBed, fakeAsync, flushMicrotasks} from '@angular/core/testing';
@@ -196,7 +194,7 @@ describe('Splash Page', () => {
 
   it('should get testimonials correctly', function () {
     component.ngOnInit();
-    expect(component.getTestimonials().length).toBe(component.testimonialCount);
+    expect(component.testimonialCount).toBe(component.getTestimonials().length);
   });
 
   it('should evaluate if user is logged in', fakeAsync(() => {


### PR DESCRIPTION
## Overview

1. This PR fixes part of #27171.

3. This PR does the following: 
    - **core/templates/pages/donate-page/donate-page-root.component.spec.ts** - All types were already correct, only needed the `// @ts-nocheck` removed

    - **core/templates/pages/login-page/login-page.component.spec.ts** - TS flagged `.toBeTrue();` due to `Property 'toBeTrue' does not exist on type 'JestMatchersShape...'` which was replaced by `.toBe(true);`

    - **core/templates/pages/splash-page/splash-page.component.spec.ts** - Here `expect(component.getTestimonials().length).toBe(component.testimonialCount);` - `component.getTestimonials().length` is strictly number 4 while `component.testimonialCount` is number. So it comes down to be - `expect(4).toBe(number);` , here TS complains since a number might not be 4 -> we change it to `expect(number).toBe(4);` since 4 is definitely a valid number

    - **core/templates/pages/about-page/about-page.component.spec.ts** - The component expects a real `Observable<Event>`. The old test only returned an object with a `subscribe` function, which failed TypeScript's check because it was missing the rest of the standard Observable methods and properties. Used `of(new Event('resize'))` which provides a valid, fully-typed observable that we can still spy on.

    - **core/templates/pages/blog-home-page/blog-home-page.component.spec.ts** - Instead of using `as unknown as` to spy on the private route's overloaded `.subscribe()` method, we cleanly injected `ActivatedRoute` and provided a real `of(params)` observable

    - **core/templates/pages/moderator-page/moderator-page.component.spec.ts** -   Replaced private property access with `TestBed.inject(ModeratorPageBackendApiService)` and migrated custom mock promises to `Promise.reject` handled via `fakeAsync` and `tick()`


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

All local checks pass with zero errors:

1. **Strict TypeScript Checks:**
<img width="795" height="220" alt="Image" src="https://github.com/user-attachments/assets/4c48c46f-1314-4ed8-9cfc-57bf676ad6cc" />


2. **Frontend Unit Tests:**
<img width="1392" height="677" alt="Image" src="https://github.com/user-attachments/assets/aa7c20cd-7629-40a4-ad80-466294a5c363" />

3. **Linter & Style Checks:**
<img width="616" height="430" alt="Image" src="https://github.com/user-attachments/assets/e9ceba00-5c8a-46e2-9b22-7c4bb154bc5d" />

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
