### PR TITLE
Fix #13548: Enable solution fields for missing interactions

### DIFF
--- a/extensions/interactions/interaction_specs.json
+++ b/extensions/interactions/interaction_specs.json
@@ -206,7 +206,7 @@
     }
   },
   "ItemSelectionInput": {
-    "can_have_solution": false,
+    "can_have_solution": true,
     "show_generic_submit_button": true,
     "instructions": null,
     "is_trainable": false,
@@ -627,7 +627,7 @@
     }
   },
   "MultipleChoiceInput": {
-    "can_have_solution": false,
+    "can_have_solution": true,
     "show_generic_submit_button": true,
     "instructions": null,
     "is_trainable": false,


### PR DESCRIPTION
### Overview

1. This PR fixes #13548.
2. This PR does the following: Enables solution fields for missing interactions.
3. The original bug occurred because: Solution fields were not properly enabled or accounted for in these specific interactions.

### Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).