### PR TITLE
Fix #27359: Mock Azure SDK in invalid credentials TTS test

### DIFF
--- a/core/platform/speech_synthesis/azure_speech_synthesis_services_test.py
+++ b/core/platform/speech_synthesis/azure_speech_synthesis_services_test.py
@@ -194,19 +194,55 @@ class AzureSpeechSynthesisTests(test_utils.GenericTestBase):
         self.assertEqual(result_audio_offsets, mock_word_boundaries)
         self.assertIsNone(result_error)
 
+    @mock.patch('azure.cognitiveservices.speech.SpeechSynthesizer')
+    @mock.patch('azure.cognitiveservices.speech.SpeechConfig')
+    @mock.patch(
+        'core.platform.speech_synthesis.'
+        'azure_speech_synthesis_services.WordBoundaryCollection'
+    )
     def test_regenerate_speech_from_text_failed_for_invalid_credentials(
         self,
+        mock_word_boundary_collection: mock.Mock,
+        mock_speech_config: mock.Mock,
+        mock_speech_synthesizer: mock.Mock,
     ) -> None:
         plaintext = 'This is a test text'
         language_accent_code = 'en-US'
-
         mock_audio_data = None
-        mock_word_boundaries: List[Dict[str, Union[str, float]]] = []
-        mock_error_details = (
+
+        mock_speech_config_instance = mock_speech_config.return_value
+        mock_speech_config_instance.set_speech_synthesis_output_format = (
+            mock.MagicMock()
+        )
+        mock_speech_synthesizer_instance = mock_speech_synthesizer.return_value
+        mock_speech_synthesis_result = mock.MagicMock()
+        mock_speech_synthesis_result.audio_data = mock_audio_data
+        mock_cancellation_details = mock.MagicMock()
+
+        error_details = (
             'WebSocket upgrade failed: Authentication error (401). '
             'Please check subscription information and region name. USP state: '
             'Sending. Received audio size: 0 bytes.'
         )
+        mock_cancellation_details.reason = speechsdk.CancellationReason.Error
+        mock_cancellation_details.error_details = error_details
+        # Not one of the retryable error codes (TooManyRequests,
+        # ConnectionFailure, ServiceTimeout), so it fails fast without retrying.
+        mock_cancellation_details.error_code = (
+            speechsdk.CancellationErrorCode.AuthenticationFailure
+        )
+
+        mock_speech_synthesis_result.reason = speechsdk.ResultReason.Canceled
+        mock_speech_synthesis_result.cancellation_details = (
+            mock_cancellation_details
+        )
+        (
+            mock_speech_synthesizer_instance.speak_ssml_async.return_value.get.return_value
+        ) = mock_speech_synthesis_result
+        mock_word_boundary_instance = mock.MagicMock()
+        mock_word_boundaries: List[Dict[str, Union[str, float]]] = []
+        mock_word_boundary_instance.audio_offset_list = mock_word_boundaries
+        mock_word_boundary_collection.return_value = mock_word_boundary_instance
 
         with self.swap_api_key_secrets_return_secret:
             result_binary_data, result_audio_offsets, result_error = (
@@ -217,7 +253,7 @@ class AzureSpeechSynthesisTests(test_utils.GenericTestBase):
 
         self.assertEqual(result_binary_data, mock_audio_data)
         self.assertEqual(result_audio_offsets, mock_word_boundaries)
-        self.assertEqual(result_error, mock_error_details)
+        self.assertEqual(result_error, error_details)
 
     @mock.patch('azure.cognitiveservices.speech.SpeechSynthesizer')
     @mock.patch('azure.cognitiveservices.speech.SpeechConfig')


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
You should delete either `fixes` or `fixes part of` so that line 1 reads
`This PR fixes #123.` or `This PR fixes part of #123.`, where `#123` is replaced
with the issue(s) addressed.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/27359
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: test_regenerate_speech_from_text_failed_for_invalid_credentials was the only failure-path test not mocking SpeechSynthesizer/SpeechConfig,so it attempted a real connection to Azure's TTS endpoint instead of simulating a 401 auth error. In CI this produced a connection-failure message instead of the expected authentication-error message, causing the assertion to fail. Mock the SDK and cancellation details the same way the other failure tests do.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->



## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
