### PR TITLE
Fix #25741: Fix flaky acceptance test for deleting a skill

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/curriculum-admin.ts
@@ -2123,6 +2123,7 @@ export class CurriculumAdmin extends TopicManager {
           });
           const editBox = await skill.$(skillListItemOptions);
           if (editBox) {
+            await this.waitForElementToBeClickable(editBox);
             await editBox.click();
             await this.page.waitForSelector(deleteSkillButton);
           } else {
@@ -2138,6 +2139,7 @@ export class CurriculumAdmin extends TopicManager {
             throw new Error('Delete button not found');
           }
 
+          await this.waitForElementToStabilize(confirmSkillDeletionButton);
           const confirmButton = await this.page.$(confirmSkillDeletionButton);
           if (confirmButton) {
             await this.waitForElementToBeClickable(confirmButton);


### PR DESCRIPTION
## Overview

1. This PR fixes #25741.
2. This PR does the following: This PR fixes a flaky acceptance test, `curriculum-admin/create-publish-unpublish-and-delete-the-topic-and-skill`, by ensuring that the skill deletion confirmation button is stable before Puppeteer clicks it. This prevents the click from racing with the modal animation and causing the test to time out while waiting for the deletion modal to close.
3. (For bug-fixing PRs only) The original bug occurred because: The "Delete Skill" confirmation modal has an animation when it appears. The test was able to find the confirmation button while it was still moving, and Puppeteer attempted to click it before the button had stabilized. As a result, the click could miss the button, the delete confirmation action would not execute, and the test would eventually fail with a `TimeoutError: waiting for selector 'div.modal-content' to be hidden failed: timeout 30000ms exceeded`. The issue was observed on the `develop` branch before the changes in this PR.

## Essential Checklist

Please follow the [[instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request)](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

* [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
* [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
* [ ] I have written tests for my code.
* [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
* [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

#### Proof of changes on desktop with slow/throttled network

The acceptance test was run locally after the fix using:

`python -m scripts.run_acceptance_tests --suite curriculum-admin/create-publish-unpublish-and-delete-the-topic-and-skill`

The test completed successfully:

* Test Suites: 1 passed, 1 total
* Tests: 6 passed, 6 total
* Snapshots: 0 total

#### Stress Test

I also ran the Stress Test (Acceptance Test) workflow for:

`curriculum-admin/create-publish-unpublish-and-delete-the-topic-and-skill`

The test was run on the fix branch to verify that the flaky deletion step no longer fails intermittently.

* **Passing Stress Test after the fix:** https://github.com/iHamza14/oppia/actions/runs/34023526524
* **Branch:** `fix-acceptance-test-delete-skill`

The test logs also showed the confirmation button being detected as moving before the click and then being stabilized before the deletion was performed.

#### Proof of changes on mobile phone

This PR only modifies the acceptance-test utility and does not make any user-facing UI changes.

#### Proof of changes in Arabic language

This PR only modifies the acceptance-test utility and does not make any user-facing UI changes.

## PR Pointers

* Never force push! If you do, your PR will be closed.
* To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
* Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the [["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR)](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
* See the Code Owner's wiki page for what code owners will expect.