### PR TITLE
Fix #27381 :  MathEquationInput crash when an answer contains no '=' sign

### DIFF
--- a/core/templates/pages/exploration-player-page/services/exploration-engine.service.spec.ts
+++ b/core/templates/pages/exploration-player-page/services/exploration-engine.service.spec.ts
@@ -1024,6 +1024,54 @@ describe('Exploration engine service ', () => {
       }
     );
 
+    it('should not stay stuck if answer classification throws an error', fakeAsync(() => {
+      let initSuccessCb = jasmine.createSpy('success');
+      let submitAnswerSuccessCb = jasmine.createSpy('success');
+      let answer = 'answer';
+      let lastCard = StateCard.createNewCard(
+        'Card 1',
+        'Content html',
+        'Interaction text',
+        jasmine.createSpyObj('Interaction', ['']),
+        'content_id'
+      );
+
+      spyOn(playerTranscriptService, 'getLastCard').and.returnValue(lastCard);
+      spyOn(alertsService, 'addWarning');
+      spyOn(
+        answerClassificationService,
+        'getMatchingClassificationResult'
+      ).and.throwError(
+        "Cannot read properties of undefined (reading 'replace')"
+      );
+
+      explorationEngineService.init(
+        explorationDict,
+        1,
+        null,
+        true,
+        ['en'],
+        [],
+        initSuccessCb
+      );
+      tick();
+
+      const isAnswerCorrect = explorationEngineService.submitAnswer(
+        answer,
+        textInputService,
+        submitAnswerSuccessCb
+      );
+
+      expect(isAnswerCorrect).toBeFalse();
+      // The processing flag must be reset so that the learner is not
+      // permanently stuck on the card in a loading state.
+      expect(explorationEngineService.answerIsBeingProcessed).toBeFalse();
+      expect(alertsService.addWarning).toHaveBeenCalledWith(
+        'Something went wrong while processing your answer. Please try again.'
+      );
+      expect(submitAnswerSuccessCb).not.toHaveBeenCalled();
+    }));
+
     it('should show warning if interaction for the next state if stuck is not defined', fakeAsync(() => {
       const submitAnswerSuccessCb = jasmine.createSpy('submitSuccess');
 

--- a/core/templates/pages/exploration-player-page/services/exploration-engine.service.ts
+++ b/core/templates/pages/exploration-player-page/services/exploration-engine.service.ts
@@ -725,13 +725,25 @@ export class ExplorationEngineService {
     let oldStateName: string = this.playerTranscriptService.getLastStateName();
     let oldState: State = this.exploration.getState(oldStateName);
     let oldStateCard: StateCard = this.playerTranscriptService.getLastCard();
-    let classificationResult: AnswerClassificationResult =
-      this.answerClassificationService.getMatchingClassificationResult(
-        oldStateName,
-        oldStateCard.getInteraction(),
-        answer,
-        interactionRulesService
+    let classificationResult: AnswerClassificationResult;
+    try {
+      classificationResult =
+        this.answerClassificationService.getMatchingClassificationResult(
+          oldStateName,
+          oldStateCard.getInteraction(),
+          answer,
+          interactionRulesService
+        );
+    } catch (e: unknown) {
+      // Reset the processing flag so that the learner is not left stuck on the
+      // card if classification throws an error (for example, due to a rule
+      // function crashing on a malformed answer).
+      this.answerIsBeingProcessed = false;
+      this.alertsService.addWarning(
+        'Something went wrong while processing your answer. Please try again.'
       );
+      return false;
+    }
     let answerIsCorrect: boolean =
       classificationResult.outcome.labelledAsCorrect;
 

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.spec.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.spec.ts
@@ -536,4 +536,37 @@ describe('Math equation input rules service', () => {
       meirs.IsEquivalentTo('(13 + 2*w)^2 = 1156', {x: inputString})
     ).toBeFalse();
   });
+
+  it('should not throw when the answer or input is not an equation', () => {
+    // A learner's answer can reach the rules service without an '=' sign if
+    // validation is bypassed (for example when the answer is submitted via
+    // the Enter key). A rule input can also lack an '=' sign if it was
+    // created before the editor validation existed. These cases should be
+    // handled gracefully rather than crashing with an error.
+    expect(() =>
+      meirs.MatchesExactlyWith('v', {x: 'v=1', y: 'rhs'})
+    ).not.toThrow();
+    expect(meirs.MatchesExactlyWith('v', {x: 'v=1', y: 'rhs'})).toBeFalse();
+    expect(meirs.MatchesExactlyWith('v=1', {x: 'v', y: 'rhs'})).toBeFalse();
+    expect(
+      meirs.MatchesExactlyWith('v', {x: 'v=1', y: 'irrelevant'})
+    ).toBeFalse();
+
+    expect(() =>
+      meirs.MatchesUpToTrivialManipulations('v', {x: 'v=1', y: 'rhs'})
+    ).not.toThrow();
+    expect(
+      meirs.MatchesUpToTrivialManipulations('v', {x: 'v=1', y: 'rhs'})
+    ).toBeFalse();
+    expect(
+      meirs.MatchesUpToTrivialManipulations('v=1', {x: 'v', y: 'rhs'})
+    ).toBeFalse();
+
+    expect(() => meirs.IsEquivalentTo('v', {x: 'v=1'})).not.toThrow();
+    expect(meirs.IsEquivalentTo('v', {x: 'v=1'})).toBeFalse();
+    expect(meirs.IsEquivalentTo('v=1', {x: 'v'})).toBeFalse();
+    // Equations with an empty side are also treated as invalid.
+    expect(meirs.IsEquivalentTo('=v', {x: 'v=1'})).toBeFalse();
+    expect(meirs.IsEquivalentTo('v=1', {x: 'v='})).toBeFalse();
+  });
 });

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.ts
@@ -47,11 +47,14 @@ export class MathEquationInputRulesService {
 
     let positionOfTerms = inputs.y;
 
-    let splitAnswer = answer.split('=');
+    let splitAnswer = this._getEquationParts(answer);
+    let splitInput = this._getEquationParts(inputs.x);
+    if (splitAnswer === null || splitInput === null) {
+      return false;
+    }
     let lhsAnswer = splitAnswer[0];
     let rhsAnswer = splitAnswer[1];
 
-    let splitInput = inputs.x.split('=');
     let lhsInput = splitInput[0];
     let rhsInput = splitInput[1];
 
@@ -112,11 +115,14 @@ export class MathEquationInputRulesService {
 
     let positionOfTerms = inputs.y;
 
-    let splitAnswer = answer.split('=');
+    let splitAnswer = this._getEquationParts(answer);
+    let splitInput = this._getEquationParts(inputs.x);
+    if (splitAnswer === null || splitInput === null) {
+      return false;
+    }
     let lhsAnswer = splitAnswer[0];
     let rhsAnswer = splitAnswer[1];
 
-    let splitInput = inputs.x.split('=');
     let lhsInput = splitInput[0];
     let rhsInput = splitInput[1];
 
@@ -170,11 +176,14 @@ export class MathEquationInputRulesService {
     answer: MathEquationAnswer,
     inputs: MathEquationRuleInputsWithoutSide
   ): boolean {
-    let splitAnswer = answer.split('=');
+    let splitAnswer = this._getEquationParts(answer);
+    let splitInput = this._getEquationParts(inputs.x);
+    if (splitAnswer === null || splitInput === null) {
+      return false;
+    }
     let lhsAnswer = splitAnswer[0];
     let rhsAnswer = splitAnswer[1];
 
-    let splitInput = inputs.x.split('=');
     let lhsInput = splitInput[0];
     let rhsInput = splitInput[1];
 
@@ -226,5 +235,24 @@ export class MathEquationInputRulesService {
     }
     // If none of the checks pass, the answer is not equivalent.
     return false;
+  }
+
+  /**
+   * Splits an equation string into the left-hand side and right-hand side, or
+   * returns null if the string is not a well-formed equation (i.e. it does not
+   * contain exactly one '=' sign with non-empty sides). This prevents the rule
+   * functions from passing undefined sides to nerdamer or the
+   * MathInteractionsService, which would otherwise throw an error.
+   */
+  _getEquationParts(equation: string): string[] | null {
+    let splitEquation = equation.split('=');
+    if (
+      splitEquation.length !== 2 ||
+      splitEquation[0].trim().length === 0 ||
+      splitEquation[1].trim().length === 0
+    ) {
+      return null;
+    }
+    return splitEquation;
   }
 }

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.spec.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.spec.ts
@@ -310,6 +310,43 @@ describe('MathEquationInputValidationService', () => {
     ]);
   });
 
+  it('should warn and not throw if a rule input is not an equation', () => {
+    answerGroups[0].rules = [
+      Rule.createFromBackendDict(
+        {
+          rule_type: 'IsEquivalentTo',
+          inputs: {
+            x: 'v',
+          },
+        },
+        'MathEquationInput'
+      ),
+    ];
+
+    expect(() =>
+      validatorService.getAllWarnings(
+        currentState,
+        customizationArgs,
+        answerGroups,
+        goodDefaultOutcome
+      )
+    ).not.toThrow();
+    warnings = validatorService.getAllWarnings(
+      currentState,
+      customizationArgs,
+      answerGroups,
+      goodDefaultOutcome
+    );
+    expect(warnings).toEqual([
+      {
+        type: WARNING_TYPES.ERROR,
+        message:
+          'Learner answer 1 from Oppia response 1 must be an equation ' +
+          "with a single '=' sign.",
+      },
+    ]);
+  });
+
   it('should warn if there are inputs with unsupported functions', function () {
     answerGroups[0].rules = [
       Rule.createFromBackendDict(

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.ts
@@ -106,6 +106,19 @@ export class MathEquationInputValidationService {
 
         let splitInput = currentInput.split('=');
 
+        if (splitInput.length !== 2) {
+          warningsList.push({
+            type: AppConstants.WARNING_TYPES.ERROR,
+            message:
+              'Learner answer ' +
+              (j + 1) +
+              ' from Oppia response ' +
+              (i + 1) +
+              " must be an equation with a single '=' sign.",
+          });
+          continue;
+        }
+
         // Explicitly inserting '*' signs wherever necessary.
         splitInput[0] = mathInteractionsService.insertMultiplicationSigns(
           splitInput[0]

--- a/extensions/interactions/MathEquationInput/directives/oppia-interactive-math-equation-input.component.spec.ts
+++ b/extensions/interactions/MathEquationInput/directives/oppia-interactive-math-equation-input.component.spec.ts
@@ -160,6 +160,31 @@ describe('MathEquationInputInteractive', () => {
     expect(component.hasBeenTouched).toBeTrue();
   });
 
+  it('should not submit an expression even when guppy is still focused', function () {
+    // Submitting via the Enter key (the guppy 'done' event) keeps the guppy
+    // editor focused, so findActiveGuppyObject returns a guppy object. The
+    // answer must still be validated in this case, otherwise an expression
+    // without an '=' sign would be sent to the rules service and crash it.
+    spyOn(guppyInitializationService, 'findActiveGuppyObject').and.returnValue(
+      mockGuppyObject as GuppyObject
+    );
+    component.hasBeenTouched = true;
+    component.value = 'v';
+
+    spyOn(mockCurrentInteractionService, 'onSubmit');
+    spyOn(mockCurrentInteractionService, 'updateAnswerIsValid');
+    component.submitAnswer();
+    expect(mockCurrentInteractionService.onSubmit).not.toHaveBeenCalled();
+    expect(
+      mockCurrentInteractionService.updateAnswerIsValid
+    ).toHaveBeenCalledWith(false);
+    expect(component.warningText).toBe(
+      'It looks like you have entered an expression. ' +
+        'Please enter an equation instead.'
+    );
+    expect(component.hasBeenTouched).toBeTrue();
+  });
+
   it('should correctly validate current answer', function () {
     // This should be validated as true if the editor hasn't been touched.
     component.value = '';

--- a/extensions/interactions/MathEquationInput/directives/oppia-interactive-math-equation-input.component.ts
+++ b/extensions/interactions/MathEquationInput/directives/oppia-interactive-math-equation-input.component.ts
@@ -63,10 +63,7 @@ export class InteractiveMathEquationInput implements OnInit {
   isCurrentAnswerValid(checkForTouched = true): boolean {
     let activeGuppyObject =
       this.guppyInitializationService.findActiveGuppyObject();
-    if (
-      (!checkForTouched || this.hasBeenTouched) &&
-      activeGuppyObject === undefined
-    ) {
+    if (!checkForTouched || this.hasBeenTouched) {
       // Replacing abs symbol, '|x|', with text, 'abs(x)' since the symbol
       // is not compatible with nerdamer or with the backend validations.
       this.value = this.mathInteractionsService.replaceAbsSymbolWithText(
@@ -76,7 +73,15 @@ export class InteractiveMathEquationInput implements OnInit {
         this.value,
         this.guppyInitializationService.getAllowedVariables()
       );
-      this.warningText = this.mathInteractionsService.getWarningText();
+      // Show the warning text only when the learner has finished typing
+      // (i.e., the guppy editor is no longer focused) or when they are
+      // submitting their answer. This avoids distracting them while they are
+      // still entering the answer.
+      if (activeGuppyObject === undefined || !checkForTouched) {
+        this.warningText = this.mathInteractionsService.getWarningText();
+      } else {
+        this.warningText = '';
+      }
       this.currentInteractionService.updateAnswerIsValid(answerIsValid);
       return answerIsValid;
     }


### PR DESCRIPTION
fixes #27381 

## Overview
When a learner submits an answer to a MathEquationInput interaction that does not contain an "=" sign (or when a stored rule input is not a well-formed equation), the page throws `TypeError: Cannot read properties of undefined (reading 'replace')` and the interaction gets stuck in the loading state.

## Root cause
`MathEquationInputRulesService` blindly does `string.split('=')` and indexes `[1]`. If the string has no "=" (e.g. the learner pressed Enter in the Guppy editor, which skips the previous validation because the editor is still focused), the right-hand side is `undefined` and is passed to functions like `insertMultiplicationSigns`/`replaceConstantsWithVariables`/nerdamer that call `.replace()` on it.

This was exposed by **PR #16939** ("Enter key submits the answer in math expression input"), which added the `Guppy.event('done', ...)` submit path, while the unsafe split assumption dates back to the original MathEquationInput PR #9649.

## Fix
- Rule functions now treat any answer/input that is not a valid equation as "does not match" instead of throwing.
- The learner-facing component now validates the answer on submit even while the Guppy editor is focused, so expressions without "=" show a validation message.
- The editor validation service warns (instead of crashing) if a rule input is missing "=".
- The exploration engine resets `answerIsBeingProcessed` and shows a warning if classification throws, so the card never gets permanently stuck.

## Verification
- Added unit tests reproducing a no-"=" answer across all three rule types, a still-focused Guppy submit, a malformed rule input warning, and a classification exception.
- All changed files pass `prettier` (3.2.5) formatting.


## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: ...".
- [x] The PR is made from a branch off develop.
- [x] I followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia).
- [x] I ran the relevant tests and the code passes.
- [x] My changes don't cause any new lint warnings/errors.
