### PR TITLE
Fix #25748: Fix flaky timeout and clickability errors in serial chapter acceptance tests

### DIFF
--- a/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/logged-in-user.ts
@@ -3221,24 +3221,12 @@ export class LoggedInUser extends BaseUser {
         };
 
         if (!href) {
-          await Promise.all([
-            this.page.waitForNavigation({
-              waitUntil: 'networkidle2',
-              timeout: 60000,
-            }),
-            button.click(),
-          ]);
+          await button.click();
           await waitForExplorationPlayer();
           return;
         }
 
-        await Promise.all([
-          this.page.waitForNavigation({
-            waitUntil: 'networkidle2',
-            timeout: 60000,
-          }),
-          this.page.goto(href),
-        ]);
+        await this.page.goto(href);
         await waitForExplorationPlayer();
         return;
       }
@@ -4486,29 +4474,29 @@ export class LoggedInUser extends BaseUser {
     chapterNames: string[]
   ): Promise<void> {
     await this.page.waitForSelector(availableChapters);
-    const containers = await this.page.$$(availableChapters);
 
     for (const chapterName of chapterNames) {
-      let chapterFound = false;
-
-      for (const container of containers) {
-        const chapterEls = await container.$$(chapterSelector);
-
-        for (const el of chapterEls) {
-          const text = await el.evaluate(node => node.textContent?.trim());
-          if (text && text.includes(chapterName)) {
-            chapterFound = true;
-            showMessage(`Chapter "${chapterName}" found in Available list.`);
-            break;
-          }
-        }
-
-        if (chapterFound) {
-          break;
-        }
-      }
-
-      if (!chapterFound) {
+      try {
+        await this.page.waitForFunction(
+          (availableSel, chapterSel, name) => {
+            const containers = document.querySelectorAll(availableSel);
+            for (const container of containers) {
+              const elements = container.querySelectorAll(chapterSel);
+              for (const el of elements) {
+                if (el.textContent?.trim().includes(name)) {
+                  return true;
+                }
+              }
+            }
+            return false;
+          },
+          {timeout: 15000},
+          availableChapters,
+          chapterSelector,
+          chapterName
+        );
+        showMessage(`Chapter "${chapterName}" found in Available list.`);
+      } catch (error) {
         throw new Error(`Chapter "${chapterName}" not found in Available list`);
       }
     }

--- a/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
+++ b/core/tests/puppeteer-acceptance-tests/utilities/user/topic-manager.ts
@@ -5565,6 +5565,25 @@ export class TopicManager extends BaseUser {
       await this.clickOnElementWithSelector(mobileReadyToPublishButton);
     } else {
       await this.page.waitForSelector(markAsReadyToPublishButton);
+
+      // Wait for any toast messages to disappear before clicking the button to avoid click interception
+      await this.page
+        .waitForFunction(
+          () => {
+            const toasts = document.querySelectorAll(
+              '.toast-top-center, .e2e-test-toast-message'
+            );
+            for (const toast of toasts) {
+              if (toast && window.getComputedStyle(toast).display !== 'none') {
+                return false;
+              }
+            }
+            return true;
+          },
+          {timeout: 15000}
+        )
+        .catch(() => {});
+
       await this.clickOnElementWithSelector(markAsReadyToPublishButton);
 
       await this.expectElementToBeVisible(markAsReadyToPublishButton, false);


### PR DESCRIPTION
## Overview

1. This PR fixes #25748.
2. This PR does the following: 
   Fixes flakiness and timeout errors in the acceptance test suite (`serial-chapter.spec.ts`) by improving element wait conditions and navigation handling in test utilities:
   - Replaces unreliable `waitForNavigation({ waitUntil: 'networkidle2' })` in `clickLessonCardButton` (`logged-in-user.ts`) with `waitForExplorationPlayer()` to avoid timeouts caused by background network requests.
   - Updates `expectChaptersInAvailableChapterList` (`logged-in-user.ts`) to use `waitForFunction()` to poll for chapter items, ensuring Angular has finished rendering the list items into the container before asserting.
   - Adds a wait condition in `clickReadyToPublishButton` (`topic-manager.ts`) to wait for active toast notifications (`.toast-top-center` / `.e2e-test-toast-message`) to clear before attempting to click the publish button, preventing click interception timeouts.
3. (For bug-fixing PRs only) The original bug occurred because: 
   The test suite encountered three distinct timing/interactivity flakes:
   - `networkidle2` timed out after 60s because continuous background network requests prevented the network idle state from triggering.
   - `expectChaptersInAvailableChapterList` queried child elements immediately when the container selector appeared, before Angular populated the chapter list DOM nodes.
   - An active toast notification overlay was positioned over the "Mark as Ready To Publish" button, causing Puppeteer's clickability check to time out.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have referenced the issue(s) that this PR fixes or fixes part of on line 1 above. Once I open the PR, I will check that any issues this PR fully fixes are listed in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

No proof of changes needed because this is a developer-facing acceptance test utility fix. Proof is provided via passing GitHub Actions CI / Acceptance stress test runs.

Stress Test on develop before fixing issue : https://github.com/iHamza14/oppia/actions/runs/34681862066
Stress Test on my branch after fixing issue : https://github.com/iHamza14/oppia/actions/runs/34681849321

#### Proof of changes on desktop with slow/throttled network

#### Proof of changes on mobile phone

#### Proof of changes in Arabic language

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Rules-for-making-PRs#step-5-address-review-comments-until-all-reviewers-approve
- Some acceptance tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.