### PR TITLE
Fix #27381: Prevent undefined replace crash on MathEquationInput answer submission

### DIFF
--- a/core/templates/services/math-interactions.service.ts
+++ b/core/templates/services/math-interactions.service.ts
@@ -326,6 +326,10 @@ export class MathInteractionsService {
     equationString: string,
     validVariablesList: string[]
   ): boolean {
+    if (!equationString) {
+      this.warningText = 'Please enter an answer before submitting.';
+      return false;
+    }
     equationString = equationString.replace(/\s/g, '');
     if (equationString.length === 0) {
       this.warningText = 'Please enter an answer before submitting.';
@@ -396,6 +400,9 @@ export class MathInteractionsService {
   }
 
   insertMultiplicationSigns(expressionString: string): string {
+    if (!expressionString) {
+      return '';
+    }
     let greekLetters = Object.keys(AppConstants.GREEK_LETTER_NAMES_TO_SYMBOLS);
     let greekSymbols = Object.values(
       AppConstants.GREEK_LETTER_NAMES_TO_SYMBOLS
@@ -483,6 +490,9 @@ export class MathInteractionsService {
   }
 
   replaceAbsSymbolWithText(expressionString: string): string {
+    if (!expressionString) {
+      return '';
+    }
     // The guppy editor outputs abs as a symbol '|x|' but that is incompatible
     // with nerdamer and the backend validations. Both of them need 'abs(x)',
     // hence the replacement.
@@ -583,6 +593,9 @@ export class MathInteractionsService {
     expressionString: string,
     replaceZero = true
   ): string {
+    if (!expressionString) {
+      return '';
+    }
     // Multiple instances of the same constant will be replaced by the same
     // variable.
 

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.spec.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.spec.ts
@@ -88,6 +88,15 @@ describe('Math equation input rules service', () => {
         y: positionOfTerms,
       })
     ).toBeFalse();
+    expect(
+      meirs.MatchesExactlyWith('x', {x: inputString, y: positionOfTerms})
+    ).toBeFalse();
+    expect(
+      meirs.MatchesExactlyWith('v', {x: inputString, y: positionOfTerms})
+    ).toBeFalse();
+    expect(
+      meirs.MatchesExactlyWith('y=m*x+c', {x: 'x', y: positionOfTerms})
+    ).toBeFalse();
 
     positionOfTerms = 'rhs';
     // Accepted cases.
@@ -535,5 +544,8 @@ describe('Math equation input rules service', () => {
     expect(
       meirs.IsEquivalentTo('(13 + 2*w)^2 = 1156', {x: inputString})
     ).toBeFalse();
+    expect(meirs.IsEquivalentTo('x', {x: inputString})).toBeFalse();
+    expect(meirs.IsEquivalentTo('v', {x: inputString})).toBeFalse();
+    expect(meirs.IsEquivalentTo('13 + 2*w = 34', {x: 'x'})).toBeFalse();
   });
 });

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-rules.service.ts
@@ -47,11 +47,20 @@ export class MathEquationInputRulesService {
 
     let positionOfTerms = inputs.y;
 
+    if (!answer || !inputs || !inputs.x) {
+      return false;
+    }
+
     let splitAnswer = answer.split('=');
+    let splitInput = inputs.x.split('=');
+
+    if (splitAnswer.length !== 2 || splitInput.length !== 2) {
+      return false;
+    }
+
     let lhsAnswer = splitAnswer[0];
     let rhsAnswer = splitAnswer[1];
 
-    let splitInput = inputs.x.split('=');
     let lhsInput = splitInput[0];
     let rhsInput = splitInput[1];
 
@@ -112,11 +121,20 @@ export class MathEquationInputRulesService {
 
     let positionOfTerms = inputs.y;
 
+    if (!answer || !inputs || !inputs.x) {
+      return false;
+    }
+
     let splitAnswer = answer.split('=');
+    let splitInput = inputs.x.split('=');
+
+    if (splitAnswer.length !== 2 || splitInput.length !== 2) {
+      return false;
+    }
+
     let lhsAnswer = splitAnswer[0];
     let rhsAnswer = splitAnswer[1];
 
-    let splitInput = inputs.x.split('=');
     let lhsInput = splitInput[0];
     let rhsInput = splitInput[1];
 
@@ -170,11 +188,20 @@ export class MathEquationInputRulesService {
     answer: MathEquationAnswer,
     inputs: MathEquationRuleInputsWithoutSide
   ): boolean {
+    if (!answer || !inputs || !inputs.x) {
+      return false;
+    }
+
     let splitAnswer = answer.split('=');
+    let splitInput = inputs.x.split('=');
+
+    if (splitAnswer.length !== 2 || splitInput.length !== 2) {
+      return false;
+    }
+
     let lhsAnswer = splitAnswer[0];
     let rhsAnswer = splitAnswer[1];
 
-    let splitInput = inputs.x.split('=');
     let lhsInput = splitInput[0];
     let rhsInput = splitInput[1];
 

--- a/extensions/interactions/MathEquationInput/directives/oppia-interactive-math-equation-input.component.ts
+++ b/extensions/interactions/MathEquationInput/directives/oppia-interactive-math-equation-input.component.ts
@@ -64,13 +64,16 @@ export class InteractiveMathEquationInput implements OnInit {
     let activeGuppyObject =
       this.guppyInitializationService.findActiveGuppyObject();
     if (
-      (!checkForTouched || this.hasBeenTouched) &&
-      activeGuppyObject === undefined
+      !checkForTouched ||
+      (this.hasBeenTouched && activeGuppyObject === undefined)
     ) {
+      if (activeGuppyObject !== undefined) {
+        this.value = activeGuppyObject.guppyInstance.asciimath();
+      }
       // Replacing abs symbol, '|x|', with text, 'abs(x)' since the symbol
       // is not compatible with nerdamer or with the backend validations.
       this.value = this.mathInteractionsService.replaceAbsSymbolWithText(
-        this.value
+        this.value || ''
       );
       let answerIsValid = this.mathInteractionsService.validateEquation(
         this.value,


### PR DESCRIPTION
## Overview

1. This PR fixes #27381.
2. This PR does the following:
- Adds null and undefined checks to `MathInteractionsService` helper methods (`validateEquation`, `replaceAbsSymbolWithText`, `insertMultiplicationSigns`, and `replaceConstantsWithVariables`) to prevent runtime exceptions when calling string replacement methods like `.replace()` on undefined input values.
- Validates that both the answer and the rule input strings contain an `=` delimiter and split into exactly two non-undefined sides in `MathEquationInputRulesService` (`MatchesExactlyWith`, `MatchesUpToTrivialManipulations`, and `IsEquivalentTo`), returning `false` safely if either is malformed.
- Corrects the boolean check in `InteractiveMathEquationInput.validateCurrentRule` so that submitting an equation while focused (`checkForTouched = false`) validates the answer and syncs current Guppy asciimath rather than skipping validation.
- Adds test coverage in `math-equation-input-rules.service.spec.ts` for answers and inputs missing the `=` delimiter.
3. The original bug occurred because: When submitting an answer to a Math Equation Input interaction without an equals sign (or where an equation part was missing), `splitAnswer[1]` was undefined and was subsequently passed into `replaceConstantsWithVariables` / `insertMultiplicationSigns` / `replaceAbsSymbolWithText`, which called `.replace()` on undefined. In addition, operator precedence in `InteractiveMathEquationInput.validateCurrentRule` bypassed validation when submitting while the input was focused (`checkForTouched = false`).

## Essential Checklist

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because changes are defensive null/undefined guards, boolean condition correction, and unit tests covering equation parsing edge cases.
