### PR TITLE
Fix part of #26799: Migrate exploration-feedback acceptance test to Playwright

### DIFF
--- a/.github/actions/run-a-specific-acceptance-test/action.yml
+++ b/.github/actions/run-a-specific-acceptance-test/action.yml
@@ -136,7 +136,7 @@ runs:
       # which requires all previous jobs/steps to have succeeded. This is not what we want.
       # Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions
       # Quote: "A default status check of success() is applied unless you *include* one of these functions."
-      if: ${{ !cancelled() && steps.run-acceptance-test.outcome == 'failure' && inputs.modified-suite-name-for-uploads != '' }}
+      if: ${{ !cancelled() && inputs.modified-suite-name-for-uploads != '' }}
       uses: actions/upload-artifact@v4
       with:
         name: video-recordings_${{ inputs.modified-suite-name-for-uploads }}

--- a/.github/actions/run-a-specific-acceptance-test/action.yml
+++ b/.github/actions/run-a-specific-acceptance-test/action.yml
@@ -136,7 +136,7 @@ runs:
       # which requires all previous jobs/steps to have succeeded. This is not what we want.
       # Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions
       # Quote: "A default status check of success() is applied unless you *include* one of these functions."
-      if: ${{ !cancelled() && inputs.modified-suite-name-for-uploads != '' }}
+      if: ${{ !cancelled() && steps.run-acceptance-test.outcome == 'failure' && inputs.modified-suite-name-for-uploads != '' }}
       uses: actions/upload-artifact@v4
       with:
         name: video-recordings_${{ inputs.modified-suite-name-for-uploads }}

--- a/core/tests/ci-test-suite-configs/acceptance.json
+++ b/core/tests/ci-test-suite-configs/acceptance.json
@@ -347,8 +347,8 @@
     },
     {
       "name": "exploration-creator/exploration-feedback",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "exploration-creator/exploration-help",

--- a/core/tests/playwright-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The Oppia Authors. All Rights Reserved.
+// Copyright 2026 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,16 +19,20 @@
  * EC. Feedback.
  */
 
+import {test} from '@playwright/test';
 import {UserFactory} from '../../utilities/common/user-factory';
 import {ExplorationEditor} from '../../utilities/user/exploration-editor';
 
-describe('Exploration Editor', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Exploration Editor', function () {
   let explorationEditor: ExplorationEditor;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
     explorationEditor = await UserFactory.createNewUser(
       'explorationEditor',
-      'exploration_editor@example.com'
+      'exploration_editor@example.com',
+      browser
     );
 
     await explorationEditor.navigateToCreatorDashboardPage();
@@ -38,7 +42,7 @@ describe('Exploration Editor', function () {
     await explorationEditor.navigateToFeedbackTab();
   });
 
-  it('should be able to give exploration feedback', async function () {
+  test('should be able to give exploration feedback', async function () {
     await explorationEditor.startAFeedbackThread(
       'Test Feedback',
       'Test Feedback'
@@ -56,7 +60,7 @@ describe('Exploration Editor', function () {
     await explorationEditor.expectFeedbackStatusInList(1, 'Fixed');
   });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/utilities/common/playwright-utils.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/common/playwright-utils.ts
@@ -171,7 +171,15 @@ export class BaseUser {
     }
     await this.clickOnElementWithText('Sign in');
     await this.typeInInputField(testConstants.SignInDetails.inputField, email);
-    await this.clickAndWaitForNavigation('Sign In');
+    // Avoid clickAndWaitForNavigation() here: it waits on
+    // page.waitForNavigation({waitUntil: 'networkidle'}), which can hang for
+    // the full timeout if the post-login redirect doesn't settle into a
+    // "networkidle" state (e.g. background polling requests keep the network
+    // busy), even though the redirect to the username-selection page has
+    // already happened. The caller (signUpNewUser) only needs the username
+    // input to be ready, so wait for that directly instead.
+    await this.clickOnElementWithText('Sign In');
+    await this.page.waitForSelector(usernameInputSelector);
   }
 
   /**

--- a/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
@@ -1230,16 +1230,27 @@ export class ExplorationEditor extends BaseUser {
    */
   async navigateToFeedbackTab(): Promise<void> {
     if (this.isViewportAtMobileWidth()) {
-      const mobileNavbarElement = await this.getElementInParent(
-        mobileNavbarOptions
-      ).catch(() => null);
-      if (!mobileNavbarElement) {
+      const element = await this.page.$(mobileNavbarOptions);
+      // If the element is not present, it means the mobile navigation bar is not expanded.
+      // The option to save changes appears only in the mobile view after clicking on the mobile options button,
+      // which expands the mobile navigation bar.
+      if (!element) {
         await this.clickOnElementWithSelector(mobileOptionsButtonSelector);
-        await this.expectElementToBeVisible(mobileNavbarDropdown);
       }
+      await this.expectElementToBeVisible(mobileNavbarDropdown);
       await this.clickOnElementWithSelector(mobileNavbarDropdown);
       await this.expectElementToBeVisible(mobileNavbarPane);
-      await this.clickOnElementWithSelector(mobileFeedbackTabButton);
+      await this.clickAndWaitForNavigation(mobileFeedbackTabButton, true);
+
+      // Close dropdown if it doesn't automatically close.
+      const isVisible = await this.isElementVisible(
+        navigationDropdownInMobileVisibleSelector
+      );
+      if (isVisible) {
+        // We are using page.click as this button might be overlapped by the
+        // dropdown. Thus, it will fail with onClick.
+        await this.clickOnElementWithSelector(dropdownToggleIcon);
+      }
     } else {
       await this.clickOnElementWithSelector(feedBackButtonTab);
       await this.waitForNetworkIdle();

--- a/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
@@ -110,6 +110,25 @@ const textInputInteractionOption =
   'tr[id^="e2e-test-schema-based-list-editor-table-row"]';
 const intEditorField = '.e2e-test-editor-int';
 
+const feedBackButtonTab = '.e2e-test-feedback-tab';
+const mobileFeedbackTabButton = '.e2e-test-mobile-feedback-button';
+const explorationFeedbackTabContentSelector = '.e2e-test-exploration-feedback-card';
+const explorationFeedbackCardActiveSelector =
+  '.e2e-test-exploration-feedback-card-active';
+const feedbackSubjectSelector = '.e2e-test-exploration-feedback-subject';
+const feedbackStatusSelector = '.e2e-test-exploration-feedback-status';
+const feedbackAuthorSelector = '.e2e-test-exploration-feedback-author';
+const startNewFeedbackButtonSelector = '.e2e-test-start-new-thread-button';
+const newFeedbackThreadModalSelector = 'oppia-create-feedback-thread-modal';
+const feedbackSubjectSelectorInNewFeedbackModal = `${newFeedbackThreadModalSelector} input`;
+const feedbackSelectorInNewFeedbackModal = `${newFeedbackThreadModalSelector} textarea`;
+const createThreadButtonSelector = '.e2e-test-create-new-feedback-btn';
+const responseTextareaSelector = '.e2e-test-feedback-response-textarea';
+const sendButtonSelector = '.e2e-test-oppia-feedback-response-send-btn';
+const feedbackTabBackButtonSelector = '.e2e-test-oppia-feedback-back-button';
+const feedbackStatusMenu = '.e2e-test-oppia-feedback-status-menu';
+const feedbackTabRowSelector = '.e2e-test-oppia-feedback-tab-row';
+
 const feedbackEditorSelector = '.e2e-test-open-feedback-editor';
 const correctAnswerInTheGroupSelector = '.e2e-test-editor-correctness-toggle';
 const addNewResponseButton = 'button.e2e-test-add-new-response';
@@ -1204,6 +1223,173 @@ export class ExplorationEditor extends BaseUser {
     }
 
     await this.expectElementToBeVisible(translationTabContainer);
+  }
+
+  /**
+   * Function to navigate to the feedback tab.
+   */
+  async navigateToFeedbackTab(): Promise<void> {
+    if (this.isViewportAtMobileWidth()) {
+      const mobileNavbarElement = await this.getElementInParent(
+        mobileNavbarOptions
+      ).catch(() => null);
+      if (!mobileNavbarElement) {
+        await this.clickOnElementWithSelector(mobileOptionsButtonSelector);
+        await this.expectElementToBeVisible(mobileNavbarDropdown);
+      }
+      await this.clickOnElementWithSelector(mobileNavbarDropdown);
+      await this.expectElementToBeVisible(mobileNavbarPane);
+      await this.clickOnElementWithSelector(mobileFeedbackTabButton);
+    } else {
+      await this.clickOnElementWithSelector(feedBackButtonTab);
+      await this.waitForNetworkIdle();
+    }
+
+    await this.expectElementToBeVisible(explorationFeedbackTabContentSelector);
+  }
+
+  /**
+   * Starts a new feedback thread on the exploration.
+   * @param {string} subject - The subject of the feedback thread.
+   * @param {string} feedback - The feedback message.
+   */
+  async startAFeedbackThread(subject: string, feedback: string): Promise<void> {
+    await this.expectElementToBeVisible(startNewFeedbackButtonSelector);
+    await this.clickOnElementWithSelector(startNewFeedbackButtonSelector);
+
+    await this.expectElementToBeVisible(newFeedbackThreadModalSelector);
+    await this.typeInInputField(
+      feedbackSubjectSelectorInNewFeedbackModal,
+      subject
+    );
+    await this.typeInInputField(feedbackSelectorInNewFeedbackModal, feedback);
+
+    await this.clickOnElementWithSelector(createThreadButtonSelector);
+    await this.expectElementToBeVisible(newFeedbackThreadModalSelector, false);
+  }
+
+  /**
+   * Verifies that a feedback thread with the given subject is present.
+   * @param {string} feedbackSubject - The feedback subject to verify.
+   */
+  async expectFeedbackThreadToBePresent(
+    feedbackSubject: string
+  ): Promise<void> {
+    await this.expectElementToBeVisible(feedbackSubjectSelector);
+    const feedbackSubjects = await this.page.$$eval(
+      feedbackSubjectSelector,
+      subjects => subjects.map(subject => subject.textContent)
+    );
+
+    if (!feedbackSubjects.includes(feedbackSubject)) {
+      throw new Error(
+        `Feedback thread with subject "${feedbackSubject}" not found.`
+      );
+    }
+  }
+
+  /**
+   * Views a feedback thread.
+   * @param {number} expectedThread - The 1-indexed position of the expected thread.
+   */
+  async viewFeedbackThread(expectedThread: number): Promise<void> {
+    // Reloading to make sure the feedback threads are updated.
+    await this.reloadPage();
+    await this.expectElementToBeVisible(feedbackSubjectSelector);
+    const feedbackSubjects = await this.page.$$(feedbackSubjectSelector);
+
+    if (expectedThread > 0 && expectedThread <= feedbackSubjects.length) {
+      await this.clickOnElement(feedbackSubjects[expectedThread - 1]);
+      await this.expectElementToBeVisible(explorationFeedbackCardActiveSelector);
+    } else {
+      throw new Error(`Expected thread not found: ${expectedThread}`);
+    }
+  }
+
+  /**
+   * Replies to a feedback thread.
+   * @param {string} reply - The reply message.
+   */
+  async replyToSuggestion(reply: string): Promise<void> {
+    await this.expectElementToBeVisible(responseTextareaSelector);
+    await this.typeInInputField(responseTextareaSelector, reply);
+    await this.clickOnElementWithSelector(sendButtonSelector);
+    await this.expectElementToBeClickable(sendButtonSelector, false);
+  }
+
+  /**
+   * Navigates back to the feedback tab from a feedback thread.
+   */
+  async goBackToTheFeedbackTab(): Promise<void> {
+    await this.expectElementToBeVisible(feedbackTabBackButtonSelector);
+    await this.clickOnElementWithSelector(feedbackTabBackButtonSelector);
+    await this.expectElementToBeVisible(feedbackTabBackButtonSelector, false);
+  }
+
+  /**
+   * Changes the status of the current feedback thread.
+   * @param {string} statusValue - The new status value to set for the feedback.
+   */
+  async changeFeedbackStatus(statusValue: string): Promise<void> {
+    await this.expectElementToBeVisible(responseTextareaSelector);
+    if (statusValue === 'ignored' || statusValue === 'not_actionable') {
+      await this.typeInInputField(responseTextareaSelector, statusValue);
+    }
+    await this.select(feedbackStatusMenu, statusValue);
+  }
+
+  /**
+   * Verifies that a feedback thread at the specified index has the expected status.
+   * @param {number} threadIndex - The 1-indexed position of the feedback thread.
+   * @param {string} expectedStatus - The status text expected for the feedback thread.
+   */
+  async expectFeedbackStatusInList(
+    threadIndex: number,
+    expectedStatus: string
+  ): Promise<void> {
+    await this.expectElementToBeVisible(feedbackTabRowSelector);
+    await this.page.waitForFunction(
+      ({
+        selector,
+        elementNumber,
+        expectedText,
+      }: {
+        selector: string;
+        elementNumber: number;
+        expectedText: string;
+      }) => {
+        const elements = document.querySelectorAll(selector);
+        return elements[elementNumber - 1]?.textContent?.trim() === expectedText;
+      },
+      {
+        selector: feedbackStatusSelector,
+        elementNumber: threadIndex,
+        expectedText: expectedStatus,
+      }
+    );
+  }
+
+  /**
+   * Verifies that the feedback author is as expected.
+   * @param {string} expectedAuthor - The expected author.
+   */
+  async expectFeedbackAuthorToBe(expectedAuthor: string): Promise<void> {
+    await this.expectElementToBeVisible(feedbackAuthorSelector);
+    const feedbackAuthors = await this.page.$$(feedbackAuthorSelector);
+
+    if (feedbackAuthors.length === 0) {
+      throw new Error('Feedback author not found.');
+    }
+
+    const authorText = await feedbackAuthors[0].evaluate(el =>
+      el.textContent?.trim()
+    );
+
+    if (authorText !== expectedAuthor) {
+      throw new Error(
+        `Expected feedback author to be "${expectedAuthor}", but found "${authorText}".`
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview

1. This PR fixes part of #26799.
2. This PR migrates `exploration-creator/exploration-feedback.spec.ts` from Puppeteer to Playwright, as part of the broader acceptance-test migration tracked in #26799:
   - Removes `core/tests/puppeteer-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts`.
   - Adds `core/tests/playwright-acceptance-tests/specs/exploration-creator/exploration-feedback.spec.ts`, covering the same CUJ: starting a feedback thread, verifying its status/author, viewing the thread, replying, changing status to "fixed", and verifying the updated status.
   - Adds the corresponding feedback-tab utility methods (`navigateToFeedbackTab`, `startAFeedbackThread`, `viewFeedbackThread`, `replyToSuggestion`, `changeFeedbackStatus`, `goBackToTheFeedbackTab`, and related assertions) to `playwright-acceptance-tests/utilities/user/exploration-editor.ts`.
   - Updates the `framework` field for this suite to `"playwright"` in `acceptance.json`.
   - Fixes a `page.waitForNavigation` timeout flake (see below) found during the required stress-test run.
3. (Bug-fixing part) The original bug occurred because: `BaseUser.signInWithEmail()` used the deprecated `clickAndWaitForNavigation()` helper, which waits on `page.waitForNavigation({waitUntil: 'networkidle'})`. During a 200-run stress test on this branch (https://github.com/bhuvan-somisetty/oppia/actions/runs/34068048030), one desktop run timed out after 60s at that call, even though the post-login redirect to the username-selection page had already completed — `networkidle` never resolved because of ongoing background network activity. Since the only caller, `signUpNewUser()`, immediately needs the username input field to be ready, `signInWithEmail()` now waits directly on that selector instead of on the flaky navigation event. This is a shared helper used by every Playwright acceptance test that creates a user, so the fix benefits the whole Playwright suite, not just this spec.

## Testing

- `npx tsc --noEmit` passes with no errors for the full `playwright-acceptance-tests` project.
- Desktop and mobile runs for this suite were verified via GitHub Actions on my fork (linked in the issue thread).
- A 200-run stress test (100 desktop + 100 mobile) was run on this branch before the fix; 199/200 passed, with the single failure being the `waitForNavigation` timeout addressed here. I will re-run the stress test after this fix and share the link before requesting final review, per the issue's process.
- I was not able to run the full local acceptance-test stack (GAE dev server, emulators, etc.) in this environment, so I'm relying on the GitHub Actions stress-test workflow as the source of truth for end-to-end verification, consistent with the issue's stated process.

## Impact

- No production code is touched; this is a test-infrastructure-only change.
- The `signInWithEmail` fix is scoped to its single current caller (`signUpNewUser`) and does not change behavior for any other flow.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code (the new `exploration-feedback.spec.ts` acceptance test covers the feedback CUJ end-to-end).
- [x] The PR title starts with "Fix part of #26799: ...".
- [ ] Reviewers will be assigned automatically via CODEOWNERS (`@oppia/acceptance-test-reviewers`). @jayam04 PTAL.

## Proof that changes are correct

This is a test-infrastructure change with no user-facing UI, so no before/after screenshots apply. Proof of correctness is the passing acceptance-test run (desktop + mobile) and the stress-test run linked above/to follow.
