### PR TITLE
Fix N/A: Fix typos in comments, docstrings, and error messages

### DIFF
--- a/core/controllers/acl_decorators.py
+++ b/core/controllers/acl_decorators.py
@@ -1286,7 +1286,7 @@ def can_manage_contributors_role(
 
         Raises:
             NotLoggedInException. The user is not logged in.
-            UnauthorizedUserException. The user cannnot modify contributor's
+            UnauthorizedUserException. The user cannot modify contributor's
                 role for the contributor dashboard page.
         """
         if not self.user_id:

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -75,7 +75,7 @@ from core.domain import (
 
 from typing import Dict, List, Optional, TypedDict, Union, cast
 
-# Platform paramters that we plan to show on the the release-coordinator page.
+# Platform parameters that we plan to show on the the release-coordinator page.
 PLATFORM_PARAMS_TO_SHOW_IN_RC_PAGE = set(
     [
         platform_parameter_list.ParamName.PROMO_BAR_ENABLED.value,
@@ -3608,7 +3608,7 @@ class InteractionsByExplorationIdHandler(
         InteractionsByExplorationIdHandlerNormalizedRequestDict, Dict[str, str]
     ]
 ):
-    """Handler for admin to retrive the list of interactions used in
+    """Handler for admin to retrieve the list of interactions used in
     an exploration.
     """
 

--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -305,7 +305,7 @@ class CronAppFeedbackReportsScrubberHandlerPage(
         """Handles GET requests to scrub reports. This cron handler scrubs all
         app feedback report models that are expiring; expired reports have a
         created_on field at least feconf.APP_FEEDBACK_REPORT_MAX_NUMBER_OF_DAYS
-        before tthe date this services is called.
+        before the date this services is called.
         """
         app_feedback_report_services.scrub_all_unscrubbed_expiring_reports(
             feconf.APP_FEEDBACK_REPORT_SCRUBBER_BOT_ID

--- a/core/controllers/moderator.py
+++ b/core/controllers/moderator.py
@@ -81,7 +81,7 @@ class FeaturedActivitiesHandler(
         ]
 
         try:
-            # Retrieve the list for each type of inavlid ID.
+            # Retrieve the list for each type of invalid ID.
             (
                 non_existent_exploration_ids,
                 non_existent_collection_ids,

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1508,7 +1508,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
             tags: list(str). The tags given to the exploration.
             blurb: str. The blurb of the exploration.
             author_notes: str. The author notes.
-            states_schema_version: int. Tbe schema version of the exploration.
+            states_schema_version: int. The schema version of the exploration.
             init_state_name: str. The name for the initial state of the
                 exploration.
             states_dict: dict. A dict where each key-value pair represents,
@@ -1645,7 +1645,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
         empty list; 'states_schema_version' is taken from feconf; 'states_dict'
         is derived from feconf; 'param_specs_dict' is an empty dict; 'blurb' and
         'author_notes' are initialized to empty string; 'version' is
-        initializated to 0.
+        initialized to 0.
 
         Args:
             exploration_id: str. The id of the exploration.
@@ -1752,7 +1752,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
             if state_name != init_state_name:
                 exploration.add_state(
                     state_name,
-                    # These are placeholder values which will be repalced with
+                    # These are placeholder values which will be replaced with
                     # correct values below.
                     '<placeholder1>',
                     '<placeholder2>',
@@ -3111,7 +3111,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
 
         Args:
             states_dict: dict. A dict where each key-value pair represents,
-                respectively, a state name and a dict used to initalize a
+                respectively, a state name and a dict used to initialize a
                 State domain object.
             init_state_name: str. Name of the first state.
 
@@ -3212,7 +3212,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
         cls, states_dict: Dict[str, state_domain.StateDict]
     ) -> Dict[str, state_domain.StateDict]:
         """Converts from version 46 to 47. Version 52 deprecates
-        oppia-noninteractive-svgdiagram tag and converts existing occurences of
+        oppia-noninteractive-svgdiagram tag and converts existing occurrences of
         it to oppia-noninteractive-image tag.
 
         Args:
@@ -4827,7 +4827,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
         """Fixes the TextInput interaction with following checks:
         - The rules should not be duplicate else the one with not pointing to
         different state will be deleted
-        - Text input height shoule be >= 1 and <= 10 else we will replace with
+        - Text input height should be >= 1 and <= 10 else we will replace with
         10
         - `Contains` should always come after another `Contains` rule where
         the first contains rule strings is a substring of the other contains
@@ -4865,7 +4865,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
             int,
             state_dict['interaction']['customization_args']['rows']['value'],
         )
-        # Text input height shoule be >= 1 and <= 10.
+        # Text input height should be >= 1 and <= 10.
         if rows_value < 1:
             state_dict['interaction']['customization_args']['rows']['value'] = 1
         if rows_value > 10:
@@ -5697,7 +5697,7 @@ class Exploration(translation_domain.BaseTranslatableObject):
     ) -> VersionedExplorationDict:
         """Converts a v51 exploration dict into a v52 exploration dict.
         Version 52 deprecates oppia-noninteractive-svgdiagram tag and converts
-        existing occurences of it to oppia-noninteractive-image tag.
+        existing occurrences of it to oppia-noninteractive-image tag.
 
         Args:
             exploration_dict: dict. The dict representation of an exploration
@@ -7118,7 +7118,7 @@ class ExplorationMetadata:
             tags: list(str). The tags given to the exploration.
             blurb: str. The blurb of the exploration.
             author_notes: str. The author notes.
-            states_schema_version: int. Tbe schema version of the exploration.
+            states_schema_version: int. The schema version of the exploration.
             init_state_name: str. The name for the initial state of the
                 exploration.
             param_specs: dict(str, ParamSpec). A dict where each key-value pair

--- a/core/domain/exp_fetchers.py
+++ b/core/domain/exp_fetchers.py
@@ -338,7 +338,7 @@ def get_exploration_summary_from_model(
             instance.
 
     Returns:
-        ExplorationSummary. The summary domain object correspoding to the
+        ExplorationSummary. The summary domain object corresponding to the
         given exploration summary model.
     """
 
@@ -612,7 +612,7 @@ def get_exploration_user_data(
 
     Returns:
         ExplorationUserData or None. The domain object corresponding to the
-        given user and exploration. If the model corresponsing to given user
+        given user and exploration. If the model corresponding to given user
         and exploration is not found, return None.
     """
     exp_user_data_model = user_models.ExplorationUserDataModel.get(

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Funtions to create, accept, reject, update and perform other operations on
+"""Functions to create, accept, reject, update and perform other operations on
 suggestions.
 """
 
@@ -1742,7 +1742,7 @@ def _get_plain_text_from_html_content_string(html_content_string: str) -> str:
         corresponding rte component name in square brackets.
 
         Args:
-            rte_tag: MatchObject. A matched object that contins the
+            rte_tag: MatchObject. A matched object that contains the
                 oppia-noninteractive rte tags.
 
         Returns:
@@ -1768,7 +1768,7 @@ def _get_plain_text_from_html_content_string(html_content_string: str) -> str:
         # If the component name is more than word, connect the words with spaces
         # to create a single string.
         rte_component_name_string = ' '.join(rte_component_name_string_list)
-        # Captialize each word in the string.
+        # Capitalize each word in the string.
         capitalized_rte_component_name_string = (
             rte_component_name_string.title()
         )

--- a/core/domain/translation_domain.py
+++ b/core/domain/translation_domain.py
@@ -280,7 +280,7 @@ class TranslatableContentsCollection:
         Args:
             translatable_object: BaseTranslatableObject. An instance of
                 BaseTranslatableObject class.
-            **kwargs: *. The keyword args for registring translatable object.
+            **kwargs: *. The keyword args for registering translatable object.
         """
         self.content_id_to_translatable_content.update(
             translatable_object.get_translatable_contents_collection(
@@ -381,7 +381,7 @@ class BaseTranslatableObject:
         entity_translation: EntityTranslation,
         override_metadata_feature_flag: bool = False,
     ) -> int:
-        """Returs the number of updated translations avialable.
+        """Returns the number of updated translations available.
 
         Args:
             entity_translation: EntityTranslation. The translation object
@@ -390,7 +390,7 @@ class BaseTranslatableObject:
                 metadata feature flag check.
 
         Returns:
-            int. The number of translatable contnet for which translations are
+            int. The number of translatable content for which translations are
             available in the given translation object.
         """
         count = 0
@@ -410,7 +410,7 @@ class BaseTranslatableObject:
         entity_translation: EntityTranslation,
         override_metadata_feature_flag: bool = False,
     ) -> bool:
-        """Whether the given EntityTranslation in the given lanaguage is
+        """Whether the given EntityTranslation in the given language is
         displayable.
 
         A language's translations are ready to be displayed if there are less
@@ -653,31 +653,31 @@ class EntityTranslation:
         """
         if not isinstance(self.entity_type, str):
             raise utils.ValidationError(
-                'entity_type must be a string, recieved %r' % self.entity_type
+                'entity_type must be a string, received %r' % self.entity_type
             )
         if not isinstance(self.entity_id, str):
             raise utils.ValidationError(
-                'entity_id must be a string, recieved %r' % self.entity_id
+                'entity_id must be a string, received %r' % self.entity_id
             )
         if not isinstance(self.entity_version, int):
             raise utils.ValidationError(
-                'entity_version must be an int, recieved %r'
+                'entity_version must be an int, received %r'
                 % self.entity_version
             )
         if not isinstance(self.language_code, str):
             raise utils.ValidationError(
-                'language_code must be a string, recieved %r'
+                'language_code must be a string, received %r'
                 % self.language_code
             )
 
         for content_id, translated_content in self.translations.items():
             if not isinstance(content_id, str):
                 raise utils.ValidationError(
-                    'content_id must be a string, recieved %r' % content_id
+                    'content_id must be a string, received %r' % content_id
                 )
             if not isinstance(translated_content.needs_update, bool):
                 raise utils.ValidationError(
-                    'needs_update must be a bool, recieved %r'
+                    'needs_update must be a bool, received %r'
                     % translated_content.needs_update
                 )
 

--- a/core/platform/auth/firebase_auth_services.py
+++ b/core/platform/auth/firebase_auth_services.py
@@ -148,7 +148,7 @@ def establish_auth_session(
         max_age=feconf.FIREBASE_SESSION_COOKIE_MAX_AGE,
         overwrite=True,
         # Toggles https vs http. The production server uses https, but the local
-        # developement server uses http.
+        # development server uses http.
         secure=(not constants.EMULATOR_MODE),
         # Using the HttpOnly flag when generating a cookie helps mitigate the
         # risk of client side script accessing the protected cookie (if the

--- a/core/storage/improvements/gae_models.py
+++ b/core/storage/improvements/gae_models.py
@@ -60,7 +60,7 @@ class ExplorationStatsTaskEntryModel(base_models.BaseModel):
     """
 
     # Utility field which results in a 20% speedup compared to querying by each
-    # of the invididual fields used to compose it.
+    # of the individual fields used to compose it.
     # Value has the form: "[entity_type].[entity_id].[entity_version]".
     composite_entity_id = datastore_services.StringProperty(
         required=True, indexed=True


### PR DESCRIPTION
## Overview

1. This PR fixes N/A (no corresponding issue) or fixes part of N/A. There is no issue for this change: it is a small spelling-cleanup pass.
2. This PR does the following: Fixes a set of genuine misspellings in code comments, docstrings, and a few user-facing validation error messages. The misspelled words are corrected to their standard spellings (for example `cannnot` -> `cannot`, `paramters` -> `parameters`, `Tbe` -> `The`, `occurences` -> `occurrences`, `recieved` -> `received`, and `Funtions` -> `Functions`). No behavior, logic, or meaning changes are made; only the spelling is corrected.
3. (For bug-fixing PRs only) The original bug occurred because: N/A - not a bug fix.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar. (No issue applies - there is no corresponding issue.)
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code. (Not applicable: this change only corrects spelling in comments, docstrings, and error-message strings. There is no behavior to test.)
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes. (No issue number applies - there is no corresponding issue.)
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

N/A - no Beam jobs or production server data changes.

## Proof that changes are correct

The changes in this PR are limited to spelling corrections in code comments, docstrings, and validation error-message strings.

There is no behavioral change, so screenshots of the user-facing interface are not applicable.

The corrected spellings were verified against standard English and match the spelling dialect already used across the rest of the codebase.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.

Drafted with AI assistance; I found the errors, verified each one against the current code, and reviewed the diff line by line.
