### PR TITLE
Fix #18762: Add validate method for TranslationCoordinatorStats

### DIFF
--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1798,6 +1798,21 @@ class TranslationCoordinatorStats:
         self.coordinator_ids = coordinator_ids
         self.coordinators_count = coordinators_count
 
+    def validate(self) -> None:
+        """Validates the TranslationCoordinatorStats domain object."""
+        if not isinstance(self.coordinator_ids, list):
+            raise utils.ValidationError(
+                'Expected coordinator_ids to be a list, received %s.'
+                % (self.coordinator_ids)
+            )
+
+        if self.coordinators_count != len(self.coordinator_ids):
+            raise utils.ValidationError(
+                'Expected coordinators_count to match the number of '
+                'coordinator_ids, but got %d and %d respectively.'
+                % (self.coordinators_count, len(self.coordinator_ids))
+            )
+
     def to_dict(self) -> TranslationCoordinatorStatsDict:
         """Returns a dict representaion of TranslationCoordinatorStats.
 

--- a/core/domain/user_domain_test.py
+++ b/core/domain/user_domain_test.py
@@ -1855,6 +1855,36 @@ class TranslationCoordinatorStatsUnitTests(test_utils.GenericTestBase):
 
         self.assertDictEqual(actual_stats.to_dict(), self.expected_stats_dict)
 
+    def test_validate_with_valid_stats(self) -> None:
+        actual_stats = user_domain.TranslationCoordinatorStats(
+            'en', ['user1', 'user2'], 2
+        )
+        actual_stats.validate()
+
+    def test_validate_with_invalid_coordinator_ids_type(self) -> None:
+        # TODO(#13059): Here we use MyPy ignore because after we fully type the
+        # codebase we plan to get rid of the tests that intentionally test wrong
+        # inputs that we can normally catch by typing.
+        actual_stats = user_domain.TranslationCoordinatorStats(
+            'en', 'user1', 2  # type: ignore[arg-type]
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected coordinator_ids to be a list, received user1.',
+        ):
+            actual_stats.validate()
+
+    def test_validate_with_mismatching_coordinators_count(self) -> None:
+        actual_stats = user_domain.TranslationCoordinatorStats(
+            'en', ['user1', 'user2'], 3
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError,
+            'Expected coordinators_count to match the number of '
+            'coordinator_ids, but got 3 and 2 respectively.',
+        ):
+            actual_stats.validate()
+
 
 class UserContributionRightsUnitTest(test_utils.GenericTestBase):
     """Tests for the UserContributionRights class."""

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -3775,8 +3775,6 @@ class TranslationCoordinatorsModel(base_models.BaseModel):
     # The number of coordinators of this language. This property is added to
     # enable the sorting of datastore query results. It is equal to the
     # length of the coordinator_ids field.
-    # TODO(#18762): Add a validate method in domain layer to verify that the
-    # coordinators_count equals the length of coordinator_ids.
     coordinators_count = datastore_services.IntegerProperty(
         indexed=True, required=True
     )


### PR DESCRIPTION
## Overview

1. This PR fixes #18762.
2. This PR does the following: Adds a `validate()` method to the `TranslationCoordinatorStats` domain model to explicitly enforce that `coordinators_count` equals `len(coordinator_ids)`. It also adds corresponding positive and negative backend unit tests, and removes the completed `# TODO(#18762)` comment from `core/storage/suggestion/gae_models.py`.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a purely backend domain validation change that does not affect any user-facing interface. The changes are verified by the newly added backend unit tests which pass successfully.
