### PR TITLE
Fix #25732: Flush pending feature flags request in image preloader test

### DIFF
--- a/core/templates/pages/exploration-player-page/services/image-preloader.service.spec.ts
+++ b/core/templates/pages/exploration-player-page/services/image-preloader.service.spec.ts
@@ -438,6 +438,7 @@ describe('Image preloader service', () => {
   });
 
   it('should not be in exploration player before init is called', () => {
+    flushFeatureFlagsIfQueued();
     expect(imagePreloaderService.inExplorationPlayer()).toBeFalsy();
   });
 


### PR DESCRIPTION
## Overview

1. This PR fixes #25732.
2. This PR does the following: Adds `flushFeatureFlagsIfQueued();` to the failing `should not be in exploration player before init is called` test in `image-preloader.service.spec.ts`. This safely flushes a pending background HTTP request to `/feature_flags_evaluation_handler` which was being caught by the test's `afterEach` verification step during the combined CI runs.
3. (For bug-fixing PRs only) The original bug occurred because: A background asynchronous HTTP request to `/feature_flags_evaluation_handler` triggered during `TestBed.inject` setup was leaking into the execution window of this test during the `combined-tests` CI run. Unlike other tests in the same file, this specific test was missing the standard helper call to clear the pending request, causing `httpTestingController.verify()` to fail with an "Expected no open requests" error.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code. 
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this PR only affects frontend tests and does not alter the user interface or application logic. The proof is the passing GitHub Actions CI run on this PR.

<img width="1517" height="950" alt="Screenshot 2026-09-13 at 4 08 29 PM" src="https://github.com/user-attachments/assets/6ef55032-bb25-462f-a144-ffa00f819f06" />


#### Proof of changes on desktop with slow/throttled network

N/A - Test-only change.

#### Proof of changes on mobile phone

N/A - Test-only change.

#### Proof of changes in Arabic language

N/A - Test-only change.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.