### PR TITLE
Fix #19737: Use dev mode storage for profile images

### DIFF
--- a/core/controllers/resources.py
+++ b/core/controllers/resources.py
@@ -70,6 +70,7 @@ class AssetDevHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
         feconf.ENTITY_TYPE_BLOG_POST,
         feconf.ENTITY_TYPE_TOPIC,
         feconf.ENTITY_TYPE_STORY,
+        feconf.ENTITY_TYPE_USER,
         feconf.ENTITY_TYPE_QUESTION,
         feconf.IMAGE_CONTEXT_QUESTION_SUGGESTIONS,
         feconf.IMAGE_CONTEXT_EXPLORATION_SUGGESTIONS,
@@ -98,7 +99,18 @@ class AssetDevHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
             }
         },
     }
-    HANDLER_ARGS_SCHEMAS: Dict[str, Dict[str, str]] = {'GET': {}}
+    HANDLER_ARGS_SCHEMAS = {
+        'GET': {
+            # Optional cache-busting query param sent by profile image
+            # requests (see UserService.getProfileImageDataUrl). Its value
+            # is unused; it only needs to be accepted so the request isn't
+            # rejected as having unrecognized args.
+            'v': {
+                'schema': {'type': 'basestring'},
+                'default_value': None,
+            }
+        }
+    }
 
     @acl_decorators.open_access
     def get(
@@ -119,6 +131,7 @@ class AssetDevHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
                 story: story_id
                 topic: topic_id
                 skill: skill_id
+                user: username
                 subtopic: topic_name of the topic that it is part of.
             asset_type: str. Type of the asset, either image or audio.
             encoded_filename: str. The asset filename. This
@@ -145,7 +158,14 @@ class AssetDevHandler(base.BaseHandler[Dict[str, str], Dict[str, str]]):
             self.response.headers['Content-Type'] = content_type
 
             fs = fs_services.GcsFileSystem(page_context, page_identifier)
-            raw = fs.get('%s/%s' % (asset_type, filename))
+            if page_context == feconf.ENTITY_TYPE_USER:
+                # User profile pictures are committed directly under the
+                # user's assets folder (see
+                # user_services.update_profile_picture_data_url), without
+                # the 'image/' filename-prefix used by other entity types.
+                raw = fs.get(filename)
+            else:
+                raw = fs.get('%s/%s' % (asset_type, filename))
 
             self.response.cache_control.no_cache = None
             self.response.cache_control.public = True

--- a/core/controllers/resources_test.py
+++ b/core/controllers/resources_test.py
@@ -589,6 +589,91 @@ class AssetDevHandlerImageTests(test_utils.GenericTestBase):
             )
         self.logout()
 
+    def test_can_fetch_user_profile_picture_stored_via_dev_mode_storage(
+        self,
+    ) -> None:
+        """Profile pictures are committed via
+        user_services.update_profile_picture_data_url(), which stores them
+        directly under the user's assets folder (i.e. without an
+        'image/' filename-prefix). AssetDevHandler must still be able to
+        serve them at their 'assets/image/<filename>' URL. See #19737.
+        """
+        with open(
+            os.path.join(feconf.TESTS_DATA_DIR, 'img.png'), 'rb', encoding=None
+        ) as f:
+            raw_image = f.read()
+
+        fs = fs_services.GcsFileSystem(
+            feconf.ENTITY_TYPE_USER, self.EDITOR_USERNAME
+        )
+        fs.commit('profile_picture.png', raw_image, mimetype='image/png')
+
+        response = self.get_custom_response(
+            self._get_image_url(
+                feconf.ENTITY_TYPE_USER,
+                self.EDITOR_USERNAME,
+                'profile_picture.png',
+            ),
+            'image/png',
+        )
+        self.assertEqual(response.body, raw_image)
+
+    def test_fetching_missing_user_profile_picture_raises_404(self) -> None:
+        self.get_json(
+            self._get_image_url(
+                feconf.ENTITY_TYPE_USER,
+                'nonexistent_user',
+                'profile_picture.png',
+            ),
+            expected_status_int=404,
+        )
+
+    def test_can_fetch_user_profile_picture_with_cache_buster_query_param(
+        self,
+    ) -> None:
+        """Regression test for #19737. UserService.getProfileImageDataUrl()
+        appends a '?v=<cache-buster>' query param to this URL so that browsers
+        don't serve a stale cached image after the picture is changed. This
+        must not be rejected as an unrecognized argument.
+        """
+        with open(
+            os.path.join(feconf.TESTS_DATA_DIR, 'img.png'), 'rb', encoding=None
+        ) as f:
+            raw_image = f.read()
+
+        fs = fs_services.GcsFileSystem(
+            feconf.ENTITY_TYPE_USER, self.EDITOR_USERNAME
+        )
+        fs.commit('profile_picture.png', raw_image, mimetype='image/png')
+
+        response = self.get_custom_response(
+            '%s?v=1234567.89'
+            % self._get_image_url(
+                feconf.ENTITY_TYPE_USER,
+                self.EDITOR_USERNAME,
+                'profile_picture.png',
+            ),
+            'image/png',
+        )
+        self.assertEqual(response.body, raw_image)
+
+    def test_fetching_user_profile_picture_with_unrecognized_query_param_fails(
+        self,
+    ) -> None:
+        """Confirms the 'v' allowance is specific, not a general loosening of
+        argument validation: any other unrecognized query param must still be
+        rejected.
+        """
+        self.get_json(
+            '%s?unexpected_arg=1'
+            % self._get_image_url(
+                feconf.ENTITY_TYPE_USER,
+                self.EDITOR_USERNAME,
+                'profile_picture.png',
+            ),
+            expected_status_int=400,
+        )
+
 
 class AssetDevHandlerAudioTest(test_utils.GenericTestBase):
     """Test the upload of audio files to GCS."""

--- a/core/templates/pages/preferences-page/preferences-page.component.spec.ts
+++ b/core/templates/pages/preferences-page/preferences-page.component.spec.ts
@@ -52,7 +52,6 @@ import {
   HttpTestingController,
 } from '@angular/common/http/testing';
 import {AssetsBackendApiService} from 'services/assets-backend-api.service';
-import {ImageUploadHelperService} from '../../services/image-upload-helper.service';
 
 describe('Preferences Page Component', () => {
   @Pipe({name: 'truncate'})
@@ -74,7 +73,6 @@ describe('Preferences Page Component', () => {
     let ngbModal: NgbModal;
     let mockWindowRef: MockWindowRef;
     let mockUserBackendApiService: MockUserBackendApiService;
-    let imageUploadHelperService: ImageUploadHelperService;
 
     let preferencesData: PreferencesBackendDict = {
       preferred_language_codes: ['en'],
@@ -189,7 +187,6 @@ describe('Preferences Page Component', () => {
       i18nLanguageCodeService = TestBed.inject(I18nLanguageCodeService);
       ngbModal = TestBed.inject(NgbModal);
       mockUserBackendApiService = TestBed.inject(UserBackendApiService);
-      imageUploadHelperService = TestBed.inject(ImageUploadHelperService);
 
       spyOn(userService, 'getProfileImageDataUrl').and.returnValue([
         'profile-image-url-png',
@@ -598,6 +595,14 @@ describe('Preferences Page Component', () => {
 
     it('should show edit profile picture modal', fakeAsync(() => {
       let profilePictureDataUrl = 'data:image/png;base64,JUMzJTg3JTJD';
+      const updateSpy = spyOn(
+        mockUserBackendApiService,
+        'updateMultiplePreferencesDataAsync'
+      ).and.returnValue(
+        Promise.resolve({
+          bulk_email_signup_message_should_be_shown: false,
+        })
+      );
       spyOn(ngbModal, 'open').and.returnValue({
         result: Promise.resolve(profilePictureDataUrl),
       } as NgbModalRef);
@@ -624,46 +629,19 @@ describe('Preferences Page Component', () => {
       tick();
       componentInstance.savePreferences();
       tick();
-      expect(mockWindowRef.nativeWindow.sessionStorage.getItem('file')).toEqual(
-        profilePictureDataUrl
+      // The profile picture update must be sent to the backend in dev mode
+      // too (it must not be filtered out), since the backend already
+      // stores it via dev_mode_storage_services.
+      const updates = updateSpy.calls.mostRecent().args[0];
+      const profilePictureUpdate = updates.find(
+        (update: UpdatePreferenceDict) =>
+          update.update_type === 'profile_picture_data_url'
       );
+      if (profilePictureUpdate === undefined) {
+        throw new Error('Expected a profile picture update.');
+      }
+      expect(profilePictureUpdate.data).toEqual(profilePictureDataUrl);
       expect(mockWindowRef.nativeWindow.location.reload).toHaveBeenCalled();
-    }));
-
-    it('should edit profile picture modal raise error when image is invalid', fakeAsync(() => {
-      let error = 'Image uploaded is not valid.';
-      let profilePictureDataUrl = 'data:text/plain;base64,JUMzJTg3JTJD';
-      spyOn(ngbModal, 'open').and.returnValue({
-        result: Promise.resolve(profilePictureDataUrl),
-      } as NgbModalRef);
-      spyOn(
-        imageUploadHelperService,
-        'convertImageDataToImageFile'
-      ).and.returnValue(null);
-      spyOn(alertsService, 'addWarning');
-      spyOn(userService, 'getUserInfoAsync').and.returnValue(
-        Promise.resolve(
-          new UserInfo(
-            ['USER_ROLE'],
-            false,
-            false,
-            false,
-            false,
-            false,
-            'en',
-            'test',
-            'test_email@example.com',
-            true
-          )
-        )
-      );
-      componentInstance.ngOnInit();
-      tick();
-      componentInstance.showEditProfilePictureModal();
-      tick();
-      componentInstance.savePreferences();
-      tick();
-      expect(alertsService.addWarning).toHaveBeenCalledWith(error);
     }));
 
     it('should handle edit profile picture modal is canceled', fakeAsync(() => {

--- a/core/templates/pages/preferences-page/preferences-page.component.ts
+++ b/core/templates/pages/preferences-page/preferences-page.component.ts
@@ -27,8 +27,6 @@ import {
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {AlertsService} from 'services/alerts.service';
 import {I18nLanguageCodeService} from 'services/i18n-language-code.service';
-import {ImageLocalStorageService} from 'services/image-local-storage.service';
-import {ImageUploadHelperService} from 'services/image-upload-helper.service';
 import {LoaderService} from 'services/loader.service';
 import {PreventPageUnloadEventService} from 'services/prevent-page-unload-event.service';
 import {
@@ -42,7 +40,6 @@ import {UserService} from 'services/user.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 
 import {EditProfilePictureModalComponent} from './modal-templates/edit-profile-picture-modal.component';
-import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 require('cropperjs/dist/cropper.min.css');
 
 import './preferences-page.component.css';
@@ -107,8 +104,6 @@ export class PreferencesPageComponent {
     private windowRef: WindowRef,
     private alertsService: AlertsService,
     private i18nLanguageCodeService: I18nLanguageCodeService,
-    private imageLocalStorageService: ImageLocalStorageService,
-    private imageUploadHelperService: ImageUploadHelperService,
     private languageUtilService: LanguageUtilService,
     private loaderService: LoaderService,
     private preventPageUnloadEventService: PreventPageUnloadEventService,
@@ -152,25 +147,6 @@ export class PreferencesPageComponent {
     // The following line is needed to emit the statusChanges observable.
     pngControl.updateValueAndValidity();
     webpControl.updateValueAndValidity();
-  }
-
-  // TODO(#19737): Remove the following function.
-  private _saveProfileImageToLocalStorage(image: string): void {
-    const newImageFile =
-      this.imageUploadHelperService.convertImageDataToImageFile(image);
-    if (newImageFile === null) {
-      this.alertsService.addWarning('Image uploaded is not valid.');
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = () => {
-      const imageData = reader.result as string;
-      this.imageLocalStorageService.saveImage(
-        this.username + '_profile_picture.png',
-        imageData
-      );
-    };
-    reader.readAsDataURL(newImageFile);
   }
 
   showEditProfilePictureModal(): void {
@@ -364,16 +340,6 @@ export class PreferencesPageComponent {
       });
     }
 
-    // TODO(#19737): Remove the following condition.
-    if (AssetsBackendApiService.EMULATOR_MODE) {
-      // Remove 'profile_picture_data_url' from updates if the emulator mode is
-      // on because the backend doesn't support updating profile picture in
-      // emulator mode.
-      updates = updates.filter(update => {
-        return update.update_type !== 'profile_picture_data_url';
-      });
-    }
-
     this.userBackendApiService
       .updateMultiplePreferencesDataAsync(updates)
       .then(returnData => {
@@ -391,12 +357,6 @@ export class PreferencesPageComponent {
           this.alertsService.addInfoMessage('Saved!', 3000);
         }
         if (this.preferencesForm.controls.profilePicturePngDataUrl.dirty) {
-          // TODO(#19737): Remove the following 'if' condition.
-          if (AssetsBackendApiService.EMULATOR_MODE) {
-            this._saveProfileImageToLocalStorage(
-              this.preferencesForm.controls.profilePicturePngDataUrl.value
-            );
-          }
           // The reload is needed in order to update the profile picture
           // in the top-right corner(Nav Bar).
           this.preventPageUnloadEventService.removeListener();

--- a/core/templates/services/assets-backend-api.service.ts
+++ b/core/templates/services/assets-backend-api.service.ts
@@ -58,17 +58,28 @@ export class AssetsBackendApiService {
     private urlInterpolationService: UrlInterpolationService
   ) {
     let urlPrefix = '/assetsdevhandler';
+    // In emulator mode, profile images are served by AssetDevHandler, which
+    // requires an '<asset_type>' path segment (see main.py's assetsdevhandler
+    // route). In production, images are fetched directly from the GCS
+    // bucket, whose object paths have no such segment (see
+    // user_services.update_profile_picture_data_url).
+    let profileImagePngUrlTemplate =
+      urlPrefix + '/user/<username>/assets/image/profile_picture.png';
+    let profileImageWebpUrlTemplate =
+      urlPrefix + '/user/<username>/assets/image/profile_picture.webp';
     if (!AssetsBackendApiService.EMULATOR_MODE) {
       urlPrefix =
         'https://storage.googleapis.com/' +
         AssetsBackendApiService.GCS_RESOURCE_BUCKET_NAME;
+      profileImagePngUrlTemplate =
+        urlPrefix + '/user/<username>/assets/profile_picture.png';
+      profileImageWebpUrlTemplate =
+        urlPrefix + '/user/<username>/assets/profile_picture.webp';
     }
     this.downloadUrlTemplate =
       urlPrefix + '/<entity_type>/<entity_id>/assets/<asset_type>/<filename>';
-    this.profileImagePngUrlTemplate =
-      urlPrefix + '/user/<username>/assets/profile_picture.png';
-    this.profileImageWebpUrlTemplate =
-      urlPrefix + '/user/<username>/assets/profile_picture.webp';
+    this.profileImagePngUrlTemplate = profileImagePngUrlTemplate;
+    this.profileImageWebpUrlTemplate = profileImageWebpUrlTemplate;
   }
 
   static get EMULATOR_MODE(): boolean {

--- a/core/templates/services/user.service.spec.ts
+++ b/core/templates/services/user.service.spec.ts
@@ -24,9 +24,7 @@ import {
 } from '@angular/common/http/testing';
 import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 
-import {AppConstants} from 'app.constants';
 import {UserInfo} from 'domain/user/user-info.model';
-import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {WindowRef} from 'services/contextual/window-ref.service';
 import {CsrfTokenService} from 'services/csrf-token.service';
 import {UserService} from 'services/user.service';
@@ -35,7 +33,6 @@ import {
   PreferencesBackendDict,
   UserBackendApiService,
 } from './user-backend-api.service';
-import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 
 class MockWindowRef {
@@ -68,13 +65,11 @@ class MockWindowRef {
 describe('User Api Service', () => {
   describe('on dev mode', () => {
     let userService: UserService;
-    let urlInterpolationService: UrlInterpolationService;
     let urlService: UrlService;
     let httpTestingController: HttpTestingController;
     let csrfService: CsrfTokenService;
     let windowRef: MockWindowRef;
     let userBackendApiService: UserBackendApiService;
-    let imageLocalStorageService: ImageLocalStorageService;
 
     beforeEach(() => {
       windowRef = new MockWindowRef();
@@ -84,11 +79,9 @@ describe('User Api Service', () => {
       });
       httpTestingController = TestBed.inject(HttpTestingController);
       userService = TestBed.inject(UserService);
-      urlInterpolationService = TestBed.inject(UrlInterpolationService);
       urlService = TestBed.inject(UrlService);
       csrfService = TestBed.inject(CsrfTokenService);
       userBackendApiService = TestBed.inject(UserBackendApiService);
-      imageLocalStorageService = TestBed.inject(ImageLocalStorageService);
 
       spyOn(csrfService, 'getTokenAsync').and.callFake(async () => {
         return new Promise((resolve, reject) => {
@@ -217,31 +210,18 @@ describe('User Api Service', () => {
       flushMicrotasks();
     }));
 
-    it('should return image stored in session storage while in emulator mode', fakeAsync(() => {
-      let filename = 'tester_profile_picture.png';
-      const imageData = 'data:image/png;base64,JUMzJTg3JTJD';
-      imageLocalStorageService.saveImage(filename, imageData);
-      let [profileImagePng, profileImageWebp] =
-        userService.getProfileImageDataUrl('tester');
-      expect(profileImagePng).toEqual(imageData);
-      expect(profileImageWebp).toEqual(imageData);
-      imageLocalStorageService.deleteImage(filename);
-
-      flushMicrotasks();
-    }));
-
-    it('should return the default profile image path when in emulator mode', fakeAsync(() => {
-      let defaultUrlWebp = urlInterpolationService.getStaticImageUrl(
-        AppConstants.DEFAULT_PROFILE_IMAGE_WEBP_PATH
-      );
-      let defaultUrlPng = urlInterpolationService.getStaticImageUrl(
-        AppConstants.DEFAULT_PROFILE_IMAGE_PNG_PATH
-      );
+    it('should return the backend dev-storage image path in emulator mode', fakeAsync(() => {
+      let expectedPngImage =
+        '/assetsdevhandler/user/tester/assets/image/profile_picture.png';
+      let expectedWebpImage =
+        '/assetsdevhandler/user/tester/assets/image/profile_picture.webp';
       let [profileImagePng, profileImageWebp] =
         userService.getProfileImageDataUrl('tester');
       let prformanceTime = profileImagePng.split('?')[1];
-      expect(profileImagePng).toEqual(defaultUrlPng + '?' + prformanceTime);
-      expect(profileImageWebp).toEqual(defaultUrlWebp + '?' + prformanceTime);
+      expect(profileImagePng).toEqual(expectedPngImage + '?' + prformanceTime);
+      expect(profileImageWebp).toEqual(
+        expectedWebpImage + '?' + prformanceTime
+      );
 
       flushMicrotasks();
     }));

--- a/core/templates/services/user.service.ts
+++ b/core/templates/services/user.service.ts
@@ -18,8 +18,6 @@
 
 import {Injectable} from '@angular/core';
 
-import {AppConstants} from 'app.constants';
-import {ImageLocalStorageService} from 'services/image-local-storage.service';
 import {UserInfo} from 'domain/user/user-info.model';
 import {UrlInterpolationService} from 'domain/utilities/url-interpolation.service';
 import {UrlService} from 'services/contextual/url.service';
@@ -37,7 +35,6 @@ import {AssetsBackendApiService} from 'services/assets-backend-api.service';
 export class UserService {
   constructor(
     private assetsBackendApiService: AssetsBackendApiService,
-    private imageLocalStorageService: ImageLocalStorageService,
     private urlInterpolationService: UrlInterpolationService,
     private urlService: UrlService,
     private windowRef: WindowRef,
@@ -69,39 +66,21 @@ export class UserService {
     // in order to avoid cache problems.
     // Here we are using prformanceTime in order to avoid cache problems.
     // For details have a look at - https://stackoverflow.com/a/126831
-    let prformanceTime = '?' + performance.now().toString();
-    if (AssetsBackendApiService.EMULATOR_MODE) {
-      let localStoredImage = this.imageLocalStorageService.getRawImageData(
-        username + '_profile_picture.png'
-      );
-      let defaultUrlWebp = this.urlInterpolationService.getStaticImageUrl(
-        AppConstants.DEFAULT_PROFILE_IMAGE_WEBP_PATH
-      );
-      let defaultUrlPng = this.urlInterpolationService.getStaticImageUrl(
-        AppConstants.DEFAULT_PROFILE_IMAGE_PNG_PATH
-      );
-      if (localStoredImage === null) {
-        return [
-          defaultUrlPng + prformanceTime,
-          defaultUrlWebp + prformanceTime,
-        ];
-      }
-      // Normally, we return a tuple of PNG image URL and WebP image URL.
-      // In emulator mode we use local storage and we only store the PNG image.
-      // To handle this we return a tuple of the same PNG images in
-      // emulator mode.
-      return [localStoredImage, localStoredImage];
-    } else {
-      let pngImageUrl = this.urlInterpolationService.interpolateUrl(
-        this.assetsBackendApiService.profileImagePngUrlTemplate,
-        {username: username}
-      );
-      let WebpImageUrl = this.urlInterpolationService.interpolateUrl(
-        this.assetsBackendApiService.profileImageWebpUrlTemplate,
-        {username: username}
-      );
-      return [pngImageUrl + prformanceTime, WebpImageUrl + prformanceTime];
-    }
+    // The 'v' query param name matches the convention already used for
+    // optional cache-busting/version args elsewhere in the codebase (see
+    // e.g. EditorHandler and ExplorationPlayerAccessValidationPage), and is
+    // required here because AssetDevHandler (which serves this URL in DEV
+    // mode) rejects unrecognized query args.
+    let prformanceTime = '?v=' + performance.now().toString();
+    let pngImageUrl = this.urlInterpolationService.interpolateUrl(
+      this.assetsBackendApiService.profileImagePngUrlTemplate,
+      {username: username}
+    );
+    let WebpImageUrl = this.urlInterpolationService.interpolateUrl(
+      this.assetsBackendApiService.profileImageWebpUrlTemplate,
+      {username: username}
+    );
+    return [pngImageUrl + prformanceTime, WebpImageUrl + prformanceTime];
   }
 
   async setProfileImageDataUrlAsync(


### PR DESCRIPTION
## Overview

1. This PR fixes [Feature Request]: Use Dev mode storage services for storing the profile image in preferences page in DEV mode #19737.
2. This PR does the following: Updates DEV mode profile image storage to use the existing dev-mode storage services instead of browser localStorage. This removes the special-case EMULATOR_MODE handling from the preferences page and routes DEV mode profile image requests through AssetDevHandler. Cache-buster support is also added for profile image requests, along with backend and frontend tests covering the new behavior.
3. (For bug-fixing PRs only) The original bug occurred because: Profile images in DEV mode were stored in browser localStorage, which required special-case handling in preferences-page.component.ts. This PR changes the DEV mode flow to use the backend dev-mode storage service instead, consistent with the existing asset-storage architecture.

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The PR title starts with "Fix #bugnum:" or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{reviewer_username} PTAL" if I can't assign them directly).

## Proof of changes on desktop and mobile

The profile image was uploaded, cropped, saved, and verified after a page reload in DEV mode.

The browser network logs confirmed that the profile image was fetched through `AssetDevHandler` with HTTP 200 responses, including cache-busted requests.

### Profile image upload

<img width="1400" height="2565" alt="profile-image-upload" src="https://github.com/user-attachments/assets/38e4aae2-2853-44bb-bbf0-b7cd55d421bf" />

### Profile image saved

<img width="1400" height="2565" alt="profile-image-saved" src="https://github.com/user-attachments/assets/b3e892af-6d49-4443-829c-9a1086e82efc" />

### Profile image after reload

<img width="1400" height="2565" alt="profile-image-after-reload" src="https://github.com/user-attachments/assets/b077daca-ff33-407d-990f-75e0cbfa97dc" />

### Full browser verification

The attached browser verification recording demonstrates the complete profile-image upload, crop, save, and reload flow on both desktop and mobile.

[browser-verification.webm](https://github.com/user-attachments/assets/1dbb3160-4c50-484a-95ed-12c2b08d5e60)

## Proof of changes in Arabic language

<!--
Not applicable because this change does not introduce or modify user-facing text or RTL-specific UI.
-->