### PR TITLE
Fix #27301: Make opportunity lookup resilient to list refresh in contributor dashboard acceptance tests

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -30,6 +30,8 @@ const opportunityItemHeadingSelector =
   '.e2e-test-opportunity-list-item-heading';
 const opportunitySubHeadingSelector =
   '.e2e-test-opportunity-list-item-subheading';
+const opportunityLoadingPlaceholderSelector =
+  '.e2e-test-opportunity-loading-placeholder';
 const paginationButtonPreviousSelector = '.e2e-test-pagination-button-previous';
 const paginationButtonNextSelector = '.e2e-test-pagination-button-next';
 const reviewContentContainerSelector = '.e2e-test-review-content-container';
@@ -99,20 +101,25 @@ export class Contributor extends ExplorationEditor {
   }
 
   /**
-   * Checks if the translation opportunity is visible and matches the expected values.
-   * @param heading - The expected heading of the translation opportunity.
-   * @param subheading - The expected subheading of the translation opportunity.
-   * @param visible - Whether the translation opportunity should be visible or not.
+   * Waits until the opportunity list has finished loading and its contents
+   * are stable. While the list is loading, its items are hidden and
+   * placeholder items are shown instead, so callers must not scan the list
+   * before it has settled.
    */
-  async expectOpportunityToBePresent(
-    heading: string,
-    subheading: string,
-    visible: boolean = true
-  ): Promise<ElementHandle | null> {
-    await this.page.waitForNetworkIdle();
-
-    const translationOpportunitiesPreset = await this.isElementVisible(
-      opportunityItemSelector
+  private async waitForOpportunityListToStabilize(): Promise<void> {
+    // Wait for the list to finish loading: the loading placeholder is
+    // hidden once the opportunity items have been rendered.
+    await this.page.waitForFunction(
+      (selector: string) => {
+        const placeholder = document.querySelector(selector);
+        return (
+          placeholder === null ||
+          (placeholder as HTMLElement).hidden ||
+          getComputedStyle(placeholder).display === 'none'
+        );
+      },
+      {},
+      opportunityLoadingPlaceholderSelector
     );
 
     // Sometimes, the opportunities refreshes after they have been loaded.
@@ -121,6 +128,7 @@ export class Contributor extends ExplorationEditor {
     // for 200 ms.
     let previousElementIds: string[] = [];
     let opportunityItemListChanged = true;
+    const stabilizationTimeout = Date.now() + 30000;
 
     // TODO(#23395): Currently, the opportunity list is refreshed after the
     // page is loaded. This causes the test to fail. We are using a workaround
@@ -143,23 +151,17 @@ export class Contributor extends ExplorationEditor {
         );
 
       previousElementIds = currentElementIds;
-    } while (opportunityItemListChanged);
+    } while (opportunityItemListChanged && Date.now() < stabilizationTimeout);
+  }
 
-    // Handle the case where no translation opportunity is present.
-    if (!translationOpportunitiesPreset) {
-      if (visible) {
-        throw new Error(
-          `Translation opportunity for ${heading} in ${subheading} not found.`
-        );
-      } else {
-        showMessage(
-          `Success: Translation opportunity for ${heading} in ${subheading} not found.`
-        );
-        return null;
-      }
-    }
-
-    // Get the opportunity item element.
+  /**
+   * Returns the opportunity item matching the given heading and subheading,
+   * or null if no such item is currently rendered.
+   */
+  private async findOpportunityItem(
+    heading: string,
+    subheading: string
+  ): Promise<ElementHandle | null> {
     const opportunityItems = await this.page.$$(opportunityItemSelector);
     for (const opportunityItemElement of opportunityItems) {
       const opportunityItemHeading = await opportunityItemElement.evaluate(
@@ -177,24 +179,81 @@ export class Contributor extends ExplorationEditor {
         opportunityItemHeading === heading &&
         opportunityItemSubHeading?.includes(subheading)
       ) {
-        if (!visible) {
-          throw new Error(
-            `Failure: Translation opportunity for ${heading} in ${opportunityItemSubHeading} was found.`
-          );
-        }
         return opportunityItemElement;
       }
     }
-
-    if (visible) {
-      throw new Error(
-        `Translation opportunity for ${heading} in ${subheading} not found.`
-      );
-    }
-    showMessage(
-      `Success: Translation opportunity for ${heading} in ${subheading} not found.`
-    );
     return null;
+  }
+
+  /**
+   * Checks if the translation opportunity is visible and matches the expected values.
+   * @param heading - The expected heading of the translation opportunity.
+   * @param subheading - The expected subheading of the translation opportunity.
+   * @param visible - Whether the translation opportunity should be visible or not.
+   */
+  async expectOpportunityToBePresent(
+    heading: string,
+    subheading: string,
+    visible: boolean = true
+  ): Promise<ElementHandle | null> {
+    await this.page.waitForNetworkIdle();
+
+    // Handle the case where no translation opportunity is expected.
+    if (!visible) {
+      await this.waitForOpportunityListToStabilize();
+      const opportunityItemElement = await this.findOpportunityItem(
+        heading,
+        subheading
+      );
+      if (opportunityItemElement !== null) {
+        const opportunityItemSubHeading = await opportunityItemElement.evaluate(
+          (el: Element, sel: string) =>
+            el.querySelector(sel)?.textContent?.trim(),
+          opportunitySubHeadingSelector
+        );
+        throw new Error(
+          `Failure: Translation opportunity for ${heading} in ${opportunityItemSubHeading} was found.`
+        );
+      }
+      showMessage(
+        `Success: Translation opportunity for ${heading} in ${subheading} not found.`
+      );
+      return null;
+    }
+
+    // The opportunity list can be refreshed after it has been rendered (see
+    // #23395), so a single scan may run against a stale list that does not
+    // contain the target opportunity yet. Keep scanning until the target
+    // opportunity shows up.
+    const scanningTimeout = Date.now() + 30000;
+    while (true) {
+      await this.waitForOpportunityListToStabilize();
+      const opportunityItemElement = await this.findOpportunityItem(
+        heading,
+        subheading
+      );
+      if (opportunityItemElement !== null) {
+        return opportunityItemElement;
+      }
+      if (Date.now() >= scanningTimeout) {
+        const opportunityHeadings = await this.page.$$eval(
+          opportunityItemSelector,
+          (elements, headingSelector) =>
+            elements
+              .map(
+                el =>
+                  el.querySelector(headingSelector)?.textContent?.trim() || ''
+              )
+              .filter(text => text !== ''),
+          opportunityItemHeadingSelector
+        );
+        throw new Error(
+          `Translation opportunity for ${heading} in ${subheading} not found.` +
+            ` Found opportunity headings: [${opportunityHeadings.join(', ')}]`
+        );
+      }
+      await this.page.waitForTimeout(200);
+    }
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -118,7 +118,7 @@ export class Contributor extends ExplorationEditor {
           getComputedStyle(placeholder).display === 'none'
         );
       },
-      {},
+      {timeout: 30000},
       opportunityLoadingPlaceholderSelector
     );
 
@@ -161,7 +161,7 @@ export class Contributor extends ExplorationEditor {
   private async findOpportunityItem(
     heading: string,
     subheading: string
-  ): Promise<ElementHandle | null> {
+  ): Promise<ElementHandle<Element> | null> {
     const opportunityItems = await this.page.$$(opportunityItemSelector);
     for (const opportunityItemElement of opportunityItems) {
       const opportunityItemHeading = await opportunityItemElement.evaluate(
@@ -195,7 +195,7 @@ export class Contributor extends ExplorationEditor {
     heading: string,
     subheading: string,
     visible: boolean = true
-  ): Promise<ElementHandle | null> {
+  ): Promise<ElementHandle<Element> | null> {
     await this.page.waitForNetworkIdle();
 
     // Handle the case where no translation opportunity is expected.
@@ -226,7 +226,7 @@ export class Contributor extends ExplorationEditor {
     // contain the target opportunity yet. Keep scanning until the target
     // opportunity shows up.
     const scanningTimeout = Date.now() + 30000;
-    while (true) {
+    while (Date.now() < scanningTimeout) {
       await this.waitForOpportunityListToStabilize();
       const opportunityItemElement = await this.findOpportunityItem(
         heading,
@@ -235,30 +235,29 @@ export class Contributor extends ExplorationEditor {
       if (opportunityItemElement !== null) {
         return opportunityItemElement;
       }
-      if (Date.now() >= scanningTimeout) {
-        let opportunityHeadings: string[] = [];
-        try {
-          const headings = await Promise.all(
-            (await this.page.$$(opportunityItemSelector)).map(item =>
-              item.evaluate(
-                (el: Element, sel: string) =>
-                  el.querySelector(sel)?.textContent?.trim() || '',
-                opportunityItemHeadingSelector
-              )
-            )
-          );
-          opportunityHeadings = headings.filter(text => text !== '');
-        } catch {
-          // The list was re-rendered while the diagnostics were being
-          // collected; report without them.
-        }
-        throw new Error(
-          `Translation opportunity for ${heading} in ${subheading} not found.` +
-            ` Found opportunity headings: [${opportunityHeadings.join(', ')}]`
-        );
-      }
       await this.page.waitForTimeout(200);
     }
+
+    let opportunityHeadings: string[] = [];
+    try {
+      const headings = await Promise.all(
+        (await this.page.$$(opportunityItemSelector)).map(item =>
+          item.evaluate(
+            (el: Element, sel: string) =>
+              el.querySelector(sel)?.textContent?.trim() || '',
+            opportunityItemHeadingSelector
+          )
+        )
+      );
+      opportunityHeadings = headings.filter(text => text !== '');
+    } catch {
+      // The list was re-rendered while the diagnostics were being
+      // collected; report without them.
+    }
+    throw new Error(
+      `Translation opportunity for ${heading} in ${subheading} not found.` +
+        ` Found opportunity headings: [${opportunityHeadings.join(', ')}]`
+    );
   }
 
   /**

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -238,7 +238,7 @@ export class Contributor extends ExplorationEditor {
       if (Date.now() >= scanningTimeout) {
         const opportunityHeadings = await this.page.$$eval(
           opportunityItemSelector,
-          (elements, headingSelector) =>
+          (elements: Element[], headingSelector: string): string[] =>
             elements
               .map(
                 el =>

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts
@@ -236,17 +236,22 @@ export class Contributor extends ExplorationEditor {
         return opportunityItemElement;
       }
       if (Date.now() >= scanningTimeout) {
-        const opportunityHeadings = await this.page.$$eval(
-          opportunityItemSelector,
-          (elements: Element[], headingSelector: string): string[] =>
-            elements
-              .map(
-                el =>
-                  el.querySelector(headingSelector)?.textContent?.trim() || ''
+        let opportunityHeadings: string[] = [];
+        try {
+          const headings = await Promise.all(
+            (await this.page.$$(opportunityItemSelector)).map(item =>
+              item.evaluate(
+                (el: Element, sel: string) =>
+                  el.querySelector(sel)?.textContent?.trim() || '',
+                opportunityItemHeadingSelector
               )
-              .filter(text => text !== ''),
-          opportunityItemHeadingSelector
-        );
+            )
+          );
+          opportunityHeadings = headings.filter(text => text !== '');
+        } catch {
+          // The list was re-rendered while the diagnostics were being
+          // collected; report without them.
+        }
         throw new Error(
           `Translation opportunity for ${heading} in ${subheading} not found.` +
             ` Found opportunity headings: [${opportunityHeadings.join(', ')}]`


### PR DESCRIPTION
## Overview

1. This PR fixes #27301.
2. This PR does the following: Makes `expectOpportunityToBePresent` in `core/tests/puppeteer-acceptance-tests/utilities/user/contributor.ts` resilient to the contributor-dashboard opportunity list being reloaded after it has been rendered (the known double-load behavior tracked in #23395), which was causing the `practice-question-submitter/submit-practice-questions-for-review-and-check-thier-status` acceptance test to flake. Specifically, it:
   - Extracts a `waitForOpportunityListToStabilize` helper that first waits for the loading placeholder (`.e2e-test-opportunity-loading-placeholder`) to be hidden and then applies the existing 200 ms list-stability loop, now bounded by a 30 s timeout.
   - Extracts a `findOpportunityItem` helper that scans the currently rendered items for the target heading/subheading.
   - Reworks `expectOpportunityToBePresent` so that when the opportunity is expected to be present, it repeatedly (up to 30 s) waits for the list to settle and rescans it instead of throwing after a single scan. When the opportunity is expected to be absent (`visible=false`), it still waits for the list to settle and then fails if the item is found.
   - Includes the list of opportunity headings actually found on the page in the "not found" error message, to make future failures debuggable.
3. (For bug-fixing PRs only) The original bug occurred because: the acceptance test failed with `Translation opportunity for What is 10km + 11km? in Addition not found.` The utility scanned the opportunity list exactly once (after a 200 ms stability check) and threw if the target was not in that single scan. However, the contributor dashboard reloads the opportunity list after it has been rendered (see #23395), and while loading, the real items are hidden and placeholder items are shown. Under CI load, the single scan could land in this stale/loading window (or on the pre-refresh list) and miss the just-submitted question, throwing immediately. This is an environment/timing flake unrelated to PR #27284's backend-only changes.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

### Local before and after runs

The exact acceptance suite from the issue was run locally with the repository runner in WSL2 Ubuntu 22.04, using Python 3.10.16 and Node 16.13.0:

```sh
python -m scripts.run_acceptance_tests --suite=practice-question-submitter/submit-practice-questions-for-review-and-check-thier-status --headless
```

**Before the fix — baseline `79d49b792d46901df429d01e806b4773f55f795c`:** 1 test passed and 2 failed, with exit code 1. The `should be able to use all interactions in the question` test reproduced the error reported in the issue:

```text
Translation opportunity for What is 10km + 11km? in Addition not found.
```

The baseline also had a separate timeout waiting for `.e2e-test-toast-message` in `should be able to check question status`. That failure is disclosed here and is not being claimed as fixed by this patch.

**After the fix — current PR head `d1296a128b699bca32ccc73e3d5024083d819680`:** all 3 tests passed, including `should be able to use all interactions in the question`. The runner exited with code 0.

### Fork stress test — passed

[Successful Stress Test run](https://github.com/abhinav-phi/oppia/actions/runs/35218192714) on branch `fix-27301-opportunity-flake`, dispatched at PR head `d1296a128b699bca32ccc73e3d5024083d819680`.

The exact suite above passed **20/20 test jobs: 10 desktop and 10 mobile runs**. The 3 setup/build jobs also passed, so the complete workflow finished successfully with **23/23 jobs successful**. This is the separate fork stress workflow, not the ordinary PR CI run. The workflow merges upstream develop during setup.

### Before and after terminal screenshots

These terminal screenshots show excerpts from the saved local acceptance-run logs, not new test runs.

**Before the fix — baseline `79d49b792d`:** the reported opportunity-not-found error is visible, alongside the separate toast timeout disclosed above. The run finished with 1 passed test, 2 failed tests, and exit code 1.

![Before fix terminal output showing the reported opportunity-not-found error](https://raw.githubusercontent.com/abhinav-phi/oppia/0a00de84c756addb84c9d09f7ab01b1ca28a8651/proof-before-terminal.png)

**After the fix — current PR head `d1296a1`:** all 3 tests passed and the runner exited with code 0.

![After fix terminal output showing all three acceptance tests passed](https://raw.githubusercontent.com/abhinav-phi/oppia/0a00de84c756addb84c9d09f7ab01b1ca28a8651/proof-after-terminal.png)

No user-facing UI is changed by this PR.

#### Proof of changes on desktop with slow/throttled network

Not applicable: this PR does not change any user-facing UI. The change makes the acceptance-test utility *more* tolerant of slow/throttled-network conditions (the exact conditions under which the flake was observed in CI), since it now waits for the list reload to finish instead of scanning once during it.

#### Proof of changes on mobile phone

Not applicable: this PR does not change any user-facing UI. The utility is also used by mobile-viewport acceptance runs, and its behavior on mobile is unchanged except for being more tolerant of list reloads.

#### Proof of changes in Arabic language

Not applicable: this PR does not change any user-facing UI or any translated strings.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
