### PR TITLE
Fix part of #26746: Migrate exploration preview test to Playwright

### DIFF
--- a/core/tests/ci-test-suite-configs/acceptance.json
+++ b/core/tests/ci-test-suite-configs/acceptance.json
@@ -102,8 +102,8 @@
     },
     {
       "name": "exploration-editor/load-complete-and-restart-exploration-preview",
-      "module": "core/tests/puppeteer-acceptance-tests/specs/exploration-editor/load-complete-and-restart-exploration-preview.spec.ts",
-      "framework": "puppeteer"
+      "module": "core/tests/playwright-acceptance-tests/specs/exploration-editor/load-complete-and-restart-exploration-preview.spec.ts",
+      "framework": "playwright"
     },
     {
       "name": "exploration-editor/manage-exploration-misconceptions",

--- a/core/tests/playwright-acceptance-tests/specs/exploration-editor/load-complete-and-restart-exploration-preview.spec.ts
+++ b/core/tests/playwright-acceptance-tests/specs/exploration-editor/load-complete-and-restart-exploration-preview.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use explorationEditor file except in compliance with the License.
+// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //      http://www.apache.org/licenses/LICENSE-2.0
@@ -15,15 +15,13 @@
 /**
  * @fileoverview Acceptance Test for preview tab in exploration editor.
  */
+import {test} from '@playwright/test';
 import {UserFactory} from '../../utilities/common/user-factory';
-import testConstants from '../../utilities/common/test-constants';
 import {
   ExplorationEditor,
   INTERACTION_TYPES,
 } from '../../utilities/user/exploration-editor';
 
-const DEFAULT_SPEC_TIMEOUT_MSECS: number =
-  testConstants.DEFAULT_SPEC_TIMEOUT_MSECS;
 const INTRODUCTION_CARD_CONTENT: string =
   'This exploration will test your understanding of negative numbers.';
 
@@ -33,13 +31,16 @@ enum CARD_NAME {
   FINAL_CARD = 'Final Card',
 }
 
-describe('Exploration Editor', function () {
+test.describe.configure({mode: 'serial'});
+
+test.describe('Exploration Editor', function () {
   let explorationEditor: ExplorationEditor;
 
-  beforeAll(async function () {
+  test.beforeAll(async function ({browser}) {
     explorationEditor = await UserFactory.createNewUser(
       'explorationEditor',
-      'exploration_editor@example.com'
+      'exploration_editor@example.com',
+      browser
     );
     // Navigate to the creator dashboard and create a new exploration.
     await explorationEditor.navigateToCreatorDashboardPage();
@@ -60,7 +61,7 @@ describe('Exploration Editor', function () {
     await explorationEditor.addResponsesToTheInteraction(
       INTERACTION_TYPES.NUMBER_INPUT,
       '-1',
-      'Prefect!',
+      'Perfect!',
       CARD_NAME.FINAL_CARD,
       true
     );
@@ -76,37 +77,41 @@ describe('Exploration Editor', function () {
     // Navigate back to the introduction card and save the draft.
     await explorationEditor.navigateToCard(CARD_NAME.INTRODUCTION);
     await explorationEditor.saveExplorationDraft();
-  }, DEFAULT_SPEC_TIMEOUT_MSECS);
+  });
 
-  it(
-    'should be able to load, complete and restart an exploration preview',
-    async function () {
-      // Navigate to the preview tab and check the content of the first card.
-      await explorationEditor.navigateToPreviewTab();
-      await explorationEditor.expectPreviewCardContentToBe(
-        CARD_NAME.INTRODUCTION,
-        INTRODUCTION_CARD_CONTENT
-      );
+  test('should be able to load, complete and restart an exploration preview', async function () {
+    // Navigate to the preview tab and check the content of the first card.
+    await explorationEditor.navigateToPreviewTab();
+    await explorationEditor.expectPreviewCardContentToBe(
+      CARD_NAME.INTRODUCTION,
+      INTRODUCTION_CARD_CONTENT
+    );
 
-      // Continue to the next card, enter an answer, and submit it.
-      await explorationEditor.continueToNextCard();
-      await explorationEditor.submitAnswer('-40');
-      await explorationEditor.continueToNextCard();
+    // Continue to the next card, enter an answer, and submit it.
+    await explorationEditor.continueToNextCardAsExplorationEditor();
+    await explorationEditor.expectPreviewCardContentToBe(
+      CARD_NAME.TEST_QUESTION,
+      'Enter a negative number.'
+    );
+    await explorationEditor.submitNumberAnswerInPreview('-40');
+    await explorationEditor.continueToNextCardAsExplorationEditor();
+    await explorationEditor.expectPreviewCardContentToBe(
+      CARD_NAME.FINAL_CARD,
+      'We have practiced negative numbers.'
+    );
 
-      // Check the completion message and restart the exploration.
-      await explorationEditor.expectPreviewCompletionToastMessage(
-        'Congratulations for completing this lesson!'
-      );
-      await explorationEditor.restartPreview();
-      await explorationEditor.expectPreviewCardContentToBe(
-        CARD_NAME.INTRODUCTION,
-        INTRODUCTION_CARD_CONTENT
-      );
-    },
-    DEFAULT_SPEC_TIMEOUT_MSECS
-  );
+    // Check the completion message and restart the exploration.
+    await explorationEditor.expectPreviewCompletionToastMessage(
+      'Congratulations for completing this lesson!'
+    );
+    await explorationEditor.restartPreview();
+    await explorationEditor.expectPreviewCardContentToBe(
+      CARD_NAME.INTRODUCTION,
+      INTRODUCTION_CARD_CONTENT
+    );
+  });
 
-  afterAll(async function () {
+  test.afterAll(async function () {
     await UserFactory.closeAllBrowsers();
   });
 });

--- a/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
+++ b/core/tests/playwright-acceptance-tests/utilities/user/exploration-editor.ts
@@ -16,7 +16,7 @@
  * @fileoverview Utility functions for the Exploration Editor page.
  */
 
-import {Page, ElementHandle} from '@playwright/test';
+import {Page, ElementHandle, expect} from '@playwright/test';
 import {BaseUser} from '../common/playwright-utils';
 import testConstants from '../common/test-constants';
 import {showMessage} from '../common/show-message';
@@ -120,6 +120,13 @@ const mobileNavbarPane = '.oppia-exploration-editor-tabs-dropdown';
 const mobileTranslationTabButton = '.e2e-test-mobile-translation-tab';
 const mainTabButton = '.e2e-test-main-tab';
 const mobileMainTabButton = '.e2e-test-mobile-main-tab';
+const previewTabButton = '.e2e-test-preview-tab';
+const mobilePreviewTabButton = '.e2e-test-mobile-preview-button';
+const previewTabContainer = '.e2e-test-preview-tab-container';
+const previewRestartButton = '.e2e-test-preview-restart-button';
+const stateConversationContent = '.e2e-test-conversation-content';
+const explorationCompletionToastMessage = '.e2e-test-lesson-completion-message';
+const previousCardButton = '.e2e-test-back-button';
 const mainTabContainerSelector = '.e2e-test-exploration-main-tab';
 const navigationDropdownInMobileVisibleSelector =
   '.oppia-exploration-editor-tabs-dropdown.show';
@@ -218,6 +225,77 @@ export const INTERACTION_TABS_OF_INTERACTION_TYPE: Record<string, string> = {
 } as const;
 
 export class ExplorationEditor extends BaseUser {
+  /**
+   * Opens the exploration preview on desktop or mobile.
+   */
+  async navigateToPreviewTab(): Promise<void> {
+    if (this.isViewportAtMobileWidth()) {
+      if (!(await this.page.locator(mobileNavbarOptions).isVisible())) {
+        await this.page.locator(mobileOptionsButtonSelector).click();
+      }
+      if (!(await this.page.locator(`${mobileNavbarPane}.show`).isVisible())) {
+        await this.page.locator(mobileNavbarDropdown).click();
+      }
+      await this.page.locator(mobilePreviewTabButton).click();
+    } else {
+      await this.page.locator(previewTabButton).click();
+    }
+    await expect(this.page).toHaveURL(/#\/preview\//);
+    await expect(this.page.locator(previewTabContainer)).toBeVisible();
+  }
+
+  /**
+   * Checks the content of the current preview card.
+   * @param {string} cardName - The card name to include in assertion failures.
+   * @param {string} expectedCardContent - The expected card content.
+   */
+  async expectPreviewCardContentToBe(
+    cardName: string,
+    expectedCardContent: string
+  ): Promise<void> {
+    await expect(
+      this.page.locator(stateConversationContent),
+      `Preview content for ${cardName}`
+    ).toHaveText(expectedCardContent);
+  }
+
+  /**
+   * Submits a numeric answer in the exploration preview.
+   * @param {string} answer - The answer to submit.
+   */
+  async submitNumberAnswerInPreview(answer: string): Promise<void> {
+    await this.page.locator(floatFormInput).fill(answer);
+    await this.page.locator(submitAnswerButton).click();
+  }
+
+  /**
+   * Checks the preview completion message and waits for it to disappear.
+   * @param {string} message - The expected completion message.
+   */
+  async expectPreviewCompletionToastMessage(message: string): Promise<void> {
+    const completionMessage = this.page.locator(
+      explorationCompletionToastMessage
+    );
+    await expect(completionMessage).toBeVisible();
+    await expect(completionMessage).toContainText(message);
+    await expect(completionMessage).toBeHidden();
+  }
+
+  /**
+   * Restarts the preview after completing the exploration.
+   */
+  async restartPreview(): Promise<void> {
+    // Collapse the mobile navigation bar so it does not cover Restart.
+    if (
+      this.isViewportAtMobileWidth() &&
+      (await this.page.locator(mobileNavbarOptions).isVisible())
+    ) {
+      await this.page.locator(mobileOptionsButtonSelector).click();
+    }
+    await this.page.locator(previewRestartButton).click();
+    await expect(this.page.locator(previousCardButton)).toBeHidden();
+  }
+
   /**
    * Navigate to creator dashboard page.
    */


### PR DESCRIPTION
This PR fixes part of #26746.\n\nIt migrates load-complete-and-restart-exploration-preview.spec.ts from Puppeteer to Playwright, updates acceptance.json to use the Playwright framework, and adds the preview navigation, content, answer submission, completion, and restart helpers required by the spec.\n\nValidation:\n- TypeScript compilation passed with the repository's existing ignoreDeprecations setting overridden for the installed compiler.\n- Playwright desktop and mobile test discovery passed.\n- Full acceptance execution is pending because the local WSL service installation could not complete in this environment.\n- Stress-test workflow will be run once the branch workflow is available in the fork.